### PR TITLE
feat: add radix map semantic

### DIFF
--- a/core/graph/graph.go
+++ b/core/graph/graph.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dewebprotocol/malt/core/resolver/step/explicit"
 	"github.com/dewebprotocol/malt/core/resolver/step/implicit"
 	"github.com/dewebprotocol/malt/core/structure/mapping"
-	mappingindexed "github.com/dewebprotocol/malt/core/structure/mapping/indexed"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/core/writer"
 	cid "github.com/ipfs/go-cid"
@@ -61,7 +61,7 @@ func NewGraph(id string, eat eat.EAT, cas cas.Client, opts ...Option) (*Graph, e
 		scheme = s
 	}
 
-	semantic, err := mappingindexed.NewMap(scheme, eat)
+	semantic, err := mappingradix.NewMap(scheme, eat)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mapping semantic: %w", err)
 	}

--- a/core/resolver/resolver_test.go
+++ b/core/resolver/resolver_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/dewebprotocol/malt/core/resolver/step/explicit"
 	"github.com/dewebprotocol/malt/core/resolver/step/implicit"
 	"github.com/dewebprotocol/malt/core/structure/mapping"
-	mappingindexed "github.com/dewebprotocol/malt/core/structure/mapping/indexed"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/core/types/evidence"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -43,9 +43,9 @@ func newSemantic(t *testing.T, e *overwrite.EAT) mapping.Semantic {
 	if err != nil {
 		t.Fatalf("NewScheme failed: %v", err)
 	}
-	semantic, err := mappingindexed.NewMap(scheme, e)
+	semantic, err := mappingradix.NewMap(scheme, e)
 	if err != nil {
-		t.Fatalf("indexed.NewMap failed: %v", err)
+		t.Fatalf("radix.NewMap failed: %v", err)
 	}
 	return semantic
 }

