### PR TITLE
refactor: canonicalize arcset inputs

### DIFF
--- a/core/arctable/arctable.go
+++ b/core/arctable/arctable.go
@@ -29,12 +29,12 @@ type ArcTable interface {
 	// For overwrite ArcTable: root is optional (cid.Undef skips validation).
 	// For versioned ArcTable: root is the version to start the chain lookup.
 	// Returns ErrNotFound if not found.
-	Get(ctx context.Context, bucketId string, root cid.Cid, path string) (cid.Cid, error)
+	Get(ctx context.Context, bucketId string, root cid.Cid, path arcset.Path) (cid.Cid, error)
 
 	// BatchGet retrieves multiple target CIDs in a single operation.
 	// Returns a map of path -> CID for paths that were found.
 	// Paths not found are omitted from the result map (no error).
-	BatchGet(ctx context.Context, bucketId string, root cid.Cid, paths []string) (map[string]cid.Cid, error)
+	BatchGet(ctx context.Context, bucketId string, root cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error)
 
 	// Update stores arc entries with a new commitment root.
 	// bucketId is the namespace for the arc set.
@@ -42,7 +42,7 @@ type ArcTable interface {
 	// For versioned ArcTable: newRoot is linked to parentRoot via @previous.
 	// Use cid.Undef for oldRoot/parentRoot for the first version.
 	// If a target CID is cid.Undef, the corresponding arc is deleted.
-	Update(ctx context.Context, bucketId string, newRoot, oldRoot cid.Cid, arcs map[string]cid.Cid) error
+	Update(ctx context.Context, bucketId string, newRoot, oldRoot cid.Cid, arcs arcset.ArcSet) error
 
 	// Snapshot returns an immutable snapshot of all arcs for a given root.
 	// The snapshot preloads all data into memory, suitable for random access.

--- a/core/arctable/common.go
+++ b/core/arctable/common.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/dewebprotocol/malt/core/arctable/bloom"
+	"github.com/dewebprotocol/malt/core/types/arcset"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -99,9 +100,9 @@ func (bfm *BloomFilterManager) GetBloomCache() *bloom.BloomCache {
 
 // DefaultArcKey generates the standard arc key format.
 // Used by overwrite ArcTable implementation.
-func DefaultArcKey(bucketId, path string) []byte {
+func DefaultArcKey(bucketId string, path arcset.Path) []byte {
 	// Format: bucketId:path
-	return []byte(bucketId + ":" + path)
+	return []byte(bucketId + ":" + path.String())
 }
 
 // DefaultBucketPrefix generates the standard bucket prefix format.
@@ -113,9 +114,9 @@ func DefaultBucketPrefix(bucketId string) []byte {
 
 // VersionedArcKey generates a versioned arc key format.
 // Used by versioned ArcTable implementation to include version information.
-func VersionedArcKey(bucketId string, version cid.Cid, path string) []byte {
+func VersionedArcKey(bucketId string, version cid.Cid, path arcset.Path) []byte {
 	// Format: bucketId:version:path
-	return []byte(bucketId + ":" + version.String() + ":" + path)
+	return []byte(bucketId + ":" + version.String() + ":" + path.String())
 }
 
 // VersionedBucketPrefix generates a versioned bucket prefix format.

--- a/core/arctable/overwrite/arctable.go
+++ b/core/arctable/overwrite/arctable.go
@@ -74,16 +74,16 @@ func (e *ArcTable) CreateBucket(ctx context.Context, bucketId string, cfg *bloom
 // MightContain checks if a path might exist in the bucket using bloom filter.
 // Returns false if the path definitely doesn't exist (can skip KVStore lookup).
 // Returns true if the path might exist (need to call Get to verify).
-func (e *ArcTable) MightContain(ctx context.Context, bucketId string, path string) bool {
+func (e *ArcTable) MightContain(ctx context.Context, bucketId string, path arcset.Path) bool {
 	if !e.bloomManager.Enabled() {
 		return true // Bloom disabled
 	}
-	return e.bloomManager.MightContain(bucketId, path)
+	return e.bloomManager.MightContain(bucketId, path.String())
 }
 
 // MightContainBatch checks multiple paths at once using bloom filter.
-func (e *ArcTable) MightContainBatch(ctx context.Context, bucketId string, paths []string) map[string]bool {
-	result := make(map[string]bool, len(paths))
+func (e *ArcTable) MightContainBatch(ctx context.Context, bucketId string, paths []arcset.Path) map[arcset.Path]bool {
+	result := make(map[arcset.Path]bool, len(paths))
 
 	if !e.bloomManager.Enabled() {
 		for _, p := range paths {
@@ -92,7 +92,11 @@ func (e *ArcTable) MightContainBatch(ctx context.Context, bucketId string, paths
 		return result
 	}
 
-	batchResult, err := e.bloomManager.MightContainBatch(ctx, bucketId, paths)
+	pathStrings := make([]string, len(paths))
+	for i, path := range paths {
+		pathStrings[i] = path.String()
+	}
+	batchResult, err := e.bloomManager.MightContainBatch(ctx, bucketId, pathStrings)
 	if err != nil {
 		for _, p := range paths {
 			result[p] = true
@@ -100,24 +104,27 @@ func (e *ArcTable) MightContainBatch(ctx context.Context, bucketId string, paths
 		return result
 	}
 
-	return batchResult
+	for _, path := range paths {
+		result[path] = batchResult[path.String()]
+	}
+	return result
 }
 
 // Get retrieves the target CID for a path within a bucket.
 // First checks bloom filter, then queries KVStore.
-func (e *ArcTable) Get(ctx context.Context, bucketId string, root cid.Cid, path string) (cid.Cid, error) {
+func (e *ArcTable) Get(ctx context.Context, bucketId string, root cid.Cid, path arcset.Path) (cid.Cid, error) {
 	start := time.Now()
 
 	logger.Debug("ArcTable.Get started",
 		logger.String("bucket", bucketId),
 		logger.String("root", root.String()),
-		logger.String("path", path))
+		logger.String("path", path.String()))
 
 	// Quick bloom filter check
 	if !e.MightContain(ctx, bucketId, path) {
 		logger.Debug("ArcTable.Get bloom negative",
 			logger.String("bucket", bucketId),
-			logger.String("path", path))
+			logger.String("path", path.String()))
 		return cid.Cid{}, arcset.ErrNotFound
 	}
 
@@ -156,12 +163,12 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, root cid.Cid, path 
 		if err == kvstore.ErrNotFound {
 			logger.Debug("ArcTable.Get arc not found",
 				logger.String("bucket", bucketId),
-				logger.String("path", path))
+				logger.String("path", path.String()))
 			return cid.Cid{}, arcset.ErrNotFound
 		}
 		logger.Error("ArcTable.Get failed to get arc",
 			logger.String("bucket", bucketId),
-			logger.String("path", path),
+			logger.String("path", path.String()),
 			logger.Err(err))
 		return cid.Cid{}, fmt.Errorf("failed to get arc: %w", err)
 	}
@@ -170,7 +177,7 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, root cid.Cid, path 
 	if err == nil {
 		logger.Debug("ArcTable.Get success",
 			logger.String("bucket", bucketId),
-			logger.String("path", path),
+			logger.String("path", path.String()),
 			logger.String("target", result.String()),
 			logger.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000))
 	}
@@ -179,7 +186,7 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, root cid.Cid, path 
 
 // BatchGet retrieves multiple target CIDs in a single operation.
 // Uses bloom filter to filter out definitely-not-present paths.
-func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, root cid.Cid, paths []string) (map[string]cid.Cid, error) {
+func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, root cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error) {
 	start := time.Now()
 
 	logger.Debug("ArcTable.BatchGet started",
@@ -189,7 +196,7 @@ func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, root cid.Cid, 
 
 	// Filter paths using bloom filter
 	mightExist := e.MightContainBatch(ctx, bucketId, paths)
-	filteredPaths := make([]string, 0, len(paths))
+	filteredPaths := make([]arcset.Path, 0, len(paths))
 	for _, p := range paths {
 		if mightExist[p] {
 			filteredPaths = append(filteredPaths, p)
@@ -199,7 +206,7 @@ func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, root cid.Cid, 
 	if len(filteredPaths) == 0 {
 		logger.Debug("ArcTable.BatchGet all filtered by bloom",
 			logger.String("bucket", bucketId))
-		return map[string]cid.Cid{}, nil
+		return map[arcset.Path]cid.Cid{}, nil
 	}
 
 	// Validate root if provided
@@ -230,7 +237,7 @@ func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, root cid.Cid, 
 
 	// Build keys for batch get
 	keys := make([][]byte, len(filteredPaths))
-	pathToKey := make(map[string]string, len(filteredPaths))
+	pathToKey := make(map[string]arcset.Path, len(filteredPaths))
 	for i, path := range filteredPaths {
 		key := arctable.DefaultArcKey(bucketId, path)
 		keys[i] = key
@@ -247,7 +254,7 @@ func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, root cid.Cid, 
 	}
 
 	// Convert results to CID map
-	results := make(map[string]cid.Cid)
+	results := make(map[arcset.Path]cid.Cid)
 	for keyStr, val := range kvResults {
 		path := pathToKey[keyStr]
 		if c, err := cid.Cast(val); err == nil {
@@ -267,14 +274,18 @@ func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, root cid.Cid, 
 
 // Update stores arc entries with a new commitment root.
 // Updates the bucket bloom filter incrementally.
-func (e *ArcTable) Update(ctx context.Context, bucketId string, newRoot, oldRoot cid.Cid, arcs map[string]cid.Cid) error {
+func (e *ArcTable) Update(ctx context.Context, bucketId string, newRoot, oldRoot cid.Cid, arcs arcset.ArcSet) error {
+	arcMap, err := arcset.ToPathMap(arcs)
+	if err != nil {
+		return err
+	}
 	start := time.Now()
 
 	logger.Info("ArcTable.Update started",
 		logger.String("bucket", bucketId),
 		logger.String("new_root", newRoot.String()),
 		logger.String("old_root", oldRoot.String()),
-		logger.Int("arc_count", len(arcs)))
+		logger.Int("arc_count", len(arcMap)))
 
 	batch := e.kv.Batch()
 
@@ -308,7 +319,7 @@ func (e *ArcTable) Update(ctx context.Context, bucketId string, newRoot, oldRoot
 	var addedPaths []string
 
 	// Add/Update/Delete arcs
-	for path, target := range arcs {
+	for path, target := range arcMap {
 		key := arctable.DefaultArcKey(bucketId, path)
 		if target == cid.Undef {
 			// Delete the arc
@@ -316,21 +327,21 @@ func (e *ArcTable) Update(ctx context.Context, bucketId string, newRoot, oldRoot
 				batch.Cancel()
 				logger.Error("ArcTable.Update failed to delete arc",
 					logger.String("bucket", bucketId),
-					logger.String("path", path),
+					logger.String("path", path.String()),
 					logger.Err(err))
-				return fmt.Errorf("failed to delete arc %s: %w", path, err)
+				return fmt.Errorf("failed to delete arc %s: %w", path.String(), err)
 			}
 		} else {
-			addedPaths = append(addedPaths, path)
+			addedPaths = append(addedPaths, path.String())
 			// Add/Update the arc
 			val := target.Bytes()
 			if err := batch.Put(key, val); err != nil {
 				batch.Cancel()
 				logger.Error("ArcTable.Update failed to put arc",
 					logger.String("bucket", bucketId),
-					logger.String("path", path),
+					logger.String("path", path.String()),
 					logger.Err(err))
-				return fmt.Errorf("failed to put arc %s: %w", path, err)
+				return fmt.Errorf("failed to put arc %s: %w", path.String(), err)
 			}
 		}
 	}
@@ -355,7 +366,7 @@ func (e *ArcTable) Update(ctx context.Context, bucketId string, newRoot, oldRoot
 	logger.Info("ArcTable.Update completed",
 		logger.String("bucket", bucketId),
 		logger.String("new_root", newRoot.String()),
-		logger.Int("arc_count", len(arcs)),
+		logger.Int("arc_count", len(arcMap)),
 		logger.Int("added_count", len(addedPaths)),
 		logger.Bool("invalidated_old_root", oldRoot != cid.Undef),
 		logger.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000))
@@ -393,7 +404,11 @@ func (e *ArcTable) Snapshot(ctx context.Context, bucketId string, root cid.Cid) 
 		return nil, fmt.Errorf("iterator error: %w", err)
 	}
 
-	return arcset.NewSetFrom(arcs), nil
+	snapshot, err := arcset.NewArcSet(arcs)
+	if err != nil {
+		return nil, err
+	}
+	return snapshot, nil
 }
 
 // Iterate returns a streaming iterator over all arcs in the bucket.

--- a/core/arctable/overwrite/arctable_test.go
+++ b/core/arctable/overwrite/arctable_test.go
@@ -20,6 +20,14 @@ func newTestCID(data []byte) cid.Cid {
 	return cid.NewCidV1(cid.Raw, mhash)
 }
 
+func testPathSlice(paths []string) []arcset.Path {
+	out := make([]arcset.Path, len(paths))
+	for i, path := range paths {
+		out[i] = arcset.CanonicalizePath(path)
+	}
+	return out
+}
+
 // === ArcTable Tests ===
 
 func TestArcTableNew(t *testing.T) {
@@ -60,13 +68,13 @@ func TestArcTableUpdateAndGet(t *testing.T) {
 		"a": target1,
 		"b": target2,
 	}
-	err = arctable.Update(ctx, bucketId, root1, cid.Undef, arcs1)
+	err = arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(arcs1))
 	if err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
 
 	// Get via root1
-	got, err := arctable.Get(ctx, bucketId, root1, "a")
+	got, err := arctable.Get(ctx, bucketId, root1, arcset.CanonicalizePath("a"))
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
@@ -74,7 +82,7 @@ func TestArcTableUpdateAndGet(t *testing.T) {
 		t.Error("wrong value for 'a'")
 	}
 
-	got, err = arctable.Get(ctx, bucketId, root1, "b")
+	got, err = arctable.Get(ctx, bucketId, root1, arcset.CanonicalizePath("b"))
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
@@ -88,13 +96,13 @@ func TestArcTableUpdateAndGet(t *testing.T) {
 		"a": target3, // overwrite
 		"c": target3, // new
 	}
-	err = arctable.Update(ctx, bucketId, root2, root1, arcs2)
+	err = arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(arcs2))
 	if err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
 
 	// Get via root2 should work
-	got, err = arctable.Get(ctx, bucketId, root2, "a")
+	got, err = arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("a"))
 	if err != nil {
 		t.Fatalf("Get via root2 failed: %v", err)
 	}
@@ -102,7 +110,7 @@ func TestArcTableUpdateAndGet(t *testing.T) {
 		t.Error("wrong value for 'a' via root2")
 	}
 
-	got, err = arctable.Get(ctx, bucketId, root2, "b")
+	got, err = arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("b"))
 	if err != nil {
 		t.Fatalf("Get b via root2 failed: %v", err)
 	}
@@ -110,7 +118,7 @@ func TestArcTableUpdateAndGet(t *testing.T) {
 		t.Error("'b' should still be target2")
 	}
 
-	got, err = arctable.Get(ctx, bucketId, root2, "c")
+	got, err = arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("c"))
 	if err != nil {
 		t.Fatalf("Get c via root2 failed: %v", err)
 	}
@@ -119,7 +127,7 @@ func TestArcTableUpdateAndGet(t *testing.T) {
 	}
 
 	// Old root1 should no longer work
-	_, err = arctable.Get(ctx, bucketId, root1, "a")
+	_, err = arctable.Get(ctx, bucketId, root1, arcset.CanonicalizePath("a"))
 	if err == nil {
 		t.Error("old root should no longer work after update")
 	}
@@ -138,10 +146,10 @@ func TestArcTableGetWithoutRoot(t *testing.T) {
 	target := newTestCID([]byte("target"))
 
 	// Store arc
-	arctable.Update(ctx, bucketId, root, cid.Undef, map[string]cid.Cid{"a": target})
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"a": target}))
 
 	// Get with root validation
-	got, err := arctable.Get(ctx, bucketId, root, "a")
+	got, err := arctable.Get(ctx, bucketId, root, arcset.CanonicalizePath("a"))
 	if err != nil {
 		t.Fatalf("Get with root failed: %v", err)
 	}
@@ -150,7 +158,7 @@ func TestArcTableGetWithoutRoot(t *testing.T) {
 	}
 
 	// Get without root validation (root = cid.Undef)
-	got, err = arctable.Get(ctx, bucketId, cid.Undef, "a")
+	got, err = arctable.Get(ctx, bucketId, cid.Undef, arcset.CanonicalizePath("a"))
 	if err != nil {
 		t.Fatalf("Get without root failed: %v", err)
 	}
@@ -173,27 +181,27 @@ func TestArcTableDeleteViaUpdate(t *testing.T) {
 	target := newTestCID([]byte("target"))
 
 	// Setup
-	arctable.Update(ctx, bucketId, root1, cid.Undef, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target,
 		"b": target,
-	})
+	}))
 
 	// Delete 'a' using cid.Undef
-	err = arctable.Update(ctx, bucketId, root2, root1, map[string]cid.Cid{
+	err = arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": cid.Undef, // delete
-	})
+	}))
 	if err != nil {
 		t.Fatalf("Update with delete failed: %v", err)
 	}
 
 	// 'a' should be gone
-	_, err = arctable.Get(ctx, bucketId, root2, "a")
+	_, err = arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("a"))
 	if err == nil {
 		t.Error("'a' should be deleted")
 	}
 
 	// 'b' should still exist
-	got, err := arctable.Get(ctx, bucketId, root2, "b")
+	got, err := arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("b"))
 	if err != nil {
 		t.Fatalf("Get b failed: %v", err)
 	}
@@ -215,10 +223,10 @@ func TestArcTableSnapshot(t *testing.T) {
 	target1 := newTestCID([]byte("target1"))
 	target2 := newTestCID([]byte("target2"))
 
-	arctable.Update(ctx, bucketId, root, cid.Undef, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target1,
 		"b": target2,
-	})
+	}))
 
 	snapshot, err := arctable.Snapshot(ctx, bucketId, root)
 	if err != nil {
@@ -261,10 +269,10 @@ func TestArcTableIterate(t *testing.T) {
 	target1 := newTestCID([]byte("target1"))
 	target2 := newTestCID([]byte("target2"))
 
-	arctable.Update(ctx, bucketId, root, cid.Undef, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target1,
 		"b": target2,
-	})
+	}))
 
 	iter := arctable.Iterate(ctx, bucketId, root)
 	defer iter.Close()
