### PR TITLE
[codex] expose local metrics snapshots

### DIFF
--- a/core/api/metrics_test.go
+++ b/core/api/metrics_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/cas"
+	"github.com/dewebprotocol/malt/core/metrics"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	"github.com/dewebprotocol/malt/core/types/prooflist"
+	cid "github.com/ipfs/go-cid"
+)
+
+func TestNodeMetricsSnapshotAndReset(t *testing.T) {
+	node, err := NewNode(WithConfig(testConfig(t)))
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+	defer node.Close()
+
+	ctx := context.Background()
+	blocks, ok := node.CAS().(cas.Client)
+	if !ok {
+		t.Fatalf("node CAS = %T, want cas.Client", node.CAS())
+	}
+	payload := []byte("metrics payload")
+	payloadCID, err := blocks.Put(ctx, payload)
+	if err != nil {
+		t.Fatalf("put payload: %v", err)
+	}
+	if _, err := blocks.Get(ctx, payloadCID); err != nil {
+		t.Fatalf("get payload: %v", err)
+	}
+
+	g, err := node.NewGraph("metrics")
+	if err != nil {
+		t.Fatalf("NewGraph failed: %v", err)
+	}
+	root, err := g.Commit(ctx, arcset.NewSetFrom(map[string]cid.Cid{
+		"@payload": payloadCID,
+		"name":     newTestCID("name"),
+	}))
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	if _, err := g.Snapshot(ctx, root); err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+
+	node.RecordProofList(prooflist.ProofList{
+		Root: root,
+		Steps: []prooflist.Step{{
+			Kind:     prooflist.KindMapStep,
+			From:     root,
+			Target:   payloadCID,
+			Evidence: []byte{1, 2},
+			Proof:    []byte{3},
+		}},
+	})
+
+	snapshot := node.MetricsSnapshot()
+	if snapshot.CAS.PutCount != 1 {
+		t.Fatalf("CAS PutCount = %d, want 1", snapshot.CAS.PutCount)
+	}
+	if snapshot.CAS.GetCount != 1 {
+		t.Fatalf("CAS GetCount = %d, want 1", snapshot.CAS.GetCount)
+	}
+	if snapshot.CAS.BytesPut != uint64(len(payload)) {
+		t.Fatalf("CAS BytesPut = %d, want %d", snapshot.CAS.BytesPut, len(payload))
+	}
+	if snapshot.CAS.BytesGet != uint64(len(payload)) {
+		t.Fatalf("CAS BytesGet = %d, want %d", snapshot.CAS.BytesGet, len(payload))
+	}
+	if snapshot.ArcTable.UpdateCount == 0 {
+		t.Fatalf("ArcTable UpdateCount = %d, want > 0", snapshot.ArcTable.UpdateCount)
+	}
+	if snapshot.ArcTable.SnapshotCount == 0 {
+		t.Fatalf("ArcTable SnapshotCount = %d, want > 0", snapshot.ArcTable.SnapshotCount)
+	}
+	if snapshot.Proof.ProofListCount != 1 || snapshot.Proof.TotalBytes != 3 {
+		t.Fatalf("Proof stats = %+v, want one prooflist with 3 bytes", snapshot.Proof)
+	}
+
+	node.ResetMetrics()
+	if got := node.MetricsSnapshot(); got != (metrics.Snapshot{}) {
+		t.Fatalf("metrics after reset = %+v, want zero", got)
+	}
+}

--- a/core/api/node.go
+++ b/core/api/node.go
@@ -23,6 +23,8 @@ import (
 	"github.com/dewebprotocol/malt/core/kvstore/fs"
 	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
 	"github.com/dewebprotocol/malt/core/lineage"
+	"github.com/dewebprotocol/malt/core/metrics"
+	"github.com/dewebprotocol/malt/core/types/prooflist"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -47,6 +49,9 @@ type Node struct {
 	cas          cas.Reader
 	graphManager *graph.Manager
 	lineageMgr   *lineage.Manager
+
+	metricsArcTable *metrics.ArcTable
+	proofStats      metrics.ProofStatsRecorder
 }
 
 // NewNode creates a new MALT node with the given options.
@@ -110,6 +115,7 @@ func NewNode(opts ...Option) (*Node, error) {
 			return nil, fmt.Errorf("failed to initialize ArcTable: %w", err)
 		}
 	}
