### PR TITLE
fix: harden runtime daemon edges

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -38,12 +38,18 @@ func TestClientGraphFlow(t *testing.T) {
 	if graph.ID != "demo" {
 		t.Fatalf("graph id = %q, want %q", graph.ID, "demo")
 	}
+	if graph.Root != "" {
+		t.Fatalf("graph root = %q, want empty for undefined head", graph.Root)
+	}
 	loadedGraph, err := client.GetGraph(ctx, "demo")
 	if err != nil {
 		t.Fatalf("get graph: %v", err)
 	}
 	if loadedGraph.ID != "demo" {
 		t.Fatalf("loaded graph id = %q, want %q", loadedGraph.ID, "demo")
+	}
+	if loadedGraph.Root != "" {
+		t.Fatalf("loaded graph root = %q, want empty for undefined head", loadedGraph.Root)
 	}
 
 	target := fakeCIDString("alice")
@@ -114,7 +120,10 @@ func TestClientManagedGraphStructureFlow(t *testing.T) {
 	}
 
 	target := fakeCIDString("managed-alice")
-	createResp, err := client.CreateGraphStructure(ctx, "demo", map[string]string{"name": target})
+	createResp, err := client.CreateGraphStructure(ctx, "demo", map[string]string{
+		"name":  target,
+		"/name": target,
+	})
 	if err != nil {
 		t.Fatalf("create managed graph structure: %v", err)
 	}
@@ -128,6 +137,14 @@ func TestClientManagedGraphStructureFlow(t *testing.T) {
 	}
 	if resolveResp.Target != target {
 		t.Fatalf("resolved target = %q, want %q", resolveResp.Target, target)
+	}
+
+	meta, err := client.GetGraph(ctx, "demo")
+	if err != nil {
+		t.Fatalf("get managed graph metadata: %v", err)
+	}
+	if meta.ArcCount != 1 {
+		t.Fatalf("managed graph arc_count = %d, want 1 after canonicalization", meta.ArcCount)
 	}
 
 	updateTarget := fakeCIDString("managed-bob")
@@ -145,6 +162,9 @@ func TestClientManagedGraphStructureFlow(t *testing.T) {
 	}
 	if snapshotResp.Arcs["name"] != updateTarget {
 		t.Fatalf("snapshot target = %q, want %q", snapshotResp.Arcs["name"], updateTarget)
+	}
+	if len(snapshotResp.Arcs) != 1 {
+		t.Fatalf("snapshot arc count = %d, want 1", len(snapshotResp.Arcs))
 	}
 }
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1,18 +1,11 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
-	"time"
 
 	"github.com/dewebprotocol/malt/config"
-	"github.com/dewebprotocol/malt/core/api"
-	casmock "github.com/dewebprotocol/malt/core/cas/mock"
-	"github.com/dewebprotocol/malt/server"
+	daemonapp "github.com/dewebprotocol/malt/daemon"
 	"github.com/spf13/cobra"
 )
 