@@ -298,12 +306,12 @@ func TestArcTableMultipleBuckets(t *testing.T) {
 	target2 := newTestCID([]byte("target2"))
 
 	// Same path, different buckets
-	arctable.Update(ctx, "bucket1", root1, cid.Undef, map[string]cid.Cid{"key": target1})
-	arctable.Update(ctx, "bucket2", root2, cid.Undef, map[string]cid.Cid{"key": target2})
+	arctable.Update(ctx, "bucket1", root1, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"key": target1}))
+	arctable.Update(ctx, "bucket2", root2, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"key": target2}))
 
 	// Should be independent
-	got1, _ := arctable.Get(ctx, "bucket1", root1, "key")
-	got2, _ := arctable.Get(ctx, "bucket2", root2, "key")
+	got1, _ := arctable.Get(ctx, "bucket1", root1, arcset.CanonicalizePath("key"))
+	got2, _ := arctable.Get(ctx, "bucket2", root2, arcset.CanonicalizePath("key"))
 
 	if got1.Equals(got2) {
 		t.Error("different buckets should have independent values")
@@ -349,14 +357,14 @@ func TestArcTableBatchGet(t *testing.T) {
 	target3 := newTestCID([]byte("target3"))
 
 	// Setup arcs
-	arctable.Update(ctx, bucketId, root, cid.Undef, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target1,
 		"b": target2,
 		"c": target3,
-	})
+	}))
 
 	// Test: all paths found
-	results, err := arctable.BatchGet(ctx, bucketId, root, []string{"a", "b", "c"})
+	results, err := arctable.BatchGet(ctx, bucketId, root, testPathSlice([]string{"a", "b", "c"}))
 	if err != nil {
 		t.Fatalf("BatchGet failed: %v", err)
 	}
@@ -374,7 +382,7 @@ func TestArcTableBatchGet(t *testing.T) {
 	}
 
 	// Test: some paths not found
-	results, err = arctable.BatchGet(ctx, bucketId, root, []string{"a", "notexist", "b"})
+	results, err = arctable.BatchGet(ctx, bucketId, root, testPathSlice([]string{"a", "notexist", "b"}))
 	if err != nil {
 		t.Fatalf("BatchGet with missing paths failed: %v", err)
 	}
@@ -386,7 +394,7 @@ func TestArcTableBatchGet(t *testing.T) {
 	}
 
 	// Test: empty paths
-	results, err = arctable.BatchGet(ctx, bucketId, root, []string{})
+	results, err = arctable.BatchGet(ctx, bucketId, root, testPathSlice([]string{}))
 	if err != nil {
 		t.Fatalf("BatchGet with empty paths failed: %v", err)
 	}
@@ -395,7 +403,7 @@ func TestArcTableBatchGet(t *testing.T) {
 	}
 
 	// Test: all paths not found
-	results, err = arctable.BatchGet(ctx, bucketId, root, []string{"x", "y", "z"})
+	results, err = arctable.BatchGet(ctx, bucketId, root, testPathSlice([]string{"x", "y", "z"}))
 	if err != nil {
 		t.Fatalf("BatchGet with all missing paths failed: %v", err)
 	}
@@ -404,7 +412,7 @@ func TestArcTableBatchGet(t *testing.T) {
 	}
 
 	// Test: without root validation
-	results, err = arctable.BatchGet(ctx, bucketId, cid.Undef, []string{"a", "b"})
+	results, err = arctable.BatchGet(ctx, bucketId, cid.Undef, testPathSlice([]string{"a", "b"}))
 	if err != nil {
 		t.Fatalf("BatchGet without root failed: %v", err)
 	}
@@ -414,7 +422,7 @@ func TestArcTableBatchGet(t *testing.T) {
 
 	// Test: invalid root
 	invalidRoot := newTestCID([]byte("invalid"))
-	results, err = arctable.BatchGet(ctx, bucketId, invalidRoot, []string{"a", "b"})
+	results, err = arctable.BatchGet(ctx, bucketId, invalidRoot, testPathSlice([]string{"a", "b"}))
 	if err == nil {
 		t.Error("expected error for invalid root")
 	}
@@ -436,19 +444,19 @@ func TestArcTableBatchGetAfterUpdate(t *testing.T) {
 	target3 := newTestCID([]byte("target3"))
 
 	// First version
-	arctable.Update(ctx, bucketId, root1, cid.Undef, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target1,
 		"b": target2,
-	})
+	}))
 
 	// Second version (overwrites 'a', adds 'c')
-	arctable.Update(ctx, bucketId, root2, root1, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target3,
 		"c": target3,
-	})
+	}))
 
 	// BatchGet with root2 should see updated values
-	results, err := arctable.BatchGet(ctx, bucketId, root2, []string{"a", "b", "c"})
+	results, err := arctable.BatchGet(ctx, bucketId, root2, testPathSlice([]string{"a", "b", "c"}))
 	if err != nil {
 		t.Fatalf("BatchGet root2 failed: %v", err)
 	}
@@ -466,7 +474,7 @@ func TestArcTableBatchGetAfterUpdate(t *testing.T) {
 	}
 
 	// BatchGet with old root1 should fail
-	results, err = arctable.BatchGet(ctx, bucketId, root1, []string{"a"})
+	results, err = arctable.BatchGet(ctx, bucketId, root1, testPathSlice([]string{"a"}))
 	if err == nil {
 		t.Error("old root should not work after update")
 	}
@@ -486,20 +494,20 @@ func TestArcTableBatchGetAfterDelete(t *testing.T) {
 	target := newTestCID([]byte("target"))
 
 	// Setup
-	arctable.Update(ctx, bucketId, root1, cid.Undef, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target,
 		"b": target,
 		"c": target,
-	})
+	}))
 
 	// Delete 'a' and 'b'
-	arctable.Update(ctx, bucketId, root2, root1, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": cid.Undef,
 		"b": cid.Undef,
-	})
+	}))
 
 	// BatchGet should only return 'c'
-	results, err := arctable.BatchGet(ctx, bucketId, root2, []string{"a", "b", "c"})
+	results, err := arctable.BatchGet(ctx, bucketId, root2, testPathSlice([]string{"a", "b", "c"}))
 	if err != nil {
 		t.Fatalf("BatchGet after delete failed: %v", err)
 	}
@@ -530,7 +538,7 @@ func TestArcTableBatchUpdate(t *testing.T) {
 		arcs1[path] = newTestCID([]byte(path))
 	}
 
-	err = arctable.Update(ctx, bucketId, root1, cid.Undef, arcs1)
+	err = arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(arcs1))
 	if err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
@@ -550,7 +558,7 @@ func TestArcTableBatchUpdate(t *testing.T) {
 		arcs2[path] = newTestCID([]byte("new_" + path))
 	}
 
-	err = arctable.Update(ctx, bucketId, root2, root1, arcs2)
+	err = arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(arcs2))
 	if err != nil {
 		t.Fatalf("Update 2 failed: %v", err)
 	}
@@ -565,13 +573,13 @@ func TestArcTableBatchUpdate(t *testing.T) {
 	}
 
 	// Verify old root doesn't work
-	_, err = arctable.Get(ctx, bucketId, root1, "arc0")
+	_, err = arctable.Get(ctx, bucketId, root1, arcset.CanonicalizePath("arc0"))
 	if err == nil {
 		t.Error("old root should not work")
 	}
 
 	// Verify new root works
-	got, err := arctable.Get(ctx, bucketId, root2, "arc0")
+	got, err := arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("arc0"))
 	if err != nil {
 		t.Fatalf("Get arc0 via root2 failed: %v", err)
 	}
@@ -581,7 +589,7 @@ func TestArcTableBatchUpdate(t *testing.T) {
 	}
 
 	// arc50 should have new value
-	got, err = arctable.Get(ctx, bucketId, root2, "arc50")
+	got, err = arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("arc50"))
 	if err != nil {
 		t.Fatalf("Get arc50 via root2 failed: %v", err)
 	}