--- a/core/resolver/step/explicit/explicit_test.go
+++ b/core/resolver/step/explicit/explicit_test.go
@@ -10,7 +10,7 @@ import (
 	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
 	"github.com/dewebprotocol/malt/core/resolver/step/explicit"
 	"github.com/dewebprotocol/malt/core/structure/mapping"
-	mappingindexed "github.com/dewebprotocol/malt/core/structure/mapping/indexed"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/core/types/evidence"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -43,7 +43,7 @@ func newTestComponents() (*overwrite.EAT, mapping.Semantic, *kzg.Scheme) {
 	if err != nil {
 		panic(err)
 	}
-	semantic, err := mappingindexed.NewMap(scheme, e)
+	semantic, err := mappingradix.NewMap(scheme, e)
 	if err != nil {
 		panic(err)
 	}
@@ -366,9 +366,9 @@ func TestBloomFilterWithResolver(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewScheme failed: %v", err)
 	}
-	semantic, err := mappingindexed.NewMap(scheme, e)
+	semantic, err := mappingradix.NewMap(scheme, e)
 	if err != nil {
-		t.Fatalf("indexed.NewMap failed: %v", err)
+		t.Fatalf("radix.NewMap failed: %v", err)
 	}
 
 	ctx := context.Background()

--- a/core/structure/mapping/indexed/indexed.go
+++ b/core/structure/mapping/indexed/indexed.go
@@ -1,4 +1,4 @@
-// Package indexed implements the default canonical-path ordered map semantic.
+// Package indexed implements the canonical-path ordered baseline map semantic.
 package indexed
 
 import (

--- a/core/structure/mapping/mapping.go
+++ b/core/structure/mapping/mapping.go
@@ -24,9 +24,9 @@ type View interface {
 
 // Binding is the verifiable result for one keyed binding.
 //
-// The current default map semantic only emits membership proofs. Callers should
-// obtain absence through the current structure state (for example EAT lookup or
-// a supplied materialized view) rather than expecting a dedicated semantic
+// Current map semantics emit membership proofs only. Callers should obtain
+// absence through current structure state (for example EAT lookup or a
+// supplied materialized view) rather than expecting a dedicated semantic
 // non-membership proof.
 type Binding struct {
 	Value   cid.Cid
@@ -47,8 +47,6 @@ type Semantic interface {
 
 	// Update applies insert, replace, or delete semantics over the committed
 	// runtime state. oldValue=cid.Undef means insert; newValue=cid.Undef means
-	// delete. The current default map semantic preserves index-stable replacement
-	// for existing keys but may recommit the full keyed view for insert/delete,
-	// because canonical path order determines index positions.
+	// delete.
 	Update(ctx context.Context, bucketID string, root cid.Cid, key arcset.Path, oldValue, newValue cid.Cid) (cid.Cid, error)
 }

--- a/core/structure/mapping/radix/radix.go
+++ b/core/structure/mapping/radix/radix.go
@@ -1,0 +1,871 @@
+// Package radix implements a digest-keyed radix-map semantic above the
+// primitive index commitment backends.
+package radix
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/dewebprotocol/malt/core/commitment"
+	"github.com/dewebprotocol/malt/core/eat"
+	"github.com/dewebprotocol/malt/core/structure"
+	"github.com/dewebprotocol/malt/core/structure/mapping"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+const (
+	fanout = 256
+
+	leafPrefix        = "malt:map:radix:leaf:v1:"
+	bucketRefPrefix   = "malt:map:radix:bucket:v1:"
+	bucketCountPrefix = "malt:map:radix:bucket-count:v1:"
+)
+
+type Map struct {
+	scheme commitment.IndexCommitment
+	eat    eat.EAT
+}
+
+type leafBinding struct {
+	path   arcset.Path
+	value  cid.Cid
+	digest [sha256.Size]byte
+}
+
+type proofEnvelope struct {
+	Steps  []proofStep    `json:"steps"`
+	Bucket *bucketWitness `json:"bucket,omitempty"`
+}
+
+type proofStep struct {
+	Slot  []byte `json:"slot,omitempty"`
+	Proof []byte `json:"proof"`
+}
+
+type bucketWitness struct {
+	Proof []byte `json:"proof"`
+}
+
+func NewMap(scheme commitment.IndexCommitment, e eat.EAT) (*Map, error) {
+	if scheme == nil {
+		return nil, fmt.Errorf("scheme is nil")
+	}
+	if e == nil {
+		return nil, fmt.Errorf("eat is nil")
+	}
+	if scheme.MaxValues() < fanout {
+		return nil, fmt.Errorf("index commitment capacity %d is smaller than radix fanout %d", scheme.MaxValues(), fanout)
+	}
+	return &Map{scheme: scheme, eat: e}, nil
+}
+
+func (s *Map) Commit(ctx context.Context, bucketID string, view mapping.View) (cid.Cid, error) {
+	bindings, err := extractBindings(view)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return s.commitRoot(ctx, bucketID, bindings)
+}
+
+func (s *Map) Prove(ctx context.Context, bucketID string, root cid.Cid, key arcset.Path) (mapping.Binding, structure.Proof, error) {
+	if !root.Defined() {
+		return mapping.Binding{}, nil, fmt.Errorf("root is undefined")
+	}
+	if key.IsEmpty() {
+		return mapping.Binding{}, nil, fmt.Errorf("key is empty")
+	}
+
+	digest := hashPath(key)
+	currentRoot := root
+	envelope := proofEnvelope{}
+
+	for depth := 0; depth < len(digest); depth++ {
+		slots, err := s.loadValidatedNode(ctx, bucketID, currentRoot)
+		if err != nil {
+			return mapping.Binding{}, nil, err
+		}
+
+		slotIndex := digest[depth]
+		provedRoot, value, proof, err := s.scheme.Prove(cellsFromCIDs(slots), uint64(slotIndex))
+		if err != nil {
+			return mapping.Binding{}, nil, err
+		}
+		if !provedRoot.Equals(currentRoot) {
+			return mapping.Binding{}, nil, fmt.Errorf("proved root does not match requested node root")
+		}
+
+		slotCID, err := value.AsCID()
+		if err != nil {
+			return mapping.Binding{}, nil, err
+		}
+		envelope.Steps = append(envelope.Steps, proofStep{
+			Slot:  cidBytes(slotCID),
+			Proof: proof,
+		})
+
+		if !slotCID.Defined() {
+			return mapping.Binding{}, nil, fmt.Errorf("path %s not found", key.String())
+		}
+
+		if leafPath, leafValue, ok, err := tryDecodeLeafMarker(slotCID); err != nil {
+			return mapping.Binding{}, nil, err
+		} else if ok {
+			if leafPath != key {
+				return mapping.Binding{}, nil, fmt.Errorf("path %s not found", key.String())
+			}
+			proofBytes, err := json.Marshal(envelope)
+			if err != nil {
+				return mapping.Binding{}, nil, err
+			}
+			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), nil
+		}
+
+		if bucketRoot, ok, err := tryDecodeBucketRef(slotCID); err != nil {
+			return mapping.Binding{}, nil, err
+		} else if ok {
+			markers, err := s.loadBucketEntries(ctx, bucketID, bucketRoot)
+			if err != nil {
+				return mapping.Binding{}, nil, err
+			}
+			index := -1
+			for i, marker := range markers {
+				leafPath, _, err := decodeLeafMarker(marker)
+				if err != nil {
+					return mapping.Binding{}, nil, err
+				}
+				if leafPath == key {
+					index = i
+					break
+				}
+			}
+			if index < 0 {
+				return mapping.Binding{}, nil, fmt.Errorf("path %s not found", key.String())
+			}
+
+			provedRoot, value, proof, err := s.scheme.Prove(cellsFromCIDs(markers), uint64(index))
+			if err != nil {
+				return mapping.Binding{}, nil, err
+			}
+			if !provedRoot.Equals(bucketRoot) {
+				return mapping.Binding{}, nil, fmt.Errorf("bucket proof root mismatch")
+			}
+			_, leafValue, err := decodeLeafMarkerCID(value)
+			if err != nil {
+				return mapping.Binding{}, nil, err
+			}
+			envelope.Bucket = &bucketWitness{Proof: proof}
+			proofBytes, err := json.Marshal(envelope)
+			if err != nil {
+				return mapping.Binding{}, nil, err
+			}
+			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), nil
+		}
+
+		currentRoot = slotCID
+	}
+
+	return mapping.Binding{}, nil, fmt.Errorf("path %s not found", key.String())
+}
+
+func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, proof structure.Proof) (bool, error) {
+	if !expected.Present {
+		return false, fmt.Errorf("non-membership verification is not implemented")
+	}
+	if !root.Defined() {
+		return false, fmt.Errorf("root is undefined")
+	}
+	if key.IsEmpty() {
+		return false, fmt.Errorf("key is empty")
+	}
+
+	var envelope proofEnvelope
+	if err := json.Unmarshal(proof, &envelope); err != nil {
+		return false, err
+	}
+	if len(envelope.Steps) == 0 {
+		return false, fmt.Errorf("missing proof steps")
+	}
+
+	digest := hashPath(key)
+	if len(envelope.Steps) > len(digest) {
+		return false, fmt.Errorf("proof has too many radix steps")
+	}
+	currentRoot := root
+	expectedLeaf, err := encodeLeafMarker(key, expected.Value)
+	if err != nil {
+		return false, err
+	}
+
+	for depth, step := range envelope.Steps {
+		var slotCID cid.Cid
+		if len(step.Slot) > 0 {
+			slotCID, err = cid.Cast(step.Slot)
+			if err != nil {
+				return false, err
+			}
+		}
+
+		ok, err := s.scheme.VerifyIndex(currentRoot, uint64(digest[depth]), commitment.CellFromCID(slotCID), step.Proof)
+		if err != nil || !ok {
+			return ok, err
+		}
+		if !slotCID.Defined() {
+			return false, nil
+		}
+
+		if leafPath, leafValue, ok, err := tryDecodeLeafMarker(slotCID); err != nil {
+			return false, err
+		} else if ok {
+			if depth != len(envelope.Steps)-1 || envelope.Bucket != nil {
+				return false, nil
+			}
+			return leafPath == key && leafValue.Equals(expected.Value), nil
+		}
+
+		if bucketRoot, ok, err := tryDecodeBucketRef(slotCID); err != nil {
+			return false, err
+		} else if ok {
+			if depth != len(envelope.Steps)-1 || envelope.Bucket == nil {
+				return false, nil
+			}
+			return s.scheme.VerifyProof(bucketRoot, commitment.CellFromCID(expectedLeaf), envelope.Bucket.Proof)
+		}
+
+		if depth == len(envelope.Steps)-1 {
+			return false, nil
+		}
+		currentRoot = slotCID
+	}
+
+	return false, nil
+}
+
+func (s *Map) Update(ctx context.Context, bucketID string, root cid.Cid, key arcset.Path, oldValue, newValue cid.Cid) (cid.Cid, error) {
+	if !root.Defined() {
+		return cid.Undef, fmt.Errorf("root is undefined")
+	}
+	if key.IsEmpty() {
+		return cid.Undef, fmt.Errorf("key is empty")
+	}
+
+	rootSlots, err := s.loadValidatedNode(ctx, bucketID, root)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	digest := hashPath(key)
+	slotIndex := digest[0]
+	nextSlot, err := s.updateSubtree(ctx, bucketID, rootSlots[slotIndex], digest, 1, key, oldValue, newValue)
+	if err != nil {
+		return cid.Undef, err
+	}
+	if cidEqual(nextSlot, rootSlots[slotIndex]) {
+		return root, nil
+	}
+
+	nextSlots := cloneCIDs(rootSlots)
+	nextSlots[slotIndex] = nextSlot
+	return s.commitNode(ctx, bucketID, nextSlots)
+}
+
+func (s *Map) updateSubtree(
+	ctx context.Context,
+	bucketID string,
+	current cid.Cid,
+	digest [sha256.Size]byte,
+	depth int,
+	key arcset.Path,
+	oldValue, newValue cid.Cid,
+) (cid.Cid, error) {
+	if !current.Defined() {
+		if oldValue.Defined() {
+			return cid.Undef, fmt.Errorf("path %s is absent", key.String())
+		}
+		if !newValue.Defined() {
+			return cid.Undef, nil
+		}
+		return encodeLeafMarker(key, newValue)
+	}
+
+	if leafPath, leafValue, ok, err := tryDecodeLeafMarker(current); err != nil {
+		return cid.Undef, err
+	} else if ok {
+		switch {
+		case leafPath == key:
+			if !oldValue.Defined() {
+				return cid.Undef, fmt.Errorf("path %s already exists", key.String())
+			}
+			if !leafValue.Equals(oldValue) {
+				return cid.Undef, fmt.Errorf("old value mismatch at path %s", key.String())
+			}
+			if !newValue.Defined() {
+				return cid.Undef, nil
+			}
+			return encodeLeafMarker(key, newValue)
+		default:
+			if oldValue.Defined() {
+				return cid.Undef, fmt.Errorf("path %s is absent", key.String())
+			}
+			if !newValue.Defined() {
+				return current, nil
+			}
+			existing := newLeafBinding(leafPath, leafValue)
+			inserted := leafBinding{path: key, value: newValue, digest: digest}
+			return s.buildSubtree(ctx, bucketID, []leafBinding{existing, inserted}, depth)
+		}
+	}
+
+	if bucketRoot, ok, err := tryDecodeBucketRef(current); err != nil {
+		return cid.Undef, err
+	} else if ok {
+		return s.updateBucket(ctx, bucketID, bucketRoot, key, oldValue, newValue)
+	}
+
+	if depth >= len(digest) {
+		return cid.Undef, fmt.Errorf("unexpected radix depth overflow")
+	}
+
+	slots, err := s.loadValidatedNode(ctx, bucketID, current)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	slotIndex := digest[depth]
+	nextSlot, err := s.updateSubtree(ctx, bucketID, slots[slotIndex], digest, depth+1, key, oldValue, newValue)
+	if err != nil {
+		return cid.Undef, err
+	}
+	if cidEqual(nextSlot, slots[slotIndex]) {
+		return current, nil
+	}
+
+	nextSlots := cloneCIDs(slots)
+	nextSlots[slotIndex] = nextSlot
+	return s.commitOrCollapseNode(ctx, bucketID, nextSlots)
+}
+
+func (s *Map) updateBucket(ctx context.Context, bucketID string, bucketRoot cid.Cid, key arcset.Path, oldValue, newValue cid.Cid) (cid.Cid, error) {
+	markers, err := s.loadBucketEntries(ctx, bucketID, bucketRoot)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	index := -1
+	var currentValue cid.Cid
+	for i, marker := range markers {
+		leafPath, leafValue, err := decodeLeafMarker(marker)
+		if err != nil {
+			return cid.Undef, err
+		}
+		if leafPath == key {
+			index = i
+			currentValue = leafValue
+			break
+		}
+	}
+
+	switch {
+	case index >= 0:
+		if !oldValue.Defined() {
+			return cid.Undef, fmt.Errorf("path %s already exists", key.String())
+		}
+		if !currentValue.Equals(oldValue) {
+			return cid.Undef, fmt.Errorf("old value mismatch at path %s", key.String())
+		}
+		if !newValue.Defined() {
+			next := append([]cid.Cid(nil), markers[:index]...)
+			next = append(next, markers[index+1:]...)
+			return s.commitBucketMarkers(ctx, bucketID, next)
+		}
+
+		nextMarker, err := encodeLeafMarker(key, newValue)
+		if err != nil {
+			return cid.Undef, err
+		}
+		if len(markers) == 1 {
+			return nextMarker, nil
+		}
+		root, err := s.scheme.Replace(cellsFromCIDs(markers), uint64(index), commitment.CellFromCID(markers[index]), commitment.CellFromCID(nextMarker))
+		if err != nil {
+			return cid.Undef, err
+		}
+		next := cloneCIDs(markers)
+		next[index] = nextMarker
+		if err := s.storeBucketEntries(ctx, bucketID, root, next); err != nil {
+			return cid.Undef, err
+		}
+		return encodeBucketRef(root)
+
+	default:
+		if oldValue.Defined() {
+			return cid.Undef, fmt.Errorf("path %s is absent", key.String())
+		}
+		if !newValue.Defined() {
+			return encodeBucketRef(bucketRoot)
+		}
+		nextMarker, err := encodeLeafMarker(key, newValue)
+		if err != nil {
+			return cid.Undef, err
+		}
+		next := append([]cid.Cid(nil), markers...)
+		next = append(next, nextMarker)
+		slices.SortFunc(next, func(a, b cid.Cid) int {
+			ap, _, err := decodeLeafMarker(a)
+			if err != nil {
+				return 0
+			}
+			bp, _, err := decodeLeafMarker(b)
+			if err != nil {
+				return 0
+			}
+			switch {
+			case ap < bp:
+				return -1
+			case ap > bp:
+				return 1
+			default:
+				return 0
+			}
+		})
+		return s.commitBucketMarkers(ctx, bucketID, next)
+	}
+}
+
+func (s *Map) commitRoot(ctx context.Context, bucketID string, bindings []leafBinding) (cid.Cid, error) {
+	slots := make([]cid.Cid, fanout)
+	for slotIndex, group := range groupBindings(bindings, 0) {
+		child, err := s.buildSubtree(ctx, bucketID, group, 1)
+		if err != nil {
+			return cid.Undef, err
+		}
+		slots[slotIndex] = child
+	}
+	return s.commitNode(ctx, bucketID, slots)
+}
+
+func (s *Map) buildSubtree(ctx context.Context, bucketID string, bindings []leafBinding, depth int) (cid.Cid, error) {
+	switch len(bindings) {
+	case 0:
+		return cid.Undef, nil
+	case 1:
+		return encodeLeafMarker(bindings[0].path, bindings[0].value)
+	}
+
+	if depth >= sha256.Size || allSameDigest(bindings) {
+		markers := make([]cid.Cid, len(bindings))
+		for i, binding := range bindings {
+			marker, err := encodeLeafMarker(binding.path, binding.value)
+			if err != nil {
+				return cid.Undef, err
+			}
+			markers[i] = marker
+		}
+		return s.commitBucketMarkers(ctx, bucketID, markers)
+	}
+
+	slots := make([]cid.Cid, fanout)
+	for slotIndex, group := range groupBindings(bindings, depth) {
+		child, err := s.buildSubtree(ctx, bucketID, group, depth+1)
+		if err != nil {
+			return cid.Undef, err
+		}
+		slots[slotIndex] = child
+	}
+	return s.commitNode(ctx, bucketID, slots)
+}
+
+func (s *Map) commitNode(ctx context.Context, bucketID string, slots []cid.Cid) (cid.Cid, error) {
+	root, err := s.scheme.Commit(cellsFromCIDs(slots))
+	if err != nil {
+		return cid.Undef, err
+	}
+	if err := s.storeNodeSlots(ctx, bucketID, root, slots); err != nil {
+		return cid.Undef, err
+	}
+	return root, nil
+}
+
+func (s *Map) commitOrCollapseNode(ctx context.Context, bucketID string, slots []cid.Cid) (cid.Cid, error) {
+	var only cid.Cid
+	count := 0
+	for _, slot := range slots {
+		if !slot.Defined() {
+			continue
+		}
+		count++
+		only = slot
+		if count > 1 {
+			break
+		}
+	}
+	if count == 0 {
+		return cid.Undef, nil
+	}
+	if count == 1 {
+		if _, _, ok, err := tryDecodeLeafMarker(only); err != nil {
+			return cid.Undef, err
+		} else if ok {
+			return only, nil
+		}
+		if _, ok, err := tryDecodeBucketRef(only); err != nil {
+			return cid.Undef, err
+		} else if ok {
+			return only, nil
+		}
+	}
+	return s.commitNode(ctx, bucketID, slots)
+}
+
+func (s *Map) commitBucketMarkers(ctx context.Context, bucketID string, markers []cid.Cid) (cid.Cid, error) {
+	switch len(markers) {
+	case 0:
+		return cid.Undef, nil
+	case 1:
+		return markers[0], nil
+	}
+	if len(markers) > s.scheme.MaxValues() {
+		return cid.Undef, fmt.Errorf("bucket size %d exceeds commitment capacity %d", len(markers), s.scheme.MaxValues())
+	}
+
+	root, err := s.scheme.Commit(cellsFromCIDs(markers))
+	if err != nil {
+		return cid.Undef, err
+	}
+	if err := s.storeBucketEntries(ctx, bucketID, root, markers); err != nil {
+		return cid.Undef, err
+	}
+	return encodeBucketRef(root)
+}
+
+func extractBindings(view mapping.View) ([]leafBinding, error) {
+	if view == nil {
+		return nil, fmt.Errorf("view is nil")
+	}
+
+	bindings := make([]leafBinding, 0, view.Len())
+	iter := view.Iterate()
+	for {
+		path, value, ok := iter.Next()
+		if !ok {
+			break
+		}
+		bindings = append(bindings, newLeafBinding(path, value))
+	}
+	if err := iter.Err(); err != nil {
+		return nil, err
+	}
+	if !slices.IsSortedFunc(bindings, func(a, b leafBinding) int {
+		switch {
+		case a.path < b.path:
+			return -1
+		case a.path > b.path:
+			return 1
+		default:
+			return 0
+		}
+	}) {
+		return nil, fmt.Errorf("view iteration is not in canonical key order")
+	}
+	return bindings, nil
+}
+
+func groupBindings(bindings []leafBinding, depth int) map[byte][]leafBinding {
+	grouped := make(map[byte][]leafBinding)
+	for _, binding := range bindings {
+		grouped[binding.digest[depth]] = append(grouped[binding.digest[depth]], binding)
+	}
+	return grouped
+}
+
+func allSameDigest(bindings []leafBinding) bool {
+	for i := 1; i < len(bindings); i++ {
+		if bindings[i].digest != bindings[0].digest {
+			return false
+		}
+	}
+	return true
+}
+
+func newLeafBinding(path arcset.Path, value cid.Cid) leafBinding {
+	return leafBinding{
+		path:   path,
+		value:  value,
+		digest: hashPath(path),
+	}
+}
+
+func hashPath(path arcset.Path) [sha256.Size]byte {
+	return sha256.Sum256([]byte(path.String()))
+}
+
+func (s *Map) loadValidatedNode(ctx context.Context, bucketID string, root cid.Cid) ([]cid.Cid, error) {
+	slots, err := s.loadNodeSlots(ctx, bucketID, root)
+	if err != nil {
+		return nil, err
+	}
+	recomputed, err := s.scheme.Commit(cellsFromCIDs(slots))
+	if err != nil {
+		return nil, err
+	}
+	if !recomputed.Equals(root) {
+		return nil, fmt.Errorf("materialized node state does not match root %s", root.String())
+	}
+	return slots, nil
+}
+
+func (s *Map) loadNodeSlots(ctx context.Context, bucketID string, root cid.Cid) ([]cid.Cid, error) {
+	paths := make([]string, fanout)
+	for i := 0; i < fanout; i++ {
+		paths[i] = nodeSlotPath(root, byte(i)).String()
+	}
+	found, err := s.eat.BatchGet(ctx, bucketID, cid.Undef, paths)
+	if err != nil {
+		return nil, err
+	}
+
+	slots := make([]cid.Cid, fanout)
+	for i, path := range paths {
+		if target, ok := found[path]; ok {
+			slots[i] = target
+		}
+	}
+	return slots, nil
+}
+
+func (s *Map) storeNodeSlots(ctx context.Context, bucketID string, root cid.Cid, slots []cid.Cid) error {
+	arcs := make(map[string]cid.Cid)
+	for i, slot := range slots {
+		if !slot.Defined() {
+			continue
+		}
+		arcs[nodeSlotPath(root, byte(i)).String()] = slot
+	}
+	if len(arcs) == 0 {
+		return nil
+	}
+	return s.eat.Update(ctx, bucketID, cid.Undef, cid.Undef, arcs)
+}
+
+func (s *Map) loadBucketEntries(ctx context.Context, bucketID string, root cid.Cid) ([]cid.Cid, error) {
+	countCID, err := s.eat.Get(ctx, bucketID, cid.Undef, bucketCountPath(root).String())
+	if err != nil {
+		return nil, err
+	}
+	count, err := decodeBucketCountMarker(countCID)
+	if err != nil {
+		return nil, err
+	}
+
+	paths := make([]string, count)
+	for i := uint64(0); i < count; i++ {
+		paths[i] = bucketEntryPath(root, i).String()
+	}
+	found, err := s.eat.BatchGet(ctx, bucketID, cid.Undef, paths)
+	if err != nil {
+		return nil, err
+	}
+
+	markers := make([]cid.Cid, count)
+	for i, path := range paths {
+		marker, ok := found[path]
+		if !ok {
+			return nil, fmt.Errorf("missing bucket entry %d", i)
+		}
+		markers[i] = marker
+	}
+	return markers, nil
+}
+
+func (s *Map) storeBucketEntries(ctx context.Context, bucketID string, root cid.Cid, markers []cid.Cid) error {
+	arcs := make(map[string]cid.Cid, len(markers)+1)
+	countMarker, err := encodeBucketCountMarker(uint64(len(markers)))
+	if err != nil {
+		return err
+	}
+	arcs[bucketCountPath(root).String()] = countMarker
+	for i, marker := range markers {
+		arcs[bucketEntryPath(root, uint64(i)).String()] = marker
+	}
+	return s.eat.Update(ctx, bucketID, cid.Undef, cid.Undef, arcs)
+}
+
+func cellsFromCIDs(values []cid.Cid) []commitment.Cell {
+	cells := make([]commitment.Cell, len(values))
+	for i, value := range values {
+		cells[i] = commitment.CellFromCID(value)
+	}
+	return cells
+}
+
+func cloneCIDs(values []cid.Cid) []cid.Cid {
+	return append([]cid.Cid(nil), values...)
+}
+
+func cidEqual(a, b cid.Cid) bool {
+	if !a.Defined() && !b.Defined() {
+		return true
+	}
+	return a.Equals(b)
+}
+
+func cidBytes(value cid.Cid) []byte {
+	if !value.Defined() {
+		return nil
+	}
+	return value.Bytes()
+}
+
+func nodeSlotPath(root cid.Cid, slot byte) arcset.Path {
+	return arcset.CanonicalizePath(fmt.Sprintf("runtime/map/radix/nodes/%s/slots/%d", root.String(), slot))
+}
+
+func bucketCountPath(root cid.Cid) arcset.Path {
+	return arcset.CanonicalizePath(fmt.Sprintf("runtime/map/radix/buckets/%s/count", root.String()))
+}
+
+func bucketEntryPath(root cid.Cid, index uint64) arcset.Path {
+	return arcset.CanonicalizePath(fmt.Sprintf("runtime/map/radix/buckets/%s/entries/%d", root.String(), index))
+}
+
+func encodeLeafMarker(path arcset.Path, value cid.Cid) (cid.Cid, error) {
+	if path.IsEmpty() {
+		return cid.Undef, fmt.Errorf("path is empty")
+	}
+	if !value.Defined() {
+		return cid.Undef, fmt.Errorf("value is undefined")
+	}
+
+	pathBytes := []byte(path.String())
+	if len(pathBytes) > 0xffff {
+		return cid.Undef, fmt.Errorf("path %q is too long", path.String())
+	}
+
+	payload := make([]byte, 0, len(leafPrefix)+2+len(pathBytes)+len(value.Bytes()))
+	payload = append(payload, []byte(leafPrefix)...)
+	payload = binary.BigEndian.AppendUint16(payload, uint16(len(pathBytes)))
+	payload = append(payload, pathBytes...)
+	payload = append(payload, value.Bytes()...)
+
+	sum, err := mh.Sum(payload, mh.IDENTITY, len(payload))
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, sum), nil
+}
+
+func decodeLeafMarker(marker cid.Cid) (arcset.Path, cid.Cid, error) {
+	payload, err := decodeIdentityPayload(marker)
+	if err != nil {
+		return "", cid.Undef, err
+	}
+	if len(payload) < len(leafPrefix)+2 || string(payload[:len(leafPrefix)]) != leafPrefix {
+		return "", cid.Undef, fmt.Errorf("leaf marker prefix mismatch")
+	}
+	pathLen := int(binary.BigEndian.Uint16(payload[len(leafPrefix) : len(leafPrefix)+2]))
+	offset := len(leafPrefix) + 2
+	if len(payload) < offset+pathLen {
+		return "", cid.Undef, fmt.Errorf("leaf marker truncated")
+	}
+	path := arcset.CanonicalizePath(string(payload[offset : offset+pathLen]))
+	value, err := cid.Cast(payload[offset+pathLen:])
+	if err != nil {
+		return "", cid.Undef, err
+	}
+	return path, value, nil
+}
+
+func tryDecodeLeafMarker(marker cid.Cid) (arcset.Path, cid.Cid, bool, error) {
+	payload, err := decodeIdentityPayload(marker)
+	if err != nil {
+		if !marker.Defined() {
+			return "", cid.Undef, false, nil
+		}
+		return "", cid.Undef, false, nil
+	}
+	if len(payload) < len(leafPrefix) || string(payload[:len(leafPrefix)]) != leafPrefix {
+		return "", cid.Undef, false, nil
+	}
+	path, value, err := decodeLeafMarker(marker)
+	return path, value, err == nil, err
+}
+
+func decodeLeafMarkerCID(cell commitment.Cell) (arcset.Path, cid.Cid, error) {
+	slotCID, err := cell.AsCID()
+	if err != nil {
+		return "", cid.Undef, err
+	}
+	return decodeLeafMarker(slotCID)
+}
+
+func encodeBucketRef(root cid.Cid) (cid.Cid, error) {
+	if !root.Defined() {
+		return cid.Undef, fmt.Errorf("bucket root is undefined")
+	}
+	payload := make([]byte, 0, len(bucketRefPrefix)+len(root.Bytes()))
+	payload = append(payload, []byte(bucketRefPrefix)...)
+	payload = append(payload, root.Bytes()...)
+	sum, err := mh.Sum(payload, mh.IDENTITY, len(payload))
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, sum), nil
+}
+
+func tryDecodeBucketRef(marker cid.Cid) (cid.Cid, bool, error) {
+	payload, err := decodeIdentityPayload(marker)
+	if err != nil {
+		if !marker.Defined() {
+			return cid.Undef, false, nil
+		}
+		return cid.Undef, false, nil
+	}
+	if len(payload) < len(bucketRefPrefix) || string(payload[:len(bucketRefPrefix)]) != bucketRefPrefix {
+		return cid.Undef, false, nil
+	}
+	root, err := cid.Cast(payload[len(bucketRefPrefix):])
+	return root, err == nil, err
+}
+
+func encodeBucketCountMarker(count uint64) (cid.Cid, error) {
+	payload := make([]byte, 0, len(bucketCountPrefix)+8)
+	payload = append(payload, []byte(bucketCountPrefix)...)
+	payload = binary.BigEndian.AppendUint64(payload, count)
+	sum, err := mh.Sum(payload, mh.IDENTITY, len(payload))
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, sum), nil
+}
+
+func decodeBucketCountMarker(marker cid.Cid) (uint64, error) {
+	payload, err := decodeIdentityPayload(marker)
+	if err != nil {
+		return 0, err
+	}
+	if len(payload) != len(bucketCountPrefix)+8 || string(payload[:len(bucketCountPrefix)]) != bucketCountPrefix {
+		return 0, fmt.Errorf("bucket count marker prefix mismatch")
+	}
+	return binary.BigEndian.Uint64(payload[len(bucketCountPrefix):]), nil
+}
+
+func decodeIdentityPayload(value cid.Cid) ([]byte, error) {
+	if !value.Defined() {
+		return nil, fmt.Errorf("marker is undefined")
+	}
+	decoded, err := mh.Decode(value.Hash())
+	if err != nil {
+		return nil, err
+	}
+	if decoded.Code != mh.IDENTITY {
+		return nil, fmt.Errorf("marker is not identity-encoded")
+	}
+	return decoded.Digest, nil
+}
+
+var _ mapping.Semantic = (*Map)(nil)

