### PR TITLE
feat: add client import workflow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,6 +28,10 @@ Current command model:
   - long-running local process
   - owns hot structure state
   - serves local HTTP/JSON API requests
+- `malt import`
+  - client-side orchestration for file and directory import
+  - uploads payload blocks to CAS
+  - then commits the resulting bindings through the daemon API
 - `malt ...`
   - thin client commands for inspection, mutation, and convenience workflows
 - `malt cas ...`
@@ -35,7 +39,7 @@ Current command model:
 
 Current code status:
 
-- `cmd/malt` now provides `malt init`, `malt daemon`, thin client graph/resolve/prove/update/verify/lineage commands, and `malt cas`
+- `cmd/malt` now provides `malt init`, `malt daemon`, thin client graph/import/resolve/prove/update/verify/lineage commands, and `malt cas`
 - `server/` provides the daemon HTTP server
 - `client/` provides the thin daemon HTTP client
 - `httpapi/` holds the shared `/api/v1` request/response model
@@ -201,6 +205,13 @@ Read path:
 
 This means MALT should not be framed primarily as a payload-upload proxy.
 Its core role is structure management, authenticated resolution, and proof generation.
+
+`malt import ...` does not change that boundary. It is only a client-side convenience
+workflow that performs:
+
+1. local file traversal
+2. direct payload upload to CAS
+3. follow-up structure attachment through the daemon
 
 ### Mock CAS Direction
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Current runtime shape:
 - `malt daemon`
   - long-running local process
   - owns hot proving/index state
+- `malt import`
+  - client-side workflow that uploads payload directly to CAS
+  - then attaches resulting `path -> CID` bindings to a graph or root through the daemon
 - `malt graph`, `malt resolve`, `malt prove`, `malt update`, `malt verify`, `malt lineage`
   - thin HTTP clients against the local daemon
 - `malt cas`
@@ -126,6 +129,12 @@ Recommended boundary:
 
 `malt cas ...` commands are still useful convenience tooling, but they should
 not be mistaken for the conceptual center of the system.
+
+`malt import ...` is therefore best understood as a client-side orchestration convenience:
+
+- payload publication still goes directly to CAS
+- structure attachment still goes through the daemon API
+- the command only hides that two-step interaction behind one local workflow
 
 ## Interoperability
 

