### PR TITLE
feat: route unixfs writes via gateway

### DIFF
--- a/core/layout/malt/unixfs/mutation.go
+++ b/core/layout/malt/unixfs/mutation.go
@@ -91,6 +91,94 @@ func (l *Layout) MutationPlanForPath(ctx context.Context, root cid.Cid, path str
 	return plan, nil
 }
 
+// MutationPlanForRoot exposes canonical map/list arcsets for the complete
+// UnixFS tree rooted at root. Child payloads and maps are emitted before their
+// parent directories so the final put is the canonical bucket-head map.
+func (l *Layout) MutationPlanForRoot(ctx context.Context, baseRoot cid.Cid, root cid.Cid) (*MutationPlan, error) {
+	if !root.Defined() {
+		return nil, fmt.Errorf("root is undefined")
+	}
+
+	plan := &MutationPlan{
+		BucketID: l.bucketID,
+		BaseRoot: baseRoot,
+	}
+	if err := l.appendRootMutationPuts(ctx, plan, root); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func (l *Layout) appendRootMutationPuts(ctx context.Context, plan *MutationPlan, nodeRoot cid.Cid) error {
+	kind, err := l.nodeType(ctx, nodeRoot)
+	if err != nil {
+		return err
+	}
+
+	switch kind {
+	case typeDirectory:
+		payload, _, ok, err := l.lookup(ctx, nodeRoot, payloadPath)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("%w: missing @payload", ErrNotFound)
+		}
+		names, err := l.loadDirectoryManifest(ctx, payload)
+		if err != nil {
+			return err
+		}
+		for _, name := range names {
+			child, _, ok, err := l.lookup(ctx, nodeRoot, arcset.CanonicalizePath(name))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("%w: missing directory entry %s", ErrNotFound, name)
+			}
+			if err := l.appendRootMutationPuts(ctx, plan, child); err != nil {
+				return err
+			}
+		}
+	case typeFile:
+		payload, _, ok, err := l.lookup(ctx, nodeRoot, payloadPath)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("%w: missing @payload", ErrNotFound)
+		}
+		if codec.SemanticKindOf(payload) == codec.SemanticKindList {
+			info, err := l.fileInfo(ctx, nodeRoot, payload)
+			if err != nil {
+				return err
+			}
+			listArcSet, err := l.canonicalListArcSet(ctx, payload, chunkCount(info.size, info.chunkSize))
+			if err != nil {
+				return err
+			}
+			plan.Puts = append(plan.Puts, MutationPut{
+				Object: payload,
+				Kind:   arcset.KindList,
+				ArcSet: listArcSet,
+			})
+		}
+	default:
+		return fmt.Errorf("unsupported unixfs node kind %q", kind)
+	}
+
+	nodeArcSet, err := l.canonicalNodeArcSet(ctx, nodeRoot, kind)
+	if err != nil {
+		return err
+	}
+	plan.Puts = append(plan.Puts, MutationPut{
+		Object: nodeRoot,
+		Kind:   arcset.KindMap,
+		ArcSet: nodeArcSet,
+	})
+	return nil
+}
+
 func (l *Layout) canonicalNodeArcSet(ctx context.Context, nodeRoot cid.Cid, kind string) (*arcset.CanonicalArcSet, error) {
 	typeCID, _, ok, err := l.lookup(ctx, nodeRoot, typePath)
 	if err != nil {

--- a/core/layout/malt/unixfs/mutation_test.go
+++ b/core/layout/malt/unixfs/mutation_test.go
@@ -114,6 +114,36 @@ func TestDirectoryMutationPlanSortsEntriesAndRejectsReservedPath(t *testing.T) {
 	}
 }
 
+func TestRootMutationPlanIncludesDescendantsBeforeRoot(t *testing.T) {
+	ctx := context.Background()
+	layout := newLayout(t, 4)
+
+	root, err := layout.AddFile(ctx, cid.Undef, "docs/readme.txt", []byte("hello world"))
+	if err != nil {
+		t.Fatalf("AddFile failed: %v", err)
+	}
+
+	plan, err := layout.MutationPlanForRoot(ctx, cid.Undef, root)
+	if err != nil {
+		t.Fatalf("MutationPlanForRoot failed: %v", err)
+	}
+	if !plan.BaseRoot.Equals(cid.Undef) {
+		t.Fatalf("plan BaseRoot = %s, want undefined", plan.BaseRoot)
+	}
+	if len(plan.Puts) != 4 {
+		t.Fatalf("put count = %d, want 4", len(plan.Puts))
+	}
+	if plan.Puts[0].Kind != arcset.KindList {
+		t.Fatalf("put 0 kind = %q, want list payload first", plan.Puts[0].Kind)
+	}
+	if plan.Puts[len(plan.Puts)-1].Kind != arcset.KindMap {
+		t.Fatalf("last put kind = %q, want root map", plan.Puts[len(plan.Puts)-1].Kind)
+	}
+	if !plan.Puts[len(plan.Puts)-1].Object.Equals(root) {
+		t.Fatalf("last put object = %s, want root %s", plan.Puts[len(plan.Puts)-1].Object, root)
+	}
+}
+
 func hasEntry(set *arcset.CanonicalArcSet, coordinate string, targetKind arcset.TargetKind) bool {
 	for _, entry := range set.Entries() {
 		if entry.Coordinate.String() == coordinate && entry.Target.Kind() == targetKind {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -594,21 +594,22 @@ func (s *Server) handleBucketUnixFSFile(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	arcCount := s.unixFSArcCount(r.Context(), layout, newRoot)
-	if err := s.updateManagedGraphHead(r.Context(), graphID, newRoot, arcCount); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+	receipt, err := s.applyUnixFSGatewayMutation(r.Context(), graphID, g, layout, oldRoot, newRoot)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if lm := s.node.LineageManager(); lm != nil {
-		_ = lm.Record(r.Context(), newRoot, oldRoot, arcCount)
+	if err := s.publishUnixFSReceipt(r.Context(), graphID, oldRoot, receipt); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
 	}
 
 	resp := &httpapi.BucketUnixFSWriteResponse{
 		Bucket:   graphID,
 		Path:     p,
 		Kind:     "file",
-		NewRoot:  newRoot.String(),
-		ArcCount: arcCount,
+		NewRoot:  receipt.NewRoot.String(),
+		ArcCount: receipt.ArcCount,
 	}
 	if oldRoot.Defined() {
 		resp.OldRoot = oldRoot.String()
@@ -645,21 +646,22 @@ func (s *Server) handleBucketUnixFSDirectory(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	arcCount := s.unixFSArcCount(r.Context(), layout, newRoot)
-	if err := s.updateManagedGraphHead(r.Context(), graphID, newRoot, arcCount); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+	receipt, err := s.applyUnixFSGatewayMutation(r.Context(), graphID, g, layout, oldRoot, newRoot)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if lm := s.node.LineageManager(); lm != nil {
-		_ = lm.Record(r.Context(), newRoot, oldRoot, arcCount)
+	if err := s.publishUnixFSReceipt(r.Context(), graphID, oldRoot, receipt); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
 	}
 
 	resp := &httpapi.BucketUnixFSWriteResponse{
 		Bucket:   graphID,
 		Path:     p,
 		Kind:     "dir",
-		NewRoot:  newRoot.String(),
-		ArcCount: arcCount,
+		NewRoot:  receipt.NewRoot.String(),
+		ArcCount: receipt.ArcCount,
 	}
 	if oldRoot.Defined() {
 		resp.OldRoot = oldRoot.String()
@@ -1297,6 +1299,54 @@ func (s *Server) prepareUnixFSRoot(ctx context.Context, g *graph.Graph, layout *
 		return root, nil
 	}
 	return s.migrateLegacyTreeToUnixFS(ctx, g, layout, root)
+}
+
+func (s *Server) applyUnixFSGatewayMutation(ctx context.Context, bucketID string, g *graph.Graph, layout *unixfs.Layout, oldRoot cid.Cid, newRoot cid.Cid) (gateway.WriteReceipt, error) {
+	baseRoot := oldRoot
+	if !baseRoot.Defined() {
+		baseRoot = newRoot
+	}
+
+	plan, err := layout.MutationPlanForRoot(ctx, oldRoot, newRoot)
+	if err != nil {
+		return gateway.WriteReceipt{}, err
+	}
+	mut := gateway.SemanticMutation{
+		BucketID: bucketID,
+		BaseRoot: baseRoot,
+		Puts:     make([]gateway.ArcSetPut, 0, len(plan.Puts)),
+	}
+	for _, put := range plan.Puts {
+		mut.Puts = append(mut.Puts, gateway.ArcSetPut{
+			Object: put.Object,
+			Kind:   put.Kind,
+			ArcSet: put.ArcSet,
+		})
+	}
+
+	exec := gateway.Executor{
+		Maps:     g.Semantic(),
+		Lists:    g.ListSemantic(),
+		ArcTable: s.node.ArcTable(),
+	}
+	receipt, err := exec.Apply(ctx, mut)
+	if err != nil {
+		return gateway.WriteReceipt{}, err
+	}
+	if codec.SemanticKindOf(receipt.NewRoot) != codec.SemanticKindMap {
+		return gateway.WriteReceipt{}, fmt.Errorf("unixfs mutation result must be a map bucket head")
+	}
+	return receipt, nil
+}
+
+func (s *Server) publishUnixFSReceipt(ctx context.Context, graphID string, oldRoot cid.Cid, receipt gateway.WriteReceipt) error {
+	if err := s.updateManagedGraphHead(ctx, graphID, receipt.NewRoot, receipt.ArcCount); err != nil {
+		return err
+	}
+	if lm := s.node.LineageManager(); lm != nil {
+		_ = lm.Record(ctx, receipt.NewRoot, oldRoot, receipt.ArcCount)
+	}
+	return nil
 }
 
 func (s *Server) migrateLegacyTreeToUnixFS(ctx context.Context, g *graph.Graph, layout *unixfs.Layout, legacyRoot cid.Cid) (cid.Cid, error) {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1317,8 +1317,10 @@ func (s *Server) applyUnixFSGatewayMutation(ctx context.Context, bucketID string
 		Puts:     make([]gateway.ArcSetPut, 0, len(plan.Puts)),
 	}
 	for _, put := range plan.Puts {
+		// UnixFS replay rematerializes deterministic roots; do not treat the
+		// already-materialized object as a versioned ArcTable parent.
 		mut.Puts = append(mut.Puts, gateway.ArcSetPut{
-			Object: put.Object,
+			Object: cid.Undef,
 			Kind:   put.Kind,
 			ArcSet: put.ArcSet,
 		})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dewebprotocol/malt/config"
 	"github.com/dewebprotocol/malt/core/api"
+	"github.com/dewebprotocol/malt/core/arctable/versioned"
 	casmock "github.com/dewebprotocol/malt/core/cas/mock"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/core/types/prooflist"
@@ -878,6 +879,49 @@ func TestServerUnixFSWritesPublishGatewayReadableRoot(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK || !bytes.Equal(got, fileBody) {
 		t.Fatalf("content status/body = %d %q, want %d %q", resp.StatusCode, string(got), http.StatusOK, string(fileBody))
+	}
+}
+
+func TestServerUnixFSGatewayRootDoesNotSelfParent(t *testing.T) {
+	node := newTestNode(t)
+	arcs, ok := node.ArcTable().(*versioned.ArcTable)
+	if !ok {
+		t.Fatalf("test node ArcTable = %T, want *versioned.ArcTable", node.ArcTable())
+	}
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBucketBody, _ := json.Marshal(&httpapi.BucketCreateRequest{ID: "demo"})
+	resp, err := http.Post(ts.URL+"/api/v1/buckets", "application/json", bytes.NewReader(createBucketBody))
+	if err != nil {
+		t.Fatalf("create bucket request failed: %v", err)
+	}
+	resp.Body.Close()
+
+	resp, err = http.Post(ts.URL+"/api/v1/buckets/demo/unixfs/files?path=readme.txt", "application/octet-stream", bytes.NewReader([]byte("hello")))
+	if err != nil {
+		t.Fatalf("create unixfs file request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create unixfs file status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var writeResp httpapi.BucketUnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&writeResp); err != nil {
+		t.Fatalf("decode unixfs write response: %v", err)
+	}
+	resp.Body.Close()
+
+	root, err := cid.Decode(writeResp.NewRoot)
+	if err != nil {
+		t.Fatalf("decode unixfs write root: %v", err)
+	}
+	parent, err := arcs.GetParent(t.Context(), "demo", root)
+	if err != nil {
+		t.Fatalf("read gateway root parent: %v", err)
+	}
+	if parent.Equals(root) {
+		t.Fatalf("gateway root self-parented: %s", root)
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dewebprotocol/malt/config"
 	"github.com/dewebprotocol/malt/core/api"
 	casmock "github.com/dewebprotocol/malt/core/cas/mock"
+	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/core/types/prooflist"
 	"github.com/dewebprotocol/malt/httpapi"
 	cid "github.com/ipfs/go-cid"
@@ -771,6 +772,112 @@ func TestServerBucketSemanticMutationRejectsInvalidHead(t *testing.T) {
 				t.Fatalf("bucket root changed to %q, want %q", bucketResp.Bucket.Root, createResp.Root)
 			}
 		})
+	}
+}
+
+func TestServerUnixFSWritesPublishGatewayReadableRoot(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBucketBody, _ := json.Marshal(&httpapi.BucketCreateRequest{ID: "demo"})
+	resp, err := http.Post(ts.URL+"/api/v1/buckets", "application/json", bytes.NewReader(createBucketBody))
+	if err != nil {
+		t.Fatalf("create bucket request failed: %v", err)
+	}
+	resp.Body.Close()
+
+	resp, err = http.Post(ts.URL+"/api/v1/buckets/demo/unixfs/directories?path=docs", "application/json", nil)
+	if err != nil {
+		t.Fatalf("create unixfs directory request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create unixfs directory status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	resp.Body.Close()
+
+	fileBody := []byte("hello from gateway unixfs")
+	resp, err = http.Post(ts.URL+"/api/v1/buckets/demo/unixfs/files?path=docs/readme.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	if err != nil {
+		t.Fatalf("create unixfs file request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create unixfs file status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var writeResp httpapi.BucketUnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&writeResp); err != nil {
+		t.Fatalf("decode unixfs write response: %v", err)
+	}
+	resp.Body.Close()
+	if writeResp.Bucket != "demo" || writeResp.Path != "docs/readme.txt" || writeResp.Kind != "file" {
+		t.Fatalf("unexpected unixfs write response: %+v", writeResp)
+	}
+	if writeResp.NewRoot == "" || writeResp.ArcCount == 0 {
+		t.Fatalf("unixfs write root=%q arc_count=%d, want defined", writeResp.NewRoot, writeResp.ArcCount)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/buckets/demo")
+	if err != nil {
+		t.Fatalf("get bucket request failed: %v", err)
+	}
+	var bucketResp httpapi.BucketResponse
+	if err := json.NewDecoder(resp.Body).Decode(&bucketResp); err != nil {
+		t.Fatalf("decode bucket response: %v", err)
+	}
+	resp.Body.Close()
+	if bucketResp.Bucket.Root != writeResp.NewRoot || bucketResp.Bucket.ArcCount != writeResp.ArcCount {
+		t.Fatalf("bucket root=%q arcs=%d, want root=%q arcs=%d", bucketResp.Bucket.Root, bucketResp.Bucket.ArcCount, writeResp.NewRoot, writeResp.ArcCount)
+	}
+
+	rootCID, err := cid.Decode(writeResp.NewRoot)
+	if err != nil {
+		t.Fatalf("decode write root: %v", err)
+	}
+	if payload, err := node.ArcTable().Get(t.Context(), "demo", rootCID, arcset.CanonicalizePath("@payload")); err != nil || !payload.Defined() {
+		t.Fatalf("root @payload from arctable = %s, err %v; want defined", payload, err)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/buckets/demo/prooflist?path=docs/readme.txt")
+	if err != nil {
+		t.Fatalf("prooflist request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("prooflist status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var proofResp httpapi.ProofListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&proofResp); err != nil {
+		t.Fatalf("decode prooflist response: %v", err)
+	}
+	resp.Body.Close()
+	if proofResp.Target == "" || len(proofResp.ProofList.Steps) == 0 {
+		t.Fatalf("unexpected prooflist response: %+v", proofResp)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/buckets/demo/stat?path=docs/readme.txt")
+	if err != nil {
+		t.Fatalf("stat request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stat status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var statResp httpapi.BucketStatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&statResp); err != nil {
+		t.Fatalf("decode stat response: %v", err)
+	}
+	resp.Body.Close()
+	if statResp.Kind != "file" || statResp.Size == nil || *statResp.Size != int64(len(fileBody)) {
+		t.Fatalf("unexpected stat response: %+v", statResp)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/buckets/demo/content?path=docs/readme.txt")
+	if err != nil {
+		t.Fatalf("content request failed: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || !bytes.Equal(got, fileBody) {
+		t.Fatalf("content status/body = %d %q, want %d %q", resp.StatusCode, string(got), http.StatusOK, string(fileBody))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Route UnixFS file and directory daemon writes through gateway.Executor after layout materialization.
- Add a UnixFS root mutation plan helper that emits canonical puts for the complete tree with the root map last.
- Preserve BucketUnixFSWriteResponse while publishing the gateway receipt root as the managed bucket head.

## Validation

- go test ./server -run UnixFS
- go test ./core/layout/malt/unixfs
- go test ./server
- go test ./...