### PR TITLE
feat: add daemon semantic mutation API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -189,6 +189,15 @@ func (c *Client) SetBucketHead(ctx context.Context, id string, newRoot string, a
 	return c.do(ctx, http.MethodPut, "/buckets/"+url.PathEscape(id)+"/head", nil, req, nil)
 }
 
+// ApplyBucketSemanticMutation applies a gateway semantic mutation and advances the bucket head.
+func (c *Client) ApplyBucketSemanticMutation(ctx context.Context, id string, req *httpapi.BucketSemanticMutationRequest) (*httpapi.BucketSemanticMutationResponse, error) {
+	var resp httpapi.BucketSemanticMutationResponse
+	if err := c.do(ctx, http.MethodPost, "/buckets/"+url.PathEscape(id)+"/semantic-mutations", nil, req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 func (c *Client) AddBucketUnixFSDirectory(ctx context.Context, id string, p string) (*httpapi.BucketUnixFSWriteResponse, error) {
 	query := map[string]string{}
 	if p != "" {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -318,6 +318,71 @@ func TestClientBucketScopedMapAndListAPIs(t *testing.T) {
 	}
 }
 
+func TestClientBucketSemanticMutation(t *testing.T) {
+	cfg := testConfig(t)
+	node, err := api.NewNode(api.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = node.Close()
+	})
+
+	ts := httptest.NewServer(server.New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	cfg.RPC.Listen = ts.Listener.Addr().String()
+	client := New(cfg)
+	ctx := context.Background()
+
+	if _, err := client.CreateBucket(ctx, "demo", ""); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	createResp, err := client.CreateBucketStructure(ctx, "demo", withPayloadBinding(map[string]string{
+		"name": fakeCIDString("initial-name"),
+	}))
+	if err != nil {
+		t.Fatalf("create bucket structure: %v", err)
+	}
+
+	nextName := fakeCIDString("next-name")
+	resp, err := client.ApplyBucketSemanticMutation(ctx, "demo", &httpapi.BucketSemanticMutationRequest{
+		Puts: []httpapi.SemanticMutationPut{{
+			Object: createResp.Root,
+			Kind:   "map",
+			Entries: []httpapi.SemanticMutationEntry{
+				{Path: "@payload", Target: fakeCIDString("next-payload")},
+				{Path: "name", Target: nextName},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ApplyBucketSemanticMutation: %v", err)
+	}
+	if resp.Bucket != "demo" || resp.BaseRoot != createResp.Root || resp.NewRoot == "" {
+		t.Fatalf("unexpected semantic mutation response: %+v", resp)
+	}
+	if resp.PutCount != 1 || resp.ArcCount != 2 {
+		t.Fatalf("semantic mutation counts = puts %d arcs %d, want 1/2", resp.PutCount, resp.ArcCount)
+	}
+
+	meta, err := client.GetBucket(ctx, "demo")
+	if err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if meta.Root != resp.NewRoot || meta.ArcCount != 2 {
+		t.Fatalf("bucket root=%q arcs=%d, want root=%q arcs=2", meta.Root, meta.ArcCount, resp.NewRoot)
+	}
+
+	resolved, err := client.ResolveBucket(ctx, "demo", "name")
+	if err != nil {
+		t.Fatalf("resolve bucket: %v", err)
+	}
+	if resolved.Target != nextName {
+		t.Fatalf("resolved target = %q, want %q", resolved.Target, nextName)
+	}
+}
+
 func TestClientBucketStatAndContent(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := api.NewNode(api.WithConfig(cfg))

--- a/core/gateway/gateway.go
+++ b/core/gateway/gateway.go
@@ -131,6 +131,15 @@ func (e Executor) commitPut(ctx context.Context, bucketID string, put ArcSetPut)
 		if err != nil {
 			return cid.Undef, 0, err
 		}
+		if e.ArcTable != nil {
+			snapshot, err := canonicalMapSnapshot(put.ArcSet)
+			if err != nil {
+				return cid.Undef, 0, err
+			}
+			if err := e.ArcTable.Update(ctx, bucketID, root, put.Object, snapshot); err != nil {
+				return cid.Undef, 0, err
+			}
+		}
 		return root, put.ArcSet.Len(), nil
 	case arcset.KindList:
 		if e.Lists == nil {
@@ -160,6 +169,18 @@ func canonicalMapView(set *arcset.CanonicalArcSet) (mapping.View, error) {
 		entries[path] = entry.Target.CID()
 	}
 	return mapping.NewViewFromPaths(entries), nil
+}
+
+func canonicalMapSnapshot(set *arcset.CanonicalArcSet) (arcset.ArcSet, error) {
+	entries := make(map[arcset.Path]cid.Cid, set.Len())
+	for _, entry := range set.Entries() {
+		path := arcset.CanonicalizePath(entry.Coordinate.String())
+		if path.IsEmpty() || path.String() != entry.Coordinate.String() {
+			return nil, fmt.Errorf("invalid canonical map coordinate %q", entry.Coordinate.String())
+		}
+		entries[path] = entry.Target.CID()
+	}
+	return arcset.NewArcSetFromPaths(entries)
 }
 
 func canonicalListView(set *arcset.CanonicalArcSet) (list.View, error) {

--- a/httpapi/types.go
+++ b/httpapi/types.go
@@ -46,6 +46,36 @@ type BucketHeadSetRequest struct {
 	ExpectedOldRoot string `json:"expected_old_root,omitempty"`
 }
 
+// BucketSemanticMutationRequest applies a semantic mutation to a managed bucket head.
+type BucketSemanticMutationRequest struct {
+	BaseRoot string                `json:"base_root,omitempty"`
+	Puts     []SemanticMutationPut `json:"puts"`
+}
+
+// SemanticMutationPut replaces one semantic object's full canonical arc set.
+type SemanticMutationPut struct {
+	Object  string                  `json:"object,omitempty"`
+	Kind    string                  `json:"kind"`
+	Entries []SemanticMutationEntry `json:"entries"`
+}
+
+// SemanticMutationEntry is one canonical coordinate-to-target binding.
+type SemanticMutationEntry struct {
+	Path       string  `json:"path,omitempty"`
+	Index      *uint64 `json:"index,omitempty"`
+	Target     string  `json:"target"`
+	TargetKind string  `json:"target_kind,omitempty"`
+}
+
+// BucketSemanticMutationResponse returns the gateway write receipt after publication.
+type BucketSemanticMutationResponse struct {
+	Bucket   string `json:"bucket"`
+	BaseRoot string `json:"base_root"`
+	NewRoot  string `json:"new_root"`
+	PutCount int    `json:"put_count"`
+	ArcCount int    `json:"arc_count"`
+}
+
 // BucketMapCreateRequest creates a map root inside a bucket namespace.
 type BucketMapCreateRequest struct {
 	Bindings map[string]string `json:"bindings"`

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dewebprotocol/malt/core/bucketpath"
 	"github.com/dewebprotocol/malt/core/cas"
 	"github.com/dewebprotocol/malt/core/codec"
+	"github.com/dewebprotocol/malt/core/gateway"
 	"github.com/dewebprotocol/malt/core/graph"
 	"github.com/dewebprotocol/malt/core/layout/malt/unixfs"
 	"github.com/dewebprotocol/malt/core/lineage"
@@ -225,6 +226,83 @@ func (s *Server) handleBucketHeadSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleBucketSemanticMutation(w http.ResponseWriter, r *http.Request) {
+	bucketID := r.PathValue("id")
+	meta, g, err := s.openManagedGraph(r.Context(), bucketID, true)
+	if err != nil {
+		writeManagedGraphError(w, err)
+		return
+	}
+
+	var req httpapi.BucketSemanticMutationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+
+	baseRoot := meta.Root
+	if req.BaseRoot != "" {
+		baseRoot, err = decodeCID(req.BaseRoot)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if meta.Root != baseRoot {
+			writeError(w, http.StatusConflict, "stale base_root")
+			return
+		}
+	}
+
+	mut, err := semanticMutationFromRequest(bucketID, baseRoot, &req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if len(mut.Puts) == 0 || mut.Puts[len(mut.Puts)-1].Kind != arcset.KindMap {
+		writeError(w, http.StatusBadRequest, "semantic mutation result must be a map bucket head")
+		return
+	}
+
+	exec := gateway.Executor{
+		Maps:     g.Semantic(),
+		Lists:    g.ListSemantic(),
+		ArcTable: s.node.ArcTable(),
+	}
+	receipt, err := exec.Apply(r.Context(), mut)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if codec.SemanticKindOf(receipt.NewRoot) != codec.SemanticKindMap {
+		writeError(w, http.StatusBadRequest, "semantic mutation result must be a map bucket head")
+		return
+	}
+	if _, err := mandatoryMapPayload(r.Context(), g, receipt.NewRoot); err != nil {
+		if errors.Is(err, writer.ErrArcNotFound) {
+			writeError(w, http.StatusBadRequest, "semantic mutation result must include a mandatory @payload binding")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if err := s.updateManagedGraphHead(r.Context(), bucketID, receipt.NewRoot, receipt.ArcCount); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if lm := s.node.LineageManager(); lm != nil {
+		_ = lm.Record(r.Context(), receipt.NewRoot, receipt.BaseRoot, receipt.ArcCount)
+	}
+
+	writeJSON(w, http.StatusCreated, &httpapi.BucketSemanticMutationResponse{
+		Bucket:   receipt.BucketID,
+		BaseRoot: receipt.BaseRoot.String(),
+		NewRoot:  receipt.NewRoot.String(),
+		PutCount: receipt.PutCount,
+		ArcCount: receipt.ArcCount,
+	})
 }
 
 func (s *Server) handleBucketMapsCreate(w http.ResponseWriter, r *http.Request) {
@@ -1510,6 +1588,114 @@ func parseArcMap(raw map[string]string) (map[string]cid.Cid, error) {
 		out[path] = parsed
 	}
 	return out, nil
+}
+
+func semanticMutationFromRequest(bucketID string, baseRoot cid.Cid, req *httpapi.BucketSemanticMutationRequest) (gateway.SemanticMutation, error) {
+	if req == nil {
+		return gateway.SemanticMutation{}, fmt.Errorf("request is required")
+	}
+
+	puts := make([]gateway.ArcSetPut, 0, len(req.Puts))
+	for i, putReq := range req.Puts {
+		put, err := semanticPutFromRequest(putReq)
+		if err != nil {
+			return gateway.SemanticMutation{}, fmt.Errorf("put %d: %w", i, err)
+		}
+		puts = append(puts, put)
+	}
+
+	return gateway.SemanticMutation{
+		BucketID: bucketID,
+		BaseRoot: baseRoot,
+		Puts:     puts,
+	}, nil
+}
+
+func semanticPutFromRequest(req httpapi.SemanticMutationPut) (gateway.ArcSetPut, error) {
+	object := cid.Undef
+	if req.Object != "" {
+		parsed, err := decodeCID(req.Object)
+		if err != nil {
+			return gateway.ArcSetPut{}, fmt.Errorf("invalid object: %w", err)
+		}
+		object = parsed
+	}
+
+	kind := arcset.Kind(req.Kind)
+	entries := make([]arcset.ArcEntry, 0, len(req.Entries))
+	for i, entryReq := range req.Entries {
+		entry, err := semanticEntryFromRequest(kind, entryReq)
+		if err != nil {
+			return gateway.ArcSetPut{}, fmt.Errorf("entry %d: %w", i, err)
+		}
+		entries = append(entries, entry)
+	}
+
+	set, err := arcset.NewCanonicalArcSet(kind, entries)
+	if err != nil {
+		return gateway.ArcSetPut{}, err
+	}
+	return gateway.ArcSetPut{
+		Object: object,
+		Kind:   kind,
+		ArcSet: set,
+	}, nil
+}
+
+func semanticEntryFromRequest(kind arcset.Kind, req httpapi.SemanticMutationEntry) (arcset.ArcEntry, error) {
+	target, err := decodeCID(req.Target)
+	if err != nil {
+		return arcset.ArcEntry{}, fmt.Errorf("invalid target: %w", err)
+	}
+
+	targetRef, err := semanticTargetRef(req.TargetKind, target)
+	if err != nil {
+		return arcset.ArcEntry{}, err
+	}
+
+	var coord arcset.CanonicalCoordinate
+	switch kind {
+	case arcset.KindMap:
+		if req.Path == "" {
+			return arcset.ArcEntry{}, fmt.Errorf("path is required for map entries")
+		}
+		coord, err = arcset.NewMapCoordinate(req.Path)
+	case arcset.KindList:
+		if req.Index == nil {
+			return arcset.ArcEntry{}, fmt.Errorf("index is required for list entries")
+		}
+		if *req.Index > uint64(1<<63-1) {
+			return arcset.ArcEntry{}, fmt.Errorf("index is too large")
+		}
+		coord, err = arcset.NewListCoordinate(int64(*req.Index))
+	default:
+		return arcset.ArcEntry{}, fmt.Errorf("%w: %q", arcset.ErrInvalidKind, kind)
+	}
+	if err != nil {
+		return arcset.ArcEntry{}, err
+	}
+
+	return arcset.ArcEntry{
+		Coordinate: coord,
+		Target:     targetRef,
+	}, nil
+}
+
+func semanticTargetRef(kind string, target cid.Cid) (arcset.TargetRef, error) {
+	switch arcset.TargetKind(kind) {
+	case "":
+		return arcset.NewCIDTarget(target), nil
+	case arcset.TargetKindUnknown:
+		return arcset.NewUnknownTarget(target), nil
+	case arcset.TargetKindCAS:
+		return arcset.NewCASTarget(target), nil
+	case arcset.TargetKindMap:
+		return arcset.NewMapTarget(target), nil
+	case arcset.TargetKindList:
+		return arcset.NewListTarget(target), nil
+	default:
+		return arcset.TargetRef{}, fmt.Errorf("%w: %q", arcset.ErrInvalidTargetKind, kind)
+	}
 }
 
 func buildCreateSnapshot(arcs map[string]cid.Cid) (arcset.ArcSet, int, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -78,6 +78,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/buckets/{id}/freeze", s.handleBucketFreeze)
 	mux.HandleFunc("POST /api/v1/buckets/{id}/structure", s.handleBucketCreateStructure)
 	mux.HandleFunc("PUT /api/v1/buckets/{id}/head", s.handleBucketHeadSet)
+	mux.HandleFunc("POST /api/v1/buckets/{id}/semantic-mutations", s.handleBucketSemanticMutation)
 	mux.HandleFunc("POST /api/v1/buckets/{id}/maps", s.handleBucketMapsCreate)
 	mux.HandleFunc("GET /api/v1/buckets/{id}/maps/{root}/snapshot", s.handleBucketMapsSnapshot)
 	mux.HandleFunc("GET /api/v1/buckets/{id}/maps/{root}/resolve", s.handleBucketMapsResolve)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -485,6 +485,190 @@ func TestServerBucketScopedMapAndListAPIs(t *testing.T) {
 	}
 }
 
+func TestServerBucketSemanticMutationUpdatesHead(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBucketBody, _ := json.Marshal(&httpapi.BucketCreateRequest{ID: "demo"})
+	resp, err := http.Post(ts.URL+"/api/v1/buckets", "application/json", bytes.NewReader(createBucketBody))
+	if err != nil {
+		t.Fatalf("create bucket request failed: %v", err)
+	}
+	resp.Body.Close()
+
+	initialPayload := fakeCIDString("initial-payload")
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: map[string]string{
+			"@payload": initialPayload,
+			"name":     fakeCIDString("initial-name"),
+		},
+	})
+	resp, err = http.Post(ts.URL+"/api/v1/buckets/demo/structure", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create structure status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+
+	nextPayload := fakeCIDString("next-payload")
+	nextName := fakeCIDString("next-name")
+	mutationBody, _ := json.Marshal(&httpapi.BucketSemanticMutationRequest{
+		Puts: []httpapi.SemanticMutationPut{{
+			Object: createResp.Root,
+			Kind:   "map",
+			Entries: []httpapi.SemanticMutationEntry{
+				{Path: "@payload", Target: nextPayload},
+				{Path: "name", Target: nextName},
+			},
+		}},
+	})
+	resp, err = http.Post(ts.URL+"/api/v1/buckets/demo/semantic-mutations", "application/json", bytes.NewReader(mutationBody))
+	if err != nil {
+		t.Fatalf("semantic mutation request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("semantic mutation status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var mutationResp httpapi.BucketSemanticMutationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&mutationResp); err != nil {
+		t.Fatalf("decode semantic mutation response: %v", err)
+	}
+	resp.Body.Close()
+	if mutationResp.Bucket != "demo" {
+		t.Fatalf("bucket = %q, want demo", mutationResp.Bucket)
+	}
+	if mutationResp.BaseRoot != createResp.Root {
+		t.Fatalf("base_root = %q, want %q", mutationResp.BaseRoot, createResp.Root)
+	}
+	if mutationResp.NewRoot == "" || mutationResp.NewRoot == createResp.Root {
+		t.Fatalf("new_root = %q, want a new defined root", mutationResp.NewRoot)
+	}
+	if mutationResp.PutCount != 1 || mutationResp.ArcCount != 2 {
+		t.Fatalf("receipt counts = puts %d arcs %d, want 1/2", mutationResp.PutCount, mutationResp.ArcCount)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/buckets/demo")
+	if err != nil {
+		t.Fatalf("get bucket request failed: %v", err)
+	}
+	var bucketResp httpapi.BucketResponse
+	if err := json.NewDecoder(resp.Body).Decode(&bucketResp); err != nil {
+		t.Fatalf("decode bucket response: %v", err)
+	}
+	resp.Body.Close()
+	if bucketResp.Bucket.Root != mutationResp.NewRoot || bucketResp.Bucket.ArcCount != 2 {
+		t.Fatalf("bucket root=%q arcs=%d, want root=%q arcs=2", bucketResp.Bucket.Root, bucketResp.Bucket.ArcCount, mutationResp.NewRoot)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/buckets/demo/resolve?path=name")
+	if err != nil {
+		t.Fatalf("resolve request failed: %v", err)
+	}
+	var resolveResp httpapi.ResolveResponse
+	if err := json.NewDecoder(resp.Body).Decode(&resolveResp); err != nil {
+		t.Fatalf("decode resolve response: %v", err)
+	}
+	resp.Body.Close()
+	if resolveResp.Target != nextName {
+		t.Fatalf("resolved target = %q, want %q", resolveResp.Target, nextName)
+	}
+}
+
+func TestServerBucketSemanticMutationRejectsInvalidHead(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBucketBody, _ := json.Marshal(&httpapi.BucketCreateRequest{ID: "demo"})
+	resp, err := http.Post(ts.URL+"/api/v1/buckets", "application/json", bytes.NewReader(createBucketBody))
+	if err != nil {
+		t.Fatalf("create bucket request failed: %v", err)
+	}
+	resp.Body.Close()
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"name": fakeCIDString("initial-name")}),
+	})
+	resp, err = http.Post(ts.URL+"/api/v1/buckets/demo/structure", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure request failed: %v", err)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+
+	index := uint64(0)
+	tests := []struct {
+		name string
+		req  httpapi.BucketSemanticMutationRequest
+	}{
+		{
+			name: "list only root",
+			req: httpapi.BucketSemanticMutationRequest{
+				Puts: []httpapi.SemanticMutationPut{{
+					Object: createResp.Root,
+					Kind:   "list",
+					Entries: []httpapi.SemanticMutationEntry{{
+						Index:  &index,
+						Target: fakeCIDString("chunk"),
+					}},
+				}},
+			},
+		},
+		{
+			name: "map missing payload",
+			req: httpapi.BucketSemanticMutationRequest{
+				Puts: []httpapi.SemanticMutationPut{{
+					Object: createResp.Root,
+					Kind:   "map",
+					Entries: []httpapi.SemanticMutationEntry{{
+						Path:   "name",
+						Target: fakeCIDString("next-name"),
+					}},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, _ := json.Marshal(&tt.req)
+			resp, err := http.Post(ts.URL+"/api/v1/buckets/demo/semantic-mutations", "application/json", bytes.NewReader(body))
+			if err != nil {
+				t.Fatalf("semantic mutation request failed: %v", err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("semantic mutation status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+			}
+
+			resp, err = http.Get(ts.URL + "/api/v1/buckets/demo")
+			if err != nil {
+				t.Fatalf("get bucket request failed: %v", err)
+			}
+			var bucketResp httpapi.BucketResponse
+			if err := json.NewDecoder(resp.Body).Decode(&bucketResp); err != nil {
+				t.Fatalf("decode bucket response: %v", err)
+			}
+			resp.Body.Close()
+			if bucketResp.Bucket.Root != createResp.Root {
+				t.Fatalf("bucket root changed to %q, want %q", bucketResp.Bucket.Root, createResp.Root)
+			}
+		})
+	}
+}
+
 func TestServerBucketStatAndContentContracts(t *testing.T) {
 	node := newTestNode(t)
 	mockCAS, ok := node.CAS().(*casmock.CAS)


### PR DESCRIPTION
## Summary

- Add bucket-scoped `POST /api/v1/buckets/{id}/semantic-mutations` for daemon semantic writes.
- Convert deterministic JSON puts into `gateway.SemanticMutation` canonical map/list arcsets.
- Apply mutations through gateway semantics plus ArcTable materialization, then publish only valid map bucket heads with mandatory `@payload`.
- Add client helper and server/client tests for successful head advancement and invalid head rejection.

## Validation

- `go test ./server -run SemanticMutation`
- `go test ./client -run SemanticMutation`
- `go test ./core/gateway`
- `go test ./...`