@@ -615,16 +623,16 @@ func TestArcTableWithBloomCache(t *testing.T) {
 	}
 
 	// Add arc
-	arctable.Update(ctx, bucketId, root, cid.Undef, map[string]cid.Cid{"path/a": target})
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"path/a": target}))
 
 	// MightContain should return true for existing path
-	if !arctable.MightContain(ctx, bucketId, "path/a") {
+	if !arctable.MightContain(ctx, bucketId, arcset.CanonicalizePath("path/a")) {
 		t.Error("MightContain should return true for existing path")
 	}
 
 	// MightContain may return true or false for non-existing path
 	// (bloom filter allows false positives)
-	_ = arctable.MightContain(ctx, bucketId, "nonexistent/path")
+	_ = arctable.MightContain(ctx, bucketId, arcset.CanonicalizePath("nonexistent/path"))
 }
 
 func TestArcTableMightContainBatch(t *testing.T) {
@@ -646,17 +654,17 @@ func TestArcTableMightContainBatch(t *testing.T) {
 	for _, p := range paths {
 		arcs[p] = target
 	}
-	arctable.Update(ctx, bucketId, root, cid.Undef, arcs)
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(arcs))
 
 	// Batch check
-	results := arctable.MightContainBatch(ctx, bucketId, []string{"a", "b", "c", "nonexistent"})
+	results := arctable.MightContainBatch(ctx, bucketId, testPathSlice([]string{"a", "b", "c", "nonexistent"}))
 	if len(results) != 4 {
 		t.Errorf("expected 4 results, got %d", len(results))
 	}
 
 	// Existing paths should return true
 	for _, p := range paths {
-		if !results[p] {
+		if !results[arcset.CanonicalizePath(p)] {
 			t.Errorf("expected true for %s", p)
 		}
 	}
@@ -677,10 +685,10 @@ func TestArcTableBloomFilterOptimization(t *testing.T) {
 	arctable.CreateBucket(ctx, bucketId, nil)
 
 	// Add arcs
-	arctable.Update(ctx, bucketId, root, cid.Undef, map[string]cid.Cid{"existing": target})
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"existing": target}))
 
 	// Get for existing path should work
-	got, err := arctable.Get(ctx, bucketId, root, "existing")
+	got, err := arctable.Get(ctx, bucketId, root, arcset.CanonicalizePath("existing"))
 	if err != nil {
 		t.Fatalf("Get existing failed: %v", err)
 	}
@@ -690,7 +698,7 @@ func TestArcTableBloomFilterOptimization(t *testing.T) {
 
 	// Get for path that definitely doesn't exist (bloom says no)
 	// should return ErrNotFound without kvstore lookup
-	_, err = arctable.Get(ctx, bucketId, root, "definitely-not-exist")
+	_, err = arctable.Get(ctx, bucketId, root, arcset.CanonicalizePath("definitely-not-exist"))
 	if err == nil {
 		t.Error("expected error for non-existent path")
 	}
@@ -706,7 +714,7 @@ func TestArcTableWithoutBloomCache(t *testing.T) {
 	target := newTestCID([]byte("target"))
 
 	// Add arc
-	arctable.Update(ctx, bucketId, root, cid.Undef, map[string]cid.Cid{"a": target})
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"a": target}))
 
 	// CreateBucket should fail (no bloom cache)
 	err := arctable.CreateBucket(ctx, bucketId, nil)
@@ -715,12 +723,12 @@ func TestArcTableWithoutBloomCache(t *testing.T) {
 	}
 
 	// MightContain should return true (bloom disabled)
-	if !arctable.MightContain(ctx, bucketId, "any-path") {
+	if !arctable.MightContain(ctx, bucketId, arcset.CanonicalizePath("any-path")) {
 		t.Error("MightContain should return true when bloom disabled")
 	}
 
 	// MightContainBatch should return all true
-	results := arctable.MightContainBatch(ctx, bucketId, []string{"a", "b", "c"})
+	results := arctable.MightContainBatch(ctx, bucketId, testPathSlice([]string{"a", "b", "c"}))
 	for p, v := range results {
 		if !v {
 			t.Errorf("expected true for %s when bloom disabled", p)
@@ -746,12 +754,12 @@ func BenchmarkOverwriteArcTableGet(b *testing.B) {
 				path := fmt.Sprintf("arc%d", i)
 				arcs[path] = newTestCID([]byte(path))
 			}
-			arctable.Update(ctx, bucketId, root, cid.Undef, arcs)
+			arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(arcs))
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				path := fmt.Sprintf("arc%d", i%count)
-				arctable.Get(ctx, bucketId, root, path)
+				arctable.Get(ctx, bucketId, root, arcset.CanonicalizePath(path))
 			}
 		})
 	}
@@ -775,7 +783,7 @@ func BenchmarkOverwriteArcTableUpdate(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				root := newTestCID([]byte(fmt.Sprintf("root%d", i)))
-				arctable.Update(ctx, bucketId, root, cid.Undef, arcs)
+				arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(arcs))
 			}
 		})
 	}
@@ -796,7 +804,7 @@ func BenchmarkOverwriteArcTableSnapshot(b *testing.B) {
 				path := fmt.Sprintf("arc%d", i)
 				arcs[path] = newTestCID([]byte(path))
 			}
-			arctable.Update(ctx, bucketId, root, cid.Undef, arcs)
+			arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(arcs))
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -822,7 +830,7 @@ func BenchmarkOverwriteArcTableIterate(b *testing.B) {
 				path := fmt.Sprintf("arc%d", i)
 				arcs[path] = newTestCID([]byte(path))
 			}
