### PR TITLE
[codex] expose unixfs semantic mutation plans

### DIFF
--- a/core/layout/malt/unixfs/mutation.go
+++ b/core/layout/malt/unixfs/mutation.go
@@ -1,0 +1,234 @@
+package unixfs
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/dewebprotocol/malt/core/codec"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	cid "github.com/ipfs/go-cid"
+)
+
+// MutationPlan is a layout-produced semantic mutation snapshot for one
+// UnixFS node. It is an adapter artifact for gateway-style consumers; the
+// gateway remains responsible for owning write execution and publication.
+type MutationPlan struct {
+	BucketID string
+	BaseRoot cid.Cid
+	Puts     []MutationPut
+}
+
+// MutationPut binds one materialized semantic root to its canonical arc set.
+type MutationPut struct {
+	Object cid.Cid
+	Kind   arcset.Kind
+	ArcSet *arcset.CanonicalArcSet
+}
+
+// MutationPlanForPath exposes canonical map/list arcsets for the UnixFS node
+// already reachable at path. For directories it includes only the terminal
+// directory map, not descendant subtrees. For large files it includes the file
+// map plus the terminal payload list composed from individual list index reads.
+func (l *Layout) MutationPlanForPath(ctx context.Context, root cid.Cid, path string) (*MutationPlan, error) {
+	if !root.Defined() {
+		return nil, fmt.Errorf("root is undefined")
+	}
+
+	nodeRoot, _, err := l.resolveNode(ctx, root, path)
+	if err != nil {
+		return nil, err
+	}
+	kind, err := l.nodeType(ctx, nodeRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeArcSet, err := l.canonicalNodeArcSet(ctx, nodeRoot, kind)
+	if err != nil {
+		return nil, err
+	}
+	plan := &MutationPlan{
+		BucketID: l.bucketID,
+		BaseRoot: root,
+		Puts: []MutationPut{
+			{
+				Object: nodeRoot,
+				Kind:   arcset.KindMap,
+				ArcSet: nodeArcSet,
+			},
+		},
+	}
+
+	if kind != typeFile {
+		return plan, nil
+	}
+
+	payload, _, ok, err := l.lookup(ctx, nodeRoot, payloadPath)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("%w: missing @payload", ErrNotFound)
+	}
+	if codec.SemanticKindOf(payload) != codec.SemanticKindList {
+		return plan, nil
+	}
+
+	info, err := l.fileInfo(ctx, nodeRoot, payload)
+	if err != nil {
+		return nil, err
+	}
+	listArcSet, err := l.canonicalListArcSet(ctx, payload, chunkCount(info.size, info.chunkSize))
+	if err != nil {
+		return nil, err
+	}
+	plan.Puts = append(plan.Puts, MutationPut{
+		Object: payload,
+		Kind:   arcset.KindList,
+		ArcSet: listArcSet,
+	})
+	return plan, nil
+}
+
+func (l *Layout) canonicalNodeArcSet(ctx context.Context, nodeRoot cid.Cid, kind string) (*arcset.CanonicalArcSet, error) {
+	typeCID, _, ok, err := l.lookup(ctx, nodeRoot, typePath)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("%w: missing @type", ErrNotFound)
+	}
+	payload, _, ok, err := l.lookup(ctx, nodeRoot, payloadPath)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("%w: missing @payload", ErrNotFound)
+	}
+
+	typeEntry, err := mapEntry("@type", arcset.NewCASTarget(typeCID))
+	if err != nil {
+		return nil, err
+	}
+	payloadEntry, err := mapEntry("@payload", arcset.NewTargetRef(payloadTargetKind(payload), payload))
+	if err != nil {
+		return nil, err
+	}
+	entries := []arcset.ArcEntry{typeEntry, payloadEntry}
+
+	switch kind {
+	case typeFile:
+		sizeCID, _, ok, err := l.lookup(ctx, nodeRoot, sizePath)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("%w: missing @size", ErrNotFound)
+		}
+		chunkSizeCID, _, ok, err := l.lookup(ctx, nodeRoot, chunkSizePath)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("%w: missing @chunksize", ErrNotFound)
+		}
+		sizeEntry, err := mapEntry("@size", arcset.NewCASTarget(sizeCID))
+		if err != nil {
+			return nil, err
+		}
+		chunkSizeEntry, err := mapEntry("@chunksize", arcset.NewCASTarget(chunkSizeCID))
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, sizeEntry, chunkSizeEntry)
+	case typeDirectory:
+		names, err := l.loadDirectoryManifest(ctx, payload)
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range names {
+			child, _, ok, err := l.lookup(ctx, nodeRoot, arcset.CanonicalizePath(name))
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, fmt.Errorf("%w: missing directory entry %s", ErrNotFound, name)
+			}
+			entry, err := mapEntry(name, arcset.NewMapTarget(child))
+			if err != nil {
+				return nil, err
+			}
+			entries = append(entries, entry)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported unixfs node kind %q", kind)
+	}
+
+	return arcset.NewCanonicalArcSet(arcset.KindMap, entries)
+}
+
+func (l *Layout) canonicalListArcSet(ctx context.Context, root cid.Cid, length uint64) (*arcset.CanonicalArcSet, error) {
+	entries := make([]arcset.ArcEntry, 0, length)
+	for index := uint64(0); index < length; index++ {
+		if index > math.MaxInt64 {
+			return nil, fmt.Errorf("list index %d exceeds canonical coordinate range", index)
+		}
+		query, proof, err := l.lists.Prove(ctx, l.bucketID, root, index)
+		if err != nil {
+			return nil, err
+		}
+		ok, err := l.lists.Verify(root, index, query, proof)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("list proof failed at index %d", index)
+		}
+		if query.Length != length {
+			return nil, fmt.Errorf("list length = %d, want %d", query.Length, length)
+		}
+		if !query.Key.Defined() {
+			return nil, fmt.Errorf("%w: missing chunk %d", ErrNotFound, index)
+		}
+
+		coord, err := arcset.NewListCoordinate(int64(index))
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, arcset.ArcEntry{
+			Coordinate: coord,
+			Target:     arcset.NewCASTarget(query.Key),
+		})
+	}
+	return arcset.NewCanonicalArcSet(arcset.KindList, entries)
+}
+
+func mapEntry(key string, target arcset.TargetRef) (arcset.ArcEntry, error) {
+	coord, err := arcset.NewMapCoordinate(key)
+	if err != nil {
+		return arcset.ArcEntry{}, err
+	}
+	return arcset.ArcEntry{
+		Coordinate: coord,
+		Target:     target,
+	}, nil
+}
+
+func payloadTargetKind(payload cid.Cid) arcset.TargetKind {
+	switch codec.SemanticKindOf(payload) {
+	case codec.SemanticKindMap:
+		return arcset.TargetKindMap
+	case codec.SemanticKindList:
+		return arcset.TargetKindList
+	default:
+		return arcset.TargetKindCAS
+	}
+}
+
+func chunkCount(size, chunkSize uint64) uint64 {
+	if size == 0 {
+		return 0
+	}
+	return ((size - 1) / chunkSize) + 1
+}

