### PR TITLE
feat: add prooflist schema

### DIFF
--- a/core/layout/malt/unixfs/prooflist.go
+++ b/core/layout/malt/unixfs/prooflist.go
@@ -1,0 +1,50 @@
+package unixfs
+
+import (
+	"fmt"
+
+	"github.com/dewebprotocol/malt/core/types/prooflist"
+	cid "github.com/ipfs/go-cid"
+)
+
+// ProofListFromSteps converts UnixFS layout resolution steps into the
+// verifier-facing ProofList schema. It is an adapter over existing layout
+// proofs and does not change AddFile, Resolve, or ReadFile behavior.
+func ProofListFromSteps(root cid.Cid, queriedPath string, steps []Step) (*prooflist.ProofList, error) {
+	if !root.Defined() {
+		return nil, fmt.Errorf("root is undefined")
+	}
+
+	pl := &prooflist.ProofList{
+		Root:  root,
+		Query: queriedPath,
+		Steps: make([]prooflist.Step, 0, len(steps)),
+	}
+	for _, layoutStep := range steps {
+		path := layoutStep.Path.String()
+		pl.Steps = append(pl.Steps, prooflist.Step{
+			Kind:            unixFSStepKind(path),
+			From:            layoutStep.Root,
+			Query:           queriedPath,
+			Path:            path,
+			Target:          layoutStep.Target,
+			EvidenceKind:    "structure",
+			EvidenceBackend: "map",
+			Proof:           cloneProofBytes(layoutStep.Proof),
+		})
+	}
+	return pl, nil
+}
+
+func unixFSStepKind(path string) prooflist.StepKind {
+	if path == payloadPath.String() {
+		return prooflist.KindPayloadBinding
+	}
+	return prooflist.KindMapStep
+}
+
+func cloneProofBytes(proof []byte) []byte {
+	out := make([]byte, len(proof))
+	copy(out, proof)
+	return out
+}

--- a/core/layout/malt/unixfs/prooflist_test.go
+++ b/core/layout/malt/unixfs/prooflist_test.go
@@ -1,0 +1,70 @@
+package unixfs_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/layout/malt/unixfs"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	"github.com/dewebprotocol/malt/core/types/prooflist"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func testCID(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("mh.Sum failed: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}
+
+func TestProofListFromStepsClassifiesTerminalPayloadBinding(t *testing.T) {
+	root := testCID(t, "root")
+	fileRoot := testCID(t, "file")
+	payload := testCID(t, "payload")
+	steps := []unixfs.Step{
+		{
+			Root:   root,
+			Path:   arcset.CanonicalizePath("dir"),
+			Target: fileRoot,
+			Proof:  []byte("dir proof"),
+		},
+		{
+			Root:   fileRoot,
+			Path:   arcset.CanonicalizePath("@payload"),
+			Target: payload,
+			Proof:  []byte("payload proof"),
+		},
+	}
+
+	pl, err := unixfs.ProofListFromSteps(root, "dir/file.txt", steps)
+	if err != nil {
+		t.Fatalf("ProofListFromSteps failed: %v", err)
+	}
+	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("ValidateShape failed: %v", err)
+	}
+	if pl.Query != "dir/file.txt" {
+		t.Fatalf("query = %q, want dir/file.txt", pl.Query)
+	}
+	if len(pl.Steps) != 2 {
+		t.Fatalf("steps len = %d, want 2", len(pl.Steps))
+	}
+	if pl.Steps[0].Kind != prooflist.KindMapStep {
+		t.Fatalf("step 0 kind = %q, want %q", pl.Steps[0].Kind, prooflist.KindMapStep)
+	}
+	if pl.Steps[1].Kind != prooflist.KindPayloadBinding {
+		t.Fatalf("step 1 kind = %q, want %q", pl.Steps[1].Kind, prooflist.KindPayloadBinding)
+	}
+	if pl.Steps[1].Path != "@payload" {
+		t.Fatalf("step 1 path = %q, want @payload", pl.Steps[1].Path)
+	}
+	if pl.Steps[1].EvidenceKind != "structure" || pl.Steps[1].EvidenceBackend != "map" {
+		t.Fatalf("step 1 evidence labels = %q/%q, want structure/map", pl.Steps[1].EvidenceKind, pl.Steps[1].EvidenceBackend)
+	}
+	if !bytes.Equal(pl.Steps[1].Proof, []byte("payload proof")) {
+		t.Fatalf("terminal proof bytes were not preserved")
+	}
+}