-			arctable.Update(ctx, bucketId, root, cid.Undef, arcs)
+			arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(arcs))
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/core/arctable/versioned/versioned.go
+++ b/core/arctable/versioned/versioned.go
@@ -78,16 +78,16 @@ func (e *ArcTable) CreateBucket(ctx context.Context, bucketId string, cfg *bloom
 // MightContain checks if a path might exist in a bucket using bloom filter.
 // Returns false if the path definitely doesn't exist.
 // Returns true if the path might exist (need to call Get to verify).
-func (e *ArcTable) MightContain(ctx context.Context, bucketId string, path string) bool {
+func (e *ArcTable) MightContain(ctx context.Context, bucketId string, path arcset.Path) bool {
 	if !e.bloomManager.Enabled() {
 		return true // Bloom disabled
 	}
-	return e.bloomManager.MightContain(bucketId, path)
+	return e.bloomManager.MightContain(bucketId, path.String())
 }
 
 // MightContainBatch checks multiple paths at once using bloom filter.
-func (e *ArcTable) MightContainBatch(ctx context.Context, bucketId string, paths []string) map[string]bool {
-	result := make(map[string]bool, len(paths))
+func (e *ArcTable) MightContainBatch(ctx context.Context, bucketId string, paths []arcset.Path) map[arcset.Path]bool {
+	result := make(map[arcset.Path]bool, len(paths))
 
 	if !e.bloomManager.Enabled() {
 		for _, p := range paths {
@@ -96,7 +96,11 @@ func (e *ArcTable) MightContainBatch(ctx context.Context, bucketId string, paths
 		return result
 	}
 
-	batchResult, err := e.bloomManager.MightContainBatch(ctx, bucketId, paths)
+	pathStrings := make([]string, len(paths))
+	for i, path := range paths {
+		pathStrings[i] = path.String()
+	}
+	batchResult, err := e.bloomManager.MightContainBatch(ctx, bucketId, pathStrings)
 	if err != nil {
 		for _, p := range paths {
 			result[p] = true
@@ -104,12 +108,15 @@ func (e *ArcTable) MightContainBatch(ctx context.Context, bucketId string, paths
 		return result
 	}
 
-	return batchResult
+	for _, path := range paths {
+		result[path] = batchResult[path.String()]
+	}
+	return result
 }
 
 // Get retrieves the target CID for a path at a specific version.
 // First checks bloom filter, then walks the @previous chain.
-func (e *ArcTable) Get(ctx context.Context, bucketId string, version cid.Cid, path string) (cid.Cid, error) {
+func (e *ArcTable) Get(ctx context.Context, bucketId string, version cid.Cid, path arcset.Path) (cid.Cid, error) {
 	start := time.Now()
 
 	// Quick bloom filter check
@@ -117,7 +124,7 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, version cid.Cid, pa
 		logger.Debug("ArcTable.Get bloom negative",
 			logger.String("bucket", bucketId),
 			logger.String("version", version.String()),
-			logger.String("path", path))
+			logger.String("path", path.String()))
 		return cid.Cid{}, arcset.ErrNotFound
 	}
 
@@ -128,14 +135,14 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, version cid.Cid, pa
 	logger.Debug("ArcTable.Get started",
 		logger.String("bucket", bucketId),
 		logger.String("version", version.String()),
-		logger.String("path", path))
+		logger.String("path", path.String()))
 
 	for range maxDepth {
 		depth++
 		if ctx.Err() != nil {
 			logger.Warn("ArcTable.Get cancelled",
 				logger.String("bucket", bucketId),
-				logger.String("path", path),
+				logger.String("path", path.String()),
 				logger.Int("depth", depth),
 				logger.Err(ctx.Err()))
 			return cid.Cid{}, ctx.Err()
@@ -148,7 +155,7 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, version cid.Cid, pa
 			if len(val) == 0 {
 				logger.Debug("ArcTable.Get found tombstone",
 					logger.String("bucket", bucketId),
-					logger.String("path", path),
+					logger.String("path", path.String()),
 					logger.Int("depth", depth))
 				return cid.Cid{}, arcset.ErrNotFound
 			}
@@ -156,7 +163,7 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, version cid.Cid, pa
 			if err == nil {
 				logger.Debug("ArcTable.Get success",
 					logger.String("bucket", bucketId),
-					logger.String("path", path),
+					logger.String("path", path.String()),
 					logger.String("target", result.String()),
 					logger.Int("depth", depth),
 					logger.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000))
@@ -167,7 +174,7 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, version cid.Cid, pa
 		if err != kvstore.ErrNotFound {
 			logger.Error("ArcTable.Get kv error",
 				logger.String("bucket", bucketId),
-				logger.String("path", path),
+				logger.String("path", path.String()),
 				logger.Err(err))
 			return cid.Cid{}, fmt.Errorf("failed to get arc: %w", err)
 		}
@@ -179,7 +186,7 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, version cid.Cid, pa
 			if err == kvstore.ErrNotFound {
 				logger.Debug("ArcTable.Get not found (no parent)",
 					logger.String("bucket", bucketId),
-					logger.String("path", path),
+					logger.String("path", path.String()),
 					logger.Int("depth", depth))
 				return cid.Cid{}, arcset.ErrNotFound
 			}
@@ -190,7 +197,7 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, version cid.Cid, pa
 		if err != nil {
 			logger.Error("ArcTable.Get invalid @previous CID",
 				logger.String("bucket", bucketId),
-				logger.String("path", path),
+				logger.String("path", path.String()),
 				logger.Err(err))
 			return cid.Cid{}, fmt.Errorf("invalid @previous CID: %w", err)
 		}
@@ -199,18 +206,18 @@ func (e *ArcTable) Get(ctx context.Context, bucketId string, version cid.Cid, pa
 
 	logger.Warn("ArcTable.Get exceeded max depth",
 		logger.String("bucket", bucketId),
-		logger.String("path", path),
+		logger.String("path", path.String()),
 		logger.Int("maxDepth", maxDepth))
 	return cid.Cid{}, fmt.Errorf("version chain too deep (max %d)", maxDepth)
 }
 
 // BatchGet retrieves multiple target CIDs in a single operation.
-func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, version cid.Cid, paths []string) (map[string]cid.Cid, error) {
+func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, version cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error) {
 	start := time.Now()
 
 	// Filter paths using bloom filter
 	mightExist := e.MightContainBatch(ctx, bucketId, paths)
-	filteredPaths := make([]string, 0, len(paths))
+	filteredPaths := make([]arcset.Path, 0, len(paths))
 	for _, p := range paths {
 		if mightExist[p] {
 			filteredPaths = append(filteredPaths, p)
@@ -218,7 +225,7 @@ func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, version cid.Ci
 	}
 
 	if len(filteredPaths) == 0 {
-		return map[string]cid.Cid{}, nil
+		return map[arcset.Path]cid.Cid{}, nil
 	}
 
 	logger.Debug("ArcTable.BatchGet started",
@@ -227,13 +234,13 @@ func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, version cid.Ci
 		logger.Int("path_count", len(paths)),
 		logger.Int("filtered_count", len(filteredPaths)))
 
-	remaining := make(map[string]bool)
+	remaining := make(map[arcset.Path]bool)
 	for _, path := range filteredPaths {
 		remaining[path] = true
 	}
 
-	results := make(map[string]cid.Cid)
-	tombstones := make(map[string]bool)
+	results := make(map[arcset.Path]cid.Cid)
+	tombstones := make(map[arcset.Path]bool)
 
 	currentVersion := version
 	maxDepth := 1000
@@ -252,7 +259,7 @@ func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, version cid.Ci
 		}
 
 		keys := make([][]byte, 0, len(remaining))
-		pathForKey := make(map[string]string)
+		pathForKey := make(map[string]arcset.Path)
 		for path := range remaining {
 			if tombstones[path] {
 				continue
@@ -316,22 +323,26 @@ func (e *ArcTable) BatchGet(ctx context.Context, bucketId string, version cid.Ci
 }
 
 // Update stores arcs at a new version and updates the bucket bloom filter.
-func (e *ArcTable) Update(ctx context.Context, bucketId string, newRoot, parentRoot cid.Cid, arcs map[string]cid.Cid) error {
+func (e *ArcTable) Update(ctx context.Context, bucketId string, newRoot, parentRoot cid.Cid, arcs arcset.ArcSet) error {
+	arcMap, err := arcset.ToPathMap(arcs)
+	if err != nil {
+		return err
+	}
 	start := time.Now()
 
 	logger.Info("ArcTable.Update started",
 		logger.String("bucket", bucketId),
 		logger.String("new_root", newRoot.String()),
 		logger.String("parent_root", parentRoot.String()),
-		logger.Int("arc_count", len(arcs)))
+		logger.Int("arc_count", len(arcMap)))
 
 	batch := e.kv.Batch()
 
 	tombstoneCount := 0
-	addedPaths := make([]string, 0, len(arcs))
+	addedPaths := make([]string, 0, len(arcMap))
 
 	// Store all arcs for this version
-	for path, target := range arcs {
+	for path, target := range arcMap {
 		key := arctable.VersionedArcKey(bucketId, newRoot, path)
 		if target == cid.Undef {
 			tombstoneCount++
@@ -339,9 +350,9 @@ func (e *ArcTable) Update(ctx context.Context, bucketId string, newRoot, parentR
 				batch.Cancel()
 				logger.Error("ArcTable.Update failed to add tombstone",
 					logger.String("bucket", bucketId),
-					logger.String("path", path),
+					logger.String("path", path.String()),
 					logger.Err(err))
-				return fmt.Errorf("failed to add tombstone for arc %s: %w", path, err)
+				return fmt.Errorf("failed to add tombstone for arc %s: %w", path.String(), err)
 			}
 		} else {
 			val := target.Bytes()
@@ -349,11 +360,11 @@ func (e *ArcTable) Update(ctx context.Context, bucketId string, newRoot, parentR
 				batch.Cancel()
 				logger.Error("ArcTable.Update failed to add arc",
 					logger.String("bucket", bucketId),
-					logger.String("path", path),
+					logger.String("path", path.String()),
 					logger.Err(err))
-				return fmt.Errorf("failed to add arc %s to batch: %w", path, err)
+				return fmt.Errorf("failed to add arc %s to batch: %w", path.String(), err)
 			}
-			addedPaths = append(addedPaths, path)
+			addedPaths = append(addedPaths, path.String())
 		}
 	}
 
@@ -391,7 +402,7 @@ func (e *ArcTable) Update(ctx context.Context, bucketId string, newRoot, parentR
 	logger.Info("ArcTable.Update completed",
 		logger.String("bucket", bucketId),
 		logger.String("new_root", newRoot.String()),
-		logger.Int("arc_count", len(arcs)),
+		logger.Int("arc_count", len(arcMap)),
 		logger.Int("tombstone_count", tombstoneCount),
 		logger.Bool("has_parent", parentRoot != cid.Undef),
 		logger.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000))
@@ -436,7 +447,11 @@ func (e *ArcTable) Snapshot(ctx context.Context, bucketId string, version cid.Ci
 		logger.Int("arc_count", len(arcs)),
 		logger.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000))
 
-	return arcset.NewSetFrom(arcs), nil
+	snapshot, err := arcset.NewArcSet(arcs)
+	if err != nil {
+		return nil, err
+	}
+	return snapshot, nil
 }
 
 // collectFlattenedArcs collects all arcs visible at a version (including ancestors).

--- a/core/arctable/versioned/versioned_test.go
+++ b/core/arctable/versioned/versioned_test.go
@@ -20,6 +20,14 @@ func newTestCID(data []byte) cid.Cid {
 	return cid.NewCidV1(cid.Raw, mhash)
 }
 
+func testPathSlice(paths []string) []arcset.Path {
+	out := make([]arcset.Path, len(paths))
+	for i, path := range paths {
+		out[i] = arcset.CanonicalizePath(path)
+	}
+	return out
+}
+
 // === Versioned ArcTable Tests ===
 
 func TestVersionedArcTableNew(t *testing.T) {
@@ -59,13 +67,13 @@ func TestVersionedArcTableUpdate(t *testing.T) {
 		"a": target1,
 		"b": target2,
 	}
-	err = arctable.Update(ctx, bucketId, root1, cid.Undef, arcs1)
+	err = arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(arcs1))
 	if err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
 
 	// Get at root1
-	got, err := arctable.Get(ctx, bucketId, root1, "a")
+	got, err := arctable.Get(ctx, bucketId, root1, arcset.CanonicalizePath("a"))
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
@@ -73,7 +81,7 @@ func TestVersionedArcTableUpdate(t *testing.T) {
 		t.Error("wrong value for 'a'")
 	}
 
-	got, err = arctable.Get(ctx, bucketId, root1, "b")
+	got, err = arctable.Get(ctx, bucketId, root1, arcset.CanonicalizePath("b"))
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
@@ -104,7 +112,7 @@ func TestVersionedArcTableVersionChain(t *testing.T) {
 		"a": target1,
 		"b": target2,
 	}
-	err = arctable.Update(ctx, bucketId, root1, cid.Undef, arcs1)
+	err = arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(arcs1))
 	if err != nil {
 		t.Fatalf("Update v1 failed: %v", err)
 	}
@@ -113,7 +121,7 @@ func TestVersionedArcTableVersionChain(t *testing.T) {
 	arcs2 := map[string]cid.Cid{
 		"a": target3,
 	}
-	err = arctable.Update(ctx, bucketId, root2, root1, arcs2)
+	err = arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(arcs2))
 	if err != nil {
 		t.Fatalf("Update v2 failed: %v", err)
 	}
@@ -122,7 +130,7 @@ func TestVersionedArcTableVersionChain(t *testing.T) {
 	arcs3 := map[string]cid.Cid{
 		"c": target3,
 	}
-	err = arctable.Update(ctx, bucketId, root3, root2, arcs3)
+	err = arctable.Update(ctx, bucketId, root3, root2, arcset.NewSetFrom(arcs3))
 	if err != nil {
 		t.Fatalf("Update v3 failed: %v", err)
 	}
@@ -130,7 +138,7 @@ func TestVersionedArcTableVersionChain(t *testing.T) {
 	// Test resolution at root3
 
 	// a should resolve to target3 (overridden at v2)
-	got, err := arctable.Get(ctx, bucketId, root3, "a")
+	got, err := arctable.Get(ctx, bucketId, root3, arcset.CanonicalizePath("a"))
 	if err != nil {
 		t.Fatalf("Get a at root3 failed: %v", err)
 	}
@@ -139,7 +147,7 @@ func TestVersionedArcTableVersionChain(t *testing.T) {
 	}
 
 	// b should resolve to target2 (from v1)
-	got, err = arctable.Get(ctx, bucketId, root3, "b")
+	got, err = arctable.Get(ctx, bucketId, root3, arcset.CanonicalizePath("b"))
 	if err != nil {
 		t.Fatalf("Get b at root3 failed: %v", err)
 	}
@@ -148,7 +156,7 @@ func TestVersionedArcTableVersionChain(t *testing.T) {
 	}
 
 	// c should resolve to target3 (new at v3)
-	got, err = arctable.Get(ctx, bucketId, root3, "c")
+	got, err = arctable.Get(ctx, bucketId, root3, arcset.CanonicalizePath("c"))
 	if err != nil {
 		t.Fatalf("Get c at root3 failed: %v", err)
 	}
@@ -159,7 +167,7 @@ func TestVersionedArcTableVersionChain(t *testing.T) {
 	// Test resolution at root2
 
 	// a at root2 should be target3
-	got, err = arctable.Get(ctx, bucketId, root2, "a")
+	got, err = arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("a"))
 	if err != nil {
 		t.Fatalf("Get a at root2 failed: %v", err)
 	}
@@ -168,7 +176,7 @@ func TestVersionedArcTableVersionChain(t *testing.T) {
 	}
 
 	// b at root2 should be target2
-	got, err = arctable.Get(ctx, bucketId, root2, "b")
+	got, err = arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("b"))
 	if err != nil {
 		t.Fatalf("Get b at root2 failed: %v", err)
 	}
@@ -177,14 +185,14 @@ func TestVersionedArcTableVersionChain(t *testing.T) {
 	}
 
 	// c at root2 should not exist
-	_, err = arctable.Get(ctx, bucketId, root2, "c")
+	_, err = arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("c"))
 	if err == nil {
 		t.Error("c at root2 should not exist")
 	}
 
 	// Test resolution at root1
 
-	got, err = arctable.Get(ctx, bucketId, root1, "a")
+	got, err = arctable.Get(ctx, bucketId, root1, arcset.CanonicalizePath("a"))
 	if err != nil {
 		t.Fatalf("Get a at root1 failed: %v", err)
 	}
@@ -208,12 +216,12 @@ func TestVersionedArcTableGetParent(t *testing.T) {
 	arcs1 := map[string]cid.Cid{
 		"a": newTestCID([]byte("target1")),
 	}
-	arctable.Update(ctx, bucketId, root1, cid.Undef, arcs1)
+	arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(arcs1))
 
 	arcs2 := map[string]cid.Cid{
 		"b": newTestCID([]byte("target2")),
 	}
-	arctable.Update(ctx, bucketId, root2, root1, arcs2)
+	arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(arcs2))
 
 	// GetParent
 	parent, err := arctable.GetParent(ctx, bucketId, root2)
@@ -252,12 +260,12 @@ func TestVersionedArcTableSnapshot(t *testing.T) {
 	arcs1 := map[string]cid.Cid{
 		"a": target1,
 	}
-	arctable.Update(ctx, bucketId, root1, cid.Undef, arcs1)
+	arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(arcs1))
 
 	arcs2 := map[string]cid.Cid{
 		"b": target2,
 	}
-	arctable.Update(ctx, bucketId, root2, root1, arcs2)
+	arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(arcs2))
 
 	// Snapshot at root2
 	snapshot, err := arctable.Snapshot(ctx, bucketId, root2)
@@ -302,14 +310,14 @@ func TestVersionedArcTableBatchGet(t *testing.T) {
 	target3 := newTestCID([]byte("target3"))
 
 	// Setup arcs at root1
-	arctable.Update(ctx, bucketId, root1, cid.Undef, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target1,
 		"b": target2,
 		"c": target3,
-	})
+	}))
 
 	// Test: all paths found
-	results, err := arctable.BatchGet(ctx, bucketId, root1, []string{"a", "b", "c"})
+	results, err := arctable.BatchGet(ctx, bucketId, root1, testPathSlice([]string{"a", "b", "c"}))
 	if err != nil {
 		t.Fatalf("BatchGet failed: %v", err)
 	}
@@ -327,7 +335,7 @@ func TestVersionedArcTableBatchGet(t *testing.T) {
 	}
 
 	// Test: some paths not found
-	results, err = arctable.BatchGet(ctx, bucketId, root1, []string{"a", "notexist", "b"})
+	results, err = arctable.BatchGet(ctx, bucketId, root1, testPathSlice([]string{"a", "notexist", "b"}))
 	if err != nil {
 		t.Fatalf("BatchGet with missing paths failed: %v", err)
 	}
@@ -336,7 +344,7 @@ func TestVersionedArcTableBatchGet(t *testing.T) {
 	}
 
 	// Test: empty paths
-	results, err = arctable.BatchGet(ctx, bucketId, root1, []string{})
+	results, err = arctable.BatchGet(ctx, bucketId, root1, testPathSlice([]string{}))
 	if err != nil {
 		t.Fatalf("BatchGet with empty paths failed: %v", err)
 	}
@@ -345,7 +353,7 @@ func TestVersionedArcTableBatchGet(t *testing.T) {
 	}
 
 	// Test: all paths not found
-	results, err = arctable.BatchGet(ctx, bucketId, root1, []string{"x", "y", "z"})
+	results, err = arctable.BatchGet(ctx, bucketId, root1, testPathSlice([]string{"x", "y", "z"}))
 	if err != nil {
 		t.Fatalf("BatchGet with all missing paths failed: %v", err)
 	}
@@ -373,24 +381,24 @@ func TestVersionedArcTableBatchGetVersionChain(t *testing.T) {
 	target4 := newTestCID([]byte("target4"))
 
 	// v1: a, b
-	arctable.Update(ctx, bucketId, root1, cid.Undef, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target1,
 		"b": target2,
-	})
+	}))
 
 	// v2: c (new), a overridden
-	arctable.Update(ctx, bucketId, root2, root1, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target3,
 		"c": target3,
-	})
+	}))
 
 	// v3: d (new)
-	arctable.Update(ctx, bucketId, root3, root2, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root3, root2, arcset.NewSetFrom(map[string]cid.Cid{
 		"d": target4,
-	})
+	}))
 
 	// BatchGet at root3 should find all paths