--- a/core/layout/malt/unixfs/mutation_test.go
+++ b/core/layout/malt/unixfs/mutation_test.go
@@ -1,0 +1,133 @@
+package unixfs_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/layout/malt/unixfs"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	cid "github.com/ipfs/go-cid"
+)
+
+func TestSmallFileMutationPlanIncludesMapPayload(t *testing.T) {
+	ctx := context.Background()
+	layout := newLayout(t, 8)
+
+	root, err := layout.AddFile(ctx, cid.Undef, "hello.txt", []byte("hello"))
+	if err != nil {
+		t.Fatalf("AddFile failed: %v", err)
+	}
+
+	plan, err := layout.MutationPlanForPath(ctx, root, "hello.txt")
+	if err != nil {
+		t.Fatalf("MutationPlanForPath failed: %v", err)
+	}
+	if plan.BucketID == "" {
+		t.Fatal("plan BucketID is empty")
+	}
+	if !plan.BaseRoot.Equals(root) {
+		t.Fatalf("plan BaseRoot = %s, want %s", plan.BaseRoot, root)
+	}
+	if len(plan.Puts) != 1 {
+		t.Fatalf("put count = %d, want 1", len(plan.Puts))
+	}
+	put := plan.Puts[0]
+	if put.Kind != arcset.KindMap {
+		t.Fatalf("put kind = %q, want map", put.Kind)
+	}
+	if put.ArcSet.Kind() != arcset.KindMap {
+		t.Fatalf("arcset kind = %q, want map", put.ArcSet.Kind())
+	}
+	if !hasEntry(put.ArcSet, "@payload", arcset.TargetKindCAS) {
+		t.Fatal("file map arcset missing CAS @payload binding")
+	}
+}
+
+func TestLargeFileMutationPlanIncludesFileMapAndOrderedList(t *testing.T) {
+	ctx := context.Background()
+	layout := newLayout(t, 4)
+
+	root, err := layout.AddFile(ctx, cid.Undef, "blob.bin", []byte("abcdefghijkl"))
+	if err != nil {
+		t.Fatalf("AddFile failed: %v", err)
+	}
+
+	plan, err := layout.MutationPlanForPath(ctx, root, "blob.bin")
+	if err != nil {
+		t.Fatalf("MutationPlanForPath failed: %v", err)
+	}
+	if len(plan.Puts) != 2 {
+		t.Fatalf("put count = %d, want 2", len(plan.Puts))
+	}
+	if plan.Puts[0].Kind != arcset.KindMap {
+		t.Fatalf("put 0 kind = %q, want map", plan.Puts[0].Kind)
+	}
+	if !hasEntry(plan.Puts[0].ArcSet, "@payload", arcset.TargetKindList) {
+		t.Fatal("file map arcset missing list @payload binding")
+	}
+	if plan.Puts[1].Kind != arcset.KindList {
+		t.Fatalf("put 1 kind = %q, want list", plan.Puts[1].Kind)
+	}
+
+	got := entryCoordinates(plan.Puts[1].ArcSet)
+	want := []string{"0", "1", "2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("list coordinates = %#v, want %#v", got, want)
+	}
+	for _, entry := range plan.Puts[1].ArcSet.Entries() {
+		if entry.Target.Kind() != arcset.TargetKindCAS {
+			t.Fatalf("list entry %s target kind = %q, want cas", entry.Coordinate.String(), entry.Target.Kind())
+		}
+	}
+}
+
+func TestDirectoryMutationPlanSortsEntriesAndRejectsReservedPath(t *testing.T) {
+	ctx := context.Background()
+	layout := newLayout(t, 8)
+
+	root, err := layout.AddFile(ctx, cid.Undef, "dir/b.txt", []byte("b"))
+	if err != nil {
+		t.Fatalf("AddFile(b) failed: %v", err)
+	}
+	root, err = layout.AddFile(ctx, root, "dir/a.txt", []byte("a"))
+	if err != nil {
+		t.Fatalf("AddFile(a) failed: %v", err)
+	}
+
+	if _, err := layout.MutationPlanForPath(ctx, root, "dir/@payload"); !errors.Is(err, unixfs.ErrReservedPath) {
+		t.Fatalf("reserved path error = %v, want ErrReservedPath", err)
+	}
+
+	plan, err := layout.MutationPlanForPath(ctx, root, "dir")
+	if err != nil {
+		t.Fatalf("MutationPlanForPath(dir) failed: %v", err)
+	}
+	if len(plan.Puts) != 1 {
+		t.Fatalf("put count = %d, want 1", len(plan.Puts))
+	}
+	got := entryCoordinates(plan.Puts[0].ArcSet)
+	want := []string{"@payload", "@type", "a.txt", "b.txt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("directory map coordinates = %#v, want %#v", got, want)
+	}
+}
+
+func hasEntry(set *arcset.CanonicalArcSet, coordinate string, targetKind arcset.TargetKind) bool {
+	for _, entry := range set.Entries() {
+		if entry.Coordinate.String() == coordinate && entry.Target.Kind() == targetKind {
+			return true
+		}
+	}
+	return false
+}
+
+func entryCoordinates(set *arcset.CanonicalArcSet) []string {
+	entries := set.Entries()
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entry.Coordinate.String())
+	}
+	return out
+}

