### PR TITLE
[codex] add read benchmark runner

### DIFF
--- a/cmd/malt/eval_read.go
+++ b/cmd/malt/eval_read.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+
+	"github.com/dewebprotocol/malt/internal/eval/readbench"
+	"github.com/spf13/cobra"
+)
+
+var (
+	evalReadBucket     = readbench.DefaultBucket
+	evalReadDepth      = readbench.DefaultDirectoryDepth
+	evalReadSmallBytes = readbench.DefaultSmallFileBytes
+	evalReadLargeBytes = readbench.DefaultLargeFileBytes
+	evalReadRange      = readbench.DefaultRangeHeader
+	evalReadIterations = readbench.DefaultIterations
+)
+
+func init() {
+	rootCmd.AddCommand(evalReadCmd)
+	evalReadCmd.Flags().StringVar(&evalReadBucket, "bucket", evalReadBucket, "bucket id for the deterministic read fixture")
+	evalReadCmd.Flags().IntVar(&evalReadDepth, "depth", evalReadDepth, "directory depth for fixture paths")
+	evalReadCmd.Flags().IntVar(&evalReadSmallBytes, "small-bytes", evalReadSmallBytes, "small raw file size in bytes")
+	evalReadCmd.Flags().IntVar(&evalReadLargeBytes, "large-bytes", evalReadLargeBytes, "large list-backed file size in bytes")
+	evalReadCmd.Flags().StringVar(&evalReadRange, "range", evalReadRange, "HTTP Range header for content_range reads")
+	evalReadCmd.Flags().IntVar(&evalReadIterations, "iterations", evalReadIterations, "number of prooflist/content-range operation pairs")
+}
+
+var evalReadCmd = &cobra.Command{
+	Use:   "eval-read",
+	Short: "Run a MALT-only read benchmark and emit JSONL",
+	Args:  cobra.NoArgs,
+	RunE:  runEvalRead,
+}
+
+func runEvalRead(cmd *cobra.Command, args []string) error {
+	cfg, err := loadRuntimeConfig()
+	if err != nil {
+		return err
+	}
+
+	runner := readbench.NewRunner(cfg.APIBaseURL())
+	return runner.RunJSONL(cmd.Context(), readbench.RunConfig{
+		Fixture: readbench.FixtureConfig{
+			Bucket:         evalReadBucket,
+			DirectoryDepth: evalReadDepth,
+			SmallFileBytes: evalReadSmallBytes,
+			LargeFileBytes: evalReadLargeBytes,
+		},
+		RangeHeader: evalReadRange,
+		Iterations:  evalReadIterations,
+	}, os.Stdout)
+}

--- a/cmd/malt/eval_read.go
+++ b/cmd/malt/eval_read.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	evalReadBucket     = readbench.DefaultBucket
+	evalReadBucket     = ""
 	evalReadDepth      = readbench.DefaultDirectoryDepth
 	evalReadSmallBytes = readbench.DefaultSmallFileBytes
 	evalReadLargeBytes = readbench.DefaultLargeFileBytes