--- a/core/resolver/prooflist.go
+++ b/core/resolver/prooflist.go
@@ -1,0 +1,77 @@
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/dewebprotocol/malt/core/types/evidence"
+	"github.com/dewebprotocol/malt/core/types/prooflist"
+	cid "github.com/ipfs/go-cid"
+)
+
+// ProofListFromTranscript converts the current resolver transcript into the
+// verifier-facing ProofList schema. It preserves transcript order and evidence
+// bytes; it does not perform cryptographic verification.
+func ProofListFromTranscript(root cid.Cid, transcript *Transcript) (*prooflist.ProofList, error) {
+	if !root.Defined() {
+		return nil, fmt.Errorf("root is undefined")
+	}
+	if transcript == nil {
+		return nil, fmt.Errorf("transcript is nil")
+	}
+
+	pl := &prooflist.ProofList{
+		Root:  root,
+		Steps: make([]prooflist.Step, 0, len(transcript.Steps)),
+	}
+	from := root
+	for _, transcriptStep := range transcript.Steps {
+		step := prooflist.Step{
+			Kind:         transcriptStepKind(transcriptStep),
+			From:         from,
+			Path:         transcriptStep.Path.String(),
+			Query:        transcriptStep.Path.String(),
+			Target:       transcriptStep.Target,
+			EvidenceKind: evidenceKindLabel(transcriptStep.Evidence),
+			Evidence:     cloneEvidenceBytes(transcriptStep.Evidence),
+		}
+		pl.Steps = append(pl.Steps, step)
+		from = transcriptStep.Target
+	}
+	return pl, nil
+}
+
+func transcriptStepKind(step StepEvidence) prooflist.StepKind {
+	if step.Path.String() == "@payload" {
+		return prooflist.KindPayloadBinding
+	}
+	if step.Evidence != nil && step.Evidence.Kind() == evidence.EvidenceKindImplicit {
+		return prooflist.KindImplicitBlock
+	}
+	return prooflist.KindMapStep
+}
+
+func evidenceKindLabel(ev evidence.Evidence) string {
+	if ev == nil {
+		return ""
+	}
+	switch ev.Kind() {
+	case evidence.EvidenceKindExplicit:
+		return "explicit"
+	case evidence.EvidenceKindImplicit:
+		return "implicit"
+	case evidence.EvidenceKindHAMT:
+		return "hamt"
+	default:
+		return "unknown"
+	}
+}
+
+func cloneEvidenceBytes(ev evidence.Evidence) []byte {
+	if ev == nil {
+		return nil
+	}
+	bytes := ev.Bytes()
+	out := make([]byte, len(bytes))
+	copy(out, bytes)
+	return out
+}