--- a/core/structure/mapping/radix/radix_test.go
+++ b/core/structure/mapping/radix/radix_test.go
@@ -1,0 +1,298 @@
+package radix_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/commitment"
+	"github.com/dewebprotocol/malt/core/commitment/ipa"
+	"github.com/dewebprotocol/malt/core/commitment/kzg"
+	"github.com/dewebprotocol/malt/core/eat/overwrite"
+	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
+	"github.com/dewebprotocol/malt/core/structure/mapping"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+type schemeFactory func(t *testing.T) commitment.IndexCommitment
+
+const testBucketID = "map-radix-semantic-test"
+
+func mappingSchemes() map[string]schemeFactory {
+	return map[string]schemeFactory{
+		"ipa": func(t *testing.T) commitment.IndexCommitment {
+			t.Helper()
+			scheme, err := ipa.NewScheme()
+			if err != nil {
+				t.Fatalf("ipa.NewScheme failed: %v", err)
+			}
+			return scheme
+		},
+		"kzg": func(t *testing.T) commitment.IndexCommitment {
+			t.Helper()
+			scheme, err := kzg.NewScheme()
+			if err != nil {
+				t.Fatalf("kzg.NewScheme failed: %v", err)
+			}
+			return scheme
+		},
+	}
+}
+
+func newMap(t *testing.T, factory schemeFactory, kv *kvmemory.KV) mapping.Semantic {
+	t.Helper()
+	if kv == nil {
+		kv = kvmemory.New()
+	}
+	e, err := overwrite.NewEAT(overwrite.WithKVStore(kv))
+	if err != nil {
+		t.Fatalf("overwrite.NewEAT failed: %v", err)
+	}
+	semantic, err := mappingradix.NewMap(factory(t), e)
+	if err != nil {
+		t.Fatalf("radix.NewMap failed: %v", err)
+	}
+	return semantic
+}
+
+func fakeCID(seed string) cid.Cid {
+	sum, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		panic(err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}
+
+func TestMapCommitProveVerify(t *testing.T) {
+	ctx := context.Background()
+	view := mapping.NewViewFrom(map[string]cid.Cid{
+		"b/c":      fakeCID("value-bc"),
+		"a":        fakeCID("value-a"),
+		"@payload": fakeCID("value-payload"),
+	})
+
+	for name, factory := range mappingSchemes() {
+		t.Run(name, func(t *testing.T) {
+			semantic := newMap(t, factory, nil)
+
+			root, err := semantic.Commit(ctx, testBucketID, view)
+			if err != nil {
+				t.Fatalf("Commit failed: %v", err)
+			}
+
+			key := arcset.CanonicalizePath("b/c")
+			binding, proof, err := semantic.Prove(ctx, testBucketID, root, key)
+			if err != nil {
+				t.Fatalf("Prove failed: %v", err)
+			}
+			if !binding.Present {
+				t.Fatal("expected membership binding")
+			}
+			if !binding.Value.Equals(fakeCID("value-bc")) {
+				t.Fatalf("binding value mismatch: %s", binding.Value)
+			}
+
+			ok, err := semantic.Verify(root, key, binding, proof)
+			if err != nil {
+				t.Fatalf("Verify failed: %v", err)
+			}
+			if !ok {
+				t.Fatal("expected proof to verify")
+			}
+
+			ok, err = semantic.Verify(root, arcset.CanonicalizePath("a"), binding, proof)
+			if err == nil && ok {
+				t.Fatal("expected proof to be path-bound")
+			}
+		})
+	}
+}
+
+func TestMapUpdateReplaceInsertDelete(t *testing.T) {
+	ctx := context.Background()
+	initialEntries := map[string]cid.Cid{
+		"a": fakeCID("value-a"),
+		"c": fakeCID("value-c"),
+	}
+
+	for name, factory := range mappingSchemes() {
+		t.Run(name, func(t *testing.T) {
+			semantic := newMap(t, factory, nil)
+			initialView := mapping.NewViewFrom(initialEntries)
+
+			root, err := semantic.Commit(ctx, testBucketID, initialView)
+			if err != nil {
+				t.Fatalf("Commit(initial) failed: %v", err)
+			}
+
+			replacement := fakeCID("value-c2")
+			replacedRoot, err := semantic.Update(
+				ctx,
+				testBucketID,
+				root,
+				arcset.CanonicalizePath("c"),
+				initialEntries["c"],
+				replacement,
+			)
+			if err != nil {
+				t.Fatalf("Update(replace) failed: %v", err)
+			}
+
+			replacedView := mapping.NewViewFrom(map[string]cid.Cid{
+				"a": initialEntries["a"],
+				"c": replacement,
+			})
+			expectedReplacedRoot, err := semantic.Commit(ctx, testBucketID, replacedView)
+			if err != nil {
+				t.Fatalf("Commit(replaced) failed: %v", err)
+			}
+			if !replacedRoot.Equals(expectedReplacedRoot) {
+				t.Fatalf("replace root mismatch: got %s want %s", replacedRoot, expectedReplacedRoot)
+			}
+
+			inserted := fakeCID("value-b")
+			insertedRoot, err := semantic.Update(
+				ctx,
+				testBucketID,
+				replacedRoot,
+				arcset.CanonicalizePath("b"),
+				cid.Undef,
+				inserted,
+			)
+			if err != nil {
+				t.Fatalf("Update(insert) failed: %v", err)
+			}
+
+			insertedView := mapping.NewViewFrom(map[string]cid.Cid{
+				"a": initialEntries["a"],
+				"b": inserted,
+				"c": replacement,
+			})
+			expectedInsertedRoot, err := semantic.Commit(ctx, testBucketID, insertedView)
+			if err != nil {
+				t.Fatalf("Commit(inserted) failed: %v", err)
+			}
+			if !insertedRoot.Equals(expectedInsertedRoot) {
+				t.Fatalf("insert root mismatch: got %s want %s", insertedRoot, expectedInsertedRoot)
+			}
+
+			deletedRoot, err := semantic.Update(
+				ctx,
+				testBucketID,
+				insertedRoot,
+				arcset.CanonicalizePath("a"),
+				initialEntries["a"],
+				cid.Undef,
+			)
+			if err != nil {
+				t.Fatalf("Update(delete) failed: %v", err)
+			}
+
+			deletedView := mapping.NewViewFrom(map[string]cid.Cid{
+				"b": inserted,
+				"c": replacement,
+			})
+			expectedDeletedRoot, err := semantic.Commit(ctx, testBucketID, deletedView)
+			if err != nil {
+				t.Fatalf("Commit(deleted) failed: %v", err)
+			}
+			if !deletedRoot.Equals(expectedDeletedRoot) {
+				t.Fatalf("delete root mismatch: got %s want %s", deletedRoot, expectedDeletedRoot)
+			}
+		})
+	}
+}
+
+func TestMapUpdateRejectsInconsistentOldValue(t *testing.T) {
+	ctx := context.Background()
+	view := mapping.NewViewFrom(map[string]cid.Cid{
+		"a": fakeCID("value-a"),
+	})
+
+	for name, factory := range mappingSchemes() {
+		t.Run(name, func(t *testing.T) {
+			semantic := newMap(t, factory, nil)
+			root, err := semantic.Commit(ctx, testBucketID, view)
+			if err != nil {
+				t.Fatalf("Commit failed: %v", err)
+			}
+
+			_, err = semantic.Update(
+				ctx,
+				testBucketID,
+				root,
+				arcset.CanonicalizePath("a"),
+				fakeCID("wrong-old"),
+				fakeCID("value-a2"),
+			)
+			if err == nil {
+				t.Fatal("expected old-value mismatch error")
+			}
+		})
+	}
+}
+
+func TestMapRestartSafeProveAndUpdate(t *testing.T) {
+	ctx := context.Background()
+	initial := mapping.NewViewFrom(map[string]cid.Cid{
+		"a":       fakeCID("value-a"),
+		"aa":      fakeCID("value-aa"),
+		"aa/beta": fakeCID("value-aa-beta"),
+	})
+
+	for name, factory := range mappingSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			semantic := newMap(t, factory, kv)
+
+			root, err := semantic.Commit(ctx, testBucketID, initial)
+			if err != nil {
+				t.Fatalf("Commit failed: %v", err)
+			}
+
+			restarted := newMap(t, factory, kv)
+			key := arcset.CanonicalizePath("aa/beta")
+			binding, proof, err := restarted.Prove(ctx, testBucketID, root, key)
+			if err != nil {
+				t.Fatalf("Prove after restart failed: %v", err)
+			}
+			if !binding.Present || !binding.Value.Equals(fakeCID("value-aa-beta")) {
+				t.Fatalf("unexpected binding after restart: %+v", binding)
+			}
+
+			ok, err := restarted.Verify(root, key, binding, proof)
+			if err != nil {
+				t.Fatalf("Verify after restart failed: %v", err)
+			}
+			if !ok {
+				t.Fatal("expected restarted proof to verify")
+			}
+
+			updatedRoot, err := restarted.Update(
+				ctx,
+				testBucketID,
+				root,
+				arcset.CanonicalizePath("a"),
+				fakeCID("value-a"),
+				fakeCID("value-a2"),
+			)
+			if err != nil {
+				t.Fatalf("Update after restart failed: %v", err)
+			}
+
+			expectedRoot, err := restarted.Commit(ctx, testBucketID, mapping.NewViewFrom(map[string]cid.Cid{
+				"a":       fakeCID("value-a2"),
+				"aa":      fakeCID("value-aa"),
+				"aa/beta": fakeCID("value-aa-beta"),
+			}))
+			if err != nil {
+				t.Fatalf("Commit(expected) failed: %v", err)
+			}
+			if !updatedRoot.Equals(expectedRoot) {
+				t.Fatalf("restart-safe update root mismatch: got %s want %s", updatedRoot, expectedRoot)
+			}
+		})
+	}
+}

