### PR TITLE
feat: implement tree-shaped list semantic

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -112,7 +112,7 @@ The preferred conceptual split is:
   - `list` and `map`
 - semantic implementations
   - internal realizations of those contracts
-  - examples: flat indexed list, linked/chunked list, segment-radix map, hashed-path radix map
+  - examples: tree-shaped indexed list, future keyed structures such as segment-radix or hashed-path radix
 - commitment backend
   - internal authentication primitive used by an implementation
   - examples: KZG, IPA, hash/Merkle commitments

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ layout/backend choices internal to each semantic implementation.
 | Layer | Question | Examples |
 | --- | --- | --- |
 | Structural Semantics | What logical structure does the application expose? | `list`, `map` |
-| Semantic Implementation | How is that semantic contract realized internally? | flat indexed list, linked/chunked list, segment-radix map, hashed-path radix map |
+| Semantic Implementation | How is that semantic contract realized internally? | tree-shaped indexed list, future keyed structures such as segment-radix or hashed-path radix |
 | Commitment Backend | What primitive authenticates already-positioned values or nodes? | KZG, IPA, hash/Merkle commitments |
 
 Under this terminology:
@@ -176,10 +176,11 @@ The long-term public abstraction should look like:
 
 - `core/structure/list`
   - public stable-indexed list semantic
-  - implementations may include flat indexed layouts backed by `IPA` or `KZG`
+  - primary implementation is a tree-shaped indexed layout backed by a fixed-slot primitive such as `IPA` or `KZG`
+  - `indexed` remains as a degenerate one-node implementation for tests and minimal baselines
 - `core/structure/map`
-  - public keyed map semantic
-  - implementations may include segment-radix or hashed-path radix layouts
+  - future keyed semantic
+  - implementation remains deferred until key-placement semantics are finalized
 - commitment backends
   - internal dependencies of structure implementations rather than the primary API surface
   - they authenticate positioned slots or nodes; they do not define public `list` / `map` semantics

