### PR TITLE
feat: add gateway semantic mutation boundary

### DIFF
--- a/core/gateway/gateway.go
+++ b/core/gateway/gateway.go
@@ -1,0 +1,197 @@
+// Package gateway defines the library-level boundary for semantic mutations.
+package gateway
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/dewebprotocol/malt/core/arctable"
+	"github.com/dewebprotocol/malt/core/codec"
+	"github.com/dewebprotocol/malt/core/structure/list"
+	"github.com/dewebprotocol/malt/core/structure/mapping"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	cid "github.com/ipfs/go-cid"
+)
+
+var (
+	// ErrInvalidBucket is returned when a semantic mutation has no bucket ID.
+	ErrInvalidBucket = errors.New("invalid bucket")
+
+	// ErrInvalidBaseRoot is returned when an update mutation has no base root.
+	ErrInvalidBaseRoot = errors.New("invalid base root")
+
+	// ErrEmptyPuts is returned when a semantic mutation carries no arcset replacements.
+	ErrEmptyPuts = errors.New("empty puts")
+
+	// ErrObjectKindMismatch is returned when a put kind disagrees with its object or arcset kind.
+	ErrObjectKindMismatch = errors.New("object kind mismatch")
+
+	// ErrNilArcSet is returned when a put has no canonical arcset.
+	ErrNilArcSet = errors.New("nil arcset")
+)
+
+// SemanticMutation is the gateway write boundary emitted by application layouts.
+type SemanticMutation struct {
+	BucketID string
+	BaseRoot cid.Cid
+	Puts     []ArcSetPut
+}
+
+// ArcSetPut replaces one touched semantic object's full canonical arcset.
+type ArcSetPut struct {
+	Object cid.Cid
+	Kind   arcset.Kind
+	ArcSet *arcset.CanonicalArcSet
+}
+
+// WriteReceipt records the library-level outcome of applying a semantic mutation.
+type WriteReceipt struct {
+	BucketID string
+	BaseRoot cid.Cid
+	NewRoot  cid.Cid
+	PutCount int
+	ArcCount int
+}
+
+// Executor submits semantic mutations to the current map/list semantic backends.
+type Executor struct {
+	Maps     mapping.Semantics
+	Lists    list.Semantics
+	ArcTable arctable.ArcTable
+}
+
+// ValidateSemanticMutation validates the shape of an update semantic mutation.
+func ValidateSemanticMutation(mut SemanticMutation) error {
+	if mut.BucketID == "" {
+		return ErrInvalidBucket
+	}
+	if !mut.BaseRoot.Defined() {
+		return ErrInvalidBaseRoot
+	}
+	if len(mut.Puts) == 0 {
+		return ErrEmptyPuts
+	}
+	for i, put := range mut.Puts {
+		if put.ArcSet == nil {
+			return fmt.Errorf("put %d: %w", i, ErrNilArcSet)
+		}
+		if put.Kind != put.ArcSet.Kind() {
+			return fmt.Errorf("put %d: %w", i, ErrObjectKindMismatch)
+		}
+		if !objectKindMatches(put.Object, put.Kind) {
+			return fmt.Errorf("put %d: %w", i, ErrObjectKindMismatch)
+		}
+	}
+	return nil
+}
+
+// Apply commits full canonical arcset replacements in order.
+//
+// The executor treats BaseRoot as the caller's update base for receipt and
+// validation purposes only. It does not publish heads, arbitrate freshness, or
+// merge concurrent roots.
+func (e Executor) Apply(ctx context.Context, mut SemanticMutation) (WriteReceipt, error) {
+	if err := ValidateSemanticMutation(mut); err != nil {
+		return WriteReceipt{}, err
+	}
+
+	var newRoot cid.Cid
+	arcCount := 0
+	for i, put := range mut.Puts {
+		root, count, err := e.commitPut(ctx, mut.BucketID, put)
+		if err != nil {
+			return WriteReceipt{}, fmt.Errorf("put %d: %w", i, err)
+		}
+		newRoot = root
+		arcCount += count
+	}
+
+	return WriteReceipt{
+		BucketID: mut.BucketID,
+		BaseRoot: mut.BaseRoot,
+		NewRoot:  newRoot,
+		PutCount: len(mut.Puts),
+		ArcCount: arcCount,
+	}, nil
+}
+
+func (e Executor) commitPut(ctx context.Context, bucketID string, put ArcSetPut) (cid.Cid, int, error) {
+	switch put.Kind {
+	case arcset.KindMap:
+		if e.Maps == nil {
+			return cid.Undef, 0, errors.New("map semantics is nil")
+		}
+		view, err := canonicalMapView(put.ArcSet)
+		if err != nil {
+			return cid.Undef, 0, err
+		}
+		root, err := e.Maps.Commit(ctx, bucketID, view)
+		if err != nil {
+			return cid.Undef, 0, err
+		}
+		return root, put.ArcSet.Len(), nil
+	case arcset.KindList:
+		if e.Lists == nil {
+			return cid.Undef, 0, errors.New("list semantics is nil")
+		}
+		view, err := canonicalListView(put.ArcSet)
+		if err != nil {
+			return cid.Undef, 0, err
+		}
+		root, err := e.Lists.Commit(ctx, bucketID, view)
+		if err != nil {
+			return cid.Undef, 0, err
+		}
+		return root, put.ArcSet.Len(), nil
+	default:
+		return cid.Undef, 0, fmt.Errorf("%w: %q", arcset.ErrInvalidKind, put.Kind)
+	}
+}
+
+func canonicalMapView(set *arcset.CanonicalArcSet) (mapping.View, error) {
+	entries := make(map[arcset.Path]cid.Cid, set.Len())
+	for _, entry := range set.Entries() {
+		path := arcset.CanonicalizePath(entry.Coordinate.String())
+		if path.IsEmpty() || path.String() != entry.Coordinate.String() {
+			return nil, fmt.Errorf("invalid canonical map coordinate %q", entry.Coordinate.String())
+		}
+		entries[path] = entry.Target.CID()
+	}
+	return mapping.NewViewFromPaths(entries), nil
+}
+
+func canonicalListView(set *arcset.CanonicalArcSet) (list.View, error) {
+	entries := set.Entries()
+	values := make([]cid.Cid, len(entries))
+	for i, entry := range entries {
+		raw := entry.Coordinate.Bytes()
+		if len(raw) != 8 {
+			return nil, fmt.Errorf("invalid canonical list coordinate %q", entry.Coordinate.String())
+		}
+		index := binary.BigEndian.Uint64(raw)
+		if index != uint64(i) {
+			return nil, fmt.Errorf("canonical list arcset is sparse at index %d", index)
+		}
+		values[i] = entry.Target.CID()
+	}
+	return list.NewViewFromSlice(values), nil
+}
+
+func objectKindMatches(object cid.Cid, kind arcset.Kind) bool {
+	if !object.Defined() {
+		return true
+	}
+
+	switch codec.SemanticKindOf(object) {
+	case codec.SemanticKindUnknown:
+		return true
+	case codec.SemanticKindMap:
+		return kind == arcset.KindMap
+	case codec.SemanticKindList:
+		return kind == arcset.KindList
+	default:
+		return false
+	}
+}

