### PR TITLE
feat: add evaluation instrumentation hooks

### DIFF
--- a/core/cas/mock/mock.go
+++ b/core/cas/mock/mock.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/dewebprotocol/malt/core/cas"
 	"github.com/dewebprotocol/malt/core/kvstore/memory"
+	"github.com/dewebprotocol/malt/core/metrics"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -38,7 +39,11 @@ type CAS struct {
 	putLatency time.Duration
 	hasLatency time.Duration
 	jitter     time.Duration
+	stats      metrics.CASStatsRecorder
 }
+
+// CASStats is a point-in-time snapshot of mock CAS counters.
+type CASStats = metrics.CASStats
 
 // Option configures a mock CAS.
 type Option func(*options)
@@ -137,17 +142,20 @@ func blockKey(c cid.Cid) []byte {
 
 // Get retrieves a block from mock storage.
 func (m *CAS) Get(ctx context.Context, c cid.Cid) ([]byte, error) {
+	m.stats.RecordGetCall()
 	simulateLatency(m.getLatency, m.jitter)
 
 	data, err := m.kv.Get(ctx, blockKey(c))
 	if err != nil {
 		return nil, fmt.Errorf("block not found: %s", c.String())
 	}
+	m.stats.RecordGetBytes(len(data))
 	return data, nil
 }
 
 // Put stores a block in mock storage.
 func (m *CAS) Put(ctx context.Context, data []byte) (cid.Cid, error) {
+	m.stats.RecordPutCall()
 	simulateLatency(m.putLatency, m.jitter)
 
 	mhash, err := mh.Sum(data, mh.SHA2_256, -1)
@@ -159,11 +167,13 @@ func (m *CAS) Put(ctx context.Context, data []byte) (cid.Cid, error) {
 	if err := m.kv.Put(ctx, blockKey(c), data); err != nil {
 		return cid.Cid{}, fmt.Errorf("failed to store block: %w", err)
 	}
+	m.stats.RecordPutBytes(len(data))
 	return c, nil
 }
 
 // Has checks if a block exists in mock storage.
 func (m *CAS) Has(ctx context.Context, c cid.Cid) (bool, error) {
+	m.stats.RecordHasCall()
 	simulateLatency(m.hasLatency, m.jitter)
 
 	exists, err := m.kv.Has(ctx, blockKey(c))
@@ -176,6 +186,16 @@ func (m *CAS) Has(ctx context.Context, c cid.Cid) (bool, error) {
 // AddBlock adds a pre-existing block to mock storage without latency.
 func (m *CAS) AddBlock(c cid.Cid, data []byte) {
 	_ = m.kv.Put(context.Background(), blockKey(c), data)
+}
+
+// SnapshotStats returns the current mock CAS counters.
+func (m *CAS) SnapshotStats() CASStats {
+	return m.stats.Snapshot()
+}
+
+// ResetStats clears mock CAS counters.
+func (m *CAS) ResetStats() {
+	m.stats.Reset()
 }
 
 // Ensure CAS implements cas.Client.

--- a/core/cas/mock/stats_test.go
+++ b/core/cas/mock/stats_test.go
@@ -1,0 +1,62 @@
+package mock
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCASStatsCountOperationsAndBytes(t *testing.T) {
+	ctx := context.Background()
+	cas := NewCAS(WithoutLatency())
+
+	payload := []byte("instrumented block")
+	blockCID, err := cas.Put(ctx, payload)
+	if err != nil {
+		t.Fatalf("put block: %v", err)
+	}
+	if _, err := cas.Get(ctx, blockCID); err != nil {
+		t.Fatalf("get block: %v", err)
+	}
+	if ok, err := cas.Has(ctx, blockCID); err != nil {
+		t.Fatalf("has block: %v", err)
+	} else if !ok {
+		t.Fatal("expected block to exist")
+	}
+
+	stats := cas.SnapshotStats()
+	if stats.PutCount != 1 {
+		t.Fatalf("PutCount = %d, want 1", stats.PutCount)
+	}
+	if stats.GetCount != 1 {
+		t.Fatalf("GetCount = %d, want 1", stats.GetCount)
+	}
+	if stats.HasCount != 1 {
+		t.Fatalf("HasCount = %d, want 1", stats.HasCount)
+	}
+	if stats.BytesPut != uint64(len(payload)) {
+		t.Fatalf("BytesPut = %d, want %d", stats.BytesPut, len(payload))
+	}
+	if stats.BytesGet != uint64(len(payload)) {
+		t.Fatalf("BytesGet = %d, want %d", stats.BytesGet, len(payload))
+	}
+}
+
+func TestCASStatsResetClearsCounters(t *testing.T) {
+	ctx := context.Background()
+	cas := NewCAS(WithoutLatency())
+
+	blockCID, err := cas.Put(ctx, []byte("reset me"))
+	if err != nil {
+		t.Fatalf("put block: %v", err)
+	}
+	if _, err := cas.Get(ctx, blockCID); err != nil {
+		t.Fatalf("get block: %v", err)
+	}
+
+	cas.ResetStats()
+
+	stats := cas.SnapshotStats()
+	if stats != (CASStats{}) {
+		t.Fatalf("stats after reset = %+v, want zero", stats)
+	}
+}

--- a/core/metrics/arctable.go
+++ b/core/metrics/arctable.go
@@ -1,0 +1,138 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+
+	"github.com/dewebprotocol/malt/core/arctable"
+	"github.com/dewebprotocol/malt/core/arctable/bloom"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	cid "github.com/ipfs/go-cid"
+)
+
+// ErrBucketCreatorUnsupported is returned when a wrapped ArcTable cannot create buckets.
+var ErrBucketCreatorUnsupported = errors.New("wrapped arctable does not support bucket creation")
+
+// ArcTableStats is a point-in-time snapshot of ArcTable operation counters.
+type ArcTableStats struct {
+	GetCount          uint64
+	BatchGetCount     uint64
+	BatchGetPathCount uint64
+	UpdateCount       uint64
+	UpdateArcCount    uint64
+	SnapshotCount     uint64
+	SnapshotArcCount  uint64
+	IterateCount      uint64
+}
+
+type arcTableStatsRecorder struct {
+	getCount          atomic.Uint64
+	batchGetCount     atomic.Uint64
+	batchGetPathCount atomic.Uint64
+	updateCount       atomic.Uint64
+	updateArcCount    atomic.Uint64
+	snapshotCount     atomic.Uint64
+	snapshotArcCount  atomic.Uint64
+	iterateCount      atomic.Uint64
+}
+
+func (r *arcTableStatsRecorder) snapshot() ArcTableStats {
+	return ArcTableStats{
+		GetCount:          r.getCount.Load(),
+		BatchGetCount:     r.batchGetCount.Load(),
+		BatchGetPathCount: r.batchGetPathCount.Load(),
+		UpdateCount:       r.updateCount.Load(),
+		UpdateArcCount:    r.updateArcCount.Load(),
+		SnapshotCount:     r.snapshotCount.Load(),
+		SnapshotArcCount:  r.snapshotArcCount.Load(),
+		IterateCount:      r.iterateCount.Load(),
+	}
+}
+
+func (r *arcTableStatsRecorder) reset() {
+	r.getCount.Store(0)
+	r.batchGetCount.Store(0)
+	r.batchGetPathCount.Store(0)
+	r.updateCount.Store(0)
+	r.updateArcCount.Store(0)
+	r.snapshotCount.Store(0)
+	r.snapshotArcCount.Store(0)
+	r.iterateCount.Store(0)
+}
+
+// ArcTable wraps an arctable.ArcTable and records evaluation counters.
+type ArcTable struct {
+	base  arctable.ArcTable
+	stats arcTableStatsRecorder
+}
+
+// NewArcTable wraps base with ArcTable operation counters.
+func NewArcTable(base arctable.ArcTable) *ArcTable {
+	return &ArcTable{base: base}
+}
+
+// SnapshotStats returns the current ArcTable counters.
+func (m *ArcTable) SnapshotStats() ArcTableStats {
+	return m.stats.snapshot()
+}
+
+// ResetStats clears all ArcTable counters.
+func (m *ArcTable) ResetStats() {
+	m.stats.reset()
+}
+
+// Get retrieves the target CID for (bucketId, root, path).
+func (m *ArcTable) Get(ctx context.Context, bucketId string, root cid.Cid, path arcset.Path) (cid.Cid, error) {
+	m.stats.getCount.Add(1)
+	return m.base.Get(ctx, bucketId, root, path)
+}
+
+// BatchGet retrieves multiple target CIDs in a single operation.
+func (m *ArcTable) BatchGet(ctx context.Context, bucketId string, root cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error) {
+	m.stats.batchGetCount.Add(1)
+	m.stats.batchGetPathCount.Add(uint64(len(paths)))
+	return m.base.BatchGet(ctx, bucketId, root, paths)
+}
+
+// Update stores arc entries with a new commitment root.
+func (m *ArcTable) Update(ctx context.Context, bucketId string, newRoot, oldRoot cid.Cid, arcs arcset.ArcSet) error {
+	m.stats.updateCount.Add(1)
+	if arcs != nil {
+		m.stats.updateArcCount.Add(uint64(arcs.Len()))
+	}
+	return m.base.Update(ctx, bucketId, newRoot, oldRoot, arcs)
+}
+
+// Snapshot returns an immutable snapshot of all arcs for a given root.
+func (m *ArcTable) Snapshot(ctx context.Context, bucketId string, root cid.Cid) (arcset.ArcSet, error) {
+	m.stats.snapshotCount.Add(1)
+	arcs, err := m.base.Snapshot(ctx, bucketId, root)
+	if err == nil && arcs != nil {
+		m.stats.snapshotArcCount.Add(uint64(arcs.Len()))
+	}
+	return arcs, err
+}
+
+// Iterate returns a streaming iterator over arcs for a given root.
+func (m *ArcTable) Iterate(ctx context.Context, bucketId string, root cid.Cid) arcset.Iterator {
+	m.stats.iterateCount.Add(1)
+	return m.base.Iterate(ctx, bucketId, root)
+}
+
+// Close releases resources.
+func (m *ArcTable) Close() error {
+	return m.base.Close()
+}
+
+// CreateBucket forwards bucket creation when the wrapped ArcTable supports it.
+func (m *ArcTable) CreateBucket(ctx context.Context, bucketId string, cfg *bloom.BucketConfig) error {
+	creator, ok := m.base.(arctable.BucketCreator)
+	if !ok {
+		return ErrBucketCreatorUnsupported
+	}
+	return creator.CreateBucket(ctx, bucketId, cfg)
+}
+
+var _ arctable.ArcTable = (*ArcTable)(nil)
+var _ arctable.BucketCreator = (*ArcTable)(nil)

--- a/core/metrics/arctable_test.go
+++ b/core/metrics/arctable_test.go
@@ -1,0 +1,129 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/arctable/overwrite"
+	"github.com/dewebprotocol/malt/core/kvstore/memory"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func newTestCID(data []byte) cid.Cid {
+	mhash, err := mh.Sum(data, mh.SHA2_256, -1)
+	if err != nil {
+		panic(err)
+	}
+	return cid.NewCidV1(cid.Raw, mhash)
+}
+
+func TestArcTableStatsWrapperCountsCallsAndPreservesBehavior(t *testing.T) {
+	base, err := overwrite.NewArcTable(overwrite.WithKVStore(memory.New()))
+	if err != nil {
+		t.Fatalf("new overwrite arctable: %v", err)
+	}
+	wrapped := NewArcTable(base)
+
+	ctx := context.Background()
+	bucketID := "metrics-bucket"
+	root := newTestCID([]byte("root"))
+	targetA := newTestCID([]byte("target-a"))
+	targetB := newTestCID([]byte("target-b"))
+	arcs := arcset.NewSetFrom(map[string]cid.Cid{
+		"a": targetA,
+		"b": targetB,
+	})
+
+	if err := wrapped.Update(ctx, bucketID, root, cid.Undef, arcs); err != nil {
+		t.Fatalf("update arcs: %v", err)
+	}
+	got, err := wrapped.Get(ctx, bucketID, root, arcset.CanonicalizePath("a"))
+	if err != nil {
+		t.Fatalf("get arc: %v", err)
+	}
+	if !got.Equals(targetA) {
+		t.Fatalf("Get returned %s, want %s", got, targetA)
+	}
+
+	batch, err := wrapped.BatchGet(ctx, bucketID, root, []arcset.Path{
+		arcset.CanonicalizePath("a"),
+		arcset.CanonicalizePath("b"),
+	})
+	if err != nil {
+		t.Fatalf("batch get arcs: %v", err)
+	}
+	if len(batch) != 2 {
+		t.Fatalf("BatchGet returned %d arcs, want 2", len(batch))
+	}
+
+	snapshot, err := wrapped.Snapshot(ctx, bucketID, root)
+	if err != nil {
+		t.Fatalf("snapshot arcs: %v", err)
+	}
+	if snapshot.Len() != 2 {
+		t.Fatalf("Snapshot returned %d arcs, want 2", snapshot.Len())
+	}
+
+	iter := wrapped.Iterate(ctx, bucketID, root)
+	defer iter.Close()
+	iterated := 0
+	for {
+		_, _, ok := iter.Next()
+		if !ok {
+			break
+		}
+		iterated++
+	}
+	if err := iter.Err(); err != nil {
+		t.Fatalf("iterate arcs: %v", err)
+	}
+	if iterated != 2 {
+		t.Fatalf("Iterate returned %d arcs, want 2", iterated)
+	}
+
+	stats := wrapped.SnapshotStats()
+	if stats.GetCount != 1 {
+		t.Fatalf("GetCount = %d, want 1", stats.GetCount)
+	}
+	if stats.BatchGetCount != 1 {
+		t.Fatalf("BatchGetCount = %d, want 1", stats.BatchGetCount)
+	}
+	if stats.BatchGetPathCount != 2 {
+		t.Fatalf("BatchGetPathCount = %d, want 2", stats.BatchGetPathCount)
+	}
+	if stats.UpdateCount != 1 {
+		t.Fatalf("UpdateCount = %d, want 1", stats.UpdateCount)
+	}
+	if stats.UpdateArcCount != 2 {
+		t.Fatalf("UpdateArcCount = %d, want 2", stats.UpdateArcCount)
+	}
+	if stats.SnapshotCount != 1 {
+		t.Fatalf("SnapshotCount = %d, want 1", stats.SnapshotCount)
+	}
+	if stats.SnapshotArcCount != 2 {
+		t.Fatalf("SnapshotArcCount = %d, want 2", stats.SnapshotArcCount)
+	}
+	if stats.IterateCount != 1 {
+		t.Fatalf("IterateCount = %d, want 1", stats.IterateCount)
+	}
+}
+
+func TestArcTableStatsResetClearsCounters(t *testing.T) {
+	base, err := overwrite.NewArcTable(overwrite.WithKVStore(memory.New()))
+	if err != nil {
+		t.Fatalf("new overwrite arctable: %v", err)
+	}
+	wrapped := NewArcTable(base)
+
+	ctx := context.Background()
+	_, _ = wrapped.Get(ctx, "bucket", cid.Undef, arcset.CanonicalizePath("missing"))
+
+	wrapped.ResetStats()
+
+	stats := wrapped.SnapshotStats()
+	if stats != (ArcTableStats{}) {
+		t.Fatalf("stats after reset = %+v, want zero", stats)
+	}
+}

--- a/core/metrics/cas.go
+++ b/core/metrics/cas.go
@@ -1,0 +1,82 @@
+package metrics
+
+import "sync/atomic"
+
+// CASStats is a point-in-time snapshot of CAS operation counters.
+type CASStats struct {
+	PutCount uint64
+	GetCount uint64
+	HasCount uint64
+	BytesPut uint64
+	BytesGet uint64
+}
+
+// CASStatsRecorder records CAS counters with atomic updates.
+type CASStatsRecorder struct {
+	putCount atomic.Uint64
+	getCount atomic.Uint64
+	hasCount atomic.Uint64
+	bytesPut atomic.Uint64
+	bytesGet atomic.Uint64
+}
+
+// RecordPut records a Put call and the bytes accepted by storage.
+func (r *CASStatsRecorder) RecordPut(bytes int) {
+	r.putCount.Add(1)
+	r.RecordPutBytes(bytes)
+}
+
+// RecordPutCall records a Put call without accepted bytes.
+func (r *CASStatsRecorder) RecordPutCall() {
+	r.putCount.Add(1)
+}
+
+// RecordPutBytes records bytes accepted by storage.
+func (r *CASStatsRecorder) RecordPutBytes(bytes int) {
+	if bytes > 0 {
+		r.bytesPut.Add(uint64(bytes))
+	}
+}
+
+// RecordGet records a Get call and the bytes returned by storage.
+func (r *CASStatsRecorder) RecordGet(bytes int) {
+	r.getCount.Add(1)
+	r.RecordGetBytes(bytes)
+}
+
+// RecordGetBytes records bytes returned by storage.
+func (r *CASStatsRecorder) RecordGetBytes(bytes int) {
+	if bytes > 0 {
+		r.bytesGet.Add(uint64(bytes))
+	}
+}
+
+// RecordGetCall records a Get call without returned bytes.
+func (r *CASStatsRecorder) RecordGetCall() {
+	r.getCount.Add(1)
+}
+
+// RecordHasCall records a Has call.
+func (r *CASStatsRecorder) RecordHasCall() {
+	r.hasCount.Add(1)
+}
+
+// Snapshot returns the current CAS counters.
+func (r *CASStatsRecorder) Snapshot() CASStats {
+	return CASStats{
+		PutCount: r.putCount.Load(),
+		GetCount: r.getCount.Load(),
+		HasCount: r.hasCount.Load(),
+		BytesPut: r.bytesPut.Load(),
+		BytesGet: r.bytesGet.Load(),
+	}
+}
+
+// Reset clears all CAS counters.
+func (r *CASStatsRecorder) Reset() {
+	r.putCount.Store(0)
+	r.getCount.Store(0)
+	r.hasCount.Store(0)
+	r.bytesPut.Store(0)
+	r.bytesGet.Store(0)
+}


### PR DESCRIPTION
## Summary

- Add mock CAS stats for Put/Get/Has calls and bytes put/get returned.
- Add a `core/metrics` ArcTable wrapper that counts Get, BatchGet, Update, Snapshot, and Iterate calls.
- Keep instrumentation additive so existing production API behavior is unchanged by default.

## Validation

- `go test ./core/cas/mock ./core/arctable/... ./core/metrics`
- `go test ./...`