--- a/core/resolver/prooflist_test.go
+++ b/core/resolver/prooflist_test.go
@@ -1,0 +1,83 @@
+package resolver
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	"github.com/dewebprotocol/malt/core/types/evidence"
+	"github.com/dewebprotocol/malt/core/types/prooflist"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func testCID(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("mh.Sum failed: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}
+
+func TestProofListFromTranscriptPreservesOrderPathTargetAndEvidenceKind(t *testing.T) {
+	root := testCID(t, "root")
+	node := testCID(t, "node")
+	payload := testCID(t, "payload")
+	transcript := &Transcript{
+		Steps: []StepEvidence{
+			{
+				Path:     arcset.CanonicalizePath("dir"),
+				Target:   node,
+				Evidence: evidence.NewExplicitEvidence([]byte("map proof")),
+			},
+			{
+				Path:     arcset.CanonicalizePath("@payload"),
+				Target:   payload,
+				Evidence: evidence.NewImplicitEvidence([]byte("block bytes")),
+			},
+		},
+	}
+
+	pl, err := ProofListFromTranscript(root, transcript)
+	if err != nil {
+		t.Fatalf("ProofListFromTranscript failed: %v", err)
+	}
+	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("ValidateShape failed: %v", err)
+	}
+	if !pl.Root.Equals(root) {
+		t.Fatalf("root = %v, want %v", pl.Root, root)
+	}
+	if len(pl.Steps) != 2 {
+		t.Fatalf("steps len = %d, want 2", len(pl.Steps))
+	}
+	if pl.Steps[0].Kind != prooflist.KindMapStep {
+		t.Fatalf("step 0 kind = %q, want %q", pl.Steps[0].Kind, prooflist.KindMapStep)
+	}
+	if pl.Steps[0].Path != "dir" || !pl.Steps[0].Target.Equals(node) {
+		t.Fatalf("step 0 path/target not preserved: %#v", pl.Steps[0])
+	}
+	if !pl.Steps[0].From.Equals(root) {
+		t.Fatalf("step 0 from = %v, want root %v", pl.Steps[0].From, root)
+	}
+	if pl.Steps[0].EvidenceKind != "explicit" {
+		t.Fatalf("step 0 evidence kind = %q, want explicit", pl.Steps[0].EvidenceKind)
+	}
+	if !bytes.Equal(pl.Steps[0].Evidence, []byte("map proof")) {
+		t.Fatalf("step 0 evidence bytes not preserved")
+	}
+
+	if pl.Steps[1].Kind != prooflist.KindPayloadBinding {
+		t.Fatalf("step 1 kind = %q, want %q", pl.Steps[1].Kind, prooflist.KindPayloadBinding)
+	}
+	if !pl.Steps[1].From.Equals(node) {
+		t.Fatalf("step 1 from = %v, want previous target %v", pl.Steps[1].From, node)
+	}
+	if pl.Steps[1].Path != "@payload" || !pl.Steps[1].Target.Equals(payload) {
+		t.Fatalf("step 1 path/target not preserved: %#v", pl.Steps[1])
+	}
+	if pl.Steps[1].EvidenceKind != "implicit" {
+		t.Fatalf("step 1 evidence kind = %q, want implicit", pl.Steps[1].EvidenceKind)
+	}
+}

--- a/core/types/prooflist/prooflist.go
+++ b/core/types/prooflist/prooflist.go
@@ -1,0 +1,100 @@
+// Package prooflist defines the verifier-facing read proof transcript shape.
+package prooflist
+
+import (
+	"fmt"
+
+	cid "github.com/ipfs/go-cid"
+)
+
+// StepKind identifies the semantic role of one ordered proof step.
+type StepKind string
+
+const (
+	KindMapStep        StepKind = "map_step"
+	KindPayloadBinding StepKind = "payload_binding"
+	KindListIndex      StepKind = "list_index"
+	KindBlobBinding    StepKind = "blob_binding"
+	KindImplicitBlock  StepKind = "implicit_block"
+	KindLegacyUnknown  StepKind = "legacy_unknown"
+)
+
+// ProofList is an ordered verifier-facing proof artifact for a read.
+//
+// It is a schema and adapter boundary only. Cryptographic verification is still
+// owned by the concrete semantic backend that emitted each proof payload.
+type ProofList struct {
+	Root  cid.Cid `json:"root"`
+	Query string  `json:"query,omitempty"`
+	Steps []Step  `json:"steps"`
+}
+
+// Step records one hop from a structure root or block to a target CID.
+type Step struct {
+	Kind            StepKind `json:"kind"`
+	From            cid.Cid  `json:"from"`
+	Query           string   `json:"query,omitempty"`
+	Coordinate      string   `json:"coordinate,omitempty"`
+	Path            string   `json:"path,omitempty"`
+	Index           *uint64  `json:"index,omitempty"`
+	Target          cid.Cid  `json:"target"`
+	EvidenceKind    string   `json:"evidence_kind,omitempty"`
+	EvidenceBackend string   `json:"evidence_backend,omitempty"`
+	Evidence        []byte   `json:"evidence,omitempty"`
+	Proof           []byte   `json:"proof,omitempty"`
+}
+
+type validateConfig struct {
+	requireSteps bool
+}
+
+// ValidateOption customizes shape validation.
+type ValidateOption func(*validateConfig)
+
+// RequireSteps rejects a ProofList with no ordered steps.
+func RequireSteps() ValidateOption {
+	return func(cfg *validateConfig) {
+		cfg.requireSteps = true
+	}
+}
+
+// ValidateShape checks that the ProofList is structurally usable by a verifier.
+//
+// This does not perform cryptographic end-to-end verification.
+func (p ProofList) ValidateShape(opts ...ValidateOption) error {
+	cfg := validateConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	if !p.Root.Defined() {
+		return fmt.Errorf("prooflist root is undefined")
+	}
+	if cfg.requireSteps && len(p.Steps) == 0 {
+		return fmt.Errorf("prooflist steps are empty")
+	}
+	for i, step := range p.Steps {
+		if !step.Kind.Known() {
+			return fmt.Errorf("prooflist step %d has unknown kind %q", i, step.Kind)
+		}
+		if !step.From.Defined() {
+			return fmt.Errorf("prooflist step %d from CID is undefined", i)
+		}
+		if !step.Target.Defined() {
+			return fmt.Errorf("prooflist step %d target CID is undefined", i)
+		}
+	}
+	return nil
+}
+
+// Known reports whether k is part of the current ProofList schema.
+func (k StepKind) Known() bool {
+	switch k {
+	case KindMapStep, KindPayloadBinding, KindListIndex, KindBlobBinding, KindImplicitBlock, KindLegacyUnknown:
+		return true
+	default:
+		return false
+	}
+}

--- a/core/types/prooflist/prooflist_test.go
+++ b/core/types/prooflist/prooflist_test.go
@@ -1,0 +1,131 @@
+package prooflist
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func testCID(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("mh.Sum failed: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}
+
+func TestProofListJSONRoundTripUsesStableBase64Bytes(t *testing.T) {
+	root := testCID(t, "root")
+	target := testCID(t, "target")
+	pl := ProofList{
+		Root:  root,
+		Query: "dir/file",
+		Steps: []Step{
+			{
+				Kind:            KindMapStep,
+				From:            root,
+				Path:            "dir",
+				Query:           "dir/file",
+				Target:          target,
+				EvidenceKind:    "explicit",
+				EvidenceBackend: "kzg",
+				Evidence:        []byte{1, 2, 3},
+				Proof:           []byte{4},
+			},
+		},
+	}
+
+	data, err := json.Marshal(pl)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if !bytes.Contains(data, []byte(`"evidence":"AQID"`)) {
+		t.Fatalf("evidence bytes were not base64 encoded in JSON: %s", data)
+	}
+	if !bytes.Contains(data, []byte(`"proof":"BA=="`)) {
+		t.Fatalf("proof bytes were not base64 encoded in JSON: %s", data)
+	}
+
+	var got ProofList
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !got.Root.Equals(root) {
+		t.Fatalf("root = %v, want %v", got.Root, root)
+	}
+	if got.Query != "dir/file" {
+		t.Fatalf("query = %q, want %q", got.Query, "dir/file")
+	}
+	if len(got.Steps) != 1 {
+		t.Fatalf("steps len = %d, want 1", len(got.Steps))
+	}
+	step := got.Steps[0]
+	if step.Kind != KindMapStep {
+		t.Fatalf("kind = %q, want %q", step.Kind, KindMapStep)
+	}
+	if !step.From.Equals(root) || !step.Target.Equals(target) {
+		t.Fatalf("from/target did not round trip")
+	}
+	if step.Path != "dir" || step.Query != "dir/file" {
+		t.Fatalf("path/query did not round trip: %#v", step)
+	}
+	if !bytes.Equal(step.Evidence, []byte{1, 2, 3}) {
+		t.Fatalf("evidence = %v, want [1 2 3]", step.Evidence)
+	}
+	if !bytes.Equal(step.Proof, []byte{4}) {
+		t.Fatalf("proof = %v, want [4]", step.Proof)
+	}
+}
+
+func TestValidateShapeRejectsUndefinedRootTargetAndUnknownKind(t *testing.T) {
+	root := testCID(t, "root")
+	target := testCID(t, "target")
+
+	if err := (ProofList{Root: cid.Undef}).ValidateShape(); err == nil {
+		t.Fatal("expected undefined root to be rejected")
+	}
+
+	if err := (ProofList{
+		Root: root,
+		Steps: []Step{{
+			Kind:   KindMapStep,
+			From:   root,
+			Path:   "dir",
+			Target: cid.Undef,
+		}},
+	}).ValidateShape(); err == nil {
+		t.Fatal("expected undefined target to be rejected")
+	}
+
+	if err := (ProofList{
+		Root: root,
+		Steps: []Step{{
+			Kind:   StepKind("not_a_kind"),
+			From:   root,
+			Path:   "dir",
+			Target: target,
+		}},
+	}).ValidateShape(); err == nil {
+		t.Fatal("expected unknown kind to be rejected")
+	}
+
+	if err := (ProofList{
+		Root: root,
+		Steps: []Step{{
+			Kind:   KindLegacyUnknown,
+			From:   root,
+			Path:   "legacy",
+			Target: target,
+		}},
+	}).ValidateShape(); err != nil {
+		t.Fatalf("legacy/unknown compatibility kind should be accepted: %v", err)
+	}
+
+	if err := (ProofList{Root: root}).ValidateShape(RequireSteps()); err == nil {
+		t.Fatal("expected RequireSteps to reject an empty proof list")
+	}
+}


### PR DESCRIPTION
## Summary
- Add a verifier-facing ProofList schema with ordered proof steps and deterministic JSON fields.
- Add shape validation for defined roots, defined step targets, known step kinds, and optional non-empty step requirements.
- Add adapters from resolver transcripts and UnixFS layout steps without changing the HTTP API or UnixFS read/write logic.

## Notes
This is an additive schema and adapter layer for exposing current proof artifacts to verifiers. It does not claim cryptographic end-to-end verification and does not rewrite the gateway API.

## Tests
- go test ./core/types/prooflist ./core/resolver ./core/layout/malt/unixfs
- go test ./...