--- a/core/gateway/gateway_test.go
+++ b/core/gateway/gateway_test.go
@@ -1,0 +1,332 @@
+package gateway_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/arctable/overwrite"
+	"github.com/dewebprotocol/malt/core/codec"
+	"github.com/dewebprotocol/malt/core/commitment/kzg"
+	"github.com/dewebprotocol/malt/core/gateway"
+	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
+	listtree "github.com/dewebprotocol/malt/core/structure/list/tree"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
+	root := testCID("root")
+	payload := testCID("payload")
+	mapSet := mustCanonicalMap(t, map[string]cid.Cid{"@payload": payload})
+	listSet := mustCanonicalList(t, []cid.Cid{payload})
+
+	tests := []struct {
+		name string
+		mut  gateway.SemanticMutation
+		want error
+	}{
+		{
+			name: "missing bucket",
+			mut: gateway.SemanticMutation{
+				BaseRoot: root,
+				Puts: []gateway.ArcSetPut{{
+					Object: root,
+					Kind:   arcset.KindMap,
+					ArcSet: mapSet,
+				}},
+			},
+			want: gateway.ErrInvalidBucket,
+		},
+		{
+			name: "missing base root",
+			mut: gateway.SemanticMutation{
+				BucketID: "bucket",
+				Puts: []gateway.ArcSetPut{{
+					Object: root,
+					Kind:   arcset.KindMap,
+					ArcSet: mapSet,
+				}},
+			},
+			want: gateway.ErrInvalidBaseRoot,
+		},
+		{
+			name: "empty puts",
+			mut: gateway.SemanticMutation{
+				BucketID: "bucket",
+				BaseRoot: root,
+			},
+			want: gateway.ErrEmptyPuts,
+		},
+		{
+			name: "nil arcset",
+			mut: gateway.SemanticMutation{
+				BucketID: "bucket",
+				BaseRoot: root,
+				Puts: []gateway.ArcSetPut{{
+					Object: root,
+					Kind:   arcset.KindMap,
+				}},
+			},
+			want: gateway.ErrNilArcSet,
+		},
+		{
+			name: "put kind mismatch",
+			mut: gateway.SemanticMutation{
+				BucketID: "bucket",
+				BaseRoot: root,
+				Puts: []gateway.ArcSetPut{{
+					Object: root,
+					Kind:   arcset.KindMap,
+					ArcSet: listSet,
+				}},
+			},
+			want: gateway.ErrObjectKindMismatch,
+		},
+		{
+			name: "object kind mismatch",
+			mut: gateway.SemanticMutation{
+				BucketID: "bucket",
+				BaseRoot: root,
+				Puts: []gateway.ArcSetPut{{
+					Object: mustTypedRoot(t, codec.SemanticKindList),
+					Kind:   arcset.KindMap,
+					ArcSet: mapSet,
+				}},
+			},
+			want: gateway.ErrObjectKindMismatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := gateway.ValidateSemanticMutation(tt.mut)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("ValidateSemanticMutation error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalMapWithoutPayloadIsRejected(t *testing.T) {
+	_, err := arcset.NewCanonicalMapArcSet(map[string]cid.Cid{
+		"child": testCID("child"),
+	})
+	if !errors.Is(err, arcset.ErrMissingPayloadBinding) {
+		t.Fatalf("NewCanonicalMapArcSet error = %v, want %v", err, arcset.ErrMissingPayloadBinding)
+	}
+}
+
+func TestExecutorAppliesMapReplacementAndReturnsStableReceipt(t *testing.T) {
+	ctx := context.Background()
+	exec := newExecutor(t)
+	bucketID := "gateway-map-replacement"
+	baseRoot := testCID("base")
+	payload := testCID("payload")
+	child := testCID("child")
+	set := mustCanonicalMap(t, map[string]cid.Cid{
+		"@payload": payload,
+		"child":    child,
+	})
+
+	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
+		BucketID: bucketID,
+		BaseRoot: baseRoot,
+		Puts: []gateway.ArcSetPut{{
+			Object: baseRoot,
+			Kind:   arcset.KindMap,
+			ArcSet: set,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if receipt.BucketID != bucketID {
+		t.Fatalf("receipt bucket = %q, want %q", receipt.BucketID, bucketID)
+	}
+	if !receipt.BaseRoot.Equals(baseRoot) {
+		t.Fatalf("receipt base root = %s, want %s", receipt.BaseRoot, baseRoot)
+	}
+	if codec.SemanticKindOf(receipt.NewRoot) != codec.SemanticKindMap {
+		t.Fatalf("new root kind = %s, want %s", codec.SemanticKindOf(receipt.NewRoot), codec.SemanticKindMap)
+	}
+	if receipt.PutCount != 1 {
+		t.Fatalf("put count = %d, want 1", receipt.PutCount)
+	}
+	if receipt.ArcCount != 2 {
+		t.Fatalf("arc count = %d, want 2", receipt.ArcCount)
+	}
+
+	key := arcset.CanonicalizePath("child")
+	binding, proof, err := exec.Maps.Prove(ctx, bucketID, receipt.NewRoot, key)
+	if err != nil {
+		t.Fatalf("Prove failed: %v", err)
+	}
+	if !binding.Present || !binding.Value.Equals(child) {
+		t.Fatalf("binding = %+v, want child %s", binding, child)
+	}
+	ok, err := exec.Maps.Verify(receipt.NewRoot, key, binding, proof)
+	if err != nil {
+		t.Fatalf("Verify failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected map proof to verify")
+	}
+}
+
+func TestExecutorAppliesListReplacementAndReturnsStableReceipt(t *testing.T) {
+	ctx := context.Background()
+	exec := newExecutor(t)
+	bucketID := "gateway-list-replacement"
+	baseRoot := testCID("base")
+	first := testCID("first")
+	second := testCID("second")
+	set := mustCanonicalList(t, []cid.Cid{first, second})
+
+	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
+		BucketID: bucketID,
+		BaseRoot: baseRoot,
+		Puts: []gateway.ArcSetPut{{
+			Object: baseRoot,
+			Kind:   arcset.KindList,
+			ArcSet: set,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if codec.SemanticKindOf(receipt.NewRoot) != codec.SemanticKindList {
+		t.Fatalf("new root kind = %s, want %s", codec.SemanticKindOf(receipt.NewRoot), codec.SemanticKindList)
+	}
+	if receipt.PutCount != 1 {
+		t.Fatalf("put count = %d, want 1", receipt.PutCount)
+	}
+	if receipt.ArcCount != 2 {
+		t.Fatalf("arc count = %d, want 2", receipt.ArcCount)
+	}
+
+	query, proof, err := exec.Lists.Prove(ctx, bucketID, receipt.NewRoot, 1)
+	if err != nil {
+		t.Fatalf("Prove failed: %v", err)
+	}
+	if query.Length != 2 || !query.Key.Equals(second) {
+		t.Fatalf("query = %+v, want length 2 and key %s", query, second)
+	}
+	ok, err := exec.Lists.Verify(receipt.NewRoot, 1, query, proof)
+	if err != nil {
+		t.Fatalf("Verify failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected list proof to verify")
+	}
+}
+
+func TestExecutorAppliesPutsInOrderAndUsesFinalRoot(t *testing.T) {
+	ctx := context.Background()
+	exec := newExecutor(t)
+	bucketID := "gateway-ordered-replacements"
+	baseRoot := testCID("base")
+	mapSet := mustCanonicalMap(t, map[string]cid.Cid{
+		"@payload": testCID("payload"),
+	})
+	listSet := mustCanonicalList(t, []cid.Cid{testCID("chunk")})
+
+	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
+		BucketID: bucketID,
+		BaseRoot: baseRoot,
+		Puts: []gateway.ArcSetPut{
+			{Object: baseRoot, Kind: arcset.KindMap, ArcSet: mapSet},
+			{Object: cid.Undef, Kind: arcset.KindList, ArcSet: listSet},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if codec.SemanticKindOf(receipt.NewRoot) != codec.SemanticKindList {
+		t.Fatalf("new root kind = %s, want final put kind %s", codec.SemanticKindOf(receipt.NewRoot), codec.SemanticKindList)
+	}
+	if receipt.PutCount != 2 {
+		t.Fatalf("put count = %d, want 2", receipt.PutCount)
+	}
+	if receipt.ArcCount != 2 {
+		t.Fatalf("arc count = %d, want 2", receipt.ArcCount)
+	}
+}
+
+func newExecutor(t *testing.T) gateway.Executor {
+	t.Helper()
+
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("kzg.NewScheme failed: %v", err)
+	}
+	arcs, err := overwrite.NewArcTable(overwrite.WithKVStore(kvmemory.New()))
+	if err != nil {
+		t.Fatalf("overwrite.NewArcTable failed: %v", err)
+	}
+	maps, err := mappingradix.NewMap(scheme, arcs)
+	if err != nil {
+		t.Fatalf("radix.NewMap failed: %v", err)
+	}
+	lists, err := listtree.NewList(scheme, arcs)
+	if err != nil {
+		t.Fatalf("tree.NewList failed: %v", err)
+	}
+	return gateway.Executor{
+		Maps:     maps,
+		Lists:    lists,
+		ArcTable: arcs,
+	}
+}
+
+func mustCanonicalMap(t *testing.T, entries map[string]cid.Cid) *arcset.CanonicalArcSet {
+	t.Helper()
+
+	set, err := arcset.NewCanonicalMapArcSet(entries)
+	if err != nil {
+		t.Fatalf("NewCanonicalMapArcSet failed: %v", err)
+	}
+	return set
+}
+
+func mustCanonicalList(t *testing.T, values []cid.Cid) *arcset.CanonicalArcSet {
+	t.Helper()
+
+	set, err := arcset.NewCanonicalListArcSet(values)
+	if err != nil {
+		t.Fatalf("NewCanonicalListArcSet failed: %v", err)
+	}
+	return set
+}
+
+func mustTypedRoot(t *testing.T, kind codec.SemanticKind) cid.Cid {
+	t.Helper()
+
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("kzg.NewScheme failed: %v", err)
+	}
+	root, err := scheme.Commit(nil)
+	if err != nil {
+		t.Fatalf("scheme.Commit failed: %v", err)
+	}
+	commitment, err := codec.ExtractCommitment(root)
+	if err != nil {
+		t.Fatalf("ExtractCommitment failed: %v", err)
+	}
+	typed, err := codec.NewTypedCID(kind, codec.BackendKindKZG, commitment)
+	if err != nil {
+		t.Fatalf("NewTypedCID failed: %v", err)
+	}
+	return typed
+}
+
+func testCID(seed string) cid.Cid {
+	sum, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		panic(err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}


### PR DESCRIPTION
## Summary

- Add `core/gateway` semantic mutation request and write receipt types.
- Validate bucket IDs, update base roots, non-empty puts, nil canonical arcsets, arcset kind mismatches, and typed object/kind mismatches.
- Add a conservative full-replacement executor that commits canonical map and list arcsets through the existing semantic backends and returns stable receipt counts.

## Notes

This is a library-level boundary only. It does not change daemon HTTP behavior and does not claim head publication, freshness, MVCC merge, or multi-writer semantics.

## Validation

- `go test ./core/gateway`
- `go test ./...`