@@ -18,7 +18,7 @@ var (
 
 func init() {
 	rootCmd.AddCommand(evalReadCmd)
-	evalReadCmd.Flags().StringVar(&evalReadBucket, "bucket", evalReadBucket, "bucket id for the deterministic read fixture")
+	evalReadCmd.Flags().StringVar(&evalReadBucket, "bucket", evalReadBucket, "bucket id for the deterministic read fixture (defaults to a fresh readbench-* bucket)")
 	evalReadCmd.Flags().IntVar(&evalReadDepth, "depth", evalReadDepth, "directory depth for fixture paths")
 	evalReadCmd.Flags().IntVar(&evalReadSmallBytes, "small-bytes", evalReadSmallBytes, "small raw file size in bytes")
 	evalReadCmd.Flags().IntVar(&evalReadLargeBytes, "large-bytes", evalReadLargeBytes, "large list-backed file size in bytes")

--- a/cmd/malt/eval_read_test.go
+++ b/cmd/malt/eval_read_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dewebprotocol/malt/config"
+	"github.com/dewebprotocol/malt/core/api"
+	casmock "github.com/dewebprotocol/malt/core/cas/mock"
+	"github.com/dewebprotocol/malt/internal/eval/readbench"
+	"github.com/dewebprotocol/malt/server"
+)
+
+func TestEvalReadPrintsBenchmarkJSONL(t *testing.T) {
+	ctx := context.Background()
+	apiBaseURL, cfgPath := newEvalReadTestConfig(t)
+	if apiBaseURL == "" {
+		t.Fatal("test API base URL should not be empty")
+	}
+
+	oldCfgFile := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfgFile })
+
+	resetEvalReadFlags(t)
+	evalReadBucket = "eval-read-cli"
+	evalReadDepth = 1
+	evalReadSmallBytes = 40
+	evalReadLargeBytes = 300 * 1024
+	evalReadRange = "bytes=3-8"
+	evalReadIterations = 1
+
+	out := captureStdout(t, func() {
+		if err := runEvalRead(testCommandWithContext(ctx), nil); err != nil {
+			t.Fatalf("run eval-read: %v", err)
+		}
+	})
+
+	results := decodeEvalReadJSONL(t, out)
+	if len(results) != 2 {
+		t.Fatalf("result count = %d, want 2\n%s", len(results), out)
+	}
+	if results[0].OperationKind != readbench.OperationProofListPath {
+		t.Fatalf("first operation = %q", results[0].OperationKind)
+	}
+	if results[1].OperationKind != readbench.OperationContentRange {
+		t.Fatalf("second operation = %q", results[1].OperationKind)
+	}
+	if results[1].ContentBytes == nil || *results[1].ContentBytes != 6 {
+		t.Fatalf("content bytes = %v, want 6", results[1].ContentBytes)
+	}
+	if results[0].Proof.ProofListCount != 1 || results[1].Proof.ProofListCount != 1 {
+		t.Fatalf("proof metrics should be reset per operation: %+v %+v", results[0].Proof, results[1].Proof)
+	}
+}
+
+func decodeEvalReadJSONL(t *testing.T, raw string) []readbench.Result {
+	t.Helper()
+
+	var results []readbench.Result
+	scanner := bufio.NewScanner(bytes.NewBufferString(raw))
+	for scanner.Scan() {
+		var result readbench.Result
+		if err := json.Unmarshal(scanner.Bytes(), &result); err != nil {
+			t.Fatalf("decode eval-read JSONL %q: %v", scanner.Text(), err)
+		}
+		results = append(results, result)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan eval-read output: %v", err)
+	}
+	return results
+}
+
+func resetEvalReadFlags(t *testing.T) {
+	t.Helper()
+
+	oldBucket := evalReadBucket
+	oldDepth := evalReadDepth
+	oldSmallBytes := evalReadSmallBytes
+	oldLargeBytes := evalReadLargeBytes
+	oldRange := evalReadRange
+	oldIterations := evalReadIterations
+	t.Cleanup(func() {
+		evalReadBucket = oldBucket
+		evalReadDepth = oldDepth
+		evalReadSmallBytes = oldSmallBytes
+		evalReadLargeBytes = oldLargeBytes
+		evalReadRange = oldRange
+		evalReadIterations = oldIterations
+	})
+}
+
+func newEvalReadTestConfig(t *testing.T) (string, string) {
+	t.Helper()
+
+	mockCAS := casmock.NewCAS(casmock.WithoutLatency())
+
+	cfg := config.DefaultConfig()
+	cfg.RPC.Listen = ""
+	cfg.State.RootDir = t.TempDir()
+	cfg.State.KVStore.Type = "memory"
+
+	node, err := api.NewNode(api.WithConfig(cfg), api.WithCAS(mockCAS))
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = node.Close()
+	})
+
+	ts := httptest.NewServer(server.New(node, "127.0.0.1:0").Handler())
+	t.Cleanup(ts.Close)
+
+	cfg.RPC.Listen = ts.URL
+	cfgPath := filepath.Join(t.TempDir(), "malt.json")
+	if err := config.WriteToFile(cfgPath, cfg); err != nil {
+		t.Fatalf("write test config: %v", err)
+	}
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("stat test config: %v", err)
+	}
+	return ts.URL + "/api/v1", cfgPath
+}

--- a/internal/eval/readbench/runner.go
+++ b/internal/eval/readbench/runner.go
@@ -4,21 +4,19 @@ package readbench
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
-	"net/url"
 	"path"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	daemonclient "github.com/dewebprotocol/malt/client"
 	"github.com/dewebprotocol/malt/core/metrics"
