### PR TITLE
feat: add content proof reads

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -314,6 +314,50 @@ func (c *Client) GetBucketContent(ctx context.Context, id string, p string, rang
 	return data, status, headers, nil
 }
 
+// GetBucketContentProof reads bucket content as JSON with range metadata and a
+// ProofList for the same path/range.
+func (c *Client) GetBucketContentProof(ctx context.Context, id string, p string, rangeHeader string) (*httpapi.BucketContentProofResponse, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = path.Join(u.Path, "/buckets/"+url.PathEscape(id)+"/content:proof")
+	values := u.Query()
+	if p != "" {
+		values.Set("path", p)
+	}
+	u.RawQuery = values.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if rangeHeader != "" {
+		req.Header.Set("Range", rangeHeader)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var apiErr httpapi.ErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&apiErr); err == nil && apiErr.Error != "" {
+			return nil, &Error{StatusCode: resp.StatusCode, Message: apiErr.Error}
+		}
+		payload, _ := io.ReadAll(resp.Body)
+		return nil, &Error{StatusCode: resp.StatusCode, Message: strings.TrimSpace(string(payload))}
+	}
+
+	var out httpapi.BucketContentProofResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // OpenBucketContent opens a streaming response body for bucket content.
 // Callers must close the returned ReadCloser.
 func (c *Client) OpenBucketContent(ctx context.Context, id string, p string, rangeHeader string) (io.ReadCloser, int, http.Header, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
@@ -496,6 +497,52 @@ func TestClientBucketStatAndContent(t *testing.T) {
 	}
 	if status != 206 || string(body) != "bcd" {
 		t.Fatalf("unexpected status/body: %d %q", status, string(body))
+	}
+}
+
+func TestClientContentProofReadReturnsContentRangeAndProofList(t *testing.T) {
+	cfg := testConfig(t)
+	node, err := api.NewNode(api.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = node.Close()
+	})
+
+	ts := httptest.NewServer(server.New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	cfg.RPC.Listen = ts.Listener.Addr().String()
+	client := New(cfg)
+	ctx := context.Background()
+
+	if _, err := client.CreateBucket(ctx, "demo", ""); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	if _, err := client.AddBucketUnixFSFile(ctx, "demo", "f.txt", []byte("abcdef")); err != nil {
+		t.Fatalf("add unixfs file: %v", err)
+	}
+
+	resp, err := client.GetBucketContentProof(ctx, "demo", "f.txt", "bytes=1-3")
+	if err != nil {
+		t.Fatalf("GetBucketContentProof: %v", err)
+	}
+	if string(resp.Content) != "bcd" {
+		t.Fatalf("content = %q, want bcd", resp.Content)
+	}
+	if resp.Range.StatusCode != http.StatusPartialContent || resp.Range.ContentRange != "bytes 1-3/6" {
+		t.Fatalf("range metadata = %+v, want status 206 content-range bytes 1-3/6", resp.Range)
+	}
+	if resp.Range.Start != 1 || resp.Range.EndExclusive != 4 || resp.Range.ContentLength != 3 || resp.Range.TotalSize != 6 {
+		t.Fatalf("unexpected byte range metadata: %+v", resp.Range)
+	}
+	if err := resp.ProofList.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("prooflist shape: %v", err)
+	}
+	last := resp.ProofList.Steps[len(resp.ProofList.Steps)-1]
+	if last.Kind != prooflist.KindPayloadBinding || last.Path != "@payload" {
+		t.Fatalf("last proof step = %q/%q, want payload binding @payload", last.Kind, last.Path)
 	}
 }
 

--- a/httpapi/types.go
+++ b/httpapi/types.go
@@ -122,6 +122,30 @@ type BucketStatResponse struct {
 	Entries     []string `json:"entries,omitempty"` // directory entries when available
 }
 