-	results, err := arctable.BatchGet(ctx, bucketId, root3, []string{"a", "b", "c", "d"})
+	results, err := arctable.BatchGet(ctx, bucketId, root3, testPathSlice([]string{"a", "b", "c", "d"}))
 	if err != nil {
 		t.Fatalf("BatchGet root3 failed: %v", err)
 	}
@@ -419,7 +427,7 @@ func TestVersionedArcTableBatchGetVersionChain(t *testing.T) {
 	}
 
 	// BatchGet at root2 should not find 'd'
-	results, err = arctable.BatchGet(ctx, bucketId, root2, []string{"a", "b", "c", "d"})
+	results, err = arctable.BatchGet(ctx, bucketId, root2, testPathSlice([]string{"a", "b", "c", "d"}))
 	if err != nil {
 		t.Fatalf("BatchGet root2 failed: %v", err)
 	}
@@ -431,7 +439,7 @@ func TestVersionedArcTableBatchGetVersionChain(t *testing.T) {
 	}
 
 	// BatchGet at root1 should find original 'a'
-	results, err = arctable.BatchGet(ctx, bucketId, root1, []string{"a", "b", "c"})
+	results, err = arctable.BatchGet(ctx, bucketId, root1, testPathSlice([]string{"a", "b", "c"}))
 	if err != nil {
 		t.Fatalf("BatchGet root1 failed: %v", err)
 	}
@@ -467,25 +475,25 @@ func TestVersionedArcTableBatchGetWithTombstone(t *testing.T) {
 	target3 := newTestCID([]byte("target3"))
 
 	// v1: a, b, c
-	arctable.Update(ctx, bucketId, root1, cid.Undef, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target1,
 		"b": target2,
 		"c": target3,
-	})
+	}))
 
 	// v2: delete 'a' (tombstone), add 'd'
-	arctable.Update(ctx, bucketId, root2, root1, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": cid.Undef, // tombstone
 		"d": target3,
-	})
+	}))
 
 	// v3: delete 'b' (tombstone)
-	arctable.Update(ctx, bucketId, root3, root2, map[string]cid.Cid{
+	arctable.Update(ctx, bucketId, root3, root2, arcset.NewSetFrom(map[string]cid.Cid{
 		"b": cid.Undef, // tombstone
-	})
+	}))
 
 	// BatchGet at root3: a and b deleted, c and d exist
-	results, err := arctable.BatchGet(ctx, bucketId, root3, []string{"a", "b", "c", "d"})
+	results, err := arctable.BatchGet(ctx, bucketId, root3, testPathSlice([]string{"a", "b", "c", "d"}))
 	if err != nil {
 		t.Fatalf("BatchGet root3 failed: %v", err)
 	}
@@ -506,7 +514,7 @@ func TestVersionedArcTableBatchGetWithTombstone(t *testing.T) {
 	}
 
 	// BatchGet at root2: only 'a' deleted
-	results, err = arctable.BatchGet(ctx, bucketId, root2, []string{"a", "b", "c", "d"})
+	results, err = arctable.BatchGet(ctx, bucketId, root2, testPathSlice([]string{"a", "b", "c", "d"}))
 	if err != nil {
 		t.Fatalf("BatchGet root2 failed: %v", err)
 	}
@@ -521,7 +529,7 @@ func TestVersionedArcTableBatchGetWithTombstone(t *testing.T) {
 	}
 
 	// BatchGet at root1: all exist
-	results, err = arctable.BatchGet(ctx, bucketId, root1, []string{"a", "b", "c"})
+	results, err = arctable.BatchGet(ctx, bucketId, root1, testPathSlice([]string{"a", "b", "c"}))
 	if err != nil {
 		t.Fatalf("BatchGet root1 failed: %v", err)
 	}
@@ -547,18 +555,18 @@ func TestVersionedArcTableBatchGetMultipleBuckets(t *testing.T) {
 	target2 := newTestCID([]byte("target2"))
 
 	// Different buckets
-	arctable.Update(ctx, "bucket1", root1a, cid.Undef, map[string]cid.Cid{
+	arctable.Update(ctx, "bucket1", root1a, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target1,
 		"b": target1,
-	})
-	arctable.Update(ctx, "bucket2", root1b, cid.Undef, map[string]cid.Cid{
+	}))
+	arctable.Update(ctx, "bucket2", root1b, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 		"a": target2,
 		"b": target2,
-	})
+	}))
 
 	// BatchGet in different buckets should be independent
-	results1, _ := arctable.BatchGet(ctx, "bucket1", root1a, []string{"a", "b"})
-	results2, _ := arctable.BatchGet(ctx, "bucket2", root1b, []string{"a", "b"})
+	results1, _ := arctable.BatchGet(ctx, "bucket1", root1a, testPathSlice([]string{"a", "b"}))
+	results2, _ := arctable.BatchGet(ctx, "bucket2", root1b, testPathSlice([]string{"a", "b"}))
 
 	if len(results1) != 2 || len(results2) != 2 {
 		t.Error("expected 2 results in each bucket")
@@ -593,22 +601,22 @@ func TestVersionedArcTableDeleteViaUpdate(t *testing.T) {
 		"a": target1,
 		"b": target2,
 	}
-	arctable.Update(ctx, bucketId, root1, cid.Undef, arcs1)
+	arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(arcs1))
 
 	// v2: delete 'a' using cid.Undef (tombstone)
 	arcs2 := map[string]cid.Cid{
 		"a": cid.Undef, // tombstone - marks 'a' as deleted
 	}
-	arctable.Update(ctx, bucketId, root2, root1, arcs2)
+	arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(arcs2))
 
 	// At root2, 'a' should not be found (tombstone stops the search)
-	_, err = arctable.Get(ctx, bucketId, root2, "a")
+	_, err = arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("a"))
 	if err == nil {
 		t.Error("'a' should be deleted at root2")
 	}
 
 	// 'b' should still be accessible (from root1)
-	got, err := arctable.Get(ctx, bucketId, root2, "b")
+	got, err := arctable.Get(ctx, bucketId, root2, arcset.CanonicalizePath("b"))
 	if err != nil {
 		t.Fatalf("Get b at root2 failed: %v", err)
 	}
@@ -617,7 +625,7 @@ func TestVersionedArcTableDeleteViaUpdate(t *testing.T) {
 	}
 
 	// At root1, 'a' should still exist (tombstone is at root2, not root1)
-	got, err = arctable.Get(ctx, bucketId, root1, "a")
+	got, err = arctable.Get(ctx, bucketId, root1, arcset.CanonicalizePath("a"))
 	if err != nil {
 		t.Fatalf("Get a at root1 failed: %v", err)
 	}
@@ -629,16 +637,16 @@ func TestVersionedArcTableDeleteViaUpdate(t *testing.T) {
 	arcs3 := map[string]cid.Cid{
 		"c": target1,
 	}
-	arctable.Update(ctx, bucketId, root3, root2, arcs3)
+	arctable.Update(ctx, bucketId, root3, root2, arcset.NewSetFrom(arcs3))
 
 	// At root3, 'a' should still not be found
-	_, err = arctable.Get(ctx, bucketId, root3, "a")
+	_, err = arctable.Get(ctx, bucketId, root3, arcset.CanonicalizePath("a"))
 	if err == nil {
 		t.Error("'a' should be deleted at root3")
 	}
 
 	// 'b' and 'c' should work
-	got, err = arctable.Get(ctx, bucketId, root3, "b")
+	got, err = arctable.Get(ctx, bucketId, root3, arcset.CanonicalizePath("b"))
 	if err != nil {
 		t.Fatalf("Get b at root3 failed: %v", err)
 	}
@@ -646,7 +654,7 @@ func TestVersionedArcTableDeleteViaUpdate(t *testing.T) {
 		t.Error("b at root3 should be target2")
 	}
 
-	got, err = arctable.Get(ctx, bucketId, root3, "c")
+	got, err = arctable.Get(ctx, bucketId, root3, arcset.CanonicalizePath("c"))
 	if err != nil {
 		t.Fatalf("Get c at root3 failed: %v", err)
 	}
@@ -671,12 +679,12 @@ func TestVersionedArcTableMultipleBuckets(t *testing.T) {
 	target2 := newTestCID([]byte("target2"))
 
 	// Create versions in different buckets
-	arctable.Update(ctx, "bucket1", root1a, cid.Undef, map[string]cid.Cid{"a": target1})
-	arctable.Update(ctx, "bucket2", root2a, cid.Undef, map[string]cid.Cid{"a": target2})
+	arctable.Update(ctx, "bucket1", root1a, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"a": target1}))
+	arctable.Update(ctx, "bucket2", root2a, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"a": target2}))
 
 	// Should be independent
-	got1, _ := arctable.Get(ctx, "bucket1", root1a, "a")
-	got2, _ := arctable.Get(ctx, "bucket2", root2a, "a")
+	got1, _ := arctable.Get(ctx, "bucket1", root1a, arcset.CanonicalizePath("a"))
+	got2, _ := arctable.Get(ctx, "bucket2", root2a, arcset.CanonicalizePath("a"))
 
 	if got1.Equals(got2) {
 		t.Error("different buckets should have independent values")
@@ -716,10 +724,10 @@ func TestVersionedArcTableWithBloomCache(t *testing.T) {
 	}
 
 	// Add arc
-	arctable.Update(ctx, bucketId, root, cid.Undef, map[string]cid.Cid{"path/a": target})
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"path/a": target}))
 
 	// MightContain should return true for existing path
-	if !arctable.MightContain(ctx, bucketId, "path/a") {
+	if !arctable.MightContain(ctx, bucketId, arcset.CanonicalizePath("path/a")) {
 		t.Error("MightContain should return true for existing path")
 	}
 }
@@ -743,17 +751,17 @@ func TestVersionedArcTableMightContainBatch(t *testing.T) {
 	for _, p := range paths {
 		arcs[p] = target
 	}
-	arctable.Update(ctx, bucketId, root, cid.Undef, arcs)
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(arcs))
 
 	// Batch check
-	results := arctable.MightContainBatch(ctx, bucketId, []string{"a", "b", "c", "nonexistent"})
+	results := arctable.MightContainBatch(ctx, bucketId, testPathSlice([]string{"a", "b", "c", "nonexistent"}))
 	if len(results) != 4 {
 		t.Errorf("expected 4 results, got %d", len(results))
 	}
 
 	// Existing paths should return true
 	for _, p := range paths {
-		if !results[p] {
+		if !results[arcset.CanonicalizePath(p)] {
 			t.Errorf("expected true for %s", p)
 		}
 	}
@@ -774,10 +782,10 @@ func TestVersionedArcTableBloomFilterOptimization(t *testing.T) {
 	arctable.CreateBucket(ctx, bucketId, nil)
 
 	// Add arcs
-	arctable.Update(ctx, bucketId, root, cid.Undef, map[string]cid.Cid{"existing": target})
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"existing": target}))
 
 	// Get for existing path should work
-	got, err := arctable.Get(ctx, bucketId, root, "existing")
+	got, err := arctable.Get(ctx, bucketId, root, arcset.CanonicalizePath("existing"))
 	if err != nil {
 		t.Fatalf("Get existing failed: %v", err)
 	}
@@ -787,7 +795,7 @@ func TestVersionedArcTableBloomFilterOptimization(t *testing.T) {
 
 	// Get for path that definitely doesn't exist (bloom says no)
 	// should return ErrNotFound without version chain walk
-	_, err = arctable.Get(ctx, bucketId, root, "definitely-not-exist")
+	_, err = arctable.Get(ctx, bucketId, root, arcset.CanonicalizePath("definitely-not-exist"))
 	if err == nil {
 		t.Error("expected error for non-existent path")
 	}
@@ -809,16 +817,16 @@ func TestVersionedArcTableBloomUpdateOnUpdate(t *testing.T) {
 	arctable.CreateBucket(ctx, bucketId, nil)
 
 	// First update
-	arctable.Update(ctx, bucketId, root1, cid.Undef, map[string]cid.Cid{"a": target})
+	arctable.Update(ctx, bucketId, root1, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"a": target}))
 
 	// Second update (adds new paths)
-	arctable.Update(ctx, bucketId, root2, root1, map[string]cid.Cid{"b": target})
+	arctable.Update(ctx, bucketId, root2, root1, arcset.NewSetFrom(map[string]cid.Cid{"b": target}))
 
 	// Both paths should be in bloom
-	if !arctable.MightContain(ctx, bucketId, "a") {
+	if !arctable.MightContain(ctx, bucketId, arcset.CanonicalizePath("a")) {
 		t.Error("'a' should be in bloom")
 	}
-	if !arctable.MightContain(ctx, bucketId, "b") {
+	if !arctable.MightContain(ctx, bucketId, arcset.CanonicalizePath("b")) {
 		t.Error("'b' should be in bloom")
 	}
 }
@@ -833,7 +841,7 @@ func TestVersionedArcTableWithoutBloomCache(t *testing.T) {
 	target := newTestCID([]byte("target"))
 
 	// Add arc
-	arctable.Update(ctx, bucketId, root, cid.Undef, map[string]cid.Cid{"a": target})
+	arctable.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"a": target}))
 
 	// CreateBucket should fail (no bloom cache)
 	err := arctable.CreateBucket(ctx, bucketId, nil)
@@ -842,12 +850,12 @@ func TestVersionedArcTableWithoutBloomCache(t *testing.T) {
 	}
 
 	// MightContain should return true (bloom disabled)