-	"github.com/dewebprotocol/malt/httpapi"
 )
 
 const (
+	// DefaultBucket is the prefix used for generated benchmark fixture buckets.
 	DefaultBucket         = "readbench"
 	DefaultDirectoryDepth = 2
 	DefaultSmallFileBytes = 64
@@ -28,6 +26,8 @@ const (
 
 	minListBackedFileBytes = 256*1024 + 1
 )
+
+var generatedBucketCounter atomic.Uint64
 
 // OperationKind identifies the measured read operation.
 type OperationKind string
@@ -83,22 +83,18 @@ type operation struct {
 
 // Runner drives fixture setup and measured daemon reads.
 type Runner struct {
-	baseURL string
-	client  *daemonclient.Client
-	http    *http.Client
+	client *daemonclient.Client
 }
 
 // NewRunner creates a benchmark runner for a daemon API v1 base URL.
 func NewRunner(baseURL string) *Runner {
 	trimmed := strings.TrimRight(baseURL, "/")
 	return &Runner{
-		baseURL: trimmed,
-		client:  daemonclient.NewWithBaseURL(trimmed),
-		http:    &http.Client{Timeout: 5 * time.Minute},
+		client: daemonclient.NewWithBaseURL(trimmed),
 	}
 }
 
-// PrepareFixture creates or updates a deterministic MALT-only read fixture.
+// PrepareFixture creates a deterministic MALT-only read fixture in a fresh bucket.
 func (r *Runner) PrepareFixture(ctx context.Context, cfg FixtureConfig) (*Fixture, error) {
 	if r == nil || r.client == nil {
 		return nil, fmt.Errorf("read benchmark runner is nil")
@@ -108,7 +104,7 @@ func (r *Runner) PrepareFixture(ctx context.Context, cfg FixtureConfig) (*Fixtur
 		return nil, err
 	}
 
-	if _, err := r.client.CreateBucket(ctx, normalized.Bucket, ""); err != nil && !isDaemonStatus(err, http.StatusConflict) {
+	if _, err := r.client.CreateBucket(ctx, normalized.Bucket, ""); err != nil {
 		return nil, fmt.Errorf("create bucket %q: %w", normalized.Bucket, err)
 	}
 
@@ -219,54 +215,29 @@ func (r *Runner) measureOperation(ctx context.Context, iteration int, bucket str
 }
 
 func (r *Runner) resetMetrics(ctx context.Context) error {
-	_, err := r.doMetrics(ctx, http.MethodPost, "/metrics:reset")
+	if r == nil || r.client == nil {
+		return fmt.Errorf("read benchmark runner is nil")
+	}
+	_, err := r.client.ResetMetrics(ctx)
 	return err
 }
 
 func (r *Runner) metricsSnapshot(ctx context.Context) (metrics.Snapshot, error) {
-	return r.doMetrics(ctx, http.MethodGet, "/metrics")
-}
-
-func (r *Runner) doMetrics(ctx context.Context, method string, route string) (metrics.Snapshot, error) {
 	var zero metrics.Snapshot
-	if r == nil || r.baseURL == "" {
-		return zero, fmt.Errorf("daemon API base URL is empty")
+	if r == nil || r.client == nil {
+		return zero, fmt.Errorf("read benchmark runner is nil")
 	}
-	u, err := url.Parse(r.baseURL)
+	resp, err := r.client.MetricsSnapshot(ctx)
 	if err != nil {
 		return zero, err
 	}
-	u.Path = path.Join(u.Path, route)
-
-	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
-	if err != nil {
-		return zero, err
-	}
-	resp, err := r.http.Do(req)
-	if err != nil {
-		return zero, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		payload, _ := io.ReadAll(resp.Body)
-		return zero, fmt.Errorf("daemon metrics endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
-	}
-
-	var out httpapi.MetricsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return zero, err
-	}
-	return out.Snapshot, nil
+	return resp.Snapshot, nil
 }
 
 func normalizeRunConfig(cfg RunConfig) (RunConfig, error) {
 	fixture, err := normalizeFixtureConfig(cfg.Fixture)
 	if err != nil {
 		return RunConfig{}, err
-	}
-	if cfg.Iterations == 0 {
-		cfg.Iterations = DefaultIterations
 	}
 	if cfg.Iterations < 0 {
 		return RunConfig{}, fmt.Errorf("iterations must be non-negative")
@@ -279,8 +250,10 @@ func normalizeRunConfig(cfg RunConfig) (RunConfig, error) {
 }
 
 func normalizeFixtureConfig(cfg FixtureConfig) (FixtureConfig, error) {
-	if strings.TrimSpace(cfg.Bucket) == "" {
-		cfg.Bucket = DefaultBucket
+	if bucket := strings.TrimSpace(cfg.Bucket); bucket == "" {
+		cfg.Bucket = defaultFixtureBucket()
+	} else {
+		cfg.Bucket = bucket
 	}
 	if cfg.DirectoryDepth < 0 {
 		return FixtureConfig{}, fmt.Errorf("directory depth must be non-negative")
@@ -298,6 +271,10 @@ func normalizeFixtureConfig(cfg FixtureConfig) (FixtureConfig, error) {
 		return FixtureConfig{}, fmt.Errorf("large file bytes must be at least %d for list-backed storage", minListBackedFileBytes)
 	}
 	return cfg, nil
+}
+
+func defaultFixtureBucket() string {
+	return fmt.Sprintf("%s-%d-%d", DefaultBucket, time.Now().UTC().UnixNano(), generatedBucketCounter.Add(1))
 }
 
 func fixturePath(depth int, filename string) string {
@@ -322,9 +299,4 @@ func deterministicBytes(label string, size int) []byte {
 		out[i] = byte('a' + ((int(seed[i%len(seed)]) + i) % 26))
 	}
 	return out
-}
-
-func isDaemonStatus(err error, status int) bool {
-	var apiErr *daemonclient.Error
-	return errors.As(err, &apiErr) && apiErr.StatusCode == status
 }

--- a/internal/eval/readbench/runner.go
+++ b/internal/eval/readbench/runner.go
@@ -1,0 +1,330 @@
+// Package readbench provides a MALT-only read benchmark runner.
+package readbench
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	daemonclient "github.com/dewebprotocol/malt/client"
+	"github.com/dewebprotocol/malt/core/metrics"
+	"github.com/dewebprotocol/malt/httpapi"
+)
+
+const (
+	DefaultBucket         = "readbench"
+	DefaultDirectoryDepth = 2
+	DefaultSmallFileBytes = 64
+	DefaultLargeFileBytes = 300 * 1024
+	DefaultRangeHeader    = "bytes=0-4095"
+	DefaultIterations     = 1
+
+	minListBackedFileBytes = 256*1024 + 1
+)
+
+// OperationKind identifies the measured read operation.
+type OperationKind string
+
+const (
+	OperationProofListPath OperationKind = "prooflist_path"
+	OperationContentRange  OperationKind = "content_range"
+)
+
+// FixtureConfig controls the deterministic bucket fixture.
+type FixtureConfig struct {
+	Bucket         string
+	DirectoryDepth int
+	SmallFileBytes int
+	LargeFileBytes int
+}
+
+// RunConfig controls one JSONL benchmark run.
+type RunConfig struct {
+	Fixture     FixtureConfig
+	RangeHeader string
+	Iterations  int
+}
+
+// Fixture describes the deterministic MALT-only dataset.
+type Fixture struct {
+	Bucket    string
+	SmallPath string
+	LargePath string
+}
+
+// Result is one benchmark JSONL record.
+type Result struct {
+	OperationKind      OperationKind         `json:"operation_kind"`
+	Iteration          int                   `json:"iteration"`
+	Bucket             string                `json:"bucket"`
+	Path               string                `json:"path"`
+	RangeHeader        string                `json:"range_header,omitempty"`
+	ElapsedNS          int64                 `json:"elapsed_ns"`
+	ContentBytes       *int                  `json:"content_bytes,omitempty"`
+	ProofListStepCount int                   `json:"prooflist_step_count"`
+	Target             string                `json:"target,omitempty"`
+	CAS                metrics.CASStats      `json:"cas"`
+	ArcTable           metrics.ArcTableStats `json:"arctable"`
+	Proof              metrics.ProofStats    `json:"proof"`
+}
+
+type operation struct {
+	kind        OperationKind
+	path        string
+	rangeHeader string
+}
+
+// Runner drives fixture setup and measured daemon reads.
+type Runner struct {
+	baseURL string
+	client  *daemonclient.Client
+	http    *http.Client
+}
+
+// NewRunner creates a benchmark runner for a daemon API v1 base URL.
+func NewRunner(baseURL string) *Runner {
+	trimmed := strings.TrimRight(baseURL, "/")
+	return &Runner{
+		baseURL: trimmed,
+		client:  daemonclient.NewWithBaseURL(trimmed),
+		http:    &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+// PrepareFixture creates or updates a deterministic MALT-only read fixture.
+func (r *Runner) PrepareFixture(ctx context.Context, cfg FixtureConfig) (*Fixture, error) {
+	if r == nil || r.client == nil {
+		return nil, fmt.Errorf("read benchmark runner is nil")
+	}
+	normalized, err := normalizeFixtureConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := r.client.CreateBucket(ctx, normalized.Bucket, ""); err != nil && !isDaemonStatus(err, http.StatusConflict) {
+		return nil, fmt.Errorf("create bucket %q: %w", normalized.Bucket, err)
+	}
+
+	smallPath := fixturePath(normalized.DirectoryDepth, "small.txt")
+	largePath := fixturePath(normalized.DirectoryDepth, "large.bin")
+	if _, err := r.client.AddBucketUnixFSFile(ctx, normalized.Bucket, smallPath, deterministicBytes("small", normalized.SmallFileBytes)); err != nil {
+		return nil, fmt.Errorf("write small fixture: %w", err)
+	}
+	if _, err := r.client.AddBucketUnixFSFile(ctx, normalized.Bucket, largePath, deterministicBytes("large", normalized.LargeFileBytes)); err != nil {
+		return nil, fmt.Errorf("write large fixture: %w", err)
+	}
+
+	return &Fixture{
+		Bucket:    normalized.Bucket,
+		SmallPath: smallPath,
+		LargePath: largePath,
+	}, nil
+}
+
+// RunJSONL prepares the fixture, runs the measured reads, and writes one JSON
+// object per operation.
+func (r *Runner) RunJSONL(ctx context.Context, cfg RunConfig, w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("output writer is nil")
+	}
+	normalized, err := normalizeRunConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	fixture, err := r.PrepareFixture(ctx, normalized.Fixture)
+	if err != nil {
+		return err
+	}
+
+	ops := []operation{
+		{kind: OperationProofListPath, path: fixture.SmallPath},
+		{kind: OperationContentRange, path: fixture.LargePath, rangeHeader: normalized.RangeHeader},
+	}
+
+	enc := json.NewEncoder(w)
+	for iteration := 0; iteration < normalized.Iterations; iteration++ {
+		for _, op := range ops {
+			result, err := r.measureOperation(ctx, iteration, fixture.Bucket, op)
+			if err != nil {
+				return err
+			}
+			if err := enc.Encode(result); err != nil {
+				return fmt.Errorf("write JSONL result: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (r *Runner) measureOperation(ctx context.Context, iteration int, bucket string, op operation) (*Result, error) {
+	if err := r.resetMetrics(ctx); err != nil {
+		return nil, fmt.Errorf("reset metrics before %s: %w", op.kind, err)
+	}
+
+	start := time.Now()
+	var (
+		target       string
+		contentBytes *int
+		stepCount    int
+	)
+	switch op.kind {
+	case OperationProofListPath:
+		resp, err := r.client.ProofListBucket(ctx, bucket, op.path)
+		if err != nil {
+			return nil, fmt.Errorf("prooflist read %q: %w", op.path, err)
+		}
+		target = resp.Target
+		stepCount = len(resp.ProofList.Steps)
+	case OperationContentRange:
+		resp, err := r.client.GetBucketContentProof(ctx, bucket, op.path, op.rangeHeader)
+		if err != nil {
+			return nil, fmt.Errorf("content range read %q: %w", op.path, err)
+		}
+		count := len(resp.Content)
+		contentBytes = &count
+		target = resp.Key
+		stepCount = len(resp.ProofList.Steps)
+	default:
+		return nil, fmt.Errorf("unsupported operation kind %q", op.kind)
+	}
+	elapsed := time.Since(start).Nanoseconds()
+
+	snapshot, err := r.metricsSnapshot(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot metrics after %s: %w", op.kind, err)
+	}
+
+	return &Result{
+		OperationKind:      op.kind,
+		Iteration:          iteration,
+		Bucket:             bucket,
+		Path:               op.path,
+		RangeHeader:        op.rangeHeader,
+		ElapsedNS:          elapsed,
+		ContentBytes:       contentBytes,
+		ProofListStepCount: stepCount,
+		Target:             target,
+		CAS:                snapshot.CAS,
+		ArcTable:           snapshot.ArcTable,
+		Proof:              snapshot.Proof,
+	}, nil
+}
+
+func (r *Runner) resetMetrics(ctx context.Context) error {
+	_, err := r.doMetrics(ctx, http.MethodPost, "/metrics:reset")
+	return err
+}
+
+func (r *Runner) metricsSnapshot(ctx context.Context) (metrics.Snapshot, error) {
+	return r.doMetrics(ctx, http.MethodGet, "/metrics")
+}
+
+func (r *Runner) doMetrics(ctx context.Context, method string, route string) (metrics.Snapshot, error) {
+	var zero metrics.Snapshot
+	if r == nil || r.baseURL == "" {
+		return zero, fmt.Errorf("daemon API base URL is empty")
+	}
+	u, err := url.Parse(r.baseURL)
+	if err != nil {
+		return zero, err
+	}
+	u.Path = path.Join(u.Path, route)
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
+	if err != nil {
+		return zero, err
+	}
+	resp, err := r.http.Do(req)
+	if err != nil {
+		return zero, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		payload, _ := io.ReadAll(resp.Body)
+		return zero, fmt.Errorf("daemon metrics endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var out httpapi.MetricsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return zero, err
+	}
+	return out.Snapshot, nil
+}
+
+func normalizeRunConfig(cfg RunConfig) (RunConfig, error) {
+	fixture, err := normalizeFixtureConfig(cfg.Fixture)
+	if err != nil {
+		return RunConfig{}, err
+	}
+	if cfg.Iterations == 0 {
+		cfg.Iterations = DefaultIterations
+	}
+	if cfg.Iterations < 0 {
+		return RunConfig{}, fmt.Errorf("iterations must be non-negative")
+	}
+	if strings.TrimSpace(cfg.RangeHeader) == "" {
+		cfg.RangeHeader = DefaultRangeHeader
+	}
+	cfg.Fixture = fixture
+	return cfg, nil
+}
+
+func normalizeFixtureConfig(cfg FixtureConfig) (FixtureConfig, error) {
+	if strings.TrimSpace(cfg.Bucket) == "" {
+		cfg.Bucket = DefaultBucket
+	}
+	if cfg.DirectoryDepth < 0 {
+		return FixtureConfig{}, fmt.Errorf("directory depth must be non-negative")
+	}
+	if cfg.SmallFileBytes == 0 {
+		cfg.SmallFileBytes = DefaultSmallFileBytes
+	}
+	if cfg.SmallFileBytes < 0 {
+		return FixtureConfig{}, fmt.Errorf("small file bytes must be non-negative")
+	}
+	if cfg.LargeFileBytes == 0 {
+		cfg.LargeFileBytes = DefaultLargeFileBytes
+	}
+	if cfg.LargeFileBytes < minListBackedFileBytes {
+		return FixtureConfig{}, fmt.Errorf("large file bytes must be at least %d for list-backed storage", minListBackedFileBytes)
+	}
+	return cfg, nil
+}
+
+func fixturePath(depth int, filename string) string {
+	if depth <= 0 {
+		return filename
+	}
+	parts := make([]string, 0, depth+1)
+	for i := 0; i < depth; i++ {
+		parts = append(parts, fmt.Sprintf("dir%02d", i))
+	}
+	parts = append(parts, filename)
+	return path.Join(parts...)
+}
+
+func deterministicBytes(label string, size int) []byte {
+	out := make([]byte, size)
+	if size == 0 {
+		return out
+	}
+	seed := []byte(label)
+	for i := range out {
+		out[i] = byte('a' + ((int(seed[i%len(seed)]) + i) % 26))
+	}
+	return out
+}
+
+func isDaemonStatus(err error, status int) bool {
+	var apiErr *daemonclient.Error
+	return errors.As(err, &apiErr) && apiErr.StatusCode == status
+}

--- a/internal/eval/readbench/runner_test.go
+++ b/internal/eval/readbench/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	daemonclient "github.com/dewebprotocol/malt/client"
@@ -79,6 +80,54 @@ func TestPrepareFixtureSupportsZeroDirectoryDepth(t *testing.T) {
 	}
 	if fixture.LargePath != "large.bin" {
 		t.Fatalf("large path = %q, want root-level large.bin", fixture.LargePath)
+	}
+}
+
+func TestPrepareFixtureGeneratesUniqueBucketWhenOmitted(t *testing.T) {
+	ctx := context.Background()
+	runner := NewRunner(newTestDaemon(t))
+
+	cfg := FixtureConfig{
+		DirectoryDepth: 1,
+		SmallFileBytes: 8,
+		LargeFileBytes: 300 * 1024,
+	}
+	first, err := runner.PrepareFixture(ctx, cfg)
+	if err != nil {
+		t.Fatalf("first PrepareFixture() error = %v", err)
+	}
+	second, err := runner.PrepareFixture(ctx, cfg)
+	if err != nil {
+		t.Fatalf("second PrepareFixture() error = %v", err)
+	}
+
+	if first.Bucket == second.Bucket {
+		t.Fatalf("generated bucket reused %q", first.Bucket)
+	}
+	for _, bucket := range []string{first.Bucket, second.Bucket} {
+		if !strings.HasPrefix(bucket, DefaultBucket+"-") {
+			t.Fatalf("generated bucket = %q, want %q prefix", bucket, DefaultBucket+"-")
+		}
+	}
+}
+
+func TestPrepareFixtureRejectsExistingBucket(t *testing.T) {
+	ctx := context.Background()
+	baseURL := newTestDaemon(t)
+	client := daemonclient.NewWithBaseURL(baseURL)
+	if _, err := client.CreateBucket(ctx, "readbench-existing", ""); err != nil {
+		t.Fatalf("create existing bucket: %v", err)
+	}
+
+	runner := NewRunner(baseURL)
+	_, err := runner.PrepareFixture(ctx, FixtureConfig{
+		Bucket:         "readbench-existing",
+		DirectoryDepth: 1,
+		SmallFileBytes: 8,
+		LargeFileBytes: 300 * 1024,
+	})
+	if err == nil {
+		t.Fatal("PrepareFixture() succeeded with an existing bucket")
 	}
 }
 
@@ -156,6 +205,28 @@ func TestRunJSONLMeasuresProofListAndContentRange(t *testing.T) {
 	}
 	if rangeRead.CAS.GetCount == 0 || rangeRead.CAS.BytesGet == 0 {
 		t.Fatalf("content range CAS metrics should include bytes fetched: %+v", rangeRead.CAS)
+	}
+}
+
+func TestRunJSONLAllowsZeroIterations(t *testing.T) {
+	ctx := context.Background()
+	runner := NewRunner(newTestDaemon(t))
+
+	var out bytes.Buffer
+	err := runner.RunJSONL(ctx, RunConfig{
+		Fixture: FixtureConfig{
+			Bucket:         "readbench-zero-iterations",
+			DirectoryDepth: 1,
+			SmallFileBytes: 8,
+			LargeFileBytes: 300 * 1024,
+		},
+		Iterations: 0,
+	}, &out)
+	if err != nil {
+		t.Fatalf("RunJSONL() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("RunJSONL() wrote %q, want no records", out.String())
 	}
 }
 

--- a/internal/eval/readbench/runner_test.go
+++ b/internal/eval/readbench/runner_test.go
@@ -1,0 +1,200 @@
+package readbench
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	daemonclient "github.com/dewebprotocol/malt/client"
+	"github.com/dewebprotocol/malt/config"
+	"github.com/dewebprotocol/malt/core/api"
+	casmock "github.com/dewebprotocol/malt/core/cas/mock"
+	"github.com/dewebprotocol/malt/server"
+)
+
+func TestPrepareFixtureCreatesDeterministicMALTUnixFSPaths(t *testing.T) {
+	ctx := context.Background()
+	baseURL := newTestDaemon(t)
+	runner := NewRunner(baseURL)
+
+	fixture, err := runner.PrepareFixture(ctx, FixtureConfig{
+		Bucket:         "readbench-fixture",
+		DirectoryDepth: 3,
+		SmallFileBytes: 32,
+		LargeFileBytes: 300 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("PrepareFixture() error = %v", err)
+	}
+
+	if fixture.Bucket != "readbench-fixture" {
+		t.Fatalf("fixture bucket = %q", fixture.Bucket)
+	}
+	if fixture.SmallPath != "dir00/dir01/dir02/small.txt" {
+		t.Fatalf("small path = %q", fixture.SmallPath)
+	}
+	if fixture.LargePath != "dir00/dir01/dir02/large.bin" {
+		t.Fatalf("large path = %q", fixture.LargePath)
+	}
+
+	client := daemonclient.NewWithBaseURL(baseURL)
+	smallStat, err := client.StatBucketPath(ctx, fixture.Bucket, fixture.SmallPath)
+	if err != nil {
+		t.Fatalf("stat small fixture: %v", err)
+	}
+	if smallStat.Kind != "file" || smallStat.StorageKind != "raw" {
+		t.Fatalf("small stat = %+v, want raw file", smallStat)
+	}
+
+	largeStat, err := client.StatBucketPath(ctx, fixture.Bucket, fixture.LargePath)
+	if err != nil {
+		t.Fatalf("stat large fixture: %v", err)
+	}
+	if largeStat.Kind != "file" || largeStat.StorageKind != "list" {
+		t.Fatalf("large stat = %+v, want list-backed file", largeStat)
+	}
+	if largeStat.Size == nil || *largeStat.Size != int64(300*1024) {
+		t.Fatalf("large size = %v, want %d", largeStat.Size, 300*1024)
+	}
+}
+
+func TestPrepareFixtureSupportsZeroDirectoryDepth(t *testing.T) {
+	ctx := context.Background()
+	runner := NewRunner(newTestDaemon(t))
+
+	fixture, err := runner.PrepareFixture(ctx, FixtureConfig{
+		Bucket:         "readbench-root",
+		DirectoryDepth: 0,
+		SmallFileBytes: 8,
+		LargeFileBytes: 300 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("PrepareFixture() error = %v", err)
+	}
+	if fixture.SmallPath != "small.txt" {
+		t.Fatalf("small path = %q, want root-level small.txt", fixture.SmallPath)
+	}
+	if fixture.LargePath != "large.bin" {
+		t.Fatalf("large path = %q, want root-level large.bin", fixture.LargePath)
+	}
+}
+
+func TestRunJSONLMeasuresProofListAndContentRange(t *testing.T) {
+	ctx := context.Background()
+	runner := NewRunner(newTestDaemon(t))
+
+	var out bytes.Buffer
+	err := runner.RunJSONL(ctx, RunConfig{
+		Fixture: FixtureConfig{
+			Bucket:         "readbench-run",
+			DirectoryDepth: 2,
+			SmallFileBytes: 48,
+			LargeFileBytes: 300 * 1024,
+		},
+		RangeHeader: "bytes=7-19",
+		Iterations:  1,
+	}, &out)
+	if err != nil {
+		t.Fatalf("RunJSONL() error = %v", err)
+	}
+
+	got := decodeJSONLResults(t, out.Bytes())
+	if len(got) != 2 {
+		t.Fatalf("result count = %d, want 2\n%s", len(got), out.String())
+	}
+
+	proofRead := got[0]
+	if proofRead.OperationKind != OperationProofListPath {
+		t.Fatalf("first operation = %q, want %q", proofRead.OperationKind, OperationProofListPath)
+	}
+	if proofRead.Bucket != "readbench-run" || proofRead.Path != "dir00/dir01/small.txt" {
+		t.Fatalf("proof read target = bucket %q path %q", proofRead.Bucket, proofRead.Path)
+	}
+	if proofRead.RangeHeader != "" {
+		t.Fatalf("prooflist range header = %q, want empty", proofRead.RangeHeader)
+	}
+	if proofRead.ElapsedNS <= 0 {
+		t.Fatalf("prooflist elapsed_ns = %d, want > 0", proofRead.ElapsedNS)
+	}
+	if proofRead.ContentBytes != nil {
+		t.Fatalf("prooflist content_bytes = %v, want omitted", *proofRead.ContentBytes)
+	}
+	if proofRead.ProofListStepCount == 0 {
+		t.Fatal("prooflist step count should be recorded")
+	}
+	if proofRead.Proof.ProofListCount != 1 {
+		t.Fatalf("prooflist proof metric count = %d, want 1", proofRead.Proof.ProofListCount)
+	}
+	if proofRead.Proof.StepCount != uint64(proofRead.ProofListStepCount) {
+		t.Fatalf("prooflist proof metric steps = %d, result steps = %d", proofRead.Proof.StepCount, proofRead.ProofListStepCount)
+	}
+	if proofRead.ArcTable.GetCount+proofRead.ArcTable.BatchGetCount == 0 {
+		t.Fatalf("prooflist arctable metrics should include reads: %+v", proofRead.ArcTable)
+	}
+
+	rangeRead := got[1]
+	if rangeRead.OperationKind != OperationContentRange {
+		t.Fatalf("second operation = %q, want %q", rangeRead.OperationKind, OperationContentRange)
+	}
+	if rangeRead.Path != "dir00/dir01/large.bin" {
+		t.Fatalf("content range path = %q", rangeRead.Path)
+	}
+	if rangeRead.RangeHeader != "bytes=7-19" {
+		t.Fatalf("range header = %q", rangeRead.RangeHeader)
+	}
+	if rangeRead.ContentBytes == nil || *rangeRead.ContentBytes != 13 {
+		t.Fatalf("content bytes = %v, want 13", rangeRead.ContentBytes)
+	}
+	if rangeRead.ProofListStepCount == 0 {
+		t.Fatal("content range prooflist step count should be recorded")
+	}
+	if rangeRead.Proof.ProofListCount != 1 {
+		t.Fatalf("content proof metric count = %d, want reset per operation", rangeRead.Proof.ProofListCount)
+	}
+	if rangeRead.CAS.GetCount == 0 || rangeRead.CAS.BytesGet == 0 {
+		t.Fatalf("content range CAS metrics should include bytes fetched: %+v", rangeRead.CAS)
+	}
+}
+
+func decodeJSONLResults(t *testing.T, data []byte) []Result {
+	t.Helper()
+
+	var out []Result
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		var result Result
+		if err := json.Unmarshal(scanner.Bytes(), &result); err != nil {
+			t.Fatalf("decode JSONL result %q: %v", scanner.Text(), err)
+		}
+		out = append(out, result)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan JSONL: %v", err)
+	}
+	return out
+}
+
+func newTestDaemon(t *testing.T) string {
+	t.Helper()
+
+	mockCAS := casmock.NewCAS(casmock.WithoutLatency())
+
+	cfg := config.DefaultConfig()
+	cfg.State.RootDir = t.TempDir()
+	cfg.State.KVStore.Type = "memory"
+
+	node, err := api.NewNode(api.WithConfig(cfg), api.WithCAS(mockCAS))
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = node.Close()
+	})
+
+	ts := httptest.NewServer(server.New(node, "127.0.0.1:0").Handler())
+	t.Cleanup(ts.Close)
+	return ts.URL + "/api/v1"
+}


### PR DESCRIPTION
## Summary

- Add an internal MALT-only read benchmark runner that prepares deterministic UnixFS fixtures with one bucket, configurable directory depth, a small raw file, and a list-backed large file.
- Measure `prooflist_path` and `content_range` reads, resetting daemon metrics before each operation and writing JSONL records with latency, ProofList step counts, content bytes, and CAS/ArcTable/Proof metrics snapshots.
- Add `malt eval-read` as a thin CLI wrapper around the runner.

## Validation

- `go test ./internal/eval/readbench`
- `go test ./cmd/malt -run EvalRead`
- `go test ./...`