### PR TITLE
feat(list): harden tree runtime invariants

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -272,13 +272,16 @@ Operational components affect latency and availability, not the semantic trust b
 ### Semantic Layer
 
 - `structure/mapping`
-  - current keyed semantic used by native explicit-arc structure roots
+  - semantic contracts and shared keyed-map types
+- `structure/mapping/radix`
+  - primary keyed-map runtime semantic
+  - digest-keyed radix placement with explicit collision handling
+- `structure/mapping/indexed`
+  - older canonical-order keyed baseline kept as a simpler comparison path
 - `structure/list/indexed`
-  - simple indexed-list semantic
+  - degenerate one-node stable-indexed variant
 - `structure/list/tree`
-  - tree-shaped list semantic
-- `structure/map`
-  - still conceptually part of the architecture, but detailed implementation remains deferred
+  - primary stable-indexed list runtime semantic
 
 ### Commitment Backends
 

--- a/core/structure/list/indexed/indexed.go
+++ b/core/structure/list/indexed/indexed.go
@@ -124,6 +124,12 @@ func (s *IndexedList) Verify(root cid.Cid, index uint64, expected list.Query, pr
 }
 
 func (s *IndexedList) Replace(ctx context.Context, bucketID string, root cid.Cid, index uint64, oldKey, newKey cid.Cid) (cid.Cid, error) {
+	if !oldKey.Defined() {
+		return cid.Undef, fmt.Errorf("old key is undefined")
+	}
+	if !newKey.Defined() {
+		return cid.Undef, fmt.Errorf("new key is undefined")
+	}
 	slots, length, err := s.loadRoot(ctx, bucketID, root)
 	if err != nil {
 		return cid.Undef, err
@@ -141,6 +147,9 @@ func (s *IndexedList) Replace(ctx context.Context, bucketID string, root cid.Cid
 }
 
 func (s *IndexedList) Append(ctx context.Context, bucketID string, root cid.Cid, key cid.Cid) (cid.Cid, uint64, error) {
+	if !key.Defined() {
+		return cid.Undef, 0, fmt.Errorf("key is undefined")
+	}
 	slots, length, err := s.loadRoot(ctx, bucketID, root)
 	if err != nil {
 		return cid.Undef, 0, err
@@ -191,6 +200,9 @@ func (s *IndexedList) loadRoot(ctx context.Context, bucketID string, root cid.Ci
 	if err != nil {
 		return nil, 0, err
 	}
+	if err := listruntime.ValidateSlots(s.scheme, root, slots); err != nil {
+		return nil, 0, err
+	}
 	length, err := listruntime.DecodeLengthMarker(slots[0])
 	if err != nil {
 		return nil, 0, err
@@ -218,6 +230,9 @@ func valuesFromView(view list.View) ([]cid.Cid, error) {
 		value, ok := view.Get(i)
 		if !ok {
 			return nil, fmt.Errorf("missing value at index %d", i)
+		}
+		if !value.Defined() {
+			return nil, fmt.Errorf("value at index %d is undefined", i)
 		}
 		values[i] = value
 	}

--- a/core/structure/list/indexed/indexed_test.go
+++ b/core/structure/list/indexed/indexed_test.go
@@ -11,6 +11,7 @@ import (
 	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
 	"github.com/dewebprotocol/malt/core/structure/list"
 	"github.com/dewebprotocol/malt/core/structure/list/indexed"
+	listruntime "github.com/dewebprotocol/malt/core/structure/list/internal/runtime"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -49,15 +50,23 @@ func listSchemes() map[string]schemeFactory {
 func newList(t *testing.T, factory schemeFactory, kv *kvmemory.KV) *indexed.IndexedList {
 	t.Helper()
 
-	e, err := overwrite.NewEAT(overwrite.WithKVStore(kv))
+	semantic, _, err := newListWithEAT(factory(t), kv)
 	if err != nil {
-		t.Fatalf("overwrite.NewEAT failed: %v", err)
-	}
-	semantic, err := indexed.NewList(factory(t), e)
-	if err != nil {
-		t.Fatalf("indexed.NewList failed: %v", err)
+		t.Fatalf("newListWithEAT failed: %v", err)
 	}
 	return semantic
+}
+
+func newListWithEAT(scheme commitment.IndexCommitment, kv *kvmemory.KV) (*indexed.IndexedList, *overwrite.EAT, error) {
+	e, err := overwrite.NewEAT(overwrite.WithKVStore(kv))
+	if err != nil {
+		return nil, nil, err
+	}
+	semantic, err := indexed.NewList(scheme, e)
+	if err != nil {
+		return nil, nil, err
+	}
+	return semantic, e, nil
 }
 
 func assertVerifiedQuery(t *testing.T, semantic *indexed.IndexedList, bucketID string, root cid.Cid, index uint64, expected list.Query) {
@@ -218,6 +227,67 @@ func TestIndexedListEmptyAndRegrow(t *testing.T) {
 				Key:    cid.Undef,
 				Length: 0,
 			})
+		})
+	}
+}
+
+func TestIndexedListRejectsUndefinedCommittedKeys(t *testing.T) {
+	ctx := context.Background()
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			bucketID := "indexed-undefined-" + name
+			semantic := newList(t, factory, kv)
+
+			if _, err := semantic.Commit(ctx, bucketID, list.NewViewFromSlice([]cid.Cid{newPayloadCID([]byte("a")), cid.Undef})); err == nil {
+				t.Fatal("Commit should reject undefined committed keys")
+			}
+
+			root, err := semantic.Commit(ctx, bucketID, list.NewViewFromSlice([]cid.Cid{newPayloadCID([]byte("a"))}))
+			if err != nil {
+				t.Fatalf("Commit(valid) failed: %v", err)
+			}
+			if _, _, err := semantic.Append(ctx, bucketID, root, cid.Undef); err == nil {
+				t.Fatal("Append should reject undefined key")
+			}
+			if _, err := semantic.Replace(ctx, bucketID, root, 0, newPayloadCID([]byte("a")), cid.Undef); err == nil {
+				t.Fatal("Replace should reject undefined new key")
+			}
+		})
+	}
+}
+
+func TestIndexedListRejectsCorruptedMaterialization(t *testing.T) {
+	ctx := context.Background()
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			bucketID := "indexed-corrupt-" + name
+			scheme := factory(t)
+			semantic, e, err := newListWithEAT(scheme, kv)
+			if err != nil {
+				t.Fatalf("newListWithEAT failed: %v", err)
+			}
+
+			root, err := semantic.Commit(ctx, bucketID, list.NewViewFromSlice([]cid.Cid{
+				newPayloadCID([]byte("a")),
+				newPayloadCID([]byte("b")),
+			}))
+			if err != nil {
+				t.Fatalf("Commit failed: %v", err)
+			}
+
+			if err := e.Update(ctx, bucketID, cid.Undef, cid.Undef, map[string]cid.Cid{
+				listruntime.NodeSlotPath(root, 1).String(): newPayloadCID([]byte("corrupt-root-slot")),
+			}); err != nil {
+				t.Fatalf("failed to corrupt root materialization: %v", err)
+			}
+
+			if _, _, err := semantic.Append(ctx, bucketID, root, newPayloadCID([]byte("c"))); err == nil {
+				t.Fatal("Append should reject corrupted root materialization")
+			}
 		})
 	}
 }