--- a/core/writer/writer_test.go
+++ b/core/writer/writer_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dewebprotocol/malt/core/eat/overwrite"
 	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
 	"github.com/dewebprotocol/malt/core/structure/mapping"
-	mappingindexed "github.com/dewebprotocol/malt/core/structure/mapping/indexed"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -35,7 +35,7 @@ func newTestWriter(t *testing.T) (*Writer, *overwrite.EAT, mapping.Semantic, *kv
 		t.Fatalf("failed to create KZG scheme: %v", err)
 	}
 
-	semantic, err := mappingindexed.NewMap(scheme, e)
+	semantic, err := mappingradix.NewMap(scheme, e)
 	if err != nil {
 		t.Fatalf("failed to create mapping semantic: %v", err)
 	}
@@ -466,7 +466,7 @@ func TestWriter_LineageRecorder(t *testing.T) {
 	kv := kvmemory.New()
 	e, _ := overwrite.NewEAT(overwrite.WithKVStore(kv))
 	scheme, _ := kzg.NewScheme()
-	semantic, _ := mappingindexed.NewMap(scheme, e)
+	semantic, _ := mappingradix.NewMap(scheme, e)
 	rec := &mockLineageRecorder{}
 	w := NewWriter(semantic, e, rec)
 

--- a/eval/benchmark.go
+++ b/eval/benchmark.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dewebprotocol/malt/core/kvstore"
 	kvstore_memory "github.com/dewebprotocol/malt/core/kvstore/memory"
 	"github.com/dewebprotocol/malt/core/structure/mapping"
-	mappingindexed "github.com/dewebprotocol/malt/core/structure/mapping/indexed"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -187,7 +187,7 @@ func NewTestComponentsWithEAT(backend BackendType, eatType EATType, bucketID str
 	if err != nil {
 		return nil, fmt.Errorf("new EAT: %w", err)
 	}
-	s, err := mappingindexed.NewMap(scheme, e)
+	s, err := mappingradix.NewMap(scheme, e)
 	if err != nil {
 		return nil, fmt.Errorf("new mapping semantic: %w", err)
 	}
@@ -244,41 +244,39 @@ func (b *BenchmarkRunner) runAppendWorkload(ctx context.Context, arcCount int) (
 
 	metrics := &Metrics{ArcCount: arcCount, Backend: b.config.Backend, EATType: b.config.EATType}
 
+	// Start from an empty committed structure so append workload exercises the
+	// incremental semantic update path rather than recommitting the whole view.
+	firstStart := time.Now()
+	root, err := b.semantic.Commit(ctx, bucketID, mapping.NewViewFrom(map[string]cid.Cid{}))
+	metrics.CommitTime = time.Since(firstStart)
+	if err != nil {
+		return nil, fmt.Errorf("initial empty commit failed: %w", err)
+	}
+
 	// Track current arc set
 	currentArcsMap := make(map[string]cid.Cid)
 
 	totalUpdateTime := time.Duration(0)
-	var root cid.Cid
 
 	// Add arcs one by one (append pattern)
 	for i := range arcCount {
 		path := fmt.Sprintf("arc%d", i)
 		target, _ := newPayloadCID([]byte(fmt.Sprintf("data%d", i)))
 
-		// Add to current arc set
-		currentArcsMap[path] = target
-
-		// Create snapshot for commit
-		// Commit current arc set
 		start := time.Now()
-		newRoot, err := b.semantic.Commit(ctx, bucketID, mapping.NewViewFrom(currentArcsMap))
-		totalUpdateTime += time.Since(start)
+		newRoot, err := b.semantic.Update(ctx, bucketID, root, arcset.CanonicalizePath(path), cid.Undef, target)
 		if err != nil {
-			return nil, fmt.Errorf("commit failed at arc %d: %w", i, err)
+			return nil, fmt.Errorf("append update failed at arc %d: %w", i, err)
 		}
 
-		// Store arcs in EAT using Update
-		if err := b.eat.Update(ctx, bucketID, newRoot, root, currentArcsMap); err != nil {
+		if err := b.eat.Update(ctx, bucketID, newRoot, root, map[string]cid.Cid{path: target}); err != nil {
 			return nil, fmt.Errorf("eat update failed at arc %d: %w", i, err)
 		}
+		totalUpdateTime += time.Since(start)
 
+		currentArcsMap[path] = target
 		root = newRoot
 	}
-
-	// First commit is the initial one
-	firstStart := time.Now()
-	_, _ = b.semantic.Commit(ctx, bucketID, mapping.NewViewFrom(map[string]cid.Cid{}))
-	metrics.CommitTime = time.Since(firstStart)
 
 	metrics.UpdateTime = totalUpdateTime / time.Duration(arcCount)
 
@@ -375,24 +373,24 @@ func (b *BenchmarkRunner) runRandomWorkload(ctx context.Context, arcCount int) (
 		idx := r.Intn(arcCount)
 		path := paths[idx]
 
+		oldTarget := keys[path]
 		newKey, _ := newPayloadCID([]byte(fmt.Sprintf("updated%d_%d", idx, round)))
 
-		// Update arc set
-		arcsMap[path] = newKey
-		// Measure commit time (MockCommitment requires full commit)
 		start = time.Now()
-		newRoot, err := b.semantic.Commit(ctx, bucketID, mapping.NewViewFrom(arcsMap))
+		newRoot, err := b.semantic.Update(ctx, bucketID, root, arcset.CanonicalizePath(path), oldTarget, newKey)
+		if err != nil {
+			return nil, fmt.Errorf("update failed at round %d: %w", round, err)
+		}
+
+		if err := b.eat.Update(ctx, bucketID, newRoot, root, map[string]cid.Cid{path: newKey}); err != nil {
+			return nil, fmt.Errorf("eat update failed at round %d: %w", round, err)
+		}
 		roundTime := time.Since(start)
 		totalUpdateTime += roundTime
 		metrics.UpdateTimes = append(metrics.UpdateTimes, roundTime)
-		if err != nil {
-			return nil, fmt.Errorf("commit failed at round %d: %w", round, err)
-		}
-
-		// Store in EAT
-		b.eat.Update(ctx, bucketID, newRoot, root, arcsMap)
 
 		root = newRoot
+		arcsMap[path] = newKey
 		keys[path] = newKey
 	}
 
@@ -489,28 +487,33 @@ func (b *BenchmarkRunner) runBulkWorkload(ctx context.Context, arcCount int) (*M
 			paths[i], paths[j] = paths[j], paths[i]
 		})
 
+		delta := make(map[string]cid.Cid, bulkSize)
+		currentRoot := root
+
 		// Update arcs in bulk
+		start = time.Now()
 		for i := range bulkSize {
 			path := paths[i]
+			oldTarget := keys[path]
 			newKey, _ := newPayloadCID([]byte(fmt.Sprintf("bulk%d_%d", i, round)))
+			nextRoot, err := b.semantic.Update(ctx, bucketID, currentRoot, arcset.CanonicalizePath(path), oldTarget, newKey)
+			if err != nil {
+				return nil, fmt.Errorf("bulk update failed at round %d item %d: %w", round, i, err)
+			}
+			currentRoot = nextRoot
 			arcsMap[path] = newKey
 			keys[path] = newKey
+			delta[path] = newKey
 		}
 
-		// Commit updated arc set
-		start = time.Now()
-		newRoot, err := b.semantic.Commit(ctx, bucketID, mapping.NewViewFrom(arcsMap))
+		if err := b.eat.Update(ctx, bucketID, currentRoot, root, delta); err != nil {
+			return nil, fmt.Errorf("bulk eat update failed at round %d: %w", round, err)
+		}
+
 		roundTime := time.Since(start)
 		totalUpdateTime += roundTime
 		metrics.UpdateTimes = append(metrics.UpdateTimes, roundTime)
-		if err != nil {
-			return nil, fmt.Errorf("bulk commit failed: %w", err)
-		}
-
-		// Store in EAT
-		b.eat.Update(ctx, bucketID, newRoot, root, arcsMap)
-
-		root = newRoot
+		root = currentRoot
 	}
 
 	metrics.UpdateTime = totalUpdateTime / time.Duration(b.config.UpdateRounds)

--- a/eval/benchmark_test.go
+++ b/eval/benchmark_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dewebprotocol/malt/core/commitment/kzg"
 	"github.com/dewebprotocol/malt/core/eat/overwrite"
 	kvstore_memory "github.com/dewebprotocol/malt/core/kvstore/memory"
-	mappingindexed "github.com/dewebprotocol/malt/core/structure/mapping/indexed"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/eval"
 )
 
@@ -36,9 +36,9 @@ func TestBenchmarkRunner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewScheme failed: %v", err)
 	}