+// BucketContentRange describes the HTTP-equivalent byte range metadata for a
+// proof-bearing JSON content read.
+type BucketContentRange struct {
+	Start         int64  `json:"start"`
+	EndExclusive  int64  `json:"end_exclusive"`
+	ContentLength int64  `json:"content_length"`
+	TotalSize     int64  `json:"total_size"`
+	Partial       bool   `json:"partial"`
+	StatusCode    int    `json:"status_code"`
+	AcceptRanges  string `json:"accept_ranges"`
+	ContentRange  string `json:"content_range,omitempty"`
+}
+
+// BucketContentProofResponse returns content bytes with range metadata and the
+// verifier-facing ProofList for the same read.
+type BucketContentProofResponse struct {
+	Path        string              `json:"path,omitempty"`
+	StorageKind string              `json:"storage_kind"`
+	Key         string              `json:"key"`
+	Content     []byte              `json:"content"`
+	Range       BucketContentRange  `json:"range"`
+	ProofList   prooflist.ProofList `json:"prooflist"`
+}
+
 // BucketUnixFSWriteResponse returns the result of a UnixFS layout mutation.
 type BucketUnixFSWriteResponse struct {
 	Bucket   string `json:"bucket"`

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dewebprotocol/malt/core/structure/list"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/core/types/evidence"
+	"github.com/dewebprotocol/malt/core/types/prooflist"
 	"github.com/dewebprotocol/malt/core/writer"
 	"github.com/dewebprotocol/malt/httpapi"
 	cid "github.com/ipfs/go-cid"
@@ -735,22 +736,9 @@ func (s *Server) handleBucketContent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var payload []byte
-	switch stat.StorageKind {
-	case "raw":
-		raw, err := s.node.CAS().Get(r.Context(), key)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
-		}
-		payload = raw[start:endExclusive]
-	case "list":
-		payload, err = s.readListRange(r.Context(), g, key, start, endExclusive)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
-		}
-	default:
-		writeError(w, http.StatusInternalServerError, "unsupported storage kind for content")
+	payload, err = s.readBucketContentPayload(r.Context(), g, stat, key, start, endExclusive)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -762,6 +750,72 @@ func (s *Server) handleBucketContent(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}
 	_, _ = io.Copy(w, bytes.NewReader(payload))
+}
+
+func (s *Server) handleBucketContentProof(w http.ResponseWriter, r *http.Request) {
+	meta, g, err := s.openManagedGraph(r.Context(), r.PathValue("id"), false)
+	if err != nil {
+		writeManagedGraphError(w, err)
+		return
+	}
+	if meta == nil || !meta.Root.Defined() {
+		writeError(w, http.StatusNotFound, "path not found")
+		return
+	}
+
+	queryPath := bucketpath.CanonicalizeQueryPath(r.URL.Query().Get("path"))
+	stat, err := s.bucketStat(r.Context(), g, meta.Root, queryPath)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, errPathNotFound) || errors.Is(err, resolver.ErrResolutionFailed) {
+			status = http.StatusNotFound
+		}
+		writeError(w, status, err.Error())
+		return
+	}
+	if stat.Kind != "file" {
+		writeError(w, httpapi.StatusBucketContentIsDirectory, "content proof is only valid for file targets")
+		return
+	}
+	key, err := decodeCID(stat.Key)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	totalSize := int64(0)
+	if stat.Size != nil {
+		totalSize = *stat.Size
+	}
+
+	start, endExclusive, partial, err := parseRangeHeader(r.Header.Get("Range"), totalSize)
+	if err != nil {
+		writeError(w, httpapi.StatusBucketRangeNotSatisfiable, err.Error())
+		return
+	}
+	payload, err := s.readBucketContentPayload(r.Context(), g, stat, key, start, endExclusive)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	pl, err := s.contentProofList(r.Context(), g, meta.Root, queryPath, stat, start, endExclusive)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, errPathNotFound) || errors.Is(err, resolver.ErrResolutionFailed) || errors.Is(err, unixfs.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		writeError(w, status, err.Error())
+		return
+	}
+
+	w.Header().Set("Accept-Ranges", "bytes")
+	writeJSON(w, http.StatusOK, &httpapi.BucketContentProofResponse{
+		Path:        queryPath,
+		StorageKind: stat.StorageKind,
+		Key:         stat.Key,
+		Content:     payload,
+		Range:       contentRangeMetadata(start, endExclusive, totalSize, partial),
+		ProofList:   *pl,
+	})
 }
 
 func (s *Server) handleBucketResolve(w http.ResponseWriter, r *http.Request) {
@@ -1452,6 +1506,80 @@ func (s *Server) readStatFile(ctx context.Context, g *graph.Graph, stat *httpapi
 	}
 }
 