--- a/cmd/malt/import.go
+++ b/cmd/malt/import.go
@@ -1,0 +1,370 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	daemonclient "github.com/dewebprotocol/malt/client"
+	"github.com/dewebprotocol/malt/httpapi"
+	cid "github.com/ipfs/go-cid"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(importCmd)
+	importCmd.AddCommand(importFileCmd)
+	importCmd.AddCommand(importDirCmd)
+
+	importCmd.PersistentFlags().StringVar(&importGraphID, "graph", "", "Import into a managed graph head (created automatically if missing)")
+	importCmd.PersistentFlags().StringVar(&importRootID, "root", "", "Import into an existing explicit root instead of creating a fresh root")
+}
+
+var (
+	importGraphID string
+	importRootID  string
+)
+
+var importCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Upload local payloads and attach them to MALT structure in one step",
+}
+
+var importFileCmd = &cobra.Command{
+	Use:   "file <local-path> [<malt-path>]",
+	Short: "Import one file into CAS and attach its CID to MALT",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE:  runImportFile,
+}
+
+var importDirCmd = &cobra.Command{
+	Use:   "dir <local-dir> [<malt-prefix>]",
+	Short: "Import a directory tree into CAS and attach relative paths to MALT",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE:  runImportDir,
+}
+
+type importEntry struct {
+	LocalPath string
+	MaltPath  string
+}
+
+type importTarget struct {
+	GraphID string
+	RootID  string
+}
+
+type importSummary struct {
+	Scope        string `json:"scope"`
+	Graph        string `json:"graph,omitempty"`
+	PreviousRoot string `json:"previous_root,omitempty"`
+	Root         string `json:"root"`
+	Files        int    `json:"files"`
+	Bytes        int64  `json:"bytes"`
+}
+
+type casUploader interface {
+	Put(ctx context.Context, data []byte) (cid.Cid, error)
+}
+
+type importBackend interface {
+	GetGraph(ctx context.Context, id string) (*httpapi.Graph, error)
+	CreateGraph(ctx context.Context, id string, backend string) (*httpapi.Graph, error)
+	CreateGraphStructure(ctx context.Context, id string, arcs map[string]string) (*httpapi.CreateStructureResponse, error)
+	BatchUpdateGraph(ctx context.Context, id string, updates map[string]string) (*httpapi.WriteBatchResponse, error)
+	CreateRootStructure(ctx context.Context, arcs map[string]string) (*httpapi.CreateStructureResponse, error)
+	BatchUpdateRoot(ctx context.Context, root string, updates map[string]string) (*httpapi.WriteBatchResponse, error)
+}
+
+func runImportFile(cmd *cobra.Command, args []string) error {
+	target := importTarget{GraphID: importGraphID, RootID: importRootID}
+	if err := validateImportTarget(target); err != nil {
+		return err
+	}
+
+	maltPath := ""
+	if len(args) > 1 {
+		maltPath = args[1]
+	}
+
+	entry, err := buildFileImportEntry(args[0], maltPath)
+	if err != nil {
+		return err
+	}
+	return runImport(cmd.Context(), []importEntry{entry}, target)
+}
+
+func runImportDir(cmd *cobra.Command, args []string) error {
+	target := importTarget{GraphID: importGraphID, RootID: importRootID}
+	if err := validateImportTarget(target); err != nil {
+		return err
+	}
+
+	prefix := ""
+	if len(args) > 1 {
+		prefix = args[1]
+	}
+
+	entries, err := buildDirectoryImportEntries(args[0], prefix)
+	if err != nil {
+		return err
+	}
+	return runImport(cmd.Context(), entries, target)
+}
+
+func runImport(ctx context.Context, entries []importEntry, target importTarget) error {
+	casClient, err := makeCASClient()
+	if err != nil {
+		return err
+	}
+	daemon := mustDaemonClient()
+
+	arcs, totalBytes, err := uploadImportEntries(ctx, casClient, entries)
+	if err != nil {
+		return err
+	}
+
+	result, err := applyImportedArcs(ctx, daemon, target, arcs)
+	if err != nil {
+		return daemonCommandError(err)
+	}
+
+	result.Files = len(entries)
+	result.Bytes = totalBytes
+	printJSON(result)
+
+	switch {
+	case result.Graph != "":
+		fmt.Fprintf(os.Stderr, "imported %d file(s) into graph %q\n", result.Files, result.Graph)
+	case result.PreviousRoot != "":
+		fmt.Fprintf(os.Stderr, "imported %d file(s) and advanced root\n", result.Files)
+	default:
+		fmt.Fprintf(os.Stderr, "imported %d file(s) into a fresh root\n", result.Files)
+	}
+	return nil
+}
+
+func validateImportTarget(target importTarget) error {
+	if target.GraphID != "" && target.RootID != "" {
+		return fmt.Errorf("--graph and --root are mutually exclusive")
+	}
+	return nil
+}
+
+func buildFileImportEntry(localPath string, overridePath string) (importEntry, error) {
+	info, err := os.Stat(localPath)
+	if err != nil {
+		return importEntry{}, fmt.Errorf("stat file: %w", err)
+	}
+	if info.IsDir() {
+		return importEntry{}, fmt.Errorf("%q is a directory; use `malt import dir`", localPath)
+	}
+	if !info.Mode().IsRegular() {
+		return importEntry{}, fmt.Errorf("%q is not a regular file", localPath)
+	}
+
+	targetPath := overridePath
+	if targetPath == "" {
+		targetPath = filepath.Base(localPath)
+	}
+	targetPath = normalizeImportPath(targetPath)
+	if targetPath == "" {
+		return importEntry{}, fmt.Errorf("malt path must not be empty")
+	}
+
+	absPath, err := filepath.Abs(localPath)
+	if err != nil {
+		return importEntry{}, fmt.Errorf("resolve file path: %w", err)
+	}
+
+	return importEntry{
+		LocalPath: absPath,
+		MaltPath:  targetPath,
+	}, nil
+}
+
+func buildDirectoryImportEntries(localDir string, prefix string) ([]importEntry, error) {
+	root, err := filepath.Abs(localDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve directory path: %w", err)
+	}
+
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("stat directory: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%q is not a directory", localDir)
+	}
+
+	entries := make([]importEntry, 0)
+	seen := make(map[string]string)
+	err = filepath.WalkDir(root, func(current string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			return fmt.Errorf("symlink import is not supported: %s", current)
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", current, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("non-regular file is not supported: %s", current)
+		}
+
+		rel, err := filepath.Rel(root, current)
+		if err != nil {
+			return fmt.Errorf("compute relative path for %s: %w", current, err)
+		}
+
+		maltPath := joinImportPath(prefix, rel)
+		if previous, ok := seen[maltPath]; ok {
+			return fmt.Errorf("duplicate import target path %q from %q and %q", maltPath, previous, current)
+		}
+		seen[maltPath] = current
+		entries = append(entries, importEntry{
+			LocalPath: current,
+			MaltPath:  maltPath,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("directory %q does not contain any regular files", localDir)
+	}
+
+	slices.SortFunc(entries, func(a, b importEntry) int {
+		return strings.Compare(a.MaltPath, b.MaltPath)
+	})
+	return entries, nil
+}
+
+func normalizeImportPath(raw string) string {
+	cleaned := strings.TrimSpace(raw)
+	cleaned = strings.ReplaceAll(cleaned, "\\", "/")
+	cleaned = path.Clean("/" + cleaned)
+	cleaned = strings.TrimPrefix(cleaned, "/")
+	if cleaned == "." {
+		return ""
+	}
+	return cleaned
+}
+
+func joinImportPath(prefix string, rel string) string {
+	normalizedRel := normalizeImportPath(filepath.ToSlash(rel))
+	if prefix == "" {
+		return normalizedRel
+	}
+	return normalizeImportPath(path.Join(prefix, normalizedRel))
+}
+
+func uploadImportEntries(ctx context.Context, casClient casUploader, entries []importEntry) (map[string]string, int64, error) {
+	arcs := make(map[string]string, len(entries))
+	var totalBytes int64
+
+	for _, entry := range entries {
+		data, err := os.ReadFile(entry.LocalPath)
+		if err != nil {
+			return nil, 0, fmt.Errorf("read %s: %w", entry.LocalPath, err)
+		}
+		blockCID, err := casClient.Put(ctx, data)
+		if err != nil {
+			return nil, 0, fmt.Errorf("upload %s to CAS: %w", entry.LocalPath, err)
+		}
+
+		if _, exists := arcs[entry.MaltPath]; exists {
+			return nil, 0, fmt.Errorf("duplicate imported arc path %q", entry.MaltPath)
+		}
+		arcs[entry.MaltPath] = blockCID.String()
+		totalBytes += int64(len(data))
+	}
+
+	return arcs, totalBytes, nil
+}
+
+func applyImportedArcs(ctx context.Context, daemon importBackend, target importTarget, arcs map[string]string) (*importSummary, error) {
+	if len(arcs) == 0 {
+		return nil, fmt.Errorf("import requires at least one arc")
+	}
+
+	if target.GraphID != "" {
+		return applyImportedGraphArcs(ctx, daemon, target.GraphID, arcs)
+	}
+	if target.RootID != "" {
+		resp, err := daemon.BatchUpdateRoot(ctx, target.RootID, arcs)
+		if err != nil {
+			return nil, err
+		}
+		return &importSummary{
+			Scope:        "root",
+			PreviousRoot: resp.OldRoot,
+			Root:         resp.NewRoot,
+		}, nil
+	}
+
+	resp, err := daemon.CreateRootStructure(ctx, arcs)
+	if err != nil {
+		return nil, err
+	}
+	return &importSummary{
+		Scope: "root",
+		Root:  resp.Root,
+	}, nil
+}
+
+func applyImportedGraphArcs(ctx context.Context, daemon importBackend, graphID string, arcs map[string]string) (*importSummary, error) {
+	meta, err := ensureImportGraph(ctx, daemon, graphID)
+	if err != nil {
+		return nil, err
+	}
+
+	if meta.Root == "" {
+		resp, err := daemon.CreateGraphStructure(ctx, graphID, arcs)
+		if err != nil {
+			return nil, err
+		}
+		return &importSummary{
+			Scope: "graph",
+			Graph: graphID,
+			Root:  resp.Root,
+		}, nil
+	}
+
+	resp, err := daemon.BatchUpdateGraph(ctx, graphID, arcs)
+	if err != nil {
+		return nil, err
+	}
+	return &importSummary{
+		Scope:        "graph",
+		Graph:        graphID,
+		PreviousRoot: resp.OldRoot,
+		Root:         resp.NewRoot,
+	}, nil
+}
+
+func ensureImportGraph(ctx context.Context, daemon importBackend, graphID string) (*httpapi.Graph, error) {
+	meta, err := daemon.GetGraph(ctx, graphID)
+	if err == nil {
+		return meta, nil
+	}
+
+	var apiErr *daemonclient.Error
+	if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+		return daemon.CreateGraph(ctx, graphID, "")
+	}
+	return nil, err
+}