-	if !arctable.MightContain(ctx, bucketId, "any-path") {
+	if !arctable.MightContain(ctx, bucketId, arcset.CanonicalizePath("any-path")) {
 		t.Error("MightContain should return true when bloom disabled")
 	}
 
 	// MightContainBatch should return all true
-	results := arctable.MightContainBatch(ctx, bucketId, []string{"a", "b", "c"})
+	results := arctable.MightContainBatch(ctx, bucketId, testPathSlice([]string{"a", "b", "c"}))
 	for p, v := range results {
 		if !v {
 			t.Errorf("expected true for %s when bloom disabled", p)
@@ -867,7 +875,7 @@ func setupVersionChain(ctx context.Context, arctable *ArcTable, bucketId string,
 		arcs := map[string]cid.Cid{
 			fmt.Sprintf("v%d_arc", i): newTestCID([]byte(fmt.Sprintf("target%d", i))),
 		}
-		arctable.Update(ctx, bucketId, root, prevRoot, arcs)
+		arctable.Update(ctx, bucketId, root, prevRoot, arcset.NewSetFrom(arcs))
 		prevRoot = root
 		latestRoot = root
 	}
@@ -889,7 +897,7 @@ func BenchmarkVersionedArcTableGet(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				// Query an arc that exists at the first version (requires full chain walk)
-				arctable.Get(ctx, bucketId, latestRoot, "v0_arc")
+				arctable.Get(ctx, bucketId, latestRoot, arcset.CanonicalizePath("v0_arc"))
 			}
 		})
 	}
@@ -910,7 +918,7 @@ func BenchmarkVersionedArcTableGetLatestVersion(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				// Query an arc at the latest version (direct lookup)
-				arctable.Get(ctx, bucketId, latestRoot, fmt.Sprintf("v%d_arc", length-1))
+				arctable.Get(ctx, bucketId, latestRoot, arcset.CanonicalizePath(fmt.Sprintf("v%d_arc", length-1)))
 			}
 		})
 	}
@@ -930,7 +938,7 @@ func BenchmarkVersionedArcTableUpdate(b *testing.B) {
 			initialArcs := map[string]cid.Cid{
 				"a": newTestCID([]byte("init")),
 			}
-			arctable.Update(ctx, bucketId, initialRoot, cid.Undef, initialArcs)
+			arctable.Update(ctx, bucketId, initialRoot, cid.Undef, arcset.NewSetFrom(initialArcs))
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -939,7 +947,7 @@ func BenchmarkVersionedArcTableUpdate(b *testing.B) {
 				for j := 0; j < size; j++ {
 					arcs[fmt.Sprintf("arc%d", j)] = newTestCID([]byte(fmt.Sprintf("val%d_%d", i, j)))
 				}
-				arctable.Update(ctx, bucketId, newRoot, initialRoot, arcs)
+				arctable.Update(ctx, bucketId, newRoot, initialRoot, arcset.NewSetFrom(arcs))
 			}
 		})
 	}

--- a/core/commitment/shared.go
+++ b/core/commitment/shared.go
@@ -21,7 +21,7 @@ func ExtractSortedPathsValues(arcs arcset.ArcSet) ([]string, []cid.Cid) {
 
 	values := make([]cid.Cid, len(paths))
 	for i, path := range paths {
-		values[i], _ = arcs.Get(arcset.CanonicalizePath(path))
+		values[i], _ = arcs.Get(arcset.Path(path))
 	}
 
 	return paths, values

--- a/core/layout/malt/unixfs/layout.go
+++ b/core/layout/malt/unixfs/layout.go
@@ -49,6 +49,7 @@ var (
 	ErrNotDirectory = errors.New("unixfs path is not a directory")
 	ErrNotFile      = errors.New("unixfs path is not a file")
 	ErrReservedPath = errors.New("unixfs path uses a reserved segment")
+	ErrInvalidPath  = errors.New("unixfs path contains an unsupported segment")
 )
 
 // Options configures a UnixFS layout instance.
@@ -698,8 +699,28 @@ func splitRelativePath(path string) ([]string, error) {
 		if strings.HasPrefix(segment, "@") {
 			return nil, fmt.Errorf("%w: %s", ErrReservedPath, segment)
 		}
+		if !isPortableUnixFSSegment(segment) {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidPath, segment)
+		}
 	}
 	return segments, nil