+func (s *Server) readBucketContentPayload(ctx context.Context, g *graph.Graph, stat *httpapi.BucketStatResponse, key cid.Cid, start, endExclusive int64) ([]byte, error) {
+	switch stat.StorageKind {
+	case "raw":
+		raw, err := s.node.CAS().Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		return raw[start:endExclusive], nil
+	case "list":
+		return s.readListRange(ctx, g, key, start, endExclusive)
+	default:
+		return nil, fmt.Errorf("unsupported storage kind for content")
+	}
+}
+
+func (s *Server) contentProofList(ctx context.Context, g *graph.Graph, root cid.Cid, queryPath string, stat *httpapi.BucketStatResponse, start, endExclusive int64) (*prooflist.ProofList, error) {
+	if layout, err := s.unixFSLayout(g); err == nil {
+		if unixStat, statErr := layout.Stat(ctx, root, queryPath); statErr == nil && unixStat.Kind == "file" {
+			return s.unixFSContentProofList(ctx, layout, root, queryPath, stat, start, endExclusive)
+		}
+	}
+	return s.legacyContentProofList(ctx, g, root, queryPath, stat, start, endExclusive)
+}
+
+func (s *Server) unixFSContentProofList(ctx context.Context, layout *unixfs.Layout, root cid.Cid, queryPath string, stat *httpapi.BucketStatResponse, start, endExclusive int64) (*prooflist.ProofList, error) {
+	resolution, err := layout.Resolve(ctx, root, queryPath)
+	if err != nil {
+		return nil, err
+	}
+	pl, err := unixfs.ProofListFromSteps(root, queryPath, resolution.Steps)
+	if err != nil {
+		return nil, err
+	}
+	if stat.StorageKind == "list" && endExclusive > start {
+		steps, err := layout.ListIndexStepsForFileRange(ctx, root, queryPath, uint64(start), uint64(endExclusive-start))
+		if err != nil {
+			return nil, err
+		}
+		if err := unixfs.AppendListIndexSteps(pl, queryPath, steps); err != nil {
+			return nil, err
+		}
+	}
+	return pl, nil
+}
+
+func (s *Server) legacyContentProofList(ctx context.Context, g *graph.Graph, root cid.Cid, queryPath string, stat *httpapi.BucketStatResponse, start, endExclusive int64) (*prooflist.ProofList, error) {
+	result, err := g.Resolver().Resolve(root, queryPath)
+	if err != nil {
+		return nil, err
+	}
+	if resolveMiss(root, queryPath, result) {
+		return nil, errPathNotFound
+	}
+	pl, err := resolver.ProofListFromTranscript(root, result.Transcript)
+	if err != nil {
+		return nil, err
+	}
+	pl.Query = queryPath
+	if stat.StorageKind == "list" && endExclusive > start {
+		listRoot, err := decodeCID(stat.Key)
+		if err != nil {
+			return nil, err
+		}
+		steps, err := s.listIndexStepsForRange(ctx, g, listRoot, start, endExclusive)
+		if err != nil {
+			return nil, err
+		}
+		if err := unixfs.AppendListIndexSteps(pl, queryPath, steps); err != nil {
+			return nil, err
+		}
+	}
+	return pl, nil
+}
+
 func (s *Server) unixFSBucketStat(ctx context.Context, g *graph.Graph, root cid.Cid, p string) (*httpapi.BucketStatResponse, error) {
 	layout, err := s.unixFSLayout(g)
 	if err != nil {
@@ -1609,6 +1737,57 @@ func (s *Server) readListRange(ctx context.Context, g *graph.Graph, listRoot cid
 		out.Write(chunk[localStart:localEnd])
 	}
 	return out.Bytes(), nil
+}
+
+func (s *Server) listIndexStepsForRange(ctx context.Context, g *graph.Graph, listRoot cid.Cid, start, endExclusive int64) ([]unixfs.ListIndexStep, error) {
+	if endExclusive <= start {
+		return nil, nil
+	}
+	first := uint64(start / fixedBucketListChunkSize)
+	last := uint64((endExclusive - 1) / fixedBucketListChunkSize)
+	steps := make([]unixfs.ListIndexStep, 0, last-first+1)
+	for index := first; index <= last; index++ {
+		query, proof, err := g.ListSemantic().Prove(ctx, g.BucketId(), listRoot, index)
+		if err != nil {
+			return nil, err
+		}
+		ok, err := g.ListSemantic().Verify(listRoot, index, query, proof)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("list proof failed at index %d", index)
+		}
+		if !query.Key.Defined() {
+			return nil, fmt.Errorf("missing chunk %d", index)
+		}
+		steps = append(steps, unixfs.ListIndexStep{
+			Root:   listRoot,
+			Index:  index,
+			Target: query.Key,
+			Proof:  proof,
+		})
+	}
+	return steps, nil
+}
+
+func contentRangeMetadata(start, endExclusive, totalSize int64, partial bool) httpapi.BucketContentRange {
+	statusCode := http.StatusOK
+	contentRange := ""
+	if partial {
+		statusCode = http.StatusPartialContent
+		contentRange = fmt.Sprintf("bytes %d-%d/%d", start, endExclusive-1, totalSize)
+	}
+	return httpapi.BucketContentRange{
+		Start:         start,
+		EndExclusive:  endExclusive,
+		ContentLength: endExclusive - start,
+		TotalSize:     totalSize,
+		Partial:       partial,
+		StatusCode:    statusCode,
+		AcceptRanges:  "bytes",
+		ContentRange:  contentRange,
+	}
 }
 
 func parseRangeHeader(raw string, size int64) (start int64, endExclusive int64, partial bool, err error) {

--- a/server/server.go
+++ b/server/server.go
@@ -90,6 +90,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/buckets/{id}/unixfs/directories", s.handleBucketUnixFSDirectory)
 	mux.HandleFunc("GET /api/v1/buckets/{id}/stat", s.handleBucketStat)
 	mux.HandleFunc("GET /api/v1/buckets/{id}/content", s.handleBucketContent)
+	mux.HandleFunc("GET /api/v1/buckets/{id}/content:proof", s.handleBucketContentProof)
 	mux.HandleFunc("GET /api/v1/buckets/{id}/resolve", s.handleBucketResolve)
 	mux.HandleFunc("GET /api/v1/buckets/{id}/proof", s.handleBucketProof)
 	mux.HandleFunc("GET /api/v1/buckets/{id}/prooflist", s.handleBucketProofList)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1046,6 +1046,150 @@ func TestServerBucketStatAndContentContracts(t *testing.T) {
 	}
 }
 
