### PR TITLE
feat: add import ignore filters

### DIFF
--- a/cmd/malt/add.go
+++ b/cmd/malt/add.go
@@ -51,6 +51,9 @@ var (
 	addLayoutFlag       string
 	addFileLayoutFlag   string
 	addDirLayoutFlag    string
+	addNoGitignoreFlag  bool
+	addNoMaltignoreFlag bool
+	addIgnoreFileFlags  []string
 )
 
 func init() {
@@ -65,6 +68,9 @@ func init() {
 	addCmd.Flags().StringVar(&addLayoutFlag, "layout", "", "MALT materialization layout: flat or hierarchical")
 	addCmd.Flags().StringVar(&addFileLayoutFlag, "file-layout", "", "Merkle DAG UnixFS file layout: balanced or trickle")
 	addCmd.Flags().StringVar(&addDirLayoutFlag, "dir-layout", "", "Merkle DAG UnixFS directory layout: basic, hamt, or adaptive")
+	addCmd.Flags().BoolVar(&addNoGitignoreFlag, "no-gitignore", false, "Do not read .gitignore files while adding directories")
+	addCmd.Flags().BoolVar(&addNoMaltignoreFlag, "no-maltignore", false, "Do not read .maltignore files while adding directories")
+	addCmd.Flags().StringArrayVar(&addIgnoreFileFlags, "ignore-file", nil, "Additional gitignore-style ignore file to apply while adding directories")
 }
 
 var addCmd = &cobra.Command{
@@ -156,6 +162,11 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		Layout:     addLayoutFlag,
 		FileLayout: addFileLayoutFlag,
 		DirLayout:  addDirLayoutFlag,
+		Ignore: addIgnoreOptions{
+			NoGitignore:  addNoGitignoreFlag,
+			NoMaltignore: addNoMaltignoreFlag,
+			IgnoreFiles:  addIgnoreFileFlags,
+		},
 	})
 	if err != nil {
 		return err
@@ -220,6 +231,7 @@ type addBuildOptions struct {
 	Layout     string
 	FileLayout string
 	DirLayout  string
+	Ignore     addIgnoreOptions
 }
 
 func addInputsWithUnixFS(ctx context.Context, daemon *daemonclient.Client, casClient addCASClient, bucketID string, rawInputs []string, opts addBuildOptions) (*addUnixFSResult, error) {
@@ -325,7 +337,7 @@ func addInputsWithMALTFlatUnixFS(ctx context.Context, daemon *daemonclient.Clien
 				result.Bytes += bytesUploaded
 				continue
 			}
-			files, bytesUploaded, err := stageFlatUnixFSDirectory(ctx, root, casClient, daemon, bucketID, item)
+			files, bytesUploaded, err := stageFlatUnixFSDirectory(ctx, root, casClient, daemon, bucketID, item, opts.Ignore)
 			if err != nil {
 				return nil, err
 			}
@@ -397,11 +409,16 @@ func addInputsWithMerkleDAGUnixFS(ctx context.Context, casClient addCASClient, r
 	if len(rawInputs) != 1 {
 		return nil, fmt.Errorf("merkle-dag target expects exactly one local path")
 	}
+	ignoreFilter, err := newAddIgnoreFilter(rawInputs[0], opts.Ignore)
+	if err != nil {
+		return nil, err
+	}
 	result, err := merkledagimport.ImportPath(ctx, casClient, rawInputs[0], merkledagimport.Options{
 		Model:      opts.Model,
 		FileLayout: opts.FileLayout,
 		DirLayout:  opts.DirLayout,
 		ChunkSize:  addFixedChunkSize,
+		Ignore:     ignoreFilter,
 	})
 	if err != nil {
 		return nil, err
@@ -409,18 +426,39 @@ func addInputsWithMerkleDAGUnixFS(ctx context.Context, casClient addCASClient, r
 	return &addUnixFSResult{Files: result.Files, Bytes: result.Bytes, NewRoot: result.Root}, nil
 }
 
-func stageFlatUnixFSDirectory(ctx context.Context, root *addNode, casClient addCASClient, daemon *daemonclient.Client, bucketID string, item addMountedInput) (int, int64, error) {
+func stageFlatUnixFSDirectory(ctx context.Context, root *addNode, casClient addCASClient, daemon *daemonclient.Client, bucketID string, item addMountedInput, ignoreOpts addIgnoreOptions) (int, int64, error) {
 	mountBase := canonicalAddPath(item.MountBase)
 	if mountBase == "" {
 		return 0, 0, fmt.Errorf("directory mount path must not be empty")
 	}
 	ensureDirNode(root, mountBase)
+	ignoreFilter, err := newAddIgnoreFilter(item.Input.AbsPath, ignoreOpts)
+	if err != nil {
+		return 0, 0, err
+	}
 
 	var files int
 	var bytesUploaded int64
-	err := filepath.WalkDir(item.Input.AbsPath, func(current string, d fs.DirEntry, walkErr error) error {
+	err = filepath.WalkDir(item.Input.AbsPath, func(current string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if current != item.Input.AbsPath {
+			ignored, err := ignoreFilter.Ignored(current, d.IsDir())
+			if err != nil {
+				return err
+			}
+			if ignored {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+		if d.IsDir() {
+			if err := ignoreFilter.LoadDirectoryRules(current); err != nil {
+				return err
+			}
 		}
 		if current != item.Input.AbsPath && d.Type()&fs.ModeSymlink != 0 {
 			rel, err := filepath.Rel(item.Input.AbsPath, current)
@@ -703,10 +741,14 @@ func putAddDirectoryManifest(ctx context.Context, casClient addCASClient, node *
 	return manifestCID, nil
 }
 
-func addDirectoryWithUnixFS(ctx context.Context, daemon *daemonclient.Client, bucketID string, item addMountedInput) (int, int64, string, error) {
+func addDirectoryWithUnixFS(ctx context.Context, daemon *daemonclient.Client, bucketID string, item addMountedInput, ignoreOpts addIgnoreOptions) (int, int64, string, error) {
 	mountBase := canonicalAddPath(item.MountBase)
 	if mountBase == "" {
 		return 0, 0, "", fmt.Errorf("directory mount path must not be empty")
+	}
+	ignoreFilter, err := newAddIgnoreFilter(item.Input.AbsPath, ignoreOpts)
+	if err != nil {
+		return 0, 0, "", err
 	}
 
 	resp, err := daemon.AddBucketUnixFSDirectory(ctx, bucketID, mountBase)
@@ -720,6 +762,23 @@ func addDirectoryWithUnixFS(ctx context.Context, daemon *daemonclient.Client, bu
 	err = filepath.WalkDir(item.Input.AbsPath, func(current string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if current != item.Input.AbsPath {
+			ignored, err := ignoreFilter.Ignored(current, d.IsDir())
+			if err != nil {
+				return err
+			}
+			if ignored {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+		if d.IsDir() {
+			if err := ignoreFilter.LoadDirectoryRules(current); err != nil {
+				return err
+			}
 		}
 		if current != item.Input.AbsPath && d.Type()&fs.ModeSymlink != 0 {
 			return fmt.Errorf("symlink is not supported: %s", current)
@@ -846,7 +905,7 @@ func buildAddStagingTree(ctx context.Context, casClient addCASClient, daemon *da
 				bytesUploaded += dirBytes
 				continue
 			}
-			dirFiles, dirBytes, err := stageDirectoryInput(ctx, root, casClient, daemon, bucketID, item)
+			dirFiles, dirBytes, err := stageDirectoryInput(ctx, root, casClient, daemon, bucketID, item, opts.Ignore)
 			if err != nil {
 				return nil, err
 			}
@@ -940,15 +999,36 @@ func mountAddInputs(inputs []addInput, opts addBuildOptions) ([]addMountedInput,
 	return out, nil
 }
 
-func stageDirectoryInput(ctx context.Context, root *addNode, casClient addCASClient, daemon *daemonclient.Client, bucketID string, item addMountedInput) (int, int64, error) {
+func stageDirectoryInput(ctx context.Context, root *addNode, casClient addCASClient, daemon *daemonclient.Client, bucketID string, item addMountedInput, ignoreOpts addIgnoreOptions) (int, int64, error) {
 	mountBase := item.MountBase
 	ensureDirNode(root, mountBase)
+	ignoreFilter, err := newAddIgnoreFilter(item.Input.AbsPath, ignoreOpts)
+	if err != nil {
+		return 0, 0, err
+	}
 
 	var files int
 	var bytesUploaded int64
-	err := filepath.WalkDir(item.Input.AbsPath, func(current string, d fs.DirEntry, walkErr error) error {
+	err = filepath.WalkDir(item.Input.AbsPath, func(current string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if current != item.Input.AbsPath {
+			ignored, err := ignoreFilter.Ignored(current, d.IsDir())
+			if err != nil {
+				return err
+			}
+			if ignored {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+		if d.IsDir() {
+			if err := ignoreFilter.LoadDirectoryRules(current); err != nil {
+				return err
+			}
 		}
 		if current != item.Input.AbsPath {
 			if d.Type()&fs.ModeSymlink != 0 {

--- a/cmd/malt/add_ignore.go
+++ b/cmd/malt/add_ignore.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ignore "github.com/crackcomm/go-gitignore"
+)
+
+const (
+	addGitignoreName  = ".gitignore"
+	addMaltignoreName = ".maltignore"
+)
+
+type addIgnoreOptions struct {
+	NoGitignore  bool
+	NoMaltignore bool
+	IgnoreFiles  []string
+}
+
+type addIgnoreRuleSet struct {
+	baseRel string
+	matcher *ignore.GitIgnore
+	negated bool
+}
+
+type addIgnoreFilter struct {
+	root         string
+	rules        []addIgnoreRuleSet
+	loadedByDir  map[string]struct{}
+	noGitignore  bool
+	noMaltignore bool
+}
+
+func newAddIgnoreFilter(root string, opts addIgnoreOptions) (*addIgnoreFilter, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ignore root %q: %w", root, err)
+	}
+	filter := &addIgnoreFilter{
+		root:         filepath.Clean(absRoot),
+		loadedByDir:  make(map[string]struct{}),
+		noGitignore:  opts.NoGitignore,
+		noMaltignore: opts.NoMaltignore,
+	}
+	for _, raw := range opts.IgnoreFiles {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		if err := filter.loadRuleFile("", raw, false); err != nil {
+			return nil, err
+		}
+	}
+	return filter, nil
+}
+
+func (f *addIgnoreFilter) LoadDirectoryRules(localDir string) error {
+	return f.loadDirectoryRules(localDir)
+}
+
+func (f *addIgnoreFilter) Ignored(localPath string, isDir bool) (bool, error) {
+	return f.ignored(localPath, isDir)
+}
+
+func (f *addIgnoreFilter) loadDirectoryRules(localDir string) error {
+	absDir, err := filepath.Abs(localDir)
+	if err != nil {
+		return fmt.Errorf("resolve ignore directory %q: %w", localDir, err)
+	}
+	absDir = filepath.Clean(absDir)
+	if _, ok := f.loadedByDir[absDir]; ok {
+		return nil
+	}
+	f.loadedByDir[absDir] = struct{}{}
+
+	baseRel, err := f.relativePath(absDir)
+	if err != nil {
+		return err
+	}
+	if !f.noGitignore {
+		if err := f.loadRuleFile(baseRel, filepath.Join(absDir, addGitignoreName), true); err != nil {
+			return err
+		}
+	}
+	if !f.noMaltignore {
+		if err := f.loadRuleFile(baseRel, filepath.Join(absDir, addMaltignoreName), true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *addIgnoreFilter) loadRuleFile(baseRel, name string, optional bool) error {
+	data, err := os.ReadFile(name)
+	if err != nil {
+		if optional && os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read ignore file %q: %w", name, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		negated := strings.HasPrefix(line, "!") && !strings.HasPrefix(line, `\!`)
+		compileLine := line
+		if negated {
+			compileLine = strings.TrimPrefix(line, "!")
+		}
+		matcher, err := ignore.CompileIgnoreLines(compileLine)
+		if err != nil {
+			return fmt.Errorf("parse ignore file %q: %w", name, err)
+		}
+		f.rules = append(f.rules, addIgnoreRuleSet{
+			baseRel: baseRel,
+			matcher: matcher,
+			negated: negated,
+		})
+	}
+	return nil
+}
+
+func (f *addIgnoreFilter) ignored(localPath string, isDir bool) (bool, error) {
+	rel, err := f.relativePath(localPath)
+	if err != nil {
+		return false, err
+	}
+	if rel == "" {
+		return false, nil
+	}
+	for _, part := range strings.Split(rel, "/") {
+		if part == ".git" {
+			return true, nil
+		}
+	}
+	if strings.HasPrefix(rel, ".git/") {
+		return true, nil
+	}
+
+	ignored := false
+	for _, ruleSet := range f.rules {
+		ruleRel := rel
+		if ruleSet.baseRel != "" {
+			if rel == ruleSet.baseRel {
+				ruleRel = ""
+			} else if strings.HasPrefix(rel, ruleSet.baseRel+"/") {
+				ruleRel = strings.TrimPrefix(rel, ruleSet.baseRel+"/")
+			} else {
+				continue
+			}
+		}
+		if ruleRel == "" {
+			continue
+		}
+		if isDir {
+			ruleRel += "/"
+		}
+		if ruleSet.matcher.MatchesPath(ruleRel) {
+			ignored = !ruleSet.negated
+		}
+	}
+	return ignored, nil
+}
+
+func (f *addIgnoreFilter) relativePath(localPath string) (string, error) {
+	absPath, err := filepath.Abs(localPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve path %q: %w", localPath, err)
+	}
+	rel, err := filepath.Rel(f.root, filepath.Clean(absPath))
+	if err != nil {
+		return "", fmt.Errorf("compute ignore relative path %q: %w", localPath, err)
+	}
+	if rel == "." {
+		return "", nil
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q is outside ignore root %q", localPath, f.root)
+	}
+	return filepath.ToSlash(rel), nil
+}

--- a/cmd/malt/add_ignore_test.go
+++ b/cmd/malt/add_ignore_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	casmock "github.com/dewebprotocol/malt/core/cas/mock"
+)
+
+func TestAddIgnoreFilterUsesGitignoreAndMaltignore(t *testing.T) {
+	root := t.TempDir()
+	writeAddIgnoreTestFile(t, root, ".gitignore", "build/\n*.tmp\n")
+	writeAddIgnoreTestFile(t, root, ".maltignore", "private.txt\n")
+	writeAddIgnoreTestFile(t, root, "build/out.bin", "ignored")
+	writeAddIgnoreTestFile(t, root, "note.tmp", "ignored")
+	writeAddIgnoreTestFile(t, root, "private.txt", "ignored")
+	writeAddIgnoreTestFile(t, root, "keep.txt", "keep")
+
+	filter, err := newAddIgnoreFilter(root, addIgnoreOptions{})
+	if err != nil {
+		t.Fatalf("new filter: %v", err)
+	}
+	if err := filter.loadDirectoryRules(root); err != nil {
+		t.Fatalf("load root rules: %v", err)
+	}
+
+	assertAddIgnored(t, filter, root, "build", true)
+	assertAddIgnored(t, filter, root, "build/out.bin", false)
+	assertAddIgnored(t, filter, root, "note.tmp", false)
+	assertAddIgnored(t, filter, root, "private.txt", false)
+	assertAddNotIgnored(t, filter, root, "keep.txt", false)
+}
+
+func TestAddIgnoreFilterCanDisableGitignore(t *testing.T) {
+	root := t.TempDir()
+	writeAddIgnoreTestFile(t, root, ".gitignore", "ignored.txt\n")
+	writeAddIgnoreTestFile(t, root, ".maltignore", "malt-only.txt\n")
+
+	filter, err := newAddIgnoreFilter(root, addIgnoreOptions{NoGitignore: true})
+	if err != nil {
+		t.Fatalf("new filter: %v", err)
+	}
+	if err := filter.loadDirectoryRules(root); err != nil {
+		t.Fatalf("load root rules: %v", err)
+	}
+
+	assertAddNotIgnored(t, filter, root, "ignored.txt", false)
+	assertAddIgnored(t, filter, root, "malt-only.txt", false)
+}
+
+func TestAddIgnoreFilterCanUseExplicitIgnoreFile(t *testing.T) {
+	root := t.TempDir()
+	external := filepath.Join(t.TempDir(), "extra.ignore")
+	if err := os.WriteFile(external, []byte("scratch/\n"), 0o644); err != nil {
+		t.Fatalf("write explicit ignore file: %v", err)
+	}
+
+	filter, err := newAddIgnoreFilter(root, addIgnoreOptions{IgnoreFiles: []string{external}})
+	if err != nil {
+		t.Fatalf("new filter: %v", err)
+	}
+
+	assertAddIgnored(t, filter, root, "scratch", true)
+	assertAddIgnored(t, filter, root, "scratch/cache.bin", false)
+	assertAddNotIgnored(t, filter, root, "src/main.go", false)
+}
+
+func TestAddIgnoreFilterLetsMaltignoreReincludeGitignoredPath(t *testing.T) {
+	root := t.TempDir()
+	writeAddIgnoreTestFile(t, root, ".gitignore", "*.log\n")
+	writeAddIgnoreTestFile(t, root, ".maltignore", "!keep.log\n")
+
+	filter, err := newAddIgnoreFilter(root, addIgnoreOptions{})
+	if err != nil {
+		t.Fatalf("new filter: %v", err)
+	}
+	if err := filter.loadDirectoryRules(root); err != nil {
+		t.Fatalf("load root rules: %v", err)
+	}
+
+	assertAddIgnored(t, filter, root, "drop.log", false)
+	assertAddNotIgnored(t, filter, root, "keep.log", false)
+}
+
+func TestAddIgnoreFilterAlwaysExcludesGitDirectory(t *testing.T) {
+	root := t.TempDir()
+	filter, err := newAddIgnoreFilter(root, addIgnoreOptions{NoGitignore: true, NoMaltignore: true})
+	if err != nil {
+		t.Fatalf("new filter: %v", err)
+	}
+
+	assertAddIgnored(t, filter, root, ".git", true)
+	assertAddIgnored(t, filter, root, ".git/config", false)
+	assertAddNotIgnored(t, filter, root, ".github/workflows/test.yml", false)
+}
+
+func TestStageDirectoryInputPrunesIgnoredDirectories(t *testing.T) {
+	ctx := context.Background()
+	daemon, casClient := newAddTestClients(t)
+	bucketID := "ignore-prune"
+	if _, err := daemon.CreateBucket(ctx, bucketID, ""); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	writeAddIgnoreTestFile(t, repo, ".gitignore", "ignored/\n")
+	writeAddIgnoreTestFile(t, repo, "ignored/file.txt", "ignored")
+	writeAddIgnoreTestFile(t, repo, "keep/file.txt", "keep")
+
+	staged, err := buildAddStagingTree(ctx, casClient, daemon, bucketID, []string{repo}, addBuildOptions{})
+	if err != nil {
+		t.Fatalf("build staging: %v", err)
+	}
+	if staged.Files != 2 {
+		t.Fatalf("staged files = %d, want 2", staged.Files)
+	}
+
+	base := filepath.Base(repo)
+	mustAddNodeAtPath(t, staged.Root, base+"/keep/file.txt")
+	if addNodeExists(staged.Root, base+"/ignored") {
+		t.Fatalf("ignored directory should have been pruned: %+v", staged.Root.Children)
+	}
+}
+
+func TestStageFlatUnixFSDirectoryAppliesMaltignore(t *testing.T) {
+	ctx := context.Background()
+	daemon, casClient := newAddTestClients(t)
+	bucketID := "flat-ignore"
+	if _, err := daemon.CreateBucket(ctx, bucketID, ""); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	rootDir := t.TempDir()
+	repo := filepath.Join(rootDir, "repo")
+	writeAddIgnoreTestFile(t, repo, ".maltignore", "secret.txt\n")
+	writeAddIgnoreTestFile(t, repo, "secret.txt", "secret")
+	writeAddIgnoreTestFile(t, repo, "keep.txt", "keep")
+
+	result, err := addInputsWithUnixFS(ctx, daemon, casClient, bucketID, []string{repo}, addBuildOptions{
+		Target: addTargetMALT,
+		Model:  addModelUnixFS,
+		Layout: addLayoutFlat,
+	})
+	if err != nil {
+		t.Fatalf("add flat unixfs: %v", err)
+	}
+	if result.Files != 2 {
+		t.Fatalf("files = %d, want 2", result.Files)
+	}
+
+	base := filepath.Base(repo)
+	if _, err := daemon.StatBucketPath(ctx, bucketID, base+"/secret.txt"); err == nil {
+		t.Fatal("secret.txt should be ignored")
+	}
+	if _, err := daemon.StatBucketPath(ctx, bucketID, base+"/keep.txt"); err != nil {
+		t.Fatalf("keep.txt should be present: %v", err)
+	}
+}
+
+func TestAddInputsMerkleDAGAppliesIgnoreFilter(t *testing.T) {
+	ctx := context.Background()
+	casClient := casmock.NewCAS(casmock.WithoutLatency())
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	writeAddIgnoreTestFile(t, repo, ".gitignore", "ignored/\n")
+	writeAddIgnoreTestFile(t, repo, "ignored/file.txt", "ignored")
+	writeAddIgnoreTestFile(t, repo, "keep/file.txt", "keep")
+
+	result, err := addInputsWithUnixFS(ctx, nil, casClient, "", []string{repo}, addBuildOptions{
+		Target:     addTargetMerkleDAG,
+		Model:      addModelUnixFS,
+		FileLayout: addFileLayoutBalanced,
+		DirLayout:  addDirLayoutBasic,
+	})
+	if err != nil {
+		t.Fatalf("add merkle dag: %v", err)
+	}
+	if result.Files != 2 {
+		t.Fatalf("files = %d, want 2", result.Files)
+	}
+}
+
+func writeAddIgnoreTestFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	name := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(name), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(name), err)
+	}
+	if err := os.WriteFile(name, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func assertAddIgnored(t *testing.T, filter *addIgnoreFilter, root, rel string, isDir bool) {
+	t.Helper()
+	ignored, err := filter.ignored(filepath.Join(root, filepath.FromSlash(rel)), isDir)
+	if err != nil {
+		t.Fatalf("ignored(%s): %v", rel, err)
+	}
+	if !ignored {
+		t.Fatalf("%s should be ignored", rel)
+	}
+}
+
+func assertAddNotIgnored(t *testing.T, filter *addIgnoreFilter, root, rel string, isDir bool) {
+	t.Helper()
+	ignored, err := filter.ignored(filepath.Join(root, filepath.FromSlash(rel)), isDir)
+	if err != nil {
+		t.Fatalf("ignored(%s): %v", rel, err)
+	}
+	if ignored {
+		t.Fatalf("%s should not be ignored", rel)
+	}
+}
+
+func addNodeExists(root *addNode, p string) bool {
+	cur := root
+	for _, part := range splitAddPath(p) {
+		if cur == nil || cur.Children == nil {
+			return false
+		}
+		cur = cur.Children[part]
+	}
+	return cur != nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.6
 require (
 	github.com/bits-and-blooms/bitset v1.7.0
 	github.com/consensys/gnark-crypto v0.13.0
+	github.com/crackcomm/go-gitignore v0.0.0-20241020182519-7843d2ba8fdf
 	github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c
 	github.com/crate-crypto/go-kzg-4844 v1.1.0
 	github.com/dgraph-io/badger/v4 v4.2.0
@@ -25,7 +26,6 @@ require (
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/consensys/bavard v0.1.13 // indirect
-	github.com/crackcomm/go-gitignore v0.0.0-20241020182519-7843d2ba8fdf // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gammazero/chanqueue v1.1.1 // indirect

--- a/internal/merkledagimport/import.go
+++ b/internal/merkledagimport/import.go
@@ -42,6 +42,14 @@ type Options struct {
 	ChunkSize   int
 	HAMTFanout  int
 	RawFileLeaf bool
+	Ignore      PathFilter
+}
+
+// PathFilter lets callers apply local import policy without storing that policy
+// in the resulting Merkle DAG.
+type PathFilter interface {
+	LoadDirectoryRules(localDir string) error
+	Ignored(localPath string, isDir bool) (bool, error)
 }
 
 // Result describes the imported Merkle DAG root and local input stats.
@@ -195,11 +203,25 @@ func (i *pathImporter) importDirectory(ctx context.Context, localPath string) (i
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("read directory %s: %w", localPath, err)
 	}
+	if i.opts.Ignore != nil {
+		if err := i.opts.Ignore.LoadDirectoryRules(localPath); err != nil {
+			return nil, 0, 0, err
+		}
+	}
 
 	var files int
 	var bytesUploaded int64
 	for _, entry := range entries {
 		childPath := filepath.Join(localPath, entry.Name())
+		if i.opts.Ignore != nil {
+			ignored, err := i.opts.Ignore.Ignored(childPath, entry.IsDir())
+			if err != nil {
+				return nil, 0, 0, err
+			}
+			if ignored {
+				continue
+			}
+		}
 		child, childFiles, childBytes, err := i.importPath(ctx, childPath)
 		if err != nil {
 			return nil, 0, 0, err


### PR DESCRIPTION
## Summary

- Add gitignore-style import filtering to `malt add` with default `.gitignore` and `.maltignore` support.
- Add `--no-gitignore`, `--no-maltignore`, and repeated `--ignore-file` controls.
- Apply one shared local import filter across MALT flat, MALT hierarchical, and Merkle DAG directory imports.
- Prune `.git/` directories by default without storing ignore policy in authenticated objects.

## Tests

- `go test ./cmd/malt ./internal/merkledagimport`
- `go test ./...`

## Notes

This branch intentionally treats ignore rules as local materialization policy, not authenticated MALT state. It may need a mechanical rebase if the symlink-directory bugfix branch lands first.