### PR TITLE
[codex] add metrics CLI helpers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -58,6 +58,25 @@ func (c *Client) Health(ctx context.Context) (*httpapi.HealthResponse, error) {
 	return &resp, nil
 }
 
+// MetricsSnapshot returns node-local daemon evaluation counters.
+func (c *Client) MetricsSnapshot(ctx context.Context) (*httpapi.MetricsResponse, error) {
+	var resp httpapi.MetricsResponse
+	if err := c.do(ctx, http.MethodGet, "/metrics", nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ResetMetrics clears node-local daemon evaluation counters and returns the
+// post-reset snapshot.
+func (c *Client) ResetMetrics(ctx context.Context) (*httpapi.MetricsResponse, error) {
+	var resp httpapi.MetricsResponse
+	if err := c.do(ctx, http.MethodPost, "/metrics:reset", nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // CreateBucket creates a managed bucket.
 func (c *Client) CreateBucket(ctx context.Context, id string, backend string) (*httpapi.Bucket, error) {
 	req := &httpapi.BucketCreateRequest{ID: id, Backend: backend}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/dewebprotocol/malt/core/cas/ipfs"
 	casmock "github.com/dewebprotocol/malt/core/cas/mock"
 	"github.com/dewebprotocol/malt/core/manifest"
+	"github.com/dewebprotocol/malt/core/metrics"
 	"github.com/dewebprotocol/malt/core/types/prooflist"
 	"github.com/dewebprotocol/malt/httpapi"
 	"github.com/dewebprotocol/malt/server"
@@ -237,6 +239,64 @@ func TestClientProofListReads(t *testing.T) {
 	}
 	if rootProof.ProofList.Steps[0].Kind != prooflist.KindPayloadBinding {
 		t.Fatalf("root prooflist step kind = %q, want %q", rootProof.ProofList.Steps[0].Kind, prooflist.KindPayloadBinding)
+	}
+}
+
+func TestClientMetricsSnapshotAndReset(t *testing.T) {
+	seen := make(chan string, 2)
+	snapshotResp := httpapi.MetricsResponse{
+		Snapshot: metrics.Snapshot{
+			CAS: metrics.CASStats{
+				GetCount: 7,
+				BytesGet: 11,
+			},
+			ArcTable: metrics.ArcTableStats{
+				SnapshotCount: 2,
+			},
+			Proof: metrics.ProofStats{
+				ProofListCount: 3,
+				StepCount:      5,
+				TotalBytes:     13,
+			},
+		},
+	}
+	resetResp := httpapi.MetricsResponse{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.Method + " " + r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/metrics":
+			_ = json.NewEncoder(w).Encode(&snapshotResp)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/metrics:reset":
+			_ = json.NewEncoder(w).Encode(&resetResp)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	client := NewWithBaseURL(ts.URL + "/api/v1")
+	snapshot, err := client.MetricsSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("MetricsSnapshot: %v", err)
+	}
+	if got := <-seen; got != "GET /api/v1/metrics" {
+		t.Fatalf("MetricsSnapshot request = %q, want GET /api/v1/metrics", got)
+	}
+	if snapshot.Snapshot.CAS.GetCount != 7 || snapshot.Snapshot.ArcTable.SnapshotCount != 2 || snapshot.Snapshot.Proof.ProofListCount != 3 {
+		t.Fatalf("decoded metrics snapshot = %+v", snapshot.Snapshot)
+	}
+
+	reset, err := client.ResetMetrics(context.Background())
+	if err != nil {
+		t.Fatalf("ResetMetrics: %v", err)
+	}
+	if got := <-seen; got != "POST /api/v1/metrics:reset" {
+		t.Fatalf("ResetMetrics request = %q, want POST /api/v1/metrics:reset", got)
+	}
+	if reset.Snapshot != (metrics.Snapshot{}) {
+		t.Fatalf("decoded reset snapshot = %+v, want zero counters", reset.Snapshot)
 	}
 }
 

--- a/cmd/malt/metrics.go
+++ b/cmd/malt/metrics.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(metricsCmd)
+	metricsCmd.AddCommand(metricsSnapshotCmd, metricsResetCmd)
+}
+
+var metricsCmd = &cobra.Command{
+	Use:   "metrics",
+	Short: "Inspect daemon evaluation metrics",
+}
+
+var metricsSnapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Print daemon evaluation metrics",
+	Args:  cobra.NoArgs,
+	RunE:  runMetricsSnapshot,
+}
+
+var metricsResetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Reset daemon evaluation metrics",
+	Args:  cobra.NoArgs,
+	RunE:  runMetricsReset,
+}
+
+func runMetricsSnapshot(cmd *cobra.Command, args []string) error {
+	resp, err := mustDaemonClient().MetricsSnapshot(cmd.Context())
+	if err != nil {
+		return daemonCommandError(err)
+	}
+	return printMetricsResponse(resp)
+}
+
+func runMetricsReset(cmd *cobra.Command, args []string) error {
+	resp, err := mustDaemonClient().ResetMetrics(cmd.Context())
+	if err != nil {
+		return daemonCommandError(err)
+	}
+	return printMetricsResponse(resp)
+}
+
+func printMetricsResponse(resp any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
+}

--- a/cmd/malt/metrics_test.go
+++ b/cmd/malt/metrics_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dewebprotocol/malt/httpapi"
+)
+
+func TestMetricsCommandHasSnapshotAndResetSubcommands(t *testing.T) {
+	for _, name := range []string{"snapshot", "reset"} {
+		if cmd, _, err := metricsCmd.Find([]string{name}); err != nil || cmd == nil || cmd.Name() != name {
+			t.Fatalf("metrics subcommand %q lookup = cmd %v err %v", name, cmd, err)
+		}
+	}
+}
+
+func TestMetricsSnapshotPrintsDaemonJSON(t *testing.T) {
+	ctx := context.Background()
+	daemon, _ := newAddTestClients(t)
+	defaultClient = daemon
+	t.Cleanup(func() { defaultClient = nil })
+
+	if _, err := daemon.CreateBucket(ctx, "metrics", ""); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	if _, err := daemon.AddBucketUnixFSFile(ctx, "metrics", "file.txt", []byte("hello metrics")); err != nil {
+		t.Fatalf("add unixfs file: %v", err)
+	}
+	if _, err := daemon.GetBucketContentProof(ctx, "metrics", "file.txt", ""); err != nil {
+		t.Fatalf("content proof: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runMetricsSnapshot(testCommandWithContext(ctx), nil); err != nil {
+			t.Fatalf("run metrics snapshot: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "\n  \"snapshot\"") {
+		t.Fatalf("metrics snapshot output is not indented JSON:\n%s", out)
+	}
+	var payload httpapi.MetricsResponse
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("decode metrics snapshot output: %v\n%s", err, out)
+	}
+	if payload.Snapshot.Proof.ProofListCount == 0 {
+		t.Fatalf("proof metrics were not printed from daemon response: %+v", payload.Snapshot)
+	}
+}
+
+func TestMetricsResetPrintsDaemonJSON(t *testing.T) {
+	ctx := context.Background()
+	daemon, _ := newAddTestClients(t)
+	defaultClient = daemon
+	t.Cleanup(func() { defaultClient = nil })
+
+	if _, err := daemon.CreateBucket(ctx, "metrics-reset", ""); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	if _, err := daemon.AddBucketUnixFSFile(ctx, "metrics-reset", "file.txt", []byte("hello metrics reset")); err != nil {
+		t.Fatalf("add unixfs file: %v", err)
+	}
+	if _, err := daemon.GetBucketContentProof(ctx, "metrics-reset", "file.txt", ""); err != nil {
+		t.Fatalf("content proof: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runMetricsReset(testCommandWithContext(ctx), nil); err != nil {
+			t.Fatalf("run metrics reset: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "\n  \"snapshot\"") {
+		t.Fatalf("metrics reset output is not indented JSON:\n%s", out)
+	}
+	var payload httpapi.MetricsResponse
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("decode metrics reset output: %v\n%s", err, out)
+	}
+	if payload.Snapshot.Proof.ProofListCount != 0 || payload.Snapshot.CAS.GetCount != 0 || payload.Snapshot.ArcTable.GetCount != 0 {
+		t.Fatalf("metrics reset output = %+v, want zero counters", payload.Snapshot)
+	}
+}


### PR DESCRIPTION
﻿## Summary

- add client helpers for daemon metrics snapshot and reset endpoints
- add `malt metrics snapshot` and `malt metrics reset` commands that print the daemon JSON response shape
- cover client endpoint plumbing and CLI JSON output with focused tests

## Validation

- `go test -count=1 ./client -run Metrics`
- `go test -count=1 ./cmd/malt -run Metrics`
- `go test -count=1 ./...`