+func TestServerContentProofReadSmallUnixFSFileIncludesPayloadProof(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBucketBody, _ := json.Marshal(&httpapi.BucketCreateRequest{ID: "demo"})
+	resp, err := http.Post(ts.URL+"/api/v1/buckets", "application/json", bytes.NewReader(createBucketBody))
+	if err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	resp.Body.Close()
+
+	fileBody := []byte("hello content proof")
+	resp, err = http.Post(ts.URL+"/api/v1/buckets/demo/unixfs/files?path=docs/readme.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	if err != nil {
+		t.Fatalf("create unixfs file: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create unixfs file status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/buckets/demo/content?path=docs/readme.txt")
+	if err != nil {
+		t.Fatalf("raw content request: %v", err)
+	}
+	rawBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || !bytes.Equal(rawBody, fileBody) {
+		t.Fatalf("raw content status/body = %d %q, want %d %q", resp.StatusCode, rawBody, http.StatusOK, fileBody)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/buckets/demo/content:proof?path=docs/readme.txt")
+	if err != nil {
+		t.Fatalf("content proof request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("content proof status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var proofResp httpapi.BucketContentProofResponse
+	if err := json.NewDecoder(resp.Body).Decode(&proofResp); err != nil {
+		t.Fatalf("decode content proof response: %v", err)
+	}
+	if !bytes.Equal(proofResp.Content, fileBody) {
+		t.Fatalf("content = %q, want %q", proofResp.Content, fileBody)
+	}
+	if proofResp.Range.StatusCode != http.StatusOK || proofResp.Range.ContentLength != int64(len(fileBody)) || proofResp.Range.TotalSize != int64(len(fileBody)) {
+		t.Fatalf("unexpected range metadata: %+v", proofResp.Range)
+	}
+	if proofResp.Range.Partial || proofResp.Range.ContentRange != "" || proofResp.Range.AcceptRanges != "bytes" {
+		t.Fatalf("unexpected full-read range metadata: %+v", proofResp.Range)
+	}
+	if proofResp.ProofList.Query != "docs/readme.txt" {
+		t.Fatalf("proof query = %q, want docs/readme.txt", proofResp.ProofList.Query)
+	}
+	if err := proofResp.ProofList.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("prooflist shape: %v", err)
+	}
+	if len(proofResp.ProofList.Steps) == 0 {
+		t.Fatal("expected prooflist steps")
+	}
+	last := proofResp.ProofList.Steps[len(proofResp.ProofList.Steps)-1]
+	if last.Kind != prooflist.KindPayloadBinding || last.Path != "@payload" {
+		t.Fatalf("last proof step = %q/%q, want payload binding @payload", last.Kind, last.Path)
+	}
+	for i, step := range proofResp.ProofList.Steps {
+		if step.Kind == prooflist.KindListIndex {
+			t.Fatalf("small raw file included list-index step at %d: %+v", i, step)
+		}
+	}
+}
+
+func TestServerContentProofReadUnixFSRangeIncludesTouchedListIndexes(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBucketBody, _ := json.Marshal(&httpapi.BucketCreateRequest{ID: "demo"})
+	resp, err := http.Post(ts.URL+"/api/v1/buckets", "application/json", bytes.NewReader(createBucketBody))
+	if err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	resp.Body.Close()
+
+	fileBody := append(bytes.Repeat([]byte{'a'}, fixedBucketListChunkSize), []byte("bcdef")...)
+	resp, err = http.Post(ts.URL+"/api/v1/buckets/demo/unixfs/files?path=large.bin", "application/octet-stream", bytes.NewReader(fileBody))
+	if err != nil {
+		t.Fatalf("create unixfs large file: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create unixfs large file status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/buckets/demo/content:proof?path=large.bin", nil)
+	req.Header.Set("Range", "bytes=262142-262145")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("content proof range request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("content proof status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var proofResp httpapi.BucketContentProofResponse
+	if err := json.NewDecoder(resp.Body).Decode(&proofResp); err != nil {
+		t.Fatalf("decode content proof response: %v", err)
+	}
+	if string(proofResp.Content) != "aabc" {
+		t.Fatalf("content range = %q, want aabc", proofResp.Content)
+	}
+	wantContentRange := "bytes 262142-262145/262149"
+	if proofResp.Range.StatusCode != http.StatusPartialContent || proofResp.Range.ContentRange != wantContentRange {
+		t.Fatalf("range metadata = %+v, want status 206 content-range %q", proofResp.Range, wantContentRange)
+	}
+	if proofResp.Range.Start != 262142 || proofResp.Range.EndExclusive != 262146 || proofResp.Range.ContentLength != 4 || !proofResp.Range.Partial {
+		t.Fatalf("unexpected byte range metadata: %+v", proofResp.Range)
+	}
+	if err := proofResp.ProofList.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("prooflist shape: %v", err)
+	}
+
+	var indexes []uint64
+	for _, step := range proofResp.ProofList.Steps {
+		if step.Kind == prooflist.KindListIndex {
+			if step.Index == nil {
+				t.Fatalf("list-index step missing index: %+v", step)
+			}
+			indexes = append(indexes, *step.Index)
+			if step.EvidenceBackend != "list" {
+				t.Fatalf("list-index evidence backend = %q, want list", step.EvidenceBackend)
+			}
+		}
+	}
+	if len(indexes) != 2 || indexes[0] != 0 || indexes[1] != 1 {
+		t.Fatalf("list-index steps = %v, want [0 1]", indexes)
+	}
+}
+
 func newTestNode(t *testing.T) *api.Node {
 	t.Helper()
 


### PR DESCRIPTION
﻿## Summary
- add `GET /api/v1/buckets/{id}/content:proof` for JSON content reads with base64 JSON bytes, HTTP-equivalent range metadata, and ProofList evidence
- preserve the existing raw `/api/v1/buckets/{id}/content` byte-stream route and reuse the same range parsing/content loading behavior
- include UnixFS path-to-payload proof steps for small raw files and append list-index proof steps for touched chunks in list-backed range reads
- add `Client.GetBucketContentProof` and focused server/client tests

## Validation
- `go test ./server -run ContentProof`
- `go test ./client -run ContentProof`
- `go test ./core/layout/malt/unixfs -run ProofList`
- `go test ./...`