-	semantic, err := mappingindexed.NewMap(scheme, e)
+	semantic, err := mappingradix.NewMap(scheme, e)
 	if err != nil {
-		t.Fatalf("indexed.NewMap failed: %v", err)
+		t.Fatalf("radix.NewMap failed: %v", err)
 	}
 	c := mock.NewCAS(mock.WithoutLatency())
 
@@ -406,7 +406,7 @@ func TestGenerateLatexTable(t *testing.T) {
 func BenchmarkAppend(b *testing.B) {
 	e := newTestEAT()
 	scheme, _ := kzg.NewScheme()
-	semantic, _ := mappingindexed.NewMap(scheme, e)
+	semantic, _ := mappingradix.NewMap(scheme, e)
 	c := mock.NewCAS(mock.WithoutLatency())
 
 	cfg := &eval.BenchmarkConfig{
@@ -429,7 +429,7 @@ func BenchmarkAppend(b *testing.B) {
 func BenchmarkRandom(b *testing.B) {
 	e := newTestEAT()
 	scheme, _ := kzg.NewScheme()
-	semantic, _ := mappingindexed.NewMap(scheme, e)
+	semantic, _ := mappingradix.NewMap(scheme, e)
 	c := mock.NewCAS(mock.WithoutLatency())
 
 	cfg := &eval.BenchmarkConfig{
@@ -452,7 +452,7 @@ func BenchmarkRandom(b *testing.B) {
 func BenchmarkBulk(b *testing.B) {
 	e := newTestEAT()
 	scheme, _ := kzg.NewScheme()
-	semantic, _ := mappingindexed.NewMap(scheme, e)
+	semantic, _ := mappingradix.NewMap(scheme, e)
 	c := mock.NewCAS(mock.WithoutLatency())
 
 	cfg := &eval.BenchmarkConfig{


### PR DESCRIPTION
## Summary
- add a dedicated digest-keyed radix map semantic and make it the default map runtime
- keep the indexed map semantic as a separate baseline implementation
- switch eval workloads to incremental semantic.Update paths and add radix tests

## Testing
- go test ./...