@@ -49,75 +42,13 @@ func runGateway(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if listen != "" {
-		cfg.RPC.Listen = listen
-	}
 
-	var (
-		nodeOpts   []api.Option
-		mockSrv    *casmock.HTTPServer
-		mockSrvErr chan error
-	)
-
-	if cfg.CAS.Mode == "embedded-mock" {
-		mockOpts := []casmock.Option{}
-		if latency, err := cfg.EmbeddedMockLatency(); err == nil && latency > 0 {
-			mockOpts = append(mockOpts,
-				casmock.WithGetLatency(latency),
-				casmock.WithPutLatency(latency),
-				casmock.WithHasLatency(latency),
-			)
-		}
-		mockCAS := casmock.NewCAS(mockOpts...)
-		nodeOpts = append(nodeOpts, api.WithCAS(mockCAS))
-		mockSrv = casmock.NewHTTPServer(cfg.CAS.EmbeddedMock.Listen, mockCAS)
-		mockSrvErr = make(chan error, 1)
-		go func() {
-			if err := mockSrv.Start(); err != nil && err != http.ErrServerClosed {
-				mockSrvErr <- err
-			}
-		}()
-	}
-
-	nodeOpts = append(nodeOpts, api.WithConfig(cfg))
-	node, err := api.NewNode(nodeOpts...)
-	if err != nil {
-		return err
-	}
-	defer node.Close()
-
-	srv := server.New(node, cfg.RPC.Listen)
-	srvErr := make(chan error, 1)
-	go func() {
-		if err := srv.Start(); err != nil && err != http.ErrServerClosed {
-			srvErr <- err
-		}
-	}()
-
-	fmt.Fprintf(os.Stdout, "malt-gateway serving daemon API on %s\n", cfg.RPC.Listen)
-	if cfg.CAS.Mode == "embedded-mock" {
-		fmt.Fprintf(os.Stdout, "embedded mock CAS listening on %s\n", cfg.CAS.EmbeddedMock.Listen)
-	}
-
-	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
-
-	select {
-	case sig := <-stop:
-		fmt.Fprintf(os.Stderr, "received signal %s, shutting down\n", sig)
-	case err := <-srvErr:
-		return fmt.Errorf("daemon server failed: %w", err)
-	case err := <-gatewayMockServerError(mockSrvErr):
-		return fmt.Errorf("embedded mock CAS failed: %w", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	if mockSrv != nil {
-		_ = mockSrv.Shutdown(ctx)
-	}
-	return srv.Shutdown(ctx)
+	return daemonapp.Run(cfg, daemonapp.RunOptions{
+		ListenOverride: listen,
+		APILabel:       "malt-gateway serving daemon API",
+		Stdout:         os.Stdout,
+		Stderr:         os.Stderr,
+	})
 }
 
 func loadConfig(explicitPath string) (*config.Config, error) {
@@ -125,12 +56,4 @@ func loadConfig(explicitPath string) (*config.Config, error) {
 		return config.Load()
 	}
 	return config.LoadFromFile(explicitPath)
-}
-
-func gatewayMockServerError(ch chan error) <-chan error {
-	if ch == nil {
-		empty := make(chan error)
-		return empty
-	}
-	return ch
 }

--- a/cmd/malt/daemon.go
+++ b/cmd/malt/daemon.go
@@ -1,17 +1,9 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
-	"time"
 
-	"github.com/dewebprotocol/malt/core/api"
-	casmock "github.com/dewebprotocol/malt/core/cas/mock"
-	"github.com/dewebprotocol/malt/server"
+	daemonapp "github.com/dewebprotocol/malt/daemon"
 	"github.com/spf13/cobra"
 )
 
@@ -32,85 +24,11 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if override, _ := cmd.Flags().GetString("listen"); override != "" {
-		cfg.RPC.Listen = override
-	}
-
-	var (
-		nodeOpts    []api.Option
-		mockSrv     *casmock.HTTPServer
-		mockSrvErr  chan error
-		mockCASInst *casmock.CAS
-	)
-
-	if cfg.CAS.Mode == "embedded-mock" {
-		mockOpts := []casmock.Option{}
-		if latency, err := cfg.EmbeddedMockLatency(); err == nil && latency > 0 {
-			mockOpts = append(mockOpts,
-				casmock.WithGetLatency(latency),
-				casmock.WithPutLatency(latency),
-				casmock.WithHasLatency(latency),
-			)
-		}
-		mockCASInst = casmock.NewCAS(mockOpts...)
-		nodeOpts = append(nodeOpts, api.WithCAS(mockCASInst))
-		mockSrv = casmock.NewHTTPServer(cfg.CAS.EmbeddedMock.Listen, mockCASInst)
-		mockSrvErr = make(chan error, 1)
-		go func() {
-			if err := mockSrv.Start(); err != nil && err != http.ErrServerClosed {
-				mockSrvErr <- err
-			}
-		}()
-	}
-
-	nodeOpts = append(nodeOpts, api.WithConfig(cfg))
-	node, err := api.NewNode(nodeOpts...)
-	if err != nil {
-		return err
-	}
-	defer node.Close()
-
-	srv := server.New(node, cfg.RPC.Listen)
-	srvErr := make(chan error, 1)
-	go func() {
-		if err := srv.Start(); err != nil && err != http.ErrServerClosed {
-			srvErr <- err
-		}
-	}()
-
-	fmt.Fprintf(os.Stdout, "malt daemon listening on %s\n", cfg.RPC.Listen)
-	if cfg.CAS.Mode == "embedded-mock" {
-		fmt.Fprintf(os.Stdout, "embedded mock CAS listening on %s\n", cfg.CAS.EmbeddedMock.Listen)
-	}
-
-	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
-
-	select {
-	case sig := <-stop:
-		fmt.Fprintf(os.Stderr, "received signal %s, shutting down\n", sig)
-	case err := <-srvErr:
-		return fmt.Errorf("daemon server failed: %w", err)
-	case err := <-mockServerError(mockSrvErr):
-		return fmt.Errorf("embedded mock CAS failed: %w", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	if mockSrv != nil {
-		_ = mockSrv.Shutdown(ctx)
-	}
-	if err := srv.Shutdown(ctx); err != nil {
-		return err
-	}
-	return nil
-}
-
-func mockServerError(ch chan error) <-chan error {
-	if ch == nil {
-		empty := make(chan error)
-		return empty
-	}
-	return ch
+	override, _ := cmd.Flags().GetString("listen")
+	return daemonapp.Run(cfg, daemonapp.RunOptions{
+		ListenOverride: override,
+		APILabel:       "malt daemon",
+		Stdout:         os.Stdout,
+		Stderr:         os.Stderr,
+	})
 }

--- a/core/api/node.go
+++ b/core/api/node.go
@@ -42,7 +42,7 @@ type Node struct {
 	// Shared components (namespace by bucketId)
 	kv           kvstore.KVStore
 	eat          eat.EAT
-	cas          cas.Client
+	cas          cas.Reader
 	graphManager *graph.Manager
 	lineageMgr   *lineage.Manager
 }
@@ -172,8 +172,8 @@ func (n *Node) initEAT() error {
 	}
 }
 
-// initCAS creates a CAS client from config.
-func (n *Node) initCAS() (cas.Client, error) {
+// initCAS creates a read-side CAS client from config.
+func (n *Node) initCAS() (cas.Reader, error) {
 	switch n.cfg.CAS.Mode {
 	case "external", "embedded-mock":
 		timeout, _ := n.cfg.CASTimeout()
@@ -302,8 +302,8 @@ func (n *Node) EAT() eat.EAT {
 	return n.eat
 }
 
-// CAS returns the CAS client.
-func (n *Node) CAS() cas.Client {
+// CAS returns the read-side CAS client.
+func (n *Node) CAS() cas.Reader {
 	return n.cas
 }
 

--- a/core/api/options.go
+++ b/core/api/options.go
@@ -19,7 +19,7 @@ type options struct {
 	// Pre-built components (override config-based creation)
 	kvStore kvstore.KVStore
 	eat     eat.EAT
-	cas     cas.Client
+	cas     cas.Reader
 }
 
 func defaultOptions() *options {
@@ -54,8 +54,8 @@ func WithEAT(e eat.EAT) Option {
 	}
 }
 
-// WithCAS sets a custom CAS client.
-func WithCAS(c cas.Client) Option {
+// WithCAS sets a custom read-side CAS client.
+func WithCAS(c cas.Reader) Option {
 	return func(o *options) {
 		o.cas = c
 	}

--- a/core/cas/cas.go
+++ b/core/cas/cas.go
@@ -7,14 +7,23 @@ import (
 	cid "github.com/ipfs/go-cid"
 )
 
-// Client provides access to content-addressable storage.
-type Client interface {
+// Reader provides read-side access to content-addressable storage.
+type Reader interface {
 	// Get retrieves a block by its CID.
 	Get(ctx context.Context, c cid.Cid) ([]byte, error)
 
-	// Put stores a block and returns its CID.
-	Put(ctx context.Context, data []byte) (cid.Cid, error)
-
 	// Has checks if a block exists.
 	Has(ctx context.Context, c cid.Cid) (bool, error)
+}
+
+// Writer provides write-side access to content-addressable storage.
+type Writer interface {
+	// Put stores a block and returns its CID.
+	Put(ctx context.Context, data []byte) (cid.Cid, error)
+}
+
+// Client provides full read/write access to content-addressable storage.
+type Client interface {
+	Reader
+	Writer
 }

--- a/core/cas/ipld.go
+++ b/core/cas/ipld.go
@@ -49,11 +49,11 @@ type LinkInfo struct {
 
 // IPLDParser parses IPLD blocks and extracts links.
 type IPLDParser struct {
-	cas Client
+	cas Reader
 }
 
 // NewIPLDParser creates a new IPLD parser.
-func NewIPLDParser(cas Client) *IPLDParser {
+func NewIPLDParser(cas Reader) *IPLDParser {
 	return &IPLDParser{cas: cas}
 }
 

--- a/core/graph/graph.go
+++ b/core/graph/graph.go
@@ -37,9 +37,9 @@ type Graph struct {
 // Parameters:
 //   - id: unique graph identifier
 //   - eat: shared EAT (namespace by bucketId) — from Node
-//   - cas: shared CAS client — from Node (nil for testing/mocks)
+//   - cas: shared read-side CAS client — from Node (nil for testing/mocks)
 //   - opts: functional options (WithCommitmentScheme, WithBucketId, etc.)
-func NewGraph(id string, eat eat.EAT, cas cas.Client, opts ...Option) (*Graph, error) {
+func NewGraph(id string, eat eat.EAT, cas cas.Reader, opts ...Option) (*Graph, error) {
 	o := defaultOptions()
 	for _, opt := range opts {
 		opt(o)

--- a/core/resolver/step/hamt/hamt.go
+++ b/core/resolver/step/hamt/hamt.go
@@ -64,12 +64,12 @@ func WithMaxDepth(d int) Option {
 
 // Resolver implements step.Step for HAMT data structures.
 type Resolver struct {
-	cas    cas.Client
+	cas    cas.Reader
 	config Config
 }
 
 // NewResolver creates a new HAMT resolver with default configuration.
-func NewResolver(c cas.Client, opts ...Option) *Resolver {
+func NewResolver(c cas.Reader, opts ...Option) *Resolver {
 	config := Config{
 		BitWidth: DefaultBitWidth,
 		HashFunc: murmur3Hash,

--- a/core/resolver/step/implicit/implicit.go
+++ b/core/resolver/step/implicit/implicit.go
@@ -30,13 +30,13 @@ import (
 // It parses one block and returns the first link found in the path.
 // Multi-hop traversal should be handled by the caller.
 type Resolver struct {
-	cas        cas.Client
+	cas        cas.Reader
 	codecs     *codec.Registry
 	hamtConfig hamt.Config
 }
 
 // NewResolver creates a new implicit resolver with default codecs.
-func NewResolver(c cas.Client) *Resolver {
+func NewResolver(c cas.Reader) *Resolver {
 	registry := codec.NewRegistry()
 	registry.Register(dagcbor.New())
 	registry.Register(dagjson.New())
@@ -54,14 +54,14 @@ func NewResolver(c cas.Client) *Resolver {
 }
 
 // NewResolverWithHAMTConfig creates a resolver with custom HAMT configuration.
-func NewResolverWithHAMTConfig(c cas.Client, cfg hamt.Config) *Resolver {
+func NewResolverWithHAMTConfig(c cas.Reader, cfg hamt.Config) *Resolver {
 	r := NewResolver(c)
 	r.hamtConfig = cfg
 	return r
 }
 
 // NewResolverWithCodecs creates a resolver with custom codecs.
-func NewResolverWithCodecs(c cas.Client, registry *codec.Registry) *Resolver {
+func NewResolverWithCodecs(c cas.Reader, registry *codec.Registry) *Resolver {
 	return &Resolver{
 		cas:    c,
 		codecs: registry,

--- a/daemon/run.go
+++ b/daemon/run.go
@@ -1,0 +1,131 @@
+// Package daemon hosts the shared local daemon bootstrap used by CLI entrypoints.
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/dewebprotocol/malt/config"
+	"github.com/dewebprotocol/malt/core/api"
+	casmock "github.com/dewebprotocol/malt/core/cas/mock"
+	"github.com/dewebprotocol/malt/server"
+)
+
+// RunOptions configures daemon process startup.
+type RunOptions struct {
+	ListenOverride string
+	APILabel       string
+	Stdout         io.Writer
+	Stderr         io.Writer
+}
+
+// Run starts the daemon HTTP API and optional embedded mock CAS, then blocks
+// until shutdown or a fatal server error occurs.
+func Run(cfg *config.Config, opts RunOptions) error {
+	if cfg == nil {
+		return fmt.Errorf("config is nil")
+	}
+
+	effective := *cfg
+	if opts.ListenOverride != "" {
+		effective.RPC.Listen = opts.ListenOverride
+	}
+
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
+	label := opts.APILabel
+	if label == "" {
+		label = "malt daemon"
+	}
+
+	var (
+		nodeOpts    []api.Option
+		mockSrv     *casmock.HTTPServer
+		mockSrvErr  chan error
+		mockCASInst *casmock.CAS
+	)
+
+	if effective.CAS.Mode == "embedded-mock" {
+		mockOpts := []casmock.Option{}
+		if latency, err := effective.EmbeddedMockLatency(); err == nil && latency > 0 {
+			mockOpts = append(mockOpts,
+				casmock.WithGetLatency(latency),
+				casmock.WithPutLatency(latency),
+				casmock.WithHasLatency(latency),
+			)
+		}
+		mockCASInst = casmock.NewCAS(mockOpts...)
+		nodeOpts = append(nodeOpts, api.WithCAS(mockCASInst))
+		mockSrv = casmock.NewHTTPServer(effective.CAS.EmbeddedMock.Listen, mockCASInst)
+		mockSrvErr = make(chan error, 1)
+		go func() {
+			if err := mockSrv.Start(); err != nil && err != http.ErrServerClosed {
+				mockSrvErr <- err
+			}
+		}()
+	}
+
+	nodeOpts = append(nodeOpts, api.WithConfig(&effective))
+	node, err := api.NewNode(nodeOpts...)
+	if err != nil {
+		return err
+	}
+	defer node.Close()
+
+	srv := server.New(node, effective.RPC.Listen)
+	srvErr := make(chan error, 1)
+	go func() {
+		if err := srv.Start(); err != nil && err != http.ErrServerClosed {
+			srvErr <- err
+		}
+	}()
+
+	fmt.Fprintf(stdout, "%s listening on %s\n", label, effective.RPC.Listen)
+	if effective.CAS.Mode == "embedded-mock" {
+		fmt.Fprintf(stdout, "embedded mock CAS listening on %s\n", effective.CAS.EmbeddedMock.Listen)
+	}
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+
+	select {
+	case sig := <-stop:
+		fmt.Fprintf(stderr, "received signal %s, shutting down\n", sig)
+	case err := <-srvErr:
+		return fmt.Errorf("daemon server failed: %w", err)
+	case err := <-mockServerError(mockSrvErr):
+		return fmt.Errorf("embedded mock CAS failed: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if mockSrv != nil {
+		_ = mockSrv.Shutdown(ctx)
+	}
+	if err := srv.Shutdown(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func mockServerError(ch chan error) <-chan error {
+	if ch == nil {
+		empty := make(chan error)
+		return empty
+	}
+	return ch
+}

--- a/httpapi/types.go
+++ b/httpapi/types.go
@@ -14,7 +14,7 @@ type HealthResponse struct {
 // Graph describes graph metadata in daemon responses.
 type Graph struct {
 	ID        string `json:"id"`
-	Root      string `json:"root"`
+	Root      string `json:"root,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`
 	UpdatedAt string `json:"updated_at,omitempty"`
 	ArcCount  int    `json:"arc_count"`

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -125,13 +125,17 @@ func (s *Server) handleGraphCreateStructure(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	snapshot := arcset.NewSetFrom(parsedArcs)
+	snapshot, arcCount, err := buildCreateSnapshot(parsedArcs)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	root, err := g.Writer().CreateStructure(r.Context(), g.BucketId(), snapshot)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	if err := s.updateManagedGraphHead(r.Context(), graphID, root, countDefinedTargets(parsedArcs)); err != nil {
+	if err := s.updateManagedGraphHead(r.Context(), graphID, root, arcCount); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -270,7 +274,12 @@ func (s *Server) handleRootCreateStructure(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	root, err := g.Writer().CreateStructure(r.Context(), g.BucketId(), arcset.NewSetFrom(parsedArcs))
+	snapshot, _, err := buildCreateSnapshot(parsedArcs)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	root, err := g.Writer().CreateStructure(r.Context(), g.BucketId(), snapshot)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -539,6 +548,30 @@ func parseArcMap(raw map[string]string) (map[string]cid.Cid, error) {
 	return out, nil
 }
 
+func buildCreateSnapshot(arcs map[string]cid.Cid) (arcset.ArcSet, int, error) {
+	canonical := make(map[string]cid.Cid, len(arcs))
+	for rawPath, target := range arcs {
+		path := arcset.CanonicalizePath(rawPath)
+		if path.IsEmpty() {
+			return nil, 0, fmt.Errorf("path must not be empty")
+		}
+
+		if existing, ok := canonical[path.String()]; ok && !existing.Equals(target) {
+			return nil, 0, fmt.Errorf("duplicate canonical path %q in arcs", path.String())
+		}
+		canonical[path.String()] = target
+	}
+
+	arcCount := 0
+	for _, target := range canonical {
+		if target.Defined() {
+			arcCount++
+		}
+	}
+
+	return arcset.NewSetFrom(canonical), arcCount, nil
+}
+
 func decodeTargetCID(raw string) cid.Cid {
 	if raw == "" {
 		return cid.Undef
@@ -627,16 +660,6 @@ func nonEmpty(primary string, fallback string) string {
 		return primary
 	}
 	return fallback
-}
-
-func countDefinedTargets(arcs map[string]cid.Cid) int {
-	count := 0
-	for _, target := range arcs {
-		if target.Defined() {
-			count++
-		}
-	}
-	return count
 }
 
 func applyArcDelta(current int, op writer.ArcOp) int {

--- a/server/server.go
+++ b/server/server.go
@@ -221,9 +221,13 @@ func graphToResponse(meta *graph.GraphMeta) *httpapi.Graph {
 	if meta == nil {
 		return nil
 	}
+	root := ""
+	if meta.Root.Defined() {
+		root = meta.Root.String()
+	}
 	return &httpapi.Graph{
 		ID:        meta.ID,
-		Root:      meta.Root.String(),
+		Root:      root,
 		CreatedAt: meta.CreatedAt.Format(time.RFC3339),
 		UpdatedAt: meta.UpdatedAt.Format(time.RFC3339),
 		ArcCount:  meta.ArcCount,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -53,12 +54,23 @@ func TestServerHealthAndGraphLifecycle(t *testing.T) {
 		t.Fatalf("create graph status = %d, want %d", resp.StatusCode, http.StatusCreated)
 	}
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read graph response: %v", err)
+	}
+	if bytes.Contains(body, []byte(`"root":"b"`)) {
+		t.Fatalf("graph response leaked cid.Undef serialization: %s", string(body))
+	}
+
 	var graphResp httpapi.GraphResponse
-	if err := json.NewDecoder(resp.Body).Decode(&graphResp); err != nil {
+	if err := json.Unmarshal(body, &graphResp); err != nil {
 		t.Fatalf("decode graph response: %v", err)
 	}
 	if graphResp.Graph == nil || graphResp.Graph.ID != "demo" {
 		t.Fatalf("graph response = %+v, want id demo", graphResp.Graph)
+	}
+	if graphResp.Graph.Root != "" {
+		t.Fatalf("graph root = %q, want empty for undefined head", graphResp.Graph.Root)
 	}
 }
 
@@ -136,6 +148,65 @@ func TestServerRootCreateResolveAndVerify(t *testing.T) {
 	}
 	if !verifyResp.Valid {
 		t.Fatal("expected transcript verification to succeed")
+	}
+}
+
+func TestServerManagedGraphCreateCanonicalizesArcCount(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createGraphBody, err := json.Marshal(&httpapi.GraphCreateRequest{ID: "demo"})
+	if err != nil {
+		t.Fatalf("marshal create graph request: %v", err)
+	}
+	resp, err := http.Post(ts.URL+"/api/v1/graphs", "application/json", bytes.NewReader(createGraphBody))
+	if err != nil {
+		t.Fatalf("create graph request failed: %v", err)
+	}
+	resp.Body.Close()
+
+	target := fakeCIDString("canonical-target")
+	createStructureBody, err := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: map[string]string{
+			"foo/bar":   target,
+			"/foo//bar": target,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal create structure request: %v", err)
+	}
+
+	resp, err = http.Post(ts.URL+"/api/v1/graphs/demo/structure", "application/json", bytes.NewReader(createStructureBody))
+	if err != nil {
+		t.Fatalf("create structure request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create structure status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/graphs/demo")
+	if err != nil {
+		t.Fatalf("get graph request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get graph status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var graphResp httpapi.GraphResponse
+	if err := json.NewDecoder(resp.Body).Decode(&graphResp); err != nil {
+		t.Fatalf("decode graph response: %v", err)
+	}
+	if graphResp.Graph == nil {
+		t.Fatal("expected graph payload")
+	}
+	if graphResp.Graph.ArcCount != 1 {
+		t.Fatalf("graph arc_count = %d, want 1 after canonicalization", graphResp.Graph.ArcCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop serializing undefined managed graph heads as b
- canonicalize create-structure arc maps before counting managed graph metadata
- narrow runtime CAS dependencies to read-side interfaces and share daemon bootstrap between `malt daemon` and `cmd/gateway`

## Testing
- go test ./...