--- a/cmd/malt/import_test.go
+++ b/cmd/malt/import_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	daemonclient "github.com/dewebprotocol/malt/client"
+	"github.com/dewebprotocol/malt/config"
+	"github.com/dewebprotocol/malt/core/api"
+	"github.com/dewebprotocol/malt/core/cas/ipfs"
+	casmock "github.com/dewebprotocol/malt/core/cas/mock"
+	"github.com/dewebprotocol/malt/server"
+)
+
+func TestBuildFileImportEntryDefaultsToBaseName(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "hello.txt")
+	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	entry, err := buildFileImportEntry(file, "")
+	if err != nil {
+		t.Fatalf("build file entry: %v", err)
+	}
+	if entry.MaltPath != "hello.txt" {
+		t.Fatalf("malt path = %q, want %q", entry.MaltPath, "hello.txt")
+	}
+}
+
+func TestBuildDirectoryImportEntriesPreservesRelativePaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs", "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "readme.md"), []byte("readme"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "nested", "note.txt"), []byte("note"), 0o644); err != nil {
+		t.Fatalf("write note: %v", err)
+	}
+
+	entries, err := buildDirectoryImportEntries(root, "repo")
+	if err != nil {
+		t.Fatalf("build directory entries: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("entry count = %d, want 2", len(entries))
+	}
+	if entries[0].MaltPath != "repo/docs/nested/note.txt" {
+		t.Fatalf("entries[0].MaltPath = %q", entries[0].MaltPath)
+	}
+	if entries[1].MaltPath != "repo/docs/readme.md" {
+		t.Fatalf("entries[1].MaltPath = %q", entries[1].MaltPath)
+	}
+}
+
+func TestImportWorkflowUploadsDirectoryAndCreatesGraph(t *testing.T) {
+	ctx := context.Background()
+	daemon := newImportTestDaemonClient(t)
+	casClient := newImportTestCASClient(t)
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("malt"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "main.go"), []byte("package main"), 0o644); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+
+	entries, err := buildDirectoryImportEntries(root, "repo")
+	if err != nil {
+		t.Fatalf("build directory entries: %v", err)
+	}
+
+	arcs, totalBytes, err := uploadImportEntries(ctx, casClient, entries)
+	if err != nil {
+		t.Fatalf("upload entries: %v", err)
+	}
+	if len(arcs) != 2 {
+		t.Fatalf("arc count = %d, want 2", len(arcs))
+	}
+	if totalBytes <= 0 {
+		t.Fatalf("total bytes = %d, want > 0", totalBytes)
+	}
+
+	result, err := applyImportedArcs(ctx, daemon, importTarget{GraphID: "demo"}, arcs)
+	if err != nil {
+		t.Fatalf("apply imported arcs: %v", err)
+	}
+	if result.Graph != "demo" {
+		t.Fatalf("result.Graph = %q, want %q", result.Graph, "demo")
+	}
+	if result.Root == "" {
+		t.Fatal("expected non-empty graph root")
+	}
+
+	meta, err := daemon.GetGraph(ctx, "demo")
+	if err != nil {
+		t.Fatalf("get graph: %v", err)
+	}
+	if meta.Root != result.Root {
+		t.Fatalf("graph root = %q, want %q", meta.Root, result.Root)
+	}
+	if meta.ArcCount != 2 {
+		t.Fatalf("graph arc_count = %d, want 2", meta.ArcCount)
+	}
+
+	resolveResp, err := daemon.ResolveGraph(ctx, "demo", "repo/src/main.go")
+	if err != nil {
+		t.Fatalf("resolve graph path: %v", err)
+	}
+	if resolveResp.Target != arcs["repo/src/main.go"] {
+		t.Fatalf("resolved target = %q, want %q", resolveResp.Target, arcs["repo/src/main.go"])
+	}
+}
+
+func newImportTestDaemonClient(t *testing.T) *daemonclient.Client {
+	t.Helper()
+
+	cfg := config.DefaultConfig()
+	cfg.State.RootDir = t.TempDir()
+	cfg.State.KVStore.Type = "memory"
+	cfg.CAS.Mode = "mock"
+
+	node, err := api.NewNode(api.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = node.Close()
+	})
+
+	ts := httptest.NewServer(server.New(node, "127.0.0.1:0").Handler())
+	t.Cleanup(ts.Close)
+	return daemonclient.NewWithBaseURL(ts.URL + "/api/v1")
+}
+
+func newImportTestCASClient(t *testing.T) *ipfs.Client {
+	t.Helper()
+
+	mockCAS := casmock.NewCAS()
+	mockHTTP := casmock.NewHTTPServer("127.0.0.1:0", mockCAS)
+	ts := httptest.NewServer(mockHTTP.Handler())
+	t.Cleanup(ts.Close)
+	return ipfs.NewClient(ts.URL)
+}

--- a/cmd/malt/main.go
+++ b/cmd/malt/main.go
@@ -38,6 +38,7 @@ Primary commands:
   init        Create ~/.malt/malt.json and choose local state paths
   daemon      Run the local MALT daemon
   graph       Managed graph lifecycle operations via the daemon
+  import      Upload local files to CAS and attach them to MALT
   resolve     Resolve a path via the daemon
   update      Mutate structure via the daemon
   prove       Resolve and print transcript evidence via the daemon


### PR DESCRIPTION
## Summary
- add `malt import file` and `malt import dir` to hide the two-step CAS + daemon interaction
- auto-create a managed graph on first import, or attach to an existing graph/root
- add import workflow tests and update CLI/runtime docs

## Testing
- go test ./...