--- a/core/layout/malt/unixfs/prooflist.go
+++ b/core/layout/malt/unixfs/prooflist.go
@@ -1,11 +1,25 @@
 package unixfs
 
 import (
+	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/dewebprotocol/malt/core/codec"
+	"github.com/dewebprotocol/malt/core/structure"
 	"github.com/dewebprotocol/malt/core/types/prooflist"
 	cid "github.com/ipfs/go-cid"
 )
+
+// ListIndexStep records one list index proof used by a UnixFS large-file
+// payload read. Multiple ListIndexStep values compose range evidence; they do
+// not claim a first-class range proof.
+type ListIndexStep struct {
+	Root   cid.Cid
+	Index  uint64
+	Target cid.Cid
+	Proof  structure.Proof
+}
 
 // ProofListFromSteps converts UnixFS layout resolution steps into the
 // verifier-facing ProofList schema. It is an adapter over existing layout
@@ -34,6 +48,85 @@ func ProofListFromSteps(root cid.Cid, queriedPath string, steps []Step) (*proofl
 		})
 	}
 	return pl, nil
+}
+
+// AppendListIndexSteps appends typed list-index evidence to an existing
+// ProofList. This is intended for large-file range reads that are currently
+// represented as composed index proofs.
+func AppendListIndexSteps(pl *prooflist.ProofList, queriedPath string, steps []ListIndexStep) error {
+	if pl == nil {
+		return fmt.Errorf("prooflist is nil")
+	}
+	for _, layoutStep := range steps {
+		if !layoutStep.Root.Defined() {
+			return fmt.Errorf("list step root is undefined")
+		}
+		if !layoutStep.Target.Defined() {
+			return fmt.Errorf("list step target is undefined")
+		}
+		index := layoutStep.Index
+		pl.Steps = append(pl.Steps, prooflist.Step{
+			Kind:            prooflist.KindListIndex,
+			From:            layoutStep.Root,
+			Query:           queriedPath,
+			Coordinate:      strconv.FormatUint(layoutStep.Index, 10),
+			Index:           &index,
+			Target:          layoutStep.Target,
+			EvidenceKind:    "structure",
+			EvidenceBackend: "list",
+			Proof:           cloneProofBytes(layoutStep.Proof),
+		})
+	}
+	return nil
+}
+
+// ListIndexStepsForFileRange returns composed list-index proof steps for a
+// large-file range. Small raw-payload files return no list steps.
+func (l *Layout) ListIndexStepsForFileRange(ctx context.Context, root cid.Cid, path string, offset, length uint64) ([]ListIndexStep, error) {
+	if length == 0 {
+		return nil, nil
+	}
+	info, err := l.resolveFile(ctx, root, path)
+	if err != nil {
+		return nil, err
+	}
+	if codec.SemanticKindOf(info.payload) != codec.SemanticKindList {
+		return nil, nil
+	}
+	if offset >= info.size {
+		return nil, nil
+	}
+	if length > info.size-offset {
+		length = info.size - offset
+	}
+
+	startIndex := offset / info.chunkSize
+	endOffset := offset + length
+	endIndex := (endOffset - 1) / info.chunkSize
+	steps := make([]ListIndexStep, 0, endIndex-startIndex+1)
+	for index := startIndex; index <= endIndex; index++ {
+		query, proof, err := l.lists.Prove(ctx, l.bucketID, info.payload, index)
+		if err != nil {
+			return nil, err
+		}
+		ok, err := l.lists.Verify(info.payload, index, query, proof)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("list proof failed at index %d", index)
+		}
+		if !query.Key.Defined() {
+			return nil, fmt.Errorf("%w: missing chunk %d", ErrNotFound, index)
+		}
+		steps = append(steps, ListIndexStep{
+			Root:   info.payload,
+			Index:  index,
+			Target: query.Key,
+			Proof:  proof,
+		})
+	}
+	return steps, nil
 }
 
 func unixFSStepKind(path string) prooflist.StepKind {

--- a/core/layout/malt/unixfs/prooflist_test.go
+++ b/core/layout/malt/unixfs/prooflist_test.go
@@ -2,6 +2,7 @@ package unixfs_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/dewebprotocol/malt/core/layout/malt/unixfs"
@@ -66,5 +67,89 @@ func TestProofListFromStepsClassifiesTerminalPayloadBinding(t *testing.T) {
 	}
 	if !bytes.Equal(pl.Steps[1].Proof, []byte("payload proof")) {
 		t.Fatalf("terminal proof bytes were not preserved")
+	}
+}
+
+func TestAppendListIndexStepsClassifiesKnownListQueries(t *testing.T) {
+	root := testCID(t, "root")
+	listRoot := testCID(t, "list")
+	chunk0 := testCID(t, "chunk-0")
+	chunk1 := testCID(t, "chunk-1")
+
+	pl, err := unixfs.ProofListFromSteps(root, "blob.bin[0:8]", nil)
+	if err != nil {
+		t.Fatalf("ProofListFromSteps failed: %v", err)
+	}
+	err = unixfs.AppendListIndexSteps(pl, "blob.bin[0:8]", []unixfs.ListIndexStep{
+		{
+			Root:   listRoot,
+			Index:  0,
+			Target: chunk0,
+			Proof:  []byte("index 0 proof"),
+		},
+		{
+			Root:   listRoot,
+			Index:  1,
+			Target: chunk1,
+			Proof:  []byte("index 1 proof"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("AppendListIndexSteps failed: %v", err)
+	}
+	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("ValidateShape failed: %v", err)
+	}
+	if len(pl.Steps) != 2 {
+		t.Fatalf("steps len = %d, want 2", len(pl.Steps))
+	}
+	for i, step := range pl.Steps {
+		if step.Kind != prooflist.KindListIndex {
+			t.Fatalf("step %d kind = %q, want %q", i, step.Kind, prooflist.KindListIndex)
+		}
+		if step.Index == nil || *step.Index != uint64(i) {
+			t.Fatalf("step %d index = %v, want %d", i, step.Index, i)
+		}
+		if step.Coordinate != string(rune('0'+i)) {
+			t.Fatalf("step %d coordinate = %q, want %d", i, step.Coordinate, i)
+		}
+		if step.EvidenceKind != "structure" || step.EvidenceBackend != "list" {
+			t.Fatalf("step %d evidence labels = %q/%q, want structure/list", i, step.EvidenceKind, step.EvidenceBackend)
+		}
+	}
+	if !bytes.Equal(pl.Steps[1].Proof, []byte("index 1 proof")) {
+		t.Fatalf("list index proof bytes were not preserved")
+	}
+}
+
+func TestListIndexStepsForFileRangeReturnsComposedIndexEvidence(t *testing.T) {
+	ctx := context.Background()
+	layout := newLayout(t, 4)
+
+	root, err := layout.AddFile(ctx, cid.Undef, "blob.bin", []byte("abcdefghijkl"))
+	if err != nil {
+		t.Fatalf("AddFile failed: %v", err)
+	}
+
+	steps, err := layout.ListIndexStepsForFileRange(ctx, root, "blob.bin", 3, 6)
+	if err != nil {
+		t.Fatalf("ListIndexStepsForFileRange failed: %v", err)
+	}
+	if len(steps) != 3 {
+		t.Fatalf("steps len = %d, want 3", len(steps))
+	}
+	for i, step := range steps {
+		if step.Index != uint64(i) {
+			t.Fatalf("step %d index = %d, want %d", i, step.Index, i)
+		}
+		if !step.Root.Defined() {
+			t.Fatalf("step %d root is undefined", i)
+		}
+		if !step.Target.Defined() {
+			t.Fatalf("step %d target is undefined", i)
+		}
+		if len(step.Proof) == 0 {
+			t.Fatalf("step %d proof is empty", i)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add UnixFS layout-produced `MutationPlan` / `MutationPut` adapters with canonical map arcsets for terminal file and directory nodes.
- Include large-file payload list canonical arcsets with numerically ordered list entries.
- Add read evidence helpers for composed list index proof steps without changing existing AddFile, ReadFile, or daemon HTTP behavior.

## Tests
- `go test ./core/layout/malt/unixfs`
- `go test ./...`