--- a/core/structure/list/internal/runtime/runtime.go
+++ b/core/structure/list/internal/runtime/runtime.go
@@ -126,6 +126,18 @@ func CommitSlots(scheme commitment.IndexCommitment, slots []cid.Cid) (cid.Cid, e
 	return scheme.Commit(CellsFromSlots(slots))
 }
 
+// ValidateSlots checks that the materialized slot vector recomputes to root.
+func ValidateSlots(scheme commitment.IndexCommitment, root cid.Cid, slots []cid.Cid) error {
+	recomputed, err := CommitSlots(scheme, slots)
+	if err != nil {
+		return err
+	}
+	if !recomputed.Equals(root) {
+		return fmt.Errorf("materialized node state does not match root %s", root.String())
+	}
+	return nil
+}
+
 // ProveSlot proves one slot under a committed node.
 func ProveSlot(scheme commitment.IndexCommitment, root cid.Cid, slots []cid.Cid, slot uint64) (commitment.Cell, []byte, error) {
 	provedRoot, value, proof, err := scheme.Prove(CellsFromSlots(slots), slot)

--- a/core/structure/list/tree/tree.go
+++ b/core/structure/list/tree/tree.go
@@ -182,6 +182,12 @@ func (s *TreeList) Verify(root cid.Cid, index uint64, expected list.Query, proof
 }
 
 func (s *TreeList) Replace(ctx context.Context, bucketID string, root cid.Cid, index uint64, oldKey, newKey cid.Cid) (cid.Cid, error) {
+	if !oldKey.Defined() {
+		return cid.Undef, fmt.Errorf("old key is undefined")
+	}
+	if !newKey.Defined() {
+		return cid.Undef, fmt.Errorf("new key is undefined")
+	}
 	_, length, err := s.loadRoot(ctx, bucketID, root)
 	if err != nil {
 		return cid.Undef, err
@@ -193,6 +199,9 @@ func (s *TreeList) Replace(ctx context.Context, bucketID string, root cid.Cid, i
 }
 
 func (s *TreeList) Append(ctx context.Context, bucketID string, root cid.Cid, key cid.Cid) (cid.Cid, uint64, error) {
+	if !key.Defined() {
+		return cid.Undef, 0, fmt.Errorf("key is undefined")
+	}
 	rootSlots, length, err := s.loadRoot(ctx, bucketID, root)
 	if err != nil {
 		return cid.Undef, 0, err
@@ -561,7 +570,14 @@ func (s *TreeList) loadNode(ctx context.Context, bucketID string, root cid.Cid, 
 	if isRoot {
 		width = listruntime.RootWidth
 	}
-	return listruntime.LoadSlots(ctx, s.eat, bucketID, root, width)
+	slots, err := listruntime.LoadSlots(ctx, s.eat, bucketID, root, width)
+	if err != nil {
+		return nil, err
+	}
+	if err := listruntime.ValidateSlots(s.scheme, root, slots); err != nil {
+		return nil, err
+	}
+	return slots, nil
 }
 
 func (s *TreeList) commitSlots(ctx context.Context, bucketID string, slots []cid.Cid) (cid.Cid, error) {
@@ -593,6 +609,9 @@ func valuesFromView(view list.View) ([]cid.Cid, error) {
 		value, ok := view.Get(i)
 		if !ok {
 			return nil, fmt.Errorf("missing value at index %d", i)
+		}
+		if !value.Defined() {
+			return nil, fmt.Errorf("value at index %d is undefined", i)
 		}
 		values[i] = value
 	}

--- a/core/structure/list/tree/tree_test.go
+++ b/core/structure/list/tree/tree_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dewebprotocol/malt/core/eat/overwrite"
 	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
 	"github.com/dewebprotocol/malt/core/structure/list"
+	listruntime "github.com/dewebprotocol/malt/core/structure/list/internal/runtime"
 	"github.com/dewebprotocol/malt/core/structure/list/tree"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -57,15 +58,23 @@ func makeValues(count int) []cid.Cid {
 func newList(t *testing.T, factory schemeFactory, kv *kvmemory.KV) *tree.TreeList {
 	t.Helper()
 
-	e, err := overwrite.NewEAT(overwrite.WithKVStore(kv))
+	semantic, _, err := newListWithEAT(factory(t), kv)
 	if err != nil {
-		t.Fatalf("overwrite.NewEAT failed: %v", err)
-	}
-	semantic, err := tree.NewList(factory(t), e)
-	if err != nil {
-		t.Fatalf("tree.NewList failed: %v", err)
+		t.Fatalf("newListWithEAT failed: %v", err)
 	}
 	return semantic
+}
+
+func newListWithEAT(scheme commitment.IndexCommitment, kv *kvmemory.KV) (*tree.TreeList, *overwrite.EAT, error) {
+	e, err := overwrite.NewEAT(overwrite.WithKVStore(kv))
+	if err != nil {
+		return nil, nil, err
+	}
+	semantic, err := tree.NewList(scheme, e)
+	if err != nil {
+		return nil, nil, err
+	}
+	return semantic, e, nil
 }
 
 func assertVerifiedQuery(t *testing.T, semantic *tree.TreeList, bucketID string, root cid.Cid, index uint64, expected list.Query) {
@@ -237,6 +246,71 @@ func TestTreeListEmptyAndRegrow(t *testing.T) {
 				Key:    cid.Undef,
 				Length: 0,
 			})
+		})
+	}
+}
+
+func TestTreeListRejectsUndefinedCommittedKeys(t *testing.T) {
+	ctx := context.Background()
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			bucketID := "tree-undefined-" + name
+			semantic := newList(t, factory, kv)
+
+			if _, err := semantic.Commit(ctx, bucketID, list.NewViewFromSlice([]cid.Cid{newPayloadCID([]byte("a")), cid.Undef})); err == nil {
+				t.Fatal("Commit should reject undefined committed keys")
+			}
+
+			root, err := semantic.Commit(ctx, bucketID, list.NewViewFromSlice([]cid.Cid{newPayloadCID([]byte("a"))}))
+			if err != nil {
+				t.Fatalf("Commit(valid) failed: %v", err)
+			}
+			if _, _, err := semantic.Append(ctx, bucketID, root, cid.Undef); err == nil {
+				t.Fatal("Append should reject undefined key")
+			}
+			if _, err := semantic.Replace(ctx, bucketID, root, 0, newPayloadCID([]byte("a")), cid.Undef); err == nil {
+				t.Fatal("Replace should reject undefined new key")
+			}
+		})
+	}
+}
+
+func TestTreeListRejectsCorruptedMaterialization(t *testing.T) {
+	ctx := context.Background()
+	values := makeValues(300)
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			bucketID := "tree-corrupt-" + name
+			scheme := factory(t)
+			semantic, e, err := newListWithEAT(scheme, kv)
+			if err != nil {
+				t.Fatalf("newListWithEAT failed: %v", err)
+			}
+
+			root, err := semantic.Commit(ctx, bucketID, list.NewViewFromSlice(values))
+			if err != nil {
+				t.Fatalf("Commit failed: %v", err)
+			}
+
+			childRoot, err := e.Get(ctx, bucketID, cid.Undef, listruntime.NodeSlotPath(root, 2).String())
+			if err != nil {
+				t.Fatalf("failed to fetch child root: %v", err)
+			}
+
+			corruptValue := newPayloadCID([]byte("corrupt-child-slot"))
+			if err := e.Update(ctx, bucketID, cid.Undef, cid.Undef, map[string]cid.Cid{
+				listruntime.NodeSlotPath(childRoot, 1).String(): corruptValue,
+			}); err != nil {
+				t.Fatalf("failed to corrupt child materialization: %v", err)
+			}
+
+			if _, err := semantic.Replace(ctx, bucketID, root, 256, values[256], newPayloadCID([]byte("replacement"))); err == nil {
+				t.Fatal("Replace should reject corrupted child materialization")
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary\n- enforce list semantic invariant: in-range committed keys must be defined\n- validate EAT materialization by recomputing roots from loaded slots\n- extend list tree/indexed tests for undefined-key and corrupted materialization cases\n\n## Testing\n- go test ./...