### PR TITLE
[codex] Add CLI gateway UX commands

### DIFF
--- a/cmd/malt/prooflist.go
+++ b/cmd/malt/prooflist.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/dewebprotocol/malt/httpapi"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(proofListCmd)
+	proofListCmd.Flags().StringVarP(&proofListBucketID, "bucket", "b", "", "Generate a ProofList from the managed bucket head instead of an explicit root")
+}
+
+var proofListBucketID string
+
+var proofListCmd = &cobra.Command{
+	Use:   "prooflist [<root>] <path>",
+	Short: "Generate verifier-facing ProofList evidence for a path",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if proofListBucketID != "" {
+			return cobra.ExactArgs(1)(cmd, args)
+		}
+		return cobra.ExactArgs(2)(cmd, args)
+	},
+	RunE: runProofList,
+}
+
+func runProofList(cmd *cobra.Command, args []string) error {
+	client := mustDaemonClient()
+
+	var (
+		result *httpapi.ProofListResponse
+		err    error
+	)
+	if proofListBucketID != "" {
+		result, err = client.ProofListBucket(cmd.Context(), proofListBucketID, args[0])
+	} else {
+		result, err = client.ProofListRoot(cmd.Context(), args[0], args[1])
+	}
+	if err != nil {
+		return daemonCommandError(err)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}

--- a/cmd/malt/prooflist_test.go
+++ b/cmd/malt/prooflist_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestProofListArgumentShape(t *testing.T) {
+	proofListBucketID = ""
+	if err := proofListCmd.Args(proofListCmd, []string{"bafyroot"}); err == nil {
+		t.Fatal("expected explicit-root prooflist to require root and path")
+	}
+
+	proofListBucketID = "demo"
+	t.Cleanup(func() { proofListBucketID = "" })
+	if err := proofListCmd.Args(proofListCmd, []string{"root", "path"}); err == nil {
+		t.Fatal("expected bucket prooflist to accept only a path argument")
+	}
+}
+
+func TestProofListBucketPrintsIndentedJSON(t *testing.T) {
+	ctx := context.Background()
+	daemon, _ := newAddTestClients(t)
+	defaultClient = daemon
+	t.Cleanup(func() { defaultClient = nil })
+
+	if _, err := daemon.CreateBucket(ctx, "demo", ""); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	target := fakeAddCID("prooflist-target").String()
+	if _, err := daemon.CreateBucketStructure(ctx, "demo", map[string]string{"@payload": target, "name": target}); err != nil {
+		t.Fatalf("create bucket structure: %v", err)
+	}
+
+	proofListBucketID = "demo"
+	t.Cleanup(func() { proofListBucketID = "" })
+	out := captureStdout(t, func() {
+		if err := runProofList(testCommandWithContext(ctx), []string{"name"}); err != nil {
+			t.Fatalf("run prooflist: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "\n  \"target\"") || !strings.Contains(out, "\n  \"prooflist\"") {
+		t.Fatalf("prooflist output is not indented JSON:\n%s", out)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("decode prooflist output: %v\n%s", err, out)
+	}
+	if payload["target"] != target {
+		t.Fatalf("target = %v, want %s", payload["target"], target)
+	}
+	if _, ok := payload["prooflist"].(map[string]any); !ok {
+		t.Fatalf("prooflist field missing or wrong type: %#v", payload["prooflist"])
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+		_ = r.Close()
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout pipe: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
+	return buf.String()
+}
+
+func testCommandWithContext(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	return cmd
+}

--- a/cmd/malt/semantic_mutation.go
+++ b/cmd/malt/semantic_mutation.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/dewebprotocol/malt/httpapi"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(semanticMutationCmd)
+	semanticMutationCmd.Flags().StringVarP(&semanticMutationBucketID, "bucket", "b", "", "Bucket ID to mutate")
+	semanticMutationCmd.Flags().StringVarP(&semanticMutationFile, "file", "f", "", "Request JSON file, or - for stdin")
+}
+
+var (
+	semanticMutationBucketID string
+	semanticMutationFile     string
+)
+
+var semanticMutationCmd = &cobra.Command{
+	Use:   "semantic-mutation --bucket <id> --file <path|->",
+	Short: "Apply a bucket semantic mutation request",
+	Args:  cobra.NoArgs,
+	RunE:  runSemanticMutation,
+}
+
+func runSemanticMutation(cmd *cobra.Command, args []string) error {
+	if semanticMutationBucketID == "" {
+		return fmt.Errorf("--bucket is required")
+	}
+	if semanticMutationFile == "" {
+		return fmt.Errorf("--file is required")
+	}
+
+	req, err := readSemanticMutationRequest(semanticMutationFile)
+	if err != nil {
+		return err
+	}
+
+	resp, err := mustDaemonClient().ApplyBucketSemanticMutation(cmd.Context(), semanticMutationBucketID, req)
+	if err != nil {
+		return daemonCommandError(err)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
+}
+
+func readSemanticMutationRequest(path string) (*httpapi.BucketSemanticMutationRequest, error) {
+	var r io.Reader
+	if path == "-" {
+		r = os.Stdin
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("read semantic mutation request %q: %w", path, err)
+		}
+		defer f.Close()
+		r = f
+	}
+
+	var req httpapi.BucketSemanticMutationRequest
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&req); err != nil {
+		return nil, fmt.Errorf("decode semantic mutation request: %w", err)
+	}
+	return &req, nil
+}

--- a/cmd/malt/semantic_mutation_test.go
+++ b/cmd/malt/semantic_mutation_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSemanticMutationValidatesRequiredFlags(t *testing.T) {
+	semanticMutationBucketID = ""
+	semanticMutationFile = ""
+	if err := runSemanticMutation(semanticMutationCmd, nil); err == nil || !strings.Contains(err.Error(), "--bucket is required") {
+		t.Fatalf("missing bucket error = %v", err)
+	}
+
+	semanticMutationBucketID = "demo"
+	semanticMutationFile = ""
+	t.Cleanup(func() {
+		semanticMutationBucketID = ""
+		semanticMutationFile = ""
+	})
+	if err := runSemanticMutation(semanticMutationCmd, nil); err == nil || !strings.Contains(err.Error(), "--file is required") {
+		t.Fatalf("missing file error = %v", err)
+	}
+}
+
+func TestSemanticMutationRejectsMalformedJSON(t *testing.T) {
+	badFile := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(badFile, []byte(`{"puts":`), 0o644); err != nil {
+		t.Fatalf("write bad json: %v", err)
+	}
+
+	semanticMutationBucketID = "demo"
+	semanticMutationFile = badFile
+	t.Cleanup(func() {
+		semanticMutationBucketID = ""
+		semanticMutationFile = ""
+	})
+
+	if err := runSemanticMutation(semanticMutationCmd, nil); err == nil || !strings.Contains(err.Error(), "decode semantic mutation request") {
+		t.Fatalf("malformed json error = %v", err)
+	}
+}
+
+func TestSemanticMutationPrintsIndentedJSON(t *testing.T) {
+	ctx := context.Background()
+	daemon, _ := newAddTestClients(t)
+	defaultClient = daemon
+	t.Cleanup(func() { defaultClient = nil })
+
+	if _, err := daemon.CreateBucket(ctx, "demo", ""); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	initialPayload := fakeAddCID("semantic-initial").String()
+	initial, err := daemon.CreateBucketStructure(ctx, "demo", map[string]string{"@payload": initialPayload, "name": initialPayload})
+	if err != nil {
+		t.Fatalf("create initial structure: %v", err)
+	}
+	target := fakeAddCID("semantic-target").String()
+	reqFile := filepath.Join(t.TempDir(), "request.json")
+	req := `{"puts":[{"object":"` + initial.Root + `","kind":"map","entries":[{"path":"@payload","target":"` + target + `"},{"path":"name","target":"` + target + `"}]}]}`
+	if err := os.WriteFile(reqFile, []byte(req), 0o644); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	semanticMutationBucketID = "demo"
+	semanticMutationFile = reqFile
+	t.Cleanup(func() {
+		semanticMutationBucketID = ""
+		semanticMutationFile = ""
+	})
+	out := captureStdout(t, func() {
+		if err := runSemanticMutation(testCommandWithContext(ctx), nil); err != nil {
+			t.Fatalf("run semantic mutation: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "\n  \"bucket\"") || !strings.Contains(out, "\n  \"new_root\"") {
+		t.Fatalf("semantic mutation output is not indented JSON:\n%s", out)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("decode semantic mutation output: %v\n%s", err, out)
+	}
+	if payload["bucket"] != "demo" {
+		t.Fatalf("bucket = %v, want demo", payload["bucket"])
+	}
+	if payload["new_root"] == "" {
+		t.Fatal("new_root should be present")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `malt prooflist` for explicit-root and managed-bucket ProofList reads.
- Add `malt semantic-mutation --bucket <id> --file <path|->` for applying bucket semantic mutation JSON from a file or stdin.
- Add focused CLI tests covering argument validation and indented JSON output shape.

## Validation

- RED: `go test ./cmd/malt -run ProofList` failed with missing `proofList*` symbols before implementation.
- RED: `go test ./cmd/malt -run SemanticMutation` failed with missing `semanticMutation*` symbols before implementation.
- GREEN: `go test ./cmd/malt -run ProofList`
- GREEN: `go test ./cmd/malt -run SemanticMutation`
- GREEN: `go test ./cmd/malt`
- GREEN: `go test ./...`