+}
+
+func isPortableUnixFSSegment(segment string) bool {
+	if segment == "" || segment == "." || segment == ".." {
+		return false
+	}
+	for _, r := range segment {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '.', r == '_', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func isMapAbsent(err error) bool {

--- a/core/resolver/resolver_test.go
+++ b/core/resolver/resolver_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dewebprotocol/malt/core/resolver/step/implicit"
 	"github.com/dewebprotocol/malt/core/structure/mapping"
 	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
+	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/core/types/evidence"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -57,7 +58,7 @@ func commitStructure(t *testing.T, ctx context.Context, semantic mapping.Semanti
 	if err != nil {
 		t.Fatalf("Commit failed: %v", err)
 	}
-	if err := e.Update(ctx, bucketID, root, cid.Undef, arcs); err != nil {
+	if err := e.Update(ctx, bucketID, root, cid.Undef, arcset.NewSetFrom(arcs)); err != nil {
 		t.Fatalf("ArcTable.Update failed: %v", err)
 	}
 	return root

--- a/core/resolver/step/explicit/explicit.go
+++ b/core/resolver/step/explicit/explicit.go
@@ -71,15 +71,15 @@ func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.P
 
 	// Try from longest to shortest
 	for i := len(segments); i > 0; i-- {
-		candidatePath := strings.Join(segments[:i], "/")
+		candidatePath := arcset.Path(strings.Join(segments[:i], "/"))
 
 		target, err := r.arctable.Get(ctx, r.bucketId, root, candidatePath)
 		if err == nil {
 			// Found a match, generate proof
-			binding, proof, err := r.semantic.Prove(ctx, r.bucketId, root, arcset.CanonicalizePath(candidatePath))
+			binding, proof, err := r.semantic.Prove(ctx, r.bucketId, root, candidatePath)
 			if err != nil {
 				logger.Error("Resolver.Resolve prove failed",
-					logger.String("path", candidatePath),
+					logger.String("path", candidatePath.String()),
 					logger.Err(err))
 				return "", cid.Cid{}, nil, fmt.Errorf("failed to generate proof: %w", err)
 			}
@@ -88,15 +88,15 @@ func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.P
 				logger.String("bucket", r.bucketId),
 				logger.String("root", root.String()),
 				logger.String("requested_path", path.String()),
-				logger.String("matched_path", candidatePath),
+				logger.String("matched_path", candidatePath.String()),
 				logger.String("target", target.String()),
 				logger.Int("segment_depth", len(segments)-i),
 				logger.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000))
 
 			if !binding.Present || !binding.Value.Equals(target) {
-				return "", cid.Cid{}, nil, fmt.Errorf("semantic proof binding mismatch for path: %s", candidatePath)
+				return "", cid.Cid{}, nil, fmt.Errorf("semantic proof binding mismatch for path: %s", candidatePath.String())
 			}
-			return arcset.Path(candidatePath), target, evidence.NewExplicitEvidence(proof), nil
+			return candidatePath, target, evidence.NewExplicitEvidence(proof), nil
 		}
 	}
 

--- a/core/resolver/step/explicit/explicit_test.go
+++ b/core/resolver/step/explicit/explicit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dewebprotocol/malt/core/resolver/step/explicit"
 	"github.com/dewebprotocol/malt/core/structure/mapping"
 	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
+	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/core/types/evidence"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -58,7 +59,7 @@ func setupArcSet(t *testing.T, e *overwrite.ArcTable, semantic mapping.Semantics
 		t.Fatalf("Commit failed: %v", err)
 	}
 	ctx := context.Background()
-	if err := e.Update(ctx, testBucketId, root, cid.Undef, arcsMap); err != nil {
+	if err := e.Update(ctx, testBucketId, root, cid.Undef, arcset.NewSetFrom(arcsMap)); err != nil {
 		t.Fatalf("ArcTable.Update failed: %v", err)
 	}
 	return root
@@ -383,7 +384,7 @@ func TestBloomFilterWithResolver(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Commit failed: %v", err)
 	}
-	if err := e.Update(ctx, bucketId, root, cid.Undef, arcsMap); err != nil {
+	if err := e.Update(ctx, bucketId, root, cid.Undef, arcset.NewSetFrom(arcsMap)); err != nil {
 		t.Fatalf("ArcTable.Update failed: %v", err)
 	}
 

--- a/core/structure/list/tree/internal/layout.go
+++ b/core/structure/list/tree/internal/layout.go
@@ -86,9 +86,9 @@ func LoadSlots(ctx context.Context, e arctable.ArcTable, bucketID string, root c
 		return nil, fmt.Errorf("width must be positive")
 	}
 
-	paths := make([]string, width)
+	paths := make([]arcset.Path, width)
 	for i := range paths {
-		paths[i] = NodeSlotPath(root, uint64(i)).String()
+		paths[i] = NodeSlotPath(root, uint64(i))
 	}
 
 	found, err := e.BatchGet(ctx, bucketID, cid.Undef, paths)
@@ -114,17 +114,21 @@ func StoreSlots(ctx context.Context, e arctable.ArcTable, bucketID string, root 
 		return fmt.Errorf("node root is undefined")
 	}
 
-	arcs := make(map[string]cid.Cid)
+	arcs := make(map[arcset.Path]cid.Cid)
 	for i, slot := range slots {
 		if !slot.Defined() {
 			continue
 		}
-		arcs[NodeSlotPath(root, uint64(i)).String()] = slot
+		arcs[NodeSlotPath(root, uint64(i))] = slot
 	}
 	if len(arcs) == 0 {
 		return nil
 	}
-	return e.Update(ctx, bucketID, cid.Undef, cid.Undef, arcs)
+	snapshot, err := arcset.NewArcSetFromPaths(arcs)
+	if err != nil {
+		return err
+	}
+	return e.Update(ctx, bucketID, cid.Undef, cid.Undef, snapshot)
 }
 
 // CellsFromSlots converts a CID slot vector into commitment cells.

--- a/core/structure/list/tree/tree_test.go
+++ b/core/structure/list/tree/tree_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dewebprotocol/malt/core/structure/list"
 	"github.com/dewebprotocol/malt/core/structure/list/tree"
 	"github.com/dewebprotocol/malt/core/structure/list/tree/internal"
+	"github.com/dewebprotocol/malt/core/types/arcset"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -306,15 +307,15 @@ func TestTreeListRejectsCorruptedMaterialization(t *testing.T) {
 				t.Fatalf("Commit failed: %v", err)
 			}
 
-			childRoot, err := e.Get(ctx, bucketID, cid.Undef, layout.NodeSlotPath(root, 2).String())
+			childRoot, err := e.Get(ctx, bucketID, cid.Undef, arcset.CanonicalizePath(layout.NodeSlotPath(root, 2).String()))
 			if err != nil {
 				t.Fatalf("failed to fetch child root: %v", err)
 			}
 
 			corruptValue := newPayloadCID([]byte("corrupt-child-slot"))
-			if err := e.Update(ctx, bucketID, cid.Undef, cid.Undef, map[string]cid.Cid{
+			if err := e.Update(ctx, bucketID, cid.Undef, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
 				layout.NodeSlotPath(childRoot, 1).String(): corruptValue,
-			}); err != nil {
+			})); err != nil {
 				t.Fatalf("failed to corrupt child materialization: %v", err)
 			}
 

--- a/core/structure/mapping/indexed/indexed.go
+++ b/core/structure/mapping/indexed/indexed.go
@@ -299,7 +299,7 @@ func decodeBindingCell(path arcset.Path, cell commitment.Cell) (cid.Cid, error) 
 }
 
 func (s *Map) loadEntries(ctx context.Context, bucketID string, root cid.Cid) ([]entry, []commitment.Cell, error) {
-	countCID, err := s.arctable.Get(ctx, bucketID, cid.Undef, countPath(root).String())
+	countCID, err := s.arctable.Get(ctx, bucketID, cid.Undef, countPath(root))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -311,9 +311,9 @@ func (s *Map) loadEntries(ctx context.Context, bucketID string, root cid.Cid) ([
 		return nil, nil, nil
 	}
 
-	paths := make([]string, 0, count*2)
+	paths := make([]arcset.Path, 0, count*2)
 	for i := uint64(0); i < count; i++ {
-		paths = append(paths, entryKeyPath(root, i).String(), entryValuePath(root, i).String())
+		paths = append(paths, entryKeyPath(root, i), entryValuePath(root, i))
 	}
 	found, err := s.arctable.BatchGet(ctx, bucketID, cid.Undef, paths)
 	if err != nil {
@@ -322,11 +322,11 @@ func (s *Map) loadEntries(ctx context.Context, bucketID string, root cid.Cid) ([
 
 	entries := make([]entry, count)
 	for i := uint64(0); i < count; i++ {
-		keyCID, ok := found[entryKeyPath(root, i).String()]
+		keyCID, ok := found[entryKeyPath(root, i)]
 		if !ok {
 			return nil, nil, fmt.Errorf("missing key marker at index %d", i)
 		}
-		valueCID, ok := found[entryValuePath(root, i).String()]
+		valueCID, ok := found[entryValuePath(root, i)]
 		if !ok {
 			return nil, nil, fmt.Errorf("missing value CID at index %d", i)
 		}
@@ -345,24 +345,28 @@ func (s *Map) loadEntries(ctx context.Context, bucketID string, root cid.Cid) ([
 }
 
 func (s *Map) storeEntries(ctx context.Context, bucketID string, root cid.Cid, entries []entry) error {
-	arcs := make(map[string]cid.Cid, 1+len(entries)*2)
+	arcs := make(map[arcset.Path]cid.Cid, 1+len(entries)*2)
 
 	countCID, err := encodeCountMarker(uint64(len(entries)))
 	if err != nil {
 		return err
 	}
-	arcs[countPath(root).String()] = countCID
+	arcs[countPath(root)] = countCID
 
 	for i, ent := range entries {
 		keyCID, err := encodePathMarker(ent.path)
 		if err != nil {
 			return err
 		}
-		arcs[entryKeyPath(root, uint64(i)).String()] = keyCID
-		arcs[entryValuePath(root, uint64(i)).String()] = ent.value
+		arcs[entryKeyPath(root, uint64(i))] = keyCID
+		arcs[entryValuePath(root, uint64(i))] = ent.value
 	}
 
-	return s.arctable.Update(ctx, bucketID, cid.Undef, cid.Undef, arcs)
+	snapshot, err := arcset.NewArcSetFromPaths(arcs)
+	if err != nil {
+		return err
+	}
+	return s.arctable.Update(ctx, bucketID, cid.Undef, cid.Undef, snapshot)
 }
 
 func countPath(root cid.Cid) arcset.Path {

--- a/core/structure/mapping/radix/radix.go
+++ b/core/structure/mapping/radix/radix.go
@@ -620,9 +620,9 @@ func (s *Map) loadValidatedNode(ctx context.Context, bucketID string, root cid.C
 }
 
 func (s *Map) loadNodeSlots(ctx context.Context, bucketID string, root cid.Cid) ([]cid.Cid, error) {
-	paths := make([]string, fanout)
+	paths := make([]arcset.Path, fanout)
 	for i := 0; i < fanout; i++ {
-		paths[i] = nodeSlotPath(root, byte(i)).String()
+		paths[i] = nodeSlotPath(root, byte(i))
 	}
 	found, err := s.arctable.BatchGet(ctx, bucketID, cid.Undef, paths)
 	if err != nil {
@@ -639,21 +639,25 @@ func (s *Map) loadNodeSlots(ctx context.Context, bucketID string, root cid.Cid) 
 }
 
 func (s *Map) storeNodeSlots(ctx context.Context, bucketID string, root cid.Cid, slots []cid.Cid) error {
-	arcs := make(map[string]cid.Cid)
+	arcs := make(map[arcset.Path]cid.Cid)
 	for i, slot := range slots {
 		if !slot.Defined() {
 			continue
 		}
-		arcs[nodeSlotPath(root, byte(i)).String()] = slot
+		arcs[nodeSlotPath(root, byte(i))] = slot
 	}
 	if len(arcs) == 0 {
 		return nil
 	}
-	return s.arctable.Update(ctx, bucketID, cid.Undef, cid.Undef, arcs)
+	snapshot, err := arcset.NewArcSetFromPaths(arcs)
+	if err != nil {
+		return err
+	}
+	return s.arctable.Update(ctx, bucketID, cid.Undef, cid.Undef, snapshot)
 }
 
 func (s *Map) loadBucketEntries(ctx context.Context, bucketID string, root cid.Cid) ([]cid.Cid, error) {
-	countCID, err := s.arctable.Get(ctx, bucketID, cid.Undef, bucketCountPath(root).String())
+	countCID, err := s.arctable.Get(ctx, bucketID, cid.Undef, bucketCountPath(root))
 	if err != nil {
 		return nil, err
 	}
@@ -662,9 +666,9 @@ func (s *Map) loadBucketEntries(ctx context.Context, bucketID string, root cid.C
 		return nil, err
 	}
 
-	paths := make([]string, count)
+	paths := make([]arcset.Path, count)
 	for i := uint64(0); i < count; i++ {
-		paths[i] = bucketEntryPath(root, i).String()
+		paths[i] = bucketEntryPath(root, i)
 	}
 	found, err := s.arctable.BatchGet(ctx, bucketID, cid.Undef, paths)
 	if err != nil {
@@ -683,16 +687,20 @@ func (s *Map) loadBucketEntries(ctx context.Context, bucketID string, root cid.C
 }
 
 func (s *Map) storeBucketEntries(ctx context.Context, bucketID string, root cid.Cid, markers []cid.Cid) error {
-	arcs := make(map[string]cid.Cid, len(markers)+1)
+	arcs := make(map[arcset.Path]cid.Cid, len(markers)+1)
 	countMarker, err := encodeBucketCountMarker(uint64(len(markers)))
 	if err != nil {
 		return err
 	}
-	arcs[bucketCountPath(root).String()] = countMarker
+	arcs[bucketCountPath(root)] = countMarker
 	for i, marker := range markers {
-		arcs[bucketEntryPath(root, uint64(i)).String()] = marker
+		arcs[bucketEntryPath(root, uint64(i))] = marker
 	}
-	return s.arctable.Update(ctx, bucketID, cid.Undef, cid.Undef, arcs)
+	snapshot, err := arcset.NewArcSetFromPaths(arcs)
+	if err != nil {
+		return err
+	}
+	return s.arctable.Update(ctx, bucketID, cid.Undef, cid.Undef, snapshot)
 }
 
 func cellsFromCIDs(values []cid.Cid) []commitment.Cell {

--- a/core/structure/mapping/view.go
+++ b/core/structure/mapping/view.go
@@ -21,6 +21,15 @@ func NewViewFrom(entries map[string]cid.Cid) *SetView {
 	return &SetView{entries: out}
 }
 
+// NewViewFromArcSet creates an immutable keyed view from a canonical arc set.
+func NewViewFromArcSet(arcs arcset.ArcSet) (*SetView, error) {
+	entries, err := arcset.ToPathMap(arcs)
+	if err != nil {
+		return nil, err
+	}
+	return NewViewFromPaths(entries), nil
+}
+
 // NewViewFromPaths creates an immutable keyed view from canonical paths.
 func NewViewFromPaths(entries map[arcset.Path]cid.Cid) *SetView {
 	out := make(map[arcset.Path]cid.Cid, len(entries))

--- a/core/types/arcset/memory.go
+++ b/core/types/arcset/memory.go
@@ -1,6 +1,7 @@
 package arcset
 
 import (
+	"fmt"
 	"slices"
 
 	cid "github.com/ipfs/go-cid"
@@ -18,8 +19,40 @@ func NewSet() *Set {
 	return &Set{arcs: make(map[Path]cid.Cid)}
 }
 
+// NewArcSet creates an immutable arc set from path strings.
+// Input paths are canonicalized before insertion. Empty canonical paths and
+// conflicting duplicate canonical paths are reported as errors.
+func NewArcSet(arcs map[string]cid.Cid) (ArcSet, error) {
+	out := make(map[Path]cid.Cid, len(arcs))
+	for rawPath, target := range arcs {
+		path, err := NewPath(rawPath)
+		if err != nil {
+			return nil, err
+		}
+		if existing, ok := out[path]; ok && !cidEqual(existing, target) {
+			return nil, &PathError{Path: rawPath, Err: fmt.Errorf("%w %q", ErrDuplicatePath, path.String())}
+		}
+		out[path] = target
+	}
+	return &Set{arcs: out}, nil
+}
+
+// NewArcSetFromPaths creates an immutable arc set from canonical paths.
+func NewArcSetFromPaths(arcs map[Path]cid.Cid) (ArcSet, error) {
+	out := make(map[Path]cid.Cid, len(arcs))
+	for path, target := range arcs {
+		if path.IsEmpty() {
+			return nil, &PathError{Err: ErrEmptyPath}
+		}
+		out[path] = target
+	}
+	return &Set{arcs: out}, nil
+}
+
 // NewSetFrom creates an in-memory arc set from path strings.
 // Input paths are canonicalized before insertion.
+//
+// Deprecated: use NewArcSet so malformed input is reported.
 func NewSetFrom(arcs map[string]cid.Cid) *Set {
 	out := make(map[Path]cid.Cid, len(arcs))
 	for path, target := range arcs {
@@ -30,7 +63,11 @@ func NewSetFrom(arcs map[string]cid.Cid) *Set {
 
 // NewSetFromPaths creates an in-memory arc set from canonical paths.
 func NewSetFromPaths(arcs map[Path]cid.Cid) *Set {
-	return &Set{arcs: arcs}
+	out := make(map[Path]cid.Cid, len(arcs))
+	for path, target := range arcs {
+		out[path] = target
+	}
+	return &Set{arcs: out}
 }
 
 // Get retrieves the target CID for a path.
@@ -78,3 +115,50 @@ func (it *memoryIterator) Err() error { return nil }
 func (it *memoryIterator) Close() {}
 
 var _ ArcSet = (*Set)(nil)
+
+// ToPathMap clones an arc set into its canonical path map form.
+func ToPathMap(arcs ArcSet) (map[Path]cid.Cid, error) {
+	if arcs == nil {
+		return nil, fmt.Errorf("arc set is nil")
+	}
+
+	out := make(map[Path]cid.Cid, arcs.Len())
+	iter := arcs.Iterate()
+	for {
+		path, target, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if path.IsEmpty() {
+			return nil, &PathError{Err: ErrEmptyPath}
+		}
+		if existing, ok := out[path]; ok && !cidEqual(existing, target) {
+			return nil, &PathError{Path: path.String(), Err: fmt.Errorf("%w %q", ErrDuplicatePath, path.String())}
+		}
+		out[path] = target
+	}
+	if err := iter.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ToStringMap clones an arc set into a canonical string-keyed map.
+func ToStringMap(arcs ArcSet) (map[string]cid.Cid, error) {
+	pathMap, err := ToPathMap(arcs)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]cid.Cid, len(pathMap))
+	for path, target := range pathMap {
+		out[path.String()] = target
+	}
+	return out, nil
+}
+
+func cidEqual(a, b cid.Cid) bool {
+	if !a.Defined() && !b.Defined() {
+		return true
+	}
+	return a.Equals(b)
+}

--- a/core/types/arcset/memory_test.go
+++ b/core/types/arcset/memory_test.go
@@ -1,0 +1,69 @@
+package arcset
+
+import (
+	"errors"
+	"testing"
+
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func testCID(t *testing.T, data string) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum([]byte(data), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("mh.Sum failed: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}
+
+func TestNewArcSetCanonicalizesPaths(t *testing.T) {
+	target := testCID(t, "target")
+	arcs, err := NewArcSet(map[string]cid.Cid{
+		"/a//b/": target,
+	})
+	if err != nil {
+		t.Fatalf("NewArcSet failed: %v", err)
+	}
+
+	got, ok := arcs.Get(CanonicalizePath("a/b"))
+	if !ok {
+		t.Fatal("canonical path not found")
+	}
+	if !got.Equals(target) {
+		t.Fatal("canonical path has wrong target")
+	}
+}
+
+func TestNewArcSetRejectsEmptyCanonicalPath(t *testing.T) {
+	_, err := NewArcSet(map[string]cid.Cid{
+		"///": testCID(t, "target"),
+	})
+	if !errors.Is(err, ErrEmptyPath) {
+		t.Fatalf("err = %v, want ErrEmptyPath", err)
+	}
+}
+
+func TestNewArcSetRejectsConflictingDuplicatePath(t *testing.T) {
+	_, err := NewArcSet(map[string]cid.Cid{
+		"a/b":   testCID(t, "first"),
+		"a//b/": testCID(t, "second"),
+	})
+	if !errors.Is(err, ErrDuplicatePath) {
+		t.Fatalf("err = %v, want ErrDuplicatePath", err)
+	}
+}
+
+func TestNewArcSetAllowsEquivalentDuplicatePath(t *testing.T) {
+	target := testCID(t, "target")
+	arcs, err := NewArcSet(map[string]cid.Cid{
+		"a/b":   target,
+		"a//b/": target,
+	})
+	if err != nil {
+		t.Fatalf("NewArcSet failed: %v", err)
+	}
+	if arcs.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", arcs.Len())
+	}
+}

--- a/core/types/arcset/path.go
+++ b/core/types/arcset/path.go
@@ -1,6 +1,44 @@
 package arcset
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	// ErrEmptyPath is returned when a raw binding path canonicalizes to the
+	// empty path. Empty paths are valid for traversal state, but not for an arc
+	// binding key.
+	ErrEmptyPath = errors.New("path must not be empty")
+
+	// ErrDuplicatePath is returned when two raw paths canonicalize to the same
+	// path but carry different targets.
+	ErrDuplicatePath = errors.New("duplicate canonical path")
+)
+
+// PathError describes a raw path that cannot be used as an arc binding key.
+type PathError struct {
+	Path string
+	Err  error
+}
+
+func (e *PathError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Path == "" {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("%q: %v", e.Path, e.Err)
+}
+
+func (e *PathError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
 
 // Path is a canonical arc path used inside MALT core components.
 // The zero value represents an empty path.
@@ -22,6 +60,15 @@ func CanonicalizePath(path string) Path {
 		filtered = append(filtered, part)
 	}
 	return Path(strings.Join(filtered, "/"))
+}
+
+// NewPath canonicalizes a raw path for use as an arc binding key.
+func NewPath(raw string) (Path, error) {
+	canonical := CanonicalizePath(raw)
+	if canonical.IsEmpty() {
+		return "", &PathError{Path: raw, Err: ErrEmptyPath}
+	}
+	return canonical, nil
 }
 
 // String returns the canonical string form of the path.

--- a/core/writer/writer.go
+++ b/core/writer/writer.go
@@ -22,7 +22,7 @@ var (
 	ErrInvalidRoot = errors.New("invalid structure root")
 
 	// ErrEmptyPath is returned when the path is empty.
-	ErrEmptyPath = errors.New("path must not be empty")
+	ErrEmptyPath = arcset.ErrEmptyPath
 
 	// ErrMissingPayloadBinding is returned when a MALT-native object is missing
 	// its mandatory @payload binding.
@@ -128,18 +128,11 @@ func NewWriter(semantic mapping.Semantics, arctable arctable.ArcTable, rec Linea
 }
 
 func canonicalizeUpdateMap(updates map[string]cid.Cid) (map[arcset.Path]cid.Cid, error) {
-	out := make(map[arcset.Path]cid.Cid, len(updates))
-	for path, target := range updates {
-		canonical := arcset.CanonicalizePath(path)
-		if canonical.IsEmpty() {
-			return nil, ErrEmptyPath
-		}
-		if existing, ok := out[canonical]; ok && !existing.Equals(target) {
-			return nil, fmt.Errorf("duplicate canonical path %q in updates", canonical.String())
-		}
-		out[canonical] = target
+	snapshot, err := arcset.NewArcSet(updates)
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return arcset.ToPathMap(snapshot)
 }
 
 func canonicalizeSnapshot(arcs arcset.ArcSet) (arcset.ArcSet, map[arcset.Path]cid.Cid, error) {
@@ -148,35 +141,36 @@ func canonicalizeSnapshot(arcs arcset.ArcSet) (arcset.ArcSet, map[arcset.Path]ci
 	}
 
 	arcsMap := make(map[arcset.Path]cid.Cid, arcs.Len())
-	stringMap := make(map[string]cid.Cid, arcs.Len())
 	iter := arcs.Iterate()
 	for {
 		path, target, ok := iter.Next()
 		if !ok {
 			break
 		}
-		canonical := path
-		if canonical.IsEmpty() {
+		if path.IsEmpty() {
 			return nil, nil, ErrEmptyPath
 		}
 		if !target.Defined() {
 			continue
 		}
-		if existing, ok := arcsMap[canonical]; ok && !existing.Equals(target) {
-			return nil, nil, fmt.Errorf("duplicate canonical path %q in arc set", canonical.String())
+		if existing, ok := arcsMap[path]; ok && !existing.Equals(target) {
+			return nil, nil, fmt.Errorf("duplicate canonical path %q in arc set", path.String())
 		}
-		arcsMap[canonical] = target
-		stringMap[canonical.String()] = target
+		arcsMap[path] = target
 	}
 	if iter.Err() != nil {
 		return nil, nil, fmt.Errorf("arc iteration error: %w", iter.Err())
 	}
 
-	return arcset.NewSetFrom(stringMap), arcsMap, nil
+	normalized, err := arcset.NewArcSetFromPaths(arcsMap)
+	if err != nil {
+		return nil, nil, err
+	}
+	return normalized, arcsMap, nil
 }
 
-func diffArcMaps(oldArcs, newArcs map[string]cid.Cid) map[string]cid.Cid {
-	diff := make(map[string]cid.Cid)
+func diffArcMaps(oldArcs, newArcs map[arcset.Path]cid.Cid) (arcset.ArcSet, error) {
+	diff := make(map[arcset.Path]cid.Cid)
 
 	for path, newTarget := range newArcs {
 		oldTarget, ok := oldArcs[path]
@@ -191,20 +185,7 @@ func diffArcMaps(oldArcs, newArcs map[string]cid.Cid) map[string]cid.Cid {
 		}
 	}
 
-	return diff
-}
-
-func stringifyArcSet(arcs arcset.ArcSet) map[string]cid.Cid {
-	out := make(map[string]cid.Cid, arcs.Len())
-	iter := arcs.Iterate()
-	for {
-		path, target, ok := iter.Next()
-		if !ok {
-			break
-		}
-		out[path.String()] = target
-	}
-	return out
+	return arcset.NewArcSetFromPaths(diff)
 }
 
 func filterLogicalArcSet(arcs arcset.ArcSet) arcset.ArcSet {
@@ -212,7 +193,7 @@ func filterLogicalArcSet(arcs arcset.ArcSet) arcset.ArcSet {
 		return nil
 	}
 
-	out := make(map[string]cid.Cid)
+	out := make(map[arcset.Path]cid.Cid)
 	iter := arcs.Iterate()
 	for {
 		path, target, ok := iter.Next()
@@ -222,9 +203,13 @@ func filterLogicalArcSet(arcs arcset.ArcSet) arcset.ArcSet {
 		if path.HasPrefix(arcset.CanonicalizePath("runtime")) {
 			continue
 		}
-		out[path.String()] = target
+		out[path] = target
 	}
-	return arcset.NewSetFrom(out)
+	filtered, err := arcset.NewArcSetFromPaths(out)
+	if err != nil {
+		return arcset.NewSet()
+	}
+	return filtered
 }
 
 func hasDefinedPayloadBinding(arcs arcset.ArcSet) bool {
@@ -269,7 +254,7 @@ func (w *Writer) UpdateArc(ctx context.Context, bucketId string, root cid.Cid, p
 	}
 
 	// Step 1: Look up current binding
-	oldTarget, err := w.arctable.Get(ctx, bucketId, root, canonicalPath.String())
+	oldTarget, err := w.arctable.Get(ctx, bucketId, root, canonicalPath)
 	if err != nil && !arctable.IsNotFound(err) {
 		return nil, fmt.Errorf("ArcTable.Get failed: %w", err)
 	}
@@ -312,14 +297,23 @@ func (w *Writer) UpdateArc(ctx context.Context, bucketId string, root cid.Cid, p
 		return nil, fmt.Errorf("semantic.Update failed for arc %s: %w", op, err)
 	}
 
-	oldArcs := stringifyArcSet(snapshot)
-	updatedArcs := stringifyArcSet(snapshot)
-	if newTarget.Defined() {
-		updatedArcs[canonicalPath.String()] = newTarget
-	} else {
-		delete(updatedArcs, canonicalPath.String())
+	oldArcs, err := arcset.ToPathMap(snapshot)
+	if err != nil {
+		return nil, err
 	}
-	delta := diffArcMaps(oldArcs, updatedArcs)
+	updatedArcs := make(map[arcset.Path]cid.Cid, len(oldArcs)+1)
+	for path, target := range oldArcs {
+		updatedArcs[path] = target
+	}
+	if newTarget.Defined() {
+		updatedArcs[canonicalPath] = newTarget
+	} else {
+		delete(updatedArcs, canonicalPath)
+	}
+	delta, err := diffArcMaps(oldArcs, updatedArcs)
+	if err != nil {
+		return nil, err
+	}
 
 	// Step 3: Apply update to ArcTable as an old->new delta. This keeps versioned ArcTable
 	// compact while still emitting tombstones for deletions.
@@ -382,7 +376,7 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, bucketId string, root cid.
 	perArc := make(map[arcset.Path]UpdateResult, len(normalizedUpdates))
 
 	for path, newTarget := range normalizedUpdates {
-		oldTarget, err := w.arctable.Get(ctx, bucketId, root, path.String())
+		oldTarget, err := w.arctable.Get(ctx, bucketId, root, path)
 		if err != nil && !arctable.IsNotFound(err) {
 			return nil, fmt.Errorf("ArcTable.Get failed for %s: %w", path.String(), err)
 		}
@@ -410,31 +404,34 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, bucketId string, root cid.
 
 	// Step 3: Update commitment
 	currentRoot := root
-	currentMap := stringifyArcSet(snapshot)
 	for path, result := range perArc {
 		currentRoot, err = w.semantic.Update(ctx, bucketId, currentRoot, path, result.OldTarget, result.NewTarget)
 		if err != nil {
 			return nil, fmt.Errorf("semantic.Update failed for %s: %w", path.String(), err)
 		}
-		if result.NewTarget.Defined() {
-			currentMap[path.String()] = result.NewTarget
-		} else {
-			delete(currentMap, path.String())
-		}
 	}
 	newRoot := currentRoot
 
-	oldArcs := stringifyArcSet(snapshot)
-	updatedArcs := stringifyArcSet(snapshot)
+	oldArcs, err := arcset.ToPathMap(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	updatedArcs := make(map[arcset.Path]cid.Cid, len(oldArcs)+len(normalizedUpdates))
+	for path, target := range oldArcs {
+		updatedArcs[path] = target
+	}
 	for path, newTarget := range normalizedUpdates {
 		if newTarget.Defined() {
-			updatedArcs[path.String()] = newTarget
+			updatedArcs[path] = newTarget
 		} else {
-			delete(updatedArcs, path.String())
+			delete(updatedArcs, path)
 		}
 	}
 
-	delta := diffArcMaps(oldArcs, updatedArcs)
+	delta, err := diffArcMaps(oldArcs, updatedArcs)
+	if err != nil {
+		return nil, err
+	}
 
 	// Step 4: Apply the update delta to ArcTable.
 	if err := w.arctable.Update(ctx, bucketId, newRoot, root, delta); err != nil {
@@ -481,13 +478,17 @@ func (w *Writer) CreateStructure(ctx context.Context, bucketId string, arcs arcs
 	}
 
 	// Step 1: Commit arc set via semantic layer
-	root, err := w.semantic.Commit(ctx, bucketId, mapping.NewViewFrom(stringifyArcSet(normalizedSnapshot)))
+	view, err := mapping.NewViewFromArcSet(normalizedSnapshot)
+	if err != nil {
+		return cid.Undef, err
+	}
+	root, err := w.semantic.Commit(ctx, bucketId, view)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("semantic.Commit failed: %w", err)
 	}
 
 	// Step 2: Store arcs in ArcTable (first version)
-	if err := w.arctable.Update(ctx, bucketId, root, cid.Undef, stringifyArcSet(normalizedSnapshot)); err != nil {
+	if err := w.arctable.Update(ctx, bucketId, root, cid.Undef, normalizedSnapshot); err != nil {
 		return cid.Undef, fmt.Errorf("ArcTable.Update failed: %w", err)
 	}
 
@@ -514,7 +515,7 @@ func (w *Writer) GetArc(ctx context.Context, bucketId string, root cid.Cid, path
 		return cid.Undef, ErrEmptyPath
 	}
 
-	target, err := w.arctable.Get(ctx, bucketId, root, canonicalPath.String())
+	target, err := w.arctable.Get(ctx, bucketId, root, canonicalPath)
 	if err != nil {
 		if arctable.IsNotFound(err) {
 			return cid.Undef, fmt.Errorf("%s: %w", canonicalPath.String(), ErrArcNotFound)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1513,24 +1513,19 @@ func parseArcMap(raw map[string]string) (map[string]cid.Cid, error) {
 }
 
 func buildCreateSnapshot(arcs map[string]cid.Cid) (arcset.ArcSet, int, error) {
-	canonical := make(map[string]cid.Cid, len(arcs))
-	payloadPresent := false
-	for rawPath, target := range arcs {
-		path := arcset.CanonicalizePath(rawPath)
-		if path.IsEmpty() {
-			return nil, 0, fmt.Errorf("path must not be empty")
-		}
-
-		if existing, ok := canonical[path.String()]; ok && !existing.Equals(target) {
-			return nil, 0, fmt.Errorf("duplicate canonical path %q in arcs", path.String())
-		}
-		canonical[path.String()] = target
-		if path == explicit.PayloadArc && target.Defined() {
-			payloadPresent = true
-		}
+	snapshot, err := arcset.NewArcSet(arcs)
+	if err != nil {
+		return nil, 0, err
 	}
-	if !payloadPresent {
+
+	payload, ok := snapshot.Get(explicit.PayloadArc)
+	if !ok || !payload.Defined() {
 		return nil, 0, fmt.Errorf("@payload binding is required")
+	}
+
+	canonical, err := arcset.ToPathMap(snapshot)
+	if err != nil {
+		return nil, 0, err
 	}
 
 	arcCount := 0
@@ -1540,7 +1535,7 @@ func buildCreateSnapshot(arcs map[string]cid.Cid) (arcset.ArcSet, int, error) {
 		}
 	}
 
-	return arcset.NewSetFrom(canonical), arcCount, nil
+	return snapshot, arcCount, nil
 }
 
 func decodeTargetCID(raw string) cid.Cid {


### PR DESCRIPTION
## Summary
- add arcset.NewArcSet/NewPath constructors that canonicalize raw path maps and report empty or conflicting canonical paths
- carry arcset.Path and ArcSet through ArcTable, writer, commitment, and map/list materialization paths
- keep UnixFS filename character policy in the UnixFS layout layer

## Tests
- go test ./...