--- a/core/structure/list/indexed/semantic.go
+++ b/core/structure/list/indexed/semantic.go
@@ -1,4 +1,6 @@
-// Package indexed implements the stable-indexed list semantic using a fixed-slot backend.
+// Package indexed implements a degenerate one-node stable-indexed list over a
+// fixed-slot backend. It is the minimal semantic implementation used to
+// exercise the list contract before the tree-shaped layout is introduced.
 package indexed
 
 import (
@@ -20,7 +22,7 @@ type Semantic struct {
 
 type proofEnvelope struct {
 	LengthProof []byte `json:"length_proof"`
-	ValueProof  []byte `json:"value_proof,omitempty"`
+	KeyProof    []byte `json:"key_proof,omitempty"`
 }
 
 func New(backend commitment.ListBackend) (*Semantic, error) {
@@ -68,20 +70,17 @@ func (s *Semantic) Prove(ctx context.Context, root cid.Cid, view list.View, inde
 	}
 
 	envelope := proofEnvelope{LengthProof: lengthProof}
-	query := list.Query{
-		Length:  length,
-		Present: index < length,
-	}
+	query := list.Query{Length: length}
 
-	if query.Present {
-		value, valueProof, err := s.backend.ProveIndex(root, backing, index+1)
+	if index < length {
+		key, keyProof, err := s.backend.ProveIndex(root, backing, index+1)
 		if err != nil {
 			return list.Query{}, nil, err
 		}
-		query.Value = value
-		envelope.ValueProof = valueProof
+		query.Key = key
+		envelope.KeyProof = keyProof
 	} else {
-		query.Value = cid.Undef
+		query.Key = cid.Undef
 	}
 
 	proofBytes, err := json.Marshal(envelope)
@@ -115,20 +114,20 @@ func (s *Semantic) Verify(root cid.Cid, index uint64, expected list.Query, proof
 		return ok, err
 	}
 
-	if !expected.Present {
-		if index < expected.Length {
+	if index >= expected.Length {
+		if expected.Key.Defined() {
 			return false, nil
 		}
-		return len(envelope.ValueProof) == 0, nil
+		return len(envelope.KeyProof) == 0, nil
 	}
 
-	if index >= expected.Length || len(envelope.ValueProof) == 0 {
+	if !expected.Key.Defined() || len(envelope.KeyProof) == 0 {
 		return false, nil
 	}
-	return s.backend.VerifyIndex(root, index+1, expected.Value, envelope.ValueProof)
+	return s.backend.VerifyIndex(root, index+1, expected.Key, envelope.KeyProof)
 }
 
-func (s *Semantic) Replace(ctx context.Context, root cid.Cid, view list.View, index uint64, oldValue, newValue cid.Cid) (cid.Cid, error) {
+func (s *Semantic) Replace(ctx context.Context, root cid.Cid, view list.View, index uint64, oldKey, newKey cid.Cid) (cid.Cid, error) {
 	_ = ctx
 	values, err := valuesFromView(view)
 	if err != nil {
@@ -137,24 +136,24 @@ func (s *Semantic) Replace(ctx context.Context, root cid.Cid, view list.View, in
 	if index >= uint64(len(values)) {
 		return cid.Undef, fmt.Errorf("index %d out of range", index)
 	}
-	if !values[index].Equals(oldValue) {
-		return cid.Undef, fmt.Errorf("old value mismatch at index %d", index)
+	if !values[index].Equals(oldKey) {
+		return cid.Undef, fmt.Errorf("old key mismatch at index %d", index)
 	}
 	backing, err := backingValues(values)
 	if err != nil {
 		return cid.Undef, err
 	}
-	return s.backend.ReplaceIndex(root, backing, index+1, oldValue, newValue)
+	return s.backend.ReplaceIndex(root, backing, index+1, oldKey, newKey)
 }
 
-func (s *Semantic) Append(ctx context.Context, root cid.Cid, view list.View, value cid.Cid) (cid.Cid, uint64, error) {
+func (s *Semantic) Append(ctx context.Context, root cid.Cid, view list.View, key cid.Cid) (cid.Cid, uint64, error) {
 	_ = ctx
 	values, err := valuesFromView(view)
 	if err != nil {
 		return cid.Undef, 0, err
 	}
 	newIndex := uint64(len(values))
-	values = append(values, value)
+	values = append(values, key)
 	backing, err := backingValues(values)
 	if err != nil {
 		return cid.Undef, 0, err

--- a/core/structure/list/interface.go
+++ b/core/structure/list/interface.go
@@ -23,11 +23,11 @@ type View interface {
 
 // Query is the verifiable result for a single list position.
 // Length is committed state so that verifiers can distinguish in-range slots
-// from out-of-range queries.
+// from out-of-range queries. For a dense stable-indexed list, index < Length
+// implies Key is defined; index >= Length implies Key must be cid.Undef.
 type Query struct {
-	Value   cid.Cid
-	Length  uint64
-	Present bool
+	Key    cid.Cid
+	Length uint64
 }
 
 // Semantic defines the public stable-indexed list contract.
@@ -39,18 +39,18 @@ type Semantic interface {
 	// Commit commits the supplied list view and returns a structure root.
 	Commit(ctx context.Context, view View) (cid.Cid, error)
 
-	// Prove proves the value (or absence) at index under root.
+	// Prove proves the key (or absence) at index under root.
 	Prove(ctx context.Context, root cid.Cid, view View, index uint64) (Query, structure.Proof, error)
 
 	// Verify verifies the proof for an index query under root.
 	Verify(root cid.Cid, index uint64, expected Query, proof structure.Proof) (bool, error)
 
 	// Replace performs an index-stable replacement at an existing position.
-	Replace(ctx context.Context, root cid.Cid, view View, index uint64, oldValue, newValue cid.Cid) (cid.Cid, error)
+	Replace(ctx context.Context, root cid.Cid, view View, index uint64, oldKey, newKey cid.Cid) (cid.Cid, error)
 
-	// Append extends the list by one element and returns the new root and index.
-	Append(ctx context.Context, root cid.Cid, view View, value cid.Cid) (newRoot cid.Cid, newIndex uint64, err error)
+	// Append extends the list by one key and returns the new root and index.
+	Append(ctx context.Context, root cid.Cid, view View, key cid.Cid) (newRoot cid.Cid, newIndex uint64, err error)
 
-	// Truncate shortens the committed length without changing the prefix that remains.
+	// Truncate shrinks the committed length while preserving the remaining prefix.
 	Truncate(ctx context.Context, root cid.Cid, view View, newLen uint64) (cid.Cid, error)
 }

--- a/core/structure/list/tree/semantic.go
+++ b/core/structure/list/tree/semantic.go
@@ -1,0 +1,496 @@
+// Package tree implements the stable-indexed list semantic using a tree-shaped
+// indexed layout over a fixed-slot primitive backend.
+package tree
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dewebprotocol/malt/core/sce/commitment"
+	"github.com/dewebprotocol/malt/core/structure"
+	"github.com/dewebprotocol/malt/core/structure/list"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+const (
+	// Fanout is the fixed branching factor for the v1 tree-shaped list layout.
+	// Root slot 0 is reserved for the authenticated length marker, so the root
+	// stores at most Fanout children or direct keys.
+	Fanout = 255
+
+	maxUint64 = ^uint64(0)
+)
+
+type Semantic struct {
+	backend commitment.ListBackend
+}
+
+type proofEnvelope struct {
+	LengthProof []byte      `json:"length_proof"`
+	Steps       []proofStep `json:"steps,omitempty"`
+}
+
+type proofStep struct {
+	Target []byte `json:"target"`
+	Proof  []byte `json:"proof"`
+}
+
+type node struct {
+	height   int
+	root     cid.Cid
+	slots    []cid.Cid
+	children []*node
+}
+
+type materializedTree struct {
+	length   uint64
+	height   int
+	root     cid.Cid
+	rootNode *node
+}
+
+func New(backend commitment.ListBackend) (*Semantic, error) {
+	if backend == nil {
+		return nil, fmt.Errorf("list backend is nil")
+	}
+	if backend.MaxValues() < Fanout+1 {
+		return nil, fmt.Errorf("list backend capacity %d is smaller than required root width %d", backend.MaxValues(), Fanout+1)
+	}
+	return &Semantic{backend: backend}, nil
+}
+
+func (s *Semantic) Commit(ctx context.Context, view list.View) (cid.Cid, error) {
+	_ = ctx
+	values, err := valuesFromView(view)
+	if err != nil {
+		return cid.Undef, err
+	}
+	tree, err := s.materialize(values)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return tree.root, nil
+}
+
+func (s *Semantic) Prove(ctx context.Context, root cid.Cid, view list.View, index uint64) (list.Query, structure.Proof, error) {
+	_ = ctx
+	values, err := valuesFromView(view)
+	if err != nil {
+		return list.Query{}, nil, err
+	}
+	tree, err := s.materialize(values)
+	if err != nil {
+		return list.Query{}, nil, err
+	}
+	if !tree.root.Equals(root) {
+		return list.Query{}, nil, fmt.Errorf("root/view mismatch")
+	}
+
+	query := list.Query{Length: tree.length}
+
+	lengthMarker, err := lengthCID(tree.length)
+	if err != nil {
+		return list.Query{}, nil, err
+	}
+	_, lengthProof, err := s.backend.ProveIndex(tree.root, tree.rootNode.slots, 0)
+	if err != nil {
+		return list.Query{}, nil, err
+	}
+	if !lengthMarker.Defined() {
+		return list.Query{}, nil, fmt.Errorf("length marker is undefined")
+	}
+
+	envelope := proofEnvelope{LengthProof: lengthProof}
+	if index >= tree.length {
+		query.Key = cid.Undef
+		return encodeProof(query, envelope)
+	}
+
+	digits, err := indexDigits(index, tree.height)
+	if err != nil {
+		return list.Query{}, nil, err
+	}
+	current := tree.rootNode
+
+	for level, digit := range digits {
+		slot := uint64(digit)
+		if level == 0 {
+			slot++
+		}
+
+		target, proof, err := s.backend.ProveIndex(current.root, current.slots, slot)
+		if err != nil {
+			return list.Query{}, nil, err
+		}
+		envelope.Steps = append(envelope.Steps, newProofStep(target, proof))
+
+		if level == len(digits)-1 {
+			query.Key = target
+			break
+		}
+		if digit >= len(current.children) || current.children[digit] == nil {
+			return list.Query{}, nil, fmt.Errorf("missing child at level %d digit %d", level, digit)
+		}
+		current = current.children[digit]
+	}
+
+	return encodeProof(query, envelope)
+}
+
+func (s *Semantic) Verify(root cid.Cid, index uint64, expected list.Query, proof structure.Proof) (bool, error) {
+	var envelope proofEnvelope
+	if err := json.Unmarshal(proof, &envelope); err != nil {
+		return false, err
+	}
+	if len(envelope.LengthProof) == 0 {
+		return false, fmt.Errorf("missing length proof")
+	}
+
+	lengthMarker, err := lengthCID(expected.Length)
+	if err != nil {
+		return false, err
+	}
+	ok, err := s.backend.VerifyIndex(root, 0, lengthMarker, envelope.LengthProof)
+	if err != nil || !ok {
+		return ok, err
+	}
+
+	if index >= expected.Length {
+		if expected.Key.Defined() {
+			return false, nil
+		}
+		return len(envelope.Steps) == 0, nil
+	}
+	if !expected.Key.Defined() {
+		return false, nil
+	}
+
+	height := requiredHeight(expected.Length)
+	if len(envelope.Steps) != height+1 {
+		return false, nil
+	}
+
+	digits, err := indexDigits(index, height)
+	if err != nil {
+		return false, err
+	}
+	currentRoot := root
+	for level, digit := range digits {
+		step := envelope.Steps[level]
+		target, err := parseStepTarget(step)
+		if err != nil {
+			return false, err
+		}
+		slot := uint64(digit)
+		if level == 0 {
+			slot++
+		}
+		ok, err := s.backend.VerifyIndex(currentRoot, slot, target, step.Proof)
+		if err != nil || !ok {
+			return ok, err
+		}
+		if level == len(digits)-1 {
+			return target.Equals(expected.Key), nil
+		}
+		currentRoot = target
+	}
+	return false, nil
+}
+
+func (s *Semantic) Replace(ctx context.Context, root cid.Cid, view list.View, index uint64, oldKey, newKey cid.Cid) (cid.Cid, error) {
+	_ = ctx
+	values, err := valuesFromView(view)
+	if err != nil {
+		return cid.Undef, err
+	}
+	tree, err := s.materialize(values)
+	if err != nil {
+		return cid.Undef, err
+	}
+	if !tree.root.Equals(root) {
+		return cid.Undef, fmt.Errorf("root/view mismatch")
+	}
+	if index >= tree.length {
+		return cid.Undef, fmt.Errorf("index %d out of range", index)
+	}
+	if !values[index].Equals(oldKey) {
+		return cid.Undef, fmt.Errorf("old key mismatch at index %d", index)
+	}
+
+	nextValues := append([]cid.Cid(nil), values...)
+	nextValues[index] = newKey
+	return s.Commit(ctx, list.NewViewFromSlice(nextValues))
+}
+
+func (s *Semantic) Append(ctx context.Context, root cid.Cid, view list.View, key cid.Cid) (cid.Cid, uint64, error) {
+	_ = ctx
+	values, err := valuesFromView(view)
+	if err != nil {
+		return cid.Undef, 0, err
+	}
+	tree, err := s.materialize(values)
+	if err != nil {
+		return cid.Undef, 0, err
+	}
+	if !tree.root.Equals(root) {
+		return cid.Undef, 0, fmt.Errorf("root/view mismatch")
+	}
+
+	newIndex := uint64(len(values))
+	nextValues := append(append([]cid.Cid(nil), values...), key)
+	newRoot, err := s.Commit(ctx, list.NewViewFromSlice(nextValues))
+	return newRoot, newIndex, err
+}
+
+func (s *Semantic) Truncate(ctx context.Context, root cid.Cid, view list.View, newLen uint64) (cid.Cid, error) {
+	_ = ctx
+	values, err := valuesFromView(view)
+	if err != nil {
+		return cid.Undef, err
+	}
+	tree, err := s.materialize(values)
+	if err != nil {
+		return cid.Undef, err
+	}
+	if !tree.root.Equals(root) {
+		return cid.Undef, fmt.Errorf("root/view mismatch")
+	}
+	if newLen > uint64(len(values)) {
+		return cid.Undef, fmt.Errorf("new length %d exceeds current length %d", newLen, len(values))
+	}
+	if newLen == uint64(len(values)) {
+		return root, nil
+	}
+
+	nextValues := append([]cid.Cid(nil), values[:newLen]...)
+	return s.Commit(ctx, list.NewViewFromSlice(nextValues))
+}
+
+func (s *Semantic) materialize(values []cid.Cid) (*materializedTree, error) {
+	length := uint64(len(values))
+	height := requiredHeight(length)
+	rootNode, err := s.buildRoot(values, height)
+	if err != nil {
+		return nil, err
+	}
+	return &materializedTree{
+		length:   length,
+		height:   height,
+		root:     rootNode.root,
+		rootNode: rootNode,
+	}, nil
+}
+
+func (s *Semantic) buildRoot(values []cid.Cid, height int) (*node, error) {
+	lengthMarker, err := lengthCID(uint64(len(values)))
+	if err != nil {
+		return nil, err
+	}
+
+	if height == 0 {
+		slots := make([]cid.Cid, 1+len(values))
+		slots[0] = lengthMarker
+		copy(slots[1:], values)
+		root, err := s.backend.CommitValues(slots)
+		if err != nil {
+			return nil, err
+		}
+		return &node{
+			height: 0,
+			root:   root,
+			slots:  slots,
+		}, nil
+	}
+
+	childChunk, err := nodeCapacity(height - 1)
+	if err != nil {
+		return nil, err
+	}
+	childCount := ceilDiv(uint64(len(values)), childChunk)
+	children := make([]*node, childCount)
+	slots := make([]cid.Cid, 1+childCount)
+	slots[0] = lengthMarker
+
+	for i := 0; i < childCount; i++ {
+		start := uint64(i) * childChunk
+		end := minUint64(start+childChunk, uint64(len(values)))
+		child, err := s.buildNode(values[int(start):int(end)], height-1)
+		if err != nil {
+			return nil, err
+		}
+		children[i] = child
+		slots[1+i] = child.root
+	}
+
+	root, err := s.backend.CommitValues(slots)
+	if err != nil {
+		return nil, err
+	}
+	return &node{
+		height:   height,
+		root:     root,
+		slots:    slots,
+		children: children,
+	}, nil
+}
+
+func (s *Semantic) buildNode(values []cid.Cid, height int) (*node, error) {
+	if height == 0 {
+		slots := append([]cid.Cid(nil), values...)
+		root, err := s.backend.CommitValues(slots)
+		if err != nil {
+			return nil, err
+		}
+		return &node{
+			height: 0,
+			root:   root,
+			slots:  slots,
+		}, nil
+	}
+
+	childChunk, err := nodeCapacity(height - 1)
+	if err != nil {
+		return nil, err
+	}
+	childCount := ceilDiv(uint64(len(values)), childChunk)
+	children := make([]*node, childCount)
+	slots := make([]cid.Cid, childCount)
+
+	for i := 0; i < childCount; i++ {
+		start := uint64(i) * childChunk
+		end := minUint64(start+childChunk, uint64(len(values)))
+		child, err := s.buildNode(values[int(start):int(end)], height-1)
+		if err != nil {
+			return nil, err
+		}
+		children[i] = child
+		slots[i] = child.root
+	}
+
+	root, err := s.backend.CommitValues(slots)
+	if err != nil {
+		return nil, err
+	}
+	return &node{
+		height:   height,
+		root:     root,
+		slots:    slots,
+		children: children,
+	}, nil
+}
+
+func encodeProof(query list.Query, envelope proofEnvelope) (list.Query, structure.Proof, error) {
+	proofBytes, err := json.Marshal(envelope)
+	if err != nil {
+		return list.Query{}, nil, err
+	}
+	return query, structure.Proof(proofBytes), nil
+}
+
+func valuesFromView(view list.View) ([]cid.Cid, error) {
+	if view == nil {
+		return nil, fmt.Errorf("list view is nil")
+	}
+	values := make([]cid.Cid, view.Len())
+	for i := uint64(0); i < view.Len(); i++ {
+		value, ok := view.Get(i)
+		if !ok {
+			return nil, fmt.Errorf("missing value at index %d", i)
+		}
+		values[i] = value
+	}
+	return values, nil
+}
+
+func requiredHeight(length uint64) int {
+	if length <= Fanout {
+		return 0
+	}
+	capacity := uint64(Fanout)
+	height := 0
+	for capacity < length {
+		height++
+		if capacity > maxUint64/uint64(Fanout) {
+			return height
+		}
+		capacity *= uint64(Fanout)
+	}
+	return height
+}
+
+func nodeCapacity(height int) (uint64, error) {
+	capacity := uint64(Fanout)
+	for i := 0; i < height; i++ {
+		if capacity > maxUint64/uint64(Fanout) {
+			return 0, fmt.Errorf("list capacity overflow at height %d", height)
+		}
+		capacity *= uint64(Fanout)
+	}
+	return capacity, nil
+}
+
+func indexDigits(index uint64, height int) ([]int, error) {
+	digits := make([]int, height+1)
+	remaining := index
+	for level := 0; level <= height; level++ {
+		exp := height - level
+		if exp == 0 {
+			digits[level] = int(remaining)
+			continue
+		}
+		chunk, err := nodeCapacity(exp - 1)
+		if err != nil {
+			return nil, err
+		}
+		digits[level] = int(remaining / chunk)
+		remaining %= chunk
+	}
+	return digits, nil
+}
+
+func newProofStep(target cid.Cid, proof []byte) proofStep {
+	if !target.Defined() {
+		return proofStep{Proof: proof}
+	}
+	return proofStep{
+		Target: target.Bytes(),
+		Proof:  proof,
+	}
+}
+
+func parseStepTarget(step proofStep) (cid.Cid, error) {
+	if len(step.Target) == 0 {
+		return cid.Undef, nil
+	}
+	return cid.Cast(step.Target)
+}
+
+func ceilDiv(n, d uint64) int {
+	if n == 0 {
+		return 0
+	}
+	return int((n + d - 1) / d)
+}
+
+func minUint64(a, b uint64) uint64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func lengthCID(length uint64) (cid.Cid, error) {
+	var payload [8]byte
+	binary.BigEndian.PutUint64(payload[:], length)
+	data := append([]byte("malt:list:length:"), payload[:]...)
+	sum, err := mh.Sum(data, mh.SHA2_256, -1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, sum), nil
+}
+
+var _ list.Semantic = (*Semantic)(nil)

--- a/core/structure/list/tree/semantic_test.go
+++ b/core/structure/list/tree/semantic_test.go
@@ -1,4 +1,4 @@
-package indexed_test
+package tree_test
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"github.com/dewebprotocol/malt/core/sce/commitment/ipa"
 	"github.com/dewebprotocol/malt/core/sce/commitment/kzg"
 	"github.com/dewebprotocol/malt/core/structure/list"
-	"github.com/dewebprotocol/malt/core/structure/list/indexed"
+	"github.com/dewebprotocol/malt/core/structure/list/tree"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -37,20 +37,24 @@ func listBackends(t *testing.T) map[string]commitment.ListBackend {
 	}
 }
 
-func TestIndexedListSemanticProofs(t *testing.T) {
-	ctx := context.Background()
-	values := []cid.Cid{
-		newPayloadCID([]byte("v0")),
-		newPayloadCID([]byte("v1")),
-		newPayloadCID([]byte("v2")),
+func makeValues(count int) []cid.Cid {
+	values := make([]cid.Cid, count)
+	for i := range values {
+		values[i] = newPayloadCID([]byte{byte(i), byte(i >> 8), byte(i >> 16)})
 	}
+	return values
+}
+
+func TestTreeListSemanticProofs(t *testing.T) {
+	ctx := context.Background()
+	values := makeValues(300)
 	view := list.NewViewFromSlice(values)
 
 	for name, backend := range listBackends(t) {
 		t.Run(name, func(t *testing.T) {
-			semantic, err := indexed.New(backend)
+			semantic, err := tree.New(backend)
 			if err != nil {
-				t.Fatalf("indexed.New failed: %v", err)
+				t.Fatalf("tree.New failed: %v", err)
 			}
 
 			root, err := semantic.Commit(ctx, view)
@@ -58,15 +62,15 @@ func TestIndexedListSemanticProofs(t *testing.T) {
 				t.Fatalf("Commit failed: %v", err)
 			}
 
-			query, proof, err := semantic.Prove(ctx, root, view, 1)
+			query, proof, err := semantic.Prove(ctx, root, view, 257)
 			if err != nil {
 				t.Fatalf("Prove failed: %v", err)
 			}
-			if query.Length != 3 || !query.Key.Equals(values[1]) {
+			if query.Length != uint64(len(values)) || !query.Key.Equals(values[257]) {
 				t.Fatalf("unexpected query: %+v", query)
 			}
 
-			ok, err := semantic.Verify(root, 1, query, proof)
+			ok, err := semantic.Verify(root, 257, query, proof)
 			if err != nil {
 				t.Fatalf("Verify failed: %v", err)
 			}
@@ -74,15 +78,15 @@ func TestIndexedListSemanticProofs(t *testing.T) {
 				t.Fatal("expected present proof to verify")
 			}
 
-			absent, absentProof, err := semantic.Prove(ctx, root, view, 9)
+			absent, absentProof, err := semantic.Prove(ctx, root, view, 999)
 			if err != nil {
 				t.Fatalf("Prove absent failed: %v", err)
 			}
-			if absent.Length != 3 || absent.Key.Defined() {
+			if absent.Length != uint64(len(values)) || absent.Key.Defined() {
 				t.Fatalf("unexpected absent query: %+v", absent)
 			}
 
-			ok, err = semantic.Verify(root, 9, absent, absentProof)
+			ok, err = semantic.Verify(root, 999, absent, absentProof)
 			if err != nil {
 				t.Fatalf("Verify absent failed: %v", err)
 			}
@@ -93,19 +97,15 @@ func TestIndexedListSemanticProofs(t *testing.T) {
 	}
 }
 
-func TestIndexedListSemanticUpdates(t *testing.T) {
+func TestTreeListSemanticUpdates(t *testing.T) {
 	ctx := context.Background()
-	initial := []cid.Cid{
-		newPayloadCID([]byte("a")),
-		newPayloadCID([]byte("b")),
-		newPayloadCID([]byte("c")),
-	}
+	initial := makeValues(300)
 
 	for name, backend := range listBackends(t) {
 		t.Run(name, func(t *testing.T) {
-			semantic, err := indexed.New(backend)
+			semantic, err := tree.New(backend)
 			if err != nil {
-				t.Fatalf("indexed.New failed: %v", err)
+				t.Fatalf("tree.New failed: %v", err)
 			}
 
 			view := list.NewViewFromSlice(initial)
@@ -114,52 +114,55 @@ func TestIndexedListSemanticUpdates(t *testing.T) {
 				t.Fatalf("Commit failed: %v", err)
 			}
 
-			replacement := newPayloadCID([]byte("b2"))
-			replacedRoot, err := semantic.Replace(ctx, root, view, 1, initial[1], replacement)
+			replacement := newPayloadCID([]byte("replacement"))
+			replacedRoot, err := semantic.Replace(ctx, root, view, 257, initial[257], replacement)
 			if err != nil {
 				t.Fatalf("Replace failed: %v", err)
 			}
 
-			replacedView := list.NewViewFromSlice([]cid.Cid{initial[0], replacement, initial[2]})
-			query, proof, err := semantic.Prove(ctx, replacedRoot, replacedView, 1)
+			replacedValues := append([]cid.Cid(nil), initial...)
+			replacedValues[257] = replacement
+			replacedView := list.NewViewFromSlice(replacedValues)
+			query, proof, err := semantic.Prove(ctx, replacedRoot, replacedView, 257)
 			if err != nil {
 				t.Fatalf("Prove replaced failed: %v", err)
 			}
-			ok, err := semantic.Verify(replacedRoot, 1, query, proof)
+			ok, err := semantic.Verify(replacedRoot, 257, query, proof)
 			if err != nil || !ok {
 				t.Fatalf("Verify replaced failed: ok=%v err=%v", ok, err)
 			}
 
-			appended := newPayloadCID([]byte("d"))
+			appended := newPayloadCID([]byte("appended"))
 			appendedRoot, newIndex, err := semantic.Append(ctx, replacedRoot, replacedView, appended)
 			if err != nil {
 				t.Fatalf("Append failed: %v", err)
 			}
-			if newIndex != 3 {
+			if newIndex != uint64(len(replacedValues)) {
 				t.Fatalf("unexpected append index %d", newIndex)
 			}
 
-			appendedView := list.NewViewFromSlice([]cid.Cid{initial[0], replacement, initial[2], appended})
-			query, proof, err = semantic.Prove(ctx, appendedRoot, appendedView, 3)
+			appendedValues := append(append([]cid.Cid(nil), replacedValues...), appended)
+			appendedView := list.NewViewFromSlice(appendedValues)
+			query, proof, err = semantic.Prove(ctx, appendedRoot, appendedView, newIndex)
 			if err != nil {
 				t.Fatalf("Prove appended failed: %v", err)
 			}
-			ok, err = semantic.Verify(appendedRoot, 3, query, proof)
+			ok, err = semantic.Verify(appendedRoot, newIndex, query, proof)
 			if err != nil || !ok {
 				t.Fatalf("Verify appended failed: ok=%v err=%v", ok, err)
 			}
 
-			truncatedRoot, err := semantic.Truncate(ctx, appendedRoot, appendedView, 2)
+			truncatedRoot, err := semantic.Truncate(ctx, appendedRoot, appendedView, 128)
 			if err != nil {
 				t.Fatalf("Truncate failed: %v", err)
 			}
 
-			truncatedView := list.NewViewFromSlice([]cid.Cid{initial[0], replacement})
-			absent, absentProof, err := semantic.Prove(ctx, truncatedRoot, truncatedView, 2)
+			truncatedView := list.NewViewFromSlice(appendedValues[:128])
+			absent, absentProof, err := semantic.Prove(ctx, truncatedRoot, truncatedView, 129)
 			if err != nil {
 				t.Fatalf("Prove truncated absence failed: %v", err)
 			}
-			ok, err = semantic.Verify(truncatedRoot, 2, absent, absentProof)
+			ok, err = semantic.Verify(truncatedRoot, 129, absent, absentProof)
 			if err != nil || !ok {
 				t.Fatalf("Verify truncated absence failed: ok=%v err=%v", ok, err)
 			}


### PR DESCRIPTION
## Summary
- add a tree-shaped stable-indexed list semantic over the primitive ListBackend contract
- tighten the public list query contract to Query{Key, Length} and keep indexed as a degenerate one-node baseline
- update submodule docs to describe tree-shaped list as the active mainline layout

## Testing
- go test ./...