### PR TITLE
fix: handle symlink dirs in add

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,3 @@
 # TODO
 
 ## Follow-ups
-
-- [ ] Fix `malt add --layout hierarchical` for top-level symlink directories.
-  `collectAddInputs` follows symlink directories, but `buildAddStagingTree` routes them through `stageDirectoryInput`; `filepath.WalkDir` does not descend into the symlink root, so the add can create an empty directory with `files_imported=0`. Either special-case symlink directories in hierarchical layout or reject them explicitly, and add a regression test.

--- a/cmd/malt/add.go
+++ b/cmd/malt/add.go
@@ -834,6 +834,18 @@ func buildAddStagingTree(ctx context.Context, casClient addCASClient, daemon *da
 
 	for _, item := range mounted {
 		if item.Input.Info.IsDir() {
+			if item.Input.Symlink {
+				key, dirFiles, dirBytes, err := materializeSymlinkDirectoryBoundary(ctx, daemon, casClient, bucketID, item.Input.AbsPath)
+				if err != nil {
+					return nil, err
+				}
+				if err := setMapDirNode(root, item.MountBase, key); err != nil {
+					return nil, err
+				}
+				files += dirFiles
+				bytesUploaded += dirBytes
+				continue
+			}
 			dirFiles, dirBytes, err := stageDirectoryInput(ctx, root, casClient, daemon, bucketID, item)
 			if err != nil {
 				return nil, err

--- a/cmd/malt/add_test.go
+++ b/cmd/malt/add_test.go
@@ -285,6 +285,67 @@ func TestAddInputsFlatUnixFSUsesMapBoundaryForSymlinkDirectory(t *testing.T) {
 	}
 }
 
+func TestAddInputsHierarchicalUnixFSUsesMapBoundaryForTopLevelSymlinkDirectory(t *testing.T) {
+	ctx := context.Background()
+	daemon, casClient := newAddTestClients(t)
+	bucketID := "hierarchical-symlink-dir"
+	if _, err := daemon.CreateBucket(ctx, bucketID, ""); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	root := t.TempDir()
+	targetDir := filepath.Join(root, "target")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "note.txt"), []byte("via symlink"), 0o644); err != nil {
+		t.Fatalf("write symlink target file: %v", err)
+	}
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(targetDir, link); err != nil {
+		t.Skipf("symlink not supported in test environment: %v", err)
+	}
+
+	result, err := addInputsWithUnixFS(ctx, daemon, casClient, bucketID, []string{link}, addBuildOptions{
+		Target: addTargetMALT,
+		Model:  addModelUnixFS,
+		Layout: addLayoutHierarchical,
+	})
+	if err != nil {
+		t.Fatalf("add hierarchical unixfs with symlink dir: %v", err)
+	}
+	if result.Files != 1 {
+		t.Fatalf("files = %d, want 1", result.Files)
+	}
+
+	snapshot, err := daemon.SnapshotBucketMap(ctx, bucketID, result.NewRoot)
+	if err != nil {
+		t.Fatalf("snapshot root: %v", err)
+	}
+	linkBinding := snapshot.Bindings["linked"]
+	if linkBinding == "" {
+		t.Fatalf("root map missing symlink-dir boundary: %+v", snapshot.Bindings)
+	}
+	linkCID, err := cid.Decode(linkBinding)
+	if err != nil {
+		t.Fatalf("decode symlink-dir binding: %v", err)
+	}
+	if codec.SemanticKindOf(linkCID) != codec.SemanticKindMap {
+		t.Fatalf("symlink-dir binding kind = %s, want map", codec.SemanticKindOf(linkCID))
+	}
+	if snapshot.Bindings["linked/note.txt"] != "" {
+		t.Fatalf("root should not contain symlink-dir descendants: %+v", snapshot.Bindings)
+	}
+
+	body, status, _, err := daemon.GetBucketContent(ctx, bucketID, "linked/note.txt", "")
+	if err != nil {
+		t.Fatalf("read symlink target content: status=%d err=%v", status, err)
+	}
+	if string(body) != "via symlink" {
+		t.Fatalf("symlink target body = %q", string(body))
+	}
+}
+
 func TestAddInputsWithUnixFSMerkleDAGTarget(t *testing.T) {
 	ctx := context.Background()
 	casClient := casmock.NewCAS(casmock.WithoutLatency())


### PR DESCRIPTION
## Summary

- Materialize top-level symlink directories in hierarchical MALT add as authenticated map boundaries.
- Reuse the existing symlink-directory boundary path so descendant reads work through the boundary map.
- Remove the completed TODO entry and add a regression test for the hierarchical symlink-directory case.

## Tests

- `go test ./cmd/malt`
- Worker also reported `go test ./...` passing before push.

## Notes

This branch may conflict mechanically with the import-filter branch in `cmd/malt/add.go`; the behavioral scopes are separate.