+	node.installMetricsArcTable()
 
 	// Graph Manager
 	node.graphManager = graph.NewManager(graph.NewStore(node.kv))
@@ -125,6 +131,19 @@ func NewNode(opts ...Option) (*Node, error) {
 	}
 
 	return node, nil
+}
+
+func (n *Node) installMetricsArcTable() {
+	if n.arctable == nil {
+		return
+	}
+	if wrapped, ok := n.arctable.(*metrics.ArcTable); ok {
+		n.metricsArcTable = wrapped
+		return
+	}
+	wrapped := metrics.NewArcTable(n.arctable)
+	n.arctable = wrapped
+	n.metricsArcTable = wrapped
 }
 
 // initKVStore creates a KVStore from config.
@@ -336,6 +355,47 @@ func (n *Node) KVStore() kvstore.KVStore {
 // Config returns the node configuration.
 func (n *Node) Config() *config.Config {
 	return n.cfg
+}
+
+// MetricsSnapshot returns the current node-local evaluation counters.
+func (n *Node) MetricsSnapshot() metrics.Snapshot {
+	var snapshot metrics.Snapshot
+	if n.cas != nil {
+		if source, ok := n.cas.(interface{ SnapshotStats() metrics.CASStats }); ok {
+			snapshot.CAS = source.SnapshotStats()
+		}
+	}
+	if n.metricsArcTable != nil {
+		snapshot.ArcTable = n.metricsArcTable.SnapshotStats()
+	} else if n.arctable != nil {
+		if source, ok := n.arctable.(interface{ SnapshotStats() metrics.ArcTableStats }); ok {
+			snapshot.ArcTable = source.SnapshotStats()
+		}
+	}
+	snapshot.Proof = n.proofStats.Snapshot()
+	return snapshot
+}
+
+// ResetMetrics clears node-local evaluation counters where supported.
+func (n *Node) ResetMetrics() {
+	if n.cas != nil {
+		if resetter, ok := n.cas.(interface{ ResetStats() }); ok {
+			resetter.ResetStats()
+		}
+	}
+	if n.metricsArcTable != nil {
+		n.metricsArcTable.ResetStats()
+	} else if n.arctable != nil {
+		if resetter, ok := n.arctable.(interface{ ResetStats() }); ok {
+			resetter.ResetStats()
+		}
+	}
+	n.proofStats.Reset()
+}
+
+// RecordProofList records byte accounting for a verifier-facing proof artifact.
+func (n *Node) RecordProofList(pl prooflist.ProofList) {
+	n.proofStats.RecordProofList(pl)
 }
 
 // Close releases all resources.

--- a/core/metrics/arctable.go
+++ b/core/metrics/arctable.go
@@ -14,16 +14,19 @@ import (
 // ErrBucketCreatorUnsupported is returned when a wrapped ArcTable cannot create buckets.
 var ErrBucketCreatorUnsupported = errors.New("wrapped arctable does not support bucket creation")
 
+// ErrParentLookupUnsupported is returned when a wrapped ArcTable cannot read root parents.
+var ErrParentLookupUnsupported = errors.New("wrapped arctable does not support parent lookup")
+
 // ArcTableStats is a point-in-time snapshot of ArcTable operation counters.
 type ArcTableStats struct {
-	GetCount          uint64
-	BatchGetCount     uint64
-	BatchGetPathCount uint64
-	UpdateCount       uint64
-	UpdateArcCount    uint64
-	SnapshotCount     uint64
-	SnapshotArcCount  uint64
-	IterateCount      uint64
+	GetCount          uint64 `json:"get_count"`
+	BatchGetCount     uint64 `json:"batch_get_count"`
+	BatchGetPathCount uint64 `json:"batch_get_path_count"`
+	UpdateCount       uint64 `json:"update_count"`
+	UpdateArcCount    uint64 `json:"update_arc_count"`
+	SnapshotCount     uint64 `json:"snapshot_count"`
+	SnapshotArcCount  uint64 `json:"snapshot_arc_count"`
+	IterateCount      uint64 `json:"iterate_count"`
 }
 
 type arcTableStatsRecorder struct {
@@ -70,6 +73,11 @@ type ArcTable struct {
 // NewArcTable wraps base with ArcTable operation counters.
 func NewArcTable(base arctable.ArcTable) *ArcTable {
 	return &ArcTable{base: base}
+}
+
+// Base returns the wrapped ArcTable implementation.
+func (m *ArcTable) Base() arctable.ArcTable {
+	return m.base
 }
 
 // SnapshotStats returns the current ArcTable counters.
@@ -132,6 +140,17 @@ func (m *ArcTable) CreateBucket(ctx context.Context, bucketId string, cfg *bloom
 		return ErrBucketCreatorUnsupported
 	}
 	return creator.CreateBucket(ctx, bucketId, cfg)
+}
+
+// GetParent forwards version-parent lookups when the wrapped ArcTable supports it.
+func (m *ArcTable) GetParent(ctx context.Context, bucketId string, version cid.Cid) (cid.Cid, error) {
+	reader, ok := m.base.(interface {
+		GetParent(context.Context, string, cid.Cid) (cid.Cid, error)
+	})
+	if !ok {
+		return cid.Undef, ErrParentLookupUnsupported
+	}
+	return reader.GetParent(ctx, bucketId, version)
 }
 
 var _ arctable.ArcTable = (*ArcTable)(nil)

--- a/core/metrics/cas.go
+++ b/core/metrics/cas.go
@@ -4,11 +4,11 @@ import "sync/atomic"
 
 // CASStats is a point-in-time snapshot of CAS operation counters.
 type CASStats struct {
-	PutCount uint64
-	GetCount uint64
-	HasCount uint64
-	BytesPut uint64
-	BytesGet uint64
+	PutCount uint64 `json:"put_count"`
+	GetCount uint64 `json:"get_count"`
+	HasCount uint64 `json:"has_count"`
+	BytesPut uint64 `json:"bytes_put"`
+	BytesGet uint64 `json:"bytes_get"`
 }
 
 // CASStatsRecorder records CAS counters with atomic updates.

--- a/core/metrics/snapshot.go
+++ b/core/metrics/snapshot.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"sync/atomic"
+
+	"github.com/dewebprotocol/malt/core/types/prooflist"
+)
+
+// Snapshot is a point-in-time view of node-local evaluation counters.
+type Snapshot struct {
+	CAS      CASStats      `json:"cas"`
+	ArcTable ArcTableStats `json:"arctable"`
+	Proof    ProofStats    `json:"proof"`
+}
+
+// ProofStats is a point-in-time snapshot of verifier proof byte counters.
+type ProofStats struct {
+	ProofListCount uint64 `json:"proof_list_count"`
+	StepCount      uint64 `json:"step_count"`
+	EvidenceBytes  uint64 `json:"evidence_bytes"`
+	ProofBytes     uint64 `json:"proof_bytes"`
+	TotalBytes     uint64 `json:"total_bytes"`
+}
+
+// ProofStatsRecorder records proof-list shape and byte counters.
+type ProofStatsRecorder struct {
+	proofListCount atomic.Uint64
+	stepCount      atomic.Uint64
+	evidenceBytes  atomic.Uint64
+	proofBytes     atomic.Uint64
+}
+
+// RecordProofList records the available byte accounting for one ProofList.
+func (r *ProofStatsRecorder) RecordProofList(pl prooflist.ProofList) {
+	r.proofListCount.Add(1)
+	r.stepCount.Add(uint64(len(pl.Steps)))
+	for _, step := range pl.Steps {
+		if len(step.Evidence) > 0 {
+			r.evidenceBytes.Add(uint64(len(step.Evidence)))
+		}
+		if len(step.Proof) > 0 {
+			r.proofBytes.Add(uint64(len(step.Proof)))
+		}
+	}
+}
+
+// Snapshot returns the current proof counters.
+func (r *ProofStatsRecorder) Snapshot() ProofStats {
+	evidenceBytes := r.evidenceBytes.Load()
+	proofBytes := r.proofBytes.Load()
+	return ProofStats{
+		ProofListCount: r.proofListCount.Load(),
+		StepCount:      r.stepCount.Load(),
+		EvidenceBytes:  evidenceBytes,
+		ProofBytes:     proofBytes,
+		TotalBytes:     evidenceBytes + proofBytes,
+	}
+}
+
+// Reset clears all proof counters.
+func (r *ProofStatsRecorder) Reset() {
+	r.proofListCount.Store(0)
+	r.stepCount.Store(0)
+	r.evidenceBytes.Store(0)
+	r.proofBytes.Store(0)
+}

--- a/core/metrics/snapshot_test.go
+++ b/core/metrics/snapshot_test.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/types/prooflist"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func metricsTestCID(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("mh.Sum failed: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}
+
+func TestProofStatsRecorderCountsProofListBytesAndReset(t *testing.T) {
+	root := metricsTestCID(t, "root")
+	target := metricsTestCID(t, "target")
+
+	var recorder ProofStatsRecorder
+	recorder.RecordProofList(prooflist.ProofList{
+		Root: root,
+		Steps: []prooflist.Step{
+			{
+				Kind:     prooflist.KindMapStep,
+				From:     root,
+				Target:   target,
+				Evidence: []byte{1, 2, 3},
+				Proof:    []byte{4, 5},
+			},
+			{
+				Kind:     prooflist.KindPayloadBinding,
+				From:     target,
+				Target:   root,
+				Evidence: []byte{6},
+			},
+		},
+	})
+
+	stats := recorder.Snapshot()
+	if stats.ProofListCount != 1 {
+		t.Fatalf("ProofListCount = %d, want 1", stats.ProofListCount)
+	}
+	if stats.StepCount != 2 {
+		t.Fatalf("StepCount = %d, want 2", stats.StepCount)
+	}
+	if stats.EvidenceBytes != 4 {
+		t.Fatalf("EvidenceBytes = %d, want 4", stats.EvidenceBytes)
+	}
+	if stats.ProofBytes != 2 {
+		t.Fatalf("ProofBytes = %d, want 2", stats.ProofBytes)
+	}
+	if stats.TotalBytes != 6 {
+		t.Fatalf("TotalBytes = %d, want 6", stats.TotalBytes)
+	}
+
+	recorder.Reset()
+	if got := recorder.Snapshot(); got != (ProofStats{}) {
+		t.Fatalf("stats after reset = %+v, want zero", got)
+	}
+}

--- a/httpapi/types.go
+++ b/httpapi/types.go
@@ -1,7 +1,10 @@
 // Package httpapi defines the daemon HTTP API payloads shared by server and client.
 package httpapi
 
-import "github.com/dewebprotocol/malt/core/types/prooflist"
+import (
+	"github.com/dewebprotocol/malt/core/metrics"
+	"github.com/dewebprotocol/malt/core/types/prooflist"
+)
 
 // ErrorResponse represents a structured API error.
 type ErrorResponse struct {
@@ -11,6 +14,11 @@ type ErrorResponse struct {
 // HealthResponse is returned by the daemon health endpoint.
 type HealthResponse struct {
 	Status string `json:"status"`
+}
+
+// MetricsResponse wraps a node-local metrics snapshot.
+type MetricsResponse struct {
+	Snapshot metrics.Snapshot `json:"snapshot"`
 }
 
 // Bucket describes bucket metadata in daemon responses.

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -38,6 +38,15 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, &httpapi.HealthResponse{Status: "ok"})
 }
 
+func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, &httpapi.MetricsResponse{Snapshot: s.node.MetricsSnapshot()})
+}
+
+func (s *Server) handleMetricsReset(w http.ResponseWriter, r *http.Request) {
+	s.node.ResetMetrics()
+	writeJSON(w, http.StatusOK, &httpapi.MetricsResponse{Snapshot: s.node.MetricsSnapshot()})
+}
+
 func (s *Server) handleBucketCreate(w http.ResponseWriter, r *http.Request) {
 	var req httpapi.BucketCreateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1190,6 +1199,7 @@ func (s *Server) proofListAndWrite(w http.ResponseWriter, ctx context.Context, g
 		return
 	}
 	pl.Query = bucketpath.CanonicalizeQueryPath(rawPath)
+	s.node.RecordProofList(*pl)
 	writeJSON(w, http.StatusOK, &httpapi.ProofListResponse{
 		Target:    result.Target.String(),
 		ProofList: *pl,

--- a/server/server.go
+++ b/server/server.go
@@ -69,6 +69,8 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/health", s.handleHealth)
+	mux.HandleFunc("GET /api/v1/metrics", s.handleMetrics)
+	mux.HandleFunc("POST /api/v1/metrics:reset", s.handleMetricsReset)
 
 	// Bucket-first managed metadata surface (Phase 2).
 	mux.HandleFunc("POST /api/v1/buckets", s.handleBucketCreate)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/dewebprotocol/malt/config"
 	"github.com/dewebprotocol/malt/core/api"
-	"github.com/dewebprotocol/malt/core/arctable/versioned"
 	casmock "github.com/dewebprotocol/malt/core/cas/mock"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/core/types/prooflist"
@@ -92,6 +92,135 @@ func TestServerLegacyGraphRoutesRemoved(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("legacy graphs status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestServerMetricsSnapshotAndResetEndpoints(t *testing.T) {
+	node := newTestNode(t)
+	mockCAS, ok := node.CAS().(*casmock.CAS)
+	if !ok {
+		t.Fatal("expected mock CAS")
+	}
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	rawData := []byte("metrics raw content")
+	rawCID, err := mockCAS.Put(t.Context(), rawData)
+	if err != nil {
+		t.Fatalf("put raw content: %v", err)
+	}
+
+	createBucketBody, _ := json.Marshal(&httpapi.BucketCreateRequest{ID: "metrics"})
+	resp, err := http.Post(ts.URL+"/api/v1/buckets", "application/json", bytes.NewReader(createBucketBody))
+	if err != nil {
+		t.Fatalf("create bucket request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create bucket status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: map[string]string{
+			"@payload": rawCID.String(),
+			"file.txt": rawCID.String(),
+		},
+	})
+	resp, err = http.Post(ts.URL+"/api/v1/buckets/metrics/structure", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create structure status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/buckets/metrics/content?path=file.txt")
+	if err != nil {
+		t.Fatalf("content request failed: %v", err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("content status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/buckets/metrics/prooflist?path=file.txt")
+	if err != nil {
+		t.Fatalf("prooflist request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("prooflist status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/metrics")
+	if err != nil {
+		t.Fatalf("metrics request failed: %v", err)
+	}
+	var metricsResp httpapi.MetricsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&metricsResp); err != nil {
+		t.Fatalf("decode metrics response: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("metrics status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	snapshot := metricsResp.Snapshot
+	if snapshot.CAS.PutCount != 1 {
+		t.Fatalf("CAS PutCount = %d, want 1", snapshot.CAS.PutCount)
+	}
+	if snapshot.CAS.GetCount < 2 {
+		t.Fatalf("CAS GetCount = %d, want at least 2", snapshot.CAS.GetCount)
+	}
+	if snapshot.CAS.BytesGet < uint64(len(rawData)*2) {
+		t.Fatalf("CAS BytesGet = %d, want at least %d", snapshot.CAS.BytesGet, len(rawData)*2)
+	}
+	if snapshot.ArcTable.UpdateCount == 0 {
+		t.Fatalf("ArcTable UpdateCount = %d, want > 0", snapshot.ArcTable.UpdateCount)
+	}
+	if snapshot.ArcTable.GetCount == 0 {
+		t.Fatalf("ArcTable GetCount = %d, want > 0", snapshot.ArcTable.GetCount)
+	}
+	if snapshot.Proof.ProofListCount != 1 {
+		t.Fatalf("ProofListCount = %d, want 1", snapshot.Proof.ProofListCount)
+	}
+	if snapshot.Proof.StepCount == 0 || snapshot.Proof.TotalBytes == 0 {
+		t.Fatalf("Proof stats = %+v, want steps and byte accounting", snapshot.Proof)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/metrics:reset", nil)
+	if err != nil {
+		t.Fatalf("new reset request: %v", err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("reset request failed: %v", err)
+	}
+	var resetResp httpapi.MetricsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&resetResp); err != nil {
+		t.Fatalf("decode reset response: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("reset status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if resetResp.Snapshot.CAS.GetCount != 0 || resetResp.Snapshot.ArcTable.UpdateCount != 0 || resetResp.Snapshot.Proof.ProofListCount != 0 {
+		t.Fatalf("reset response snapshot = %+v, want zero counters", resetResp.Snapshot)
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/metrics")
+	if err != nil {
+		t.Fatalf("metrics after reset request failed: %v", err)
+	}
+	var afterReset httpapi.MetricsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&afterReset); err != nil {
+		t.Fatalf("decode metrics after reset response: %v", err)
+	}
+	resp.Body.Close()
+	if afterReset.Snapshot.CAS.GetCount != 0 || afterReset.Snapshot.ArcTable.GetCount != 0 || afterReset.Snapshot.Proof.ProofListCount != 0 {
+		t.Fatalf("metrics after reset = %+v, want zero counters", afterReset.Snapshot)
 	}
 }
 
@@ -884,9 +1013,11 @@ func TestServerUnixFSWritesPublishGatewayReadableRoot(t *testing.T) {
 
 func TestServerUnixFSGatewayRootDoesNotSelfParent(t *testing.T) {
 	node := newTestNode(t)
-	arcs, ok := node.ArcTable().(*versioned.ArcTable)
+	arcs, ok := node.ArcTable().(interface {
+		GetParent(context.Context, string, cid.Cid) (cid.Cid, error)
+	})
 	if !ok {
-		t.Fatalf("test node ArcTable = %T, want *versioned.ArcTable", node.ArcTable())
+		t.Fatalf("test node ArcTable = %T, want parent lookup support", node.ArcTable())
 	}
 
 	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())


### PR DESCRIPTION
## Summary

- Add node-local metrics snapshots for mock CAS counters, metered ArcTable counters, and verifier proof byte accounting.
- Wrap node ArcTable instances with the existing metrics wrapper while forwarding optional behavior such as bucket creation and version parent lookup.
- Add daemon endpoints for `GET /api/v1/metrics` and `POST /api/v1/metrics:reset` with shared HTTP response types.

## Validation

- `go test ./core/metrics`
- `go test ./core/api -run Metrics`
- `go test ./server -run Metrics`
- `git diff --check`
- `go test ./...`

No eval CLI runner was added; the daemon endpoint already provides machine-readable JSON for the initial evaluation metrics surface.