### PR TITLE
refactor: add root-centric gateway mutation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,7 +15,7 @@ proofs.
 GatewayRead(root, query) -> result + ProofList
 VerifyRead(root, query, result, ProofList) -> valid / invalid
 
-GatewayWrite(root, semantic mutation) -> newRoot + write metadata
+Materialize(baseRoot, semantic mutation) -> newRoot + materializationReceipt
 ```
 
 List and map are semantic abstractions:
@@ -57,13 +57,14 @@ generic enough for list, map, and future semantics, but narrow enough that it
 does not erase their differences.
 
 Conceptually, gateway reads return `result + ProofList`, where the ProofList is
-the vector-commitment proof chain from root to destination. Gateway writes
-accept semantic mutations that have already been produced by a layout. The
+the vector-commitment proof chain from root to destination. Root-centric
+gateway materialization accepts semantic mutations that have already been
+produced by a layout and returns an operational receipt without publishing a
+managed bucket head. The
 HTTP gateway may return blob content with ProofList metadata in response
 headers, and may return large-file byte ranges with ProofLists covering the
-selected list entries. The current code does not yet expose this exact
-boundary. The documented direction is to make list/map the first semantic
-abstractions and to move runtime adapters around them.
+selected list entries. Bucket routes remain compatibility/product surfaces
+around the same internal materialization namespace.
 
 ### List Semantic
 
@@ -334,8 +335,8 @@ The old architecture treated resolver and writer as central runtime layers. The
 new interpretation is narrower and introduces a clearer gateway boundary:
 
 - layouts translate source-domain data into MALT semantic mutations
-- the gateway accepts converted semantic mutations and submits them through
-  list/map semantic operations
+- the root-centric gateway materializes converted semantic mutations through
+  list/map semantic operations and returns a materialization receipt
 - gateway reads return `result + ProofList`
 - resolver adapters translate application or compatibility reads into semantic
   reads and proof chains

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ VerifyRead(root, query, result, ProofList) -> valid / invalid
 
 A structure root exposes authenticated read/write semantics, but those
 semantics are owned by `list` and `map`, not by the current runtime `graph`
-object. Gateway writes accept semantic mutations produced by layouts, rather
-than raw source-domain data. In the HTTP deployment, blob reads may carry
+object. Root-centric gateway materialization accepts semantic mutations
+produced by layouts and returns an operational receipt; managed bucket heads
+remain product/runtime publication pointers, not the gateway correctness
+interface. In the HTTP deployment, blob reads may carry
 `ProofList` in response metadata/header; large-file range reads return selected
 bytes plus the corresponding `ProofList`.
 

--- a/client/client.go
+++ b/client/client.go
@@ -227,6 +227,15 @@ func (c *Client) ApplyBucketSemanticMutation(ctx context.Context, id string, req
 	return &resp, nil
 }
 
+// ApplyRootSemanticMutation materializes a root-centric semantic mutation without publishing a bucket head.
+func (c *Client) ApplyRootSemanticMutation(ctx context.Context, root string, req *httpapi.RootSemanticMutationRequest) (*httpapi.RootSemanticMutationResponse, error) {
+	var resp httpapi.RootSemanticMutationResponse
+	if err := c.do(ctx, http.MethodPost, "/roots/"+url.PathEscape(root)+"/semantic-mutations", nil, req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 func (c *Client) AddBucketUnixFSDirectory(ctx context.Context, id string, p string) (*httpapi.BucketUnixFSWriteResponse, error) {
 	query := map[string]string{}
 	if p != "" {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -510,6 +510,60 @@ func TestClientBucketSemanticMutation(t *testing.T) {
 	}
 }
 
+func TestClientRootSemanticMutation(t *testing.T) {
+	cfg := testConfig(t)
+	node, err := api.NewNode(api.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = node.Close()
+	})
+
+	ts := httptest.NewServer(server.New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	cfg.RPC.Listen = ts.Listener.Addr().String()
+	client := New(cfg)
+	ctx := context.Background()
+
+	createResp, err := client.CreateRootStructure(ctx, withPayloadBinding(map[string]string{
+		"name": fakeCIDString("initial-name"),
+	}))
+	if err != nil {
+		t.Fatalf("create root structure: %v", err)
+	}
+
+	nextName := fakeCIDString("root-next-name")
+	resp, err := client.ApplyRootSemanticMutation(ctx, createResp.Root, &httpapi.RootSemanticMutationRequest{
+		Puts: []httpapi.SemanticMutationPut{{
+			Object: createResp.Root,
+			Kind:   "map",
+			Entries: []httpapi.SemanticMutationEntry{
+				{Path: "@payload", Target: fakeCIDString("root-next-payload")},
+				{Path: "name", Target: nextName},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ApplyRootSemanticMutation: %v", err)
+	}
+	if resp.BaseRoot != createResp.Root || resp.NewRoot == "" || resp.NewRoot == createResp.Root {
+		t.Fatalf("unexpected root semantic mutation response: %+v", resp)
+	}
+	if resp.PutCount != 1 || resp.ArcCount != 2 {
+		t.Fatalf("semantic mutation counts = puts %d arcs %d, want 1/2", resp.PutCount, resp.ArcCount)
+	}
+
+	resolved, err := client.ResolveRoot(ctx, resp.NewRoot, "name")
+	if err != nil {
+		t.Fatalf("resolve root: %v", err)
+	}
+	if resolved.Target != nextName {
+		t.Fatalf("resolved target = %q, want %q", resolved.Target, nextName)
+	}
+}
+
 func TestClientBucketStatAndContent(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := api.NewNode(api.WithConfig(cfg))

--- a/cmd/malt/semantic_mutation.go
+++ b/cmd/malt/semantic_mutation.go
@@ -12,25 +12,25 @@ import (
 
 func init() {
 	rootCmd.AddCommand(semanticMutationCmd)
-	semanticMutationCmd.Flags().StringVarP(&semanticMutationBucketID, "bucket", "b", "", "Bucket ID to mutate")
+	semanticMutationCmd.Flags().StringVar(&semanticMutationRoot, "root", "", "Base root to materialize from")
 	semanticMutationCmd.Flags().StringVarP(&semanticMutationFile, "file", "f", "", "Request JSON file, or - for stdin")
 }
 
 var (
-	semanticMutationBucketID string
-	semanticMutationFile     string
+	semanticMutationRoot string
+	semanticMutationFile string
 )
 
 var semanticMutationCmd = &cobra.Command{
-	Use:   "semantic-mutation --bucket <id> --file <path|->",
-	Short: "Apply a bucket semantic mutation request",
+	Use:   "semantic-mutation --root <base-root> --file <path|->",
+	Short: "Materialize a root-centric semantic mutation request",
 	Args:  cobra.NoArgs,
 	RunE:  runSemanticMutation,
 }
 
 func runSemanticMutation(cmd *cobra.Command, args []string) error {
-	if semanticMutationBucketID == "" {
-		return fmt.Errorf("--bucket is required")
+	if semanticMutationRoot == "" {
+		return fmt.Errorf("--root is required")
 	}
 	if semanticMutationFile == "" {
 		return fmt.Errorf("--file is required")
@@ -41,7 +41,7 @@ func runSemanticMutation(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resp, err := mustDaemonClient().ApplyBucketSemanticMutation(cmd.Context(), semanticMutationBucketID, req)
+	resp, err := mustDaemonClient().ApplyRootSemanticMutation(cmd.Context(), semanticMutationRoot, req)
 	if err != nil {
 		return daemonCommandError(err)
 	}
@@ -51,7 +51,7 @@ func runSemanticMutation(cmd *cobra.Command, args []string) error {
 	return enc.Encode(resp)
 }
 
-func readSemanticMutationRequest(path string) (*httpapi.BucketSemanticMutationRequest, error) {
+func readSemanticMutationRequest(path string) (*httpapi.RootSemanticMutationRequest, error) {
 	var r io.Reader
 	if path == "-" {
 		r = os.Stdin
@@ -64,7 +64,7 @@ func readSemanticMutationRequest(path string) (*httpapi.BucketSemanticMutationRe
 		r = f
 	}
 
-	var req httpapi.BucketSemanticMutationRequest
+	var req httpapi.RootSemanticMutationRequest
 	dec := json.NewDecoder(r)
 	if err := dec.Decode(&req); err != nil {
 		return nil, fmt.Errorf("decode semantic mutation request: %w", err)

--- a/cmd/malt/semantic_mutation_test.go
+++ b/cmd/malt/semantic_mutation_test.go
@@ -10,16 +10,16 @@ import (
 )
 
 func TestSemanticMutationValidatesRequiredFlags(t *testing.T) {
-	semanticMutationBucketID = ""
+	semanticMutationRoot = ""
 	semanticMutationFile = ""
-	if err := runSemanticMutation(semanticMutationCmd, nil); err == nil || !strings.Contains(err.Error(), "--bucket is required") {
-		t.Fatalf("missing bucket error = %v", err)
+	if err := runSemanticMutation(semanticMutationCmd, nil); err == nil || !strings.Contains(err.Error(), "--root is required") {
+		t.Fatalf("missing root error = %v", err)
 	}
 
-	semanticMutationBucketID = "demo"
+	semanticMutationRoot = fakeAddCID("semantic-base").String()
 	semanticMutationFile = ""
 	t.Cleanup(func() {
-		semanticMutationBucketID = ""
+		semanticMutationRoot = ""
 		semanticMutationFile = ""
 	})
 	if err := runSemanticMutation(semanticMutationCmd, nil); err == nil || !strings.Contains(err.Error(), "--file is required") {
@@ -33,10 +33,10 @@ func TestSemanticMutationRejectsMalformedJSON(t *testing.T) {
 		t.Fatalf("write bad json: %v", err)
 	}
 
-	semanticMutationBucketID = "demo"
+	semanticMutationRoot = fakeAddCID("semantic-base").String()
 	semanticMutationFile = badFile
 	t.Cleanup(func() {
-		semanticMutationBucketID = ""
+		semanticMutationRoot = ""
 		semanticMutationFile = ""
 	})
 
@@ -51,11 +51,8 @@ func TestSemanticMutationPrintsIndentedJSON(t *testing.T) {
 	defaultClient = daemon
 	t.Cleanup(func() { defaultClient = nil })
 
-	if _, err := daemon.CreateBucket(ctx, "demo", ""); err != nil {
-		t.Fatalf("create bucket: %v", err)
-	}
 	initialPayload := fakeAddCID("semantic-initial").String()
-	initial, err := daemon.CreateBucketStructure(ctx, "demo", map[string]string{"@payload": initialPayload, "name": initialPayload})
+	initial, err := daemon.CreateRootStructure(ctx, map[string]string{"@payload": initialPayload, "name": initialPayload})
 	if err != nil {
 		t.Fatalf("create initial structure: %v", err)
 	}
@@ -66,10 +63,10 @@ func TestSemanticMutationPrintsIndentedJSON(t *testing.T) {
 		t.Fatalf("write request: %v", err)
 	}
 
-	semanticMutationBucketID = "demo"
+	semanticMutationRoot = initial.Root
 	semanticMutationFile = reqFile
 	t.Cleanup(func() {
-		semanticMutationBucketID = ""
+		semanticMutationRoot = ""
 		semanticMutationFile = ""
 	})
 	out := captureStdout(t, func() {
@@ -78,15 +75,15 @@ func TestSemanticMutationPrintsIndentedJSON(t *testing.T) {
 		}
 	})
 
-	if !strings.Contains(out, "\n  \"bucket\"") || !strings.Contains(out, "\n  \"new_root\"") {
+	if strings.Contains(out, "\n  \"bucket\"") || !strings.Contains(out, "\n  \"new_root\"") {
 		t.Fatalf("semantic mutation output is not indented JSON:\n%s", out)
 	}
 	var payload map[string]any
 	if err := json.Unmarshal([]byte(out), &payload); err != nil {
 		t.Fatalf("decode semantic mutation output: %v\n%s", err, out)
 	}
-	if payload["bucket"] != "demo" {
-		t.Fatalf("bucket = %v, want demo", payload["bucket"])
+	if payload["base_root"] != initial.Root {
+		t.Fatalf("base_root = %v, want %s", payload["base_root"], initial.Root)
 	}
 	if payload["new_root"] == "" {
 		t.Fatal("new_root should be present")

--- a/core/gateway/gateway.go
+++ b/core/gateway/gateway.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	// ErrInvalidBucket is returned when a semantic mutation has no bucket ID.
-	ErrInvalidBucket = errors.New("invalid bucket")
+	// ErrInvalidNamespace is returned when an executor has no internal materialization namespace.
+	ErrInvalidNamespace = errors.New("invalid materialization namespace")
 
 	// ErrInvalidBaseRoot is returned when an update mutation has no base root.
 	ErrInvalidBaseRoot = errors.New("invalid base root")
@@ -34,7 +34,6 @@ var (
 
 // SemanticMutation is the gateway write boundary emitted by application layouts.
 type SemanticMutation struct {
-	BucketID string
 	BaseRoot cid.Cid
 	Puts     []ArcSetPut
 }
@@ -48,7 +47,6 @@ type ArcSetPut struct {
 
 // WriteReceipt records the library-level outcome of applying a semantic mutation.
 type WriteReceipt struct {
-	BucketID string
 	BaseRoot cid.Cid
 	NewRoot  cid.Cid
 	PutCount int
@@ -57,16 +55,14 @@ type WriteReceipt struct {
 
 // Executor submits semantic mutations to the current map/list semantic backends.
 type Executor struct {
-	Maps     mapping.Semantics
-	Lists    list.Semantics
-	ArcTable arctable.ArcTable
+	Namespace string
+	Maps      mapping.Semantics
+	Lists     list.Semantics
+	ArcTable  arctable.ArcTable
 }
 
 // ValidateSemanticMutation validates the shape of an update semantic mutation.
 func ValidateSemanticMutation(mut SemanticMutation) error {
-	if mut.BucketID == "" {
-		return ErrInvalidBucket
-	}
 	if !mut.BaseRoot.Defined() {
 		return ErrInvalidBaseRoot
 	}
@@ -93,6 +89,9 @@ func ValidateSemanticMutation(mut SemanticMutation) error {
 // validation purposes only. It does not publish heads, arbitrate freshness, or
 // merge concurrent roots.
 func (e Executor) Apply(ctx context.Context, mut SemanticMutation) (WriteReceipt, error) {
+	if e.Namespace == "" {
+		return WriteReceipt{}, ErrInvalidNamespace
+	}
 	if err := ValidateSemanticMutation(mut); err != nil {
 		return WriteReceipt{}, err
 	}
@@ -100,7 +99,7 @@ func (e Executor) Apply(ctx context.Context, mut SemanticMutation) (WriteReceipt
 	var newRoot cid.Cid
 	arcCount := 0
 	for i, put := range mut.Puts {
-		root, count, err := e.commitPut(ctx, mut.BucketID, put)
+		root, count, err := e.commitPut(ctx, e.Namespace, put)
 		if err != nil {
 			return WriteReceipt{}, fmt.Errorf("put %d: %w", i, err)
 		}
@@ -109,7 +108,6 @@ func (e Executor) Apply(ctx context.Context, mut SemanticMutation) (WriteReceipt
 	}
 
 	return WriteReceipt{
-		BucketID: mut.BucketID,
 		BaseRoot: mut.BaseRoot,
 		NewRoot:  newRoot,
 		PutCount: len(mut.Puts),

--- a/core/gateway/gateway_test.go
+++ b/core/gateway/gateway_test.go
@@ -29,21 +29,8 @@ func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
 		want error
 	}{
 		{
-			name: "missing bucket",
-			mut: gateway.SemanticMutation{
-				BaseRoot: root,
-				Puts: []gateway.ArcSetPut{{
-					Object: root,
-					Kind:   arcset.KindMap,
-					ArcSet: mapSet,
-				}},
-			},
-			want: gateway.ErrInvalidBucket,
-		},
-		{
 			name: "missing base root",
 			mut: gateway.SemanticMutation{
-				BucketID: "bucket",
 				Puts: []gateway.ArcSetPut{{
 					Object: root,
 					Kind:   arcset.KindMap,
@@ -55,7 +42,6 @@ func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
 		{
 			name: "empty puts",
 			mut: gateway.SemanticMutation{
-				BucketID: "bucket",
 				BaseRoot: root,
 			},
 			want: gateway.ErrEmptyPuts,
@@ -63,7 +49,6 @@ func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
 		{
 			name: "nil arcset",
 			mut: gateway.SemanticMutation{
-				BucketID: "bucket",
 				BaseRoot: root,
 				Puts: []gateway.ArcSetPut{{
 					Object: root,
@@ -75,7 +60,6 @@ func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
 		{
 			name: "put kind mismatch",
 			mut: gateway.SemanticMutation{
-				BucketID: "bucket",
 				BaseRoot: root,
 				Puts: []gateway.ArcSetPut{{
 					Object: root,
@@ -88,7 +72,6 @@ func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
 		{
 			name: "object kind mismatch",
 			mut: gateway.SemanticMutation{
-				BucketID: "bucket",
 				BaseRoot: root,
 				Puts: []gateway.ArcSetPut{{
 					Object: mustTypedRoot(t, codec.SemanticKindList),
@@ -110,6 +93,24 @@ func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
 	}
 }
 
+func TestValidateSemanticMutationIsRootCentric(t *testing.T) {
+	root := testCID("root-centric-base")
+	payload := testCID("root-centric-payload")
+	set := mustCanonicalMap(t, map[string]cid.Cid{"@payload": payload})
+
+	err := gateway.ValidateSemanticMutation(gateway.SemanticMutation{
+		BaseRoot: root,
+		Puts: []gateway.ArcSetPut{{
+			Object: root,
+			Kind:   arcset.KindMap,
+			ArcSet: set,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ValidateSemanticMutation failed without bucket id: %v", err)
+	}
+}
+
 func TestCanonicalMapWithoutPayloadIsRejected(t *testing.T) {
 	_, err := arcset.NewCanonicalMapArcSet(map[string]cid.Cid{
 		"child": testCID("child"),
@@ -122,7 +123,6 @@ func TestCanonicalMapWithoutPayloadIsRejected(t *testing.T) {
 func TestExecutorAppliesMapReplacementAndReturnsStableReceipt(t *testing.T) {
 	ctx := context.Background()
 	exec := newExecutor(t)
-	bucketID := "gateway-map-replacement"
 	baseRoot := testCID("base")
 	payload := testCID("payload")
 	child := testCID("child")
@@ -132,7 +132,6 @@ func TestExecutorAppliesMapReplacementAndReturnsStableReceipt(t *testing.T) {
 	})
 
 	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
-		BucketID: bucketID,
 		BaseRoot: baseRoot,
 		Puts: []gateway.ArcSetPut{{
 			Object: baseRoot,
@@ -142,9 +141,6 @@ func TestExecutorAppliesMapReplacementAndReturnsStableReceipt(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Apply failed: %v", err)
-	}
-	if receipt.BucketID != bucketID {
-		t.Fatalf("receipt bucket = %q, want %q", receipt.BucketID, bucketID)
 	}
 	if !receipt.BaseRoot.Equals(baseRoot) {
 		t.Fatalf("receipt base root = %s, want %s", receipt.BaseRoot, baseRoot)
@@ -160,7 +156,7 @@ func TestExecutorAppliesMapReplacementAndReturnsStableReceipt(t *testing.T) {
 	}
 
 	key := arcset.CanonicalizePath("child")
-	binding, proof, err := exec.Maps.Prove(ctx, bucketID, receipt.NewRoot, key)
+	binding, proof, err := exec.Maps.Prove(ctx, exec.Namespace, receipt.NewRoot, key)
 	if err != nil {
 		t.Fatalf("Prove failed: %v", err)
 	}
@@ -179,14 +175,12 @@ func TestExecutorAppliesMapReplacementAndReturnsStableReceipt(t *testing.T) {
 func TestExecutorAppliesListReplacementAndReturnsStableReceipt(t *testing.T) {
 	ctx := context.Background()
 	exec := newExecutor(t)
-	bucketID := "gateway-list-replacement"
 	baseRoot := testCID("base")
 	first := testCID("first")
 	second := testCID("second")
 	set := mustCanonicalList(t, []cid.Cid{first, second})
 
 	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
-		BucketID: bucketID,
 		BaseRoot: baseRoot,
 		Puts: []gateway.ArcSetPut{{
 			Object: baseRoot,
@@ -207,7 +201,7 @@ func TestExecutorAppliesListReplacementAndReturnsStableReceipt(t *testing.T) {
 		t.Fatalf("arc count = %d, want 2", receipt.ArcCount)
 	}
 
-	query, proof, err := exec.Lists.Prove(ctx, bucketID, receipt.NewRoot, 1)
+	query, proof, err := exec.Lists.Prove(ctx, exec.Namespace, receipt.NewRoot, 1)
 	if err != nil {
 		t.Fatalf("Prove failed: %v", err)
 	}
@@ -226,7 +220,6 @@ func TestExecutorAppliesListReplacementAndReturnsStableReceipt(t *testing.T) {
 func TestExecutorAppliesPutsInOrderAndUsesFinalRoot(t *testing.T) {
 	ctx := context.Background()
 	exec := newExecutor(t)
-	bucketID := "gateway-ordered-replacements"
 	baseRoot := testCID("base")
 	mapSet := mustCanonicalMap(t, map[string]cid.Cid{
 		"@payload": testCID("payload"),
@@ -234,7 +227,6 @@ func TestExecutorAppliesPutsInOrderAndUsesFinalRoot(t *testing.T) {
 	listSet := mustCanonicalList(t, []cid.Cid{testCID("chunk")})
 
 	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
-		BucketID: bucketID,
 		BaseRoot: baseRoot,
 		Puts: []gateway.ArcSetPut{
 			{Object: baseRoot, Kind: arcset.KindMap, ArcSet: mapSet},
@@ -275,9 +267,10 @@ func newExecutor(t *testing.T) gateway.Executor {
 		t.Fatalf("tree.NewList failed: %v", err)
 	}
 	return gateway.Executor{
-		Maps:     maps,
-		Lists:    lists,
-		ArcTable: arcs,
+		Namespace: "gateway-test",
+		Maps:      maps,
+		Lists:     lists,
+		ArcTable:  arcs,
 	}
 }
 

--- a/core/layout/malt/unixfs/mutation.go
+++ b/core/layout/malt/unixfs/mutation.go
@@ -12,9 +12,9 @@ import (
 
 // MutationPlan is a layout-produced semantic mutation snapshot for one
 // UnixFS node. It is an adapter artifact for gateway-style consumers; the
-// gateway remains responsible for owning write execution and publication.
+// gateway materializes the plan, while root publication remains application
+// policy.
 type MutationPlan struct {
-	BucketID string
 	BaseRoot cid.Cid
 	Puts     []MutationPut
 }
@@ -49,7 +49,6 @@ func (l *Layout) MutationPlanForPath(ctx context.Context, root cid.Cid, path str
 		return nil, err
 	}
 	plan := &MutationPlan{
-		BucketID: l.bucketID,
 		BaseRoot: root,
 		Puts: []MutationPut{
 			{
@@ -100,7 +99,6 @@ func (l *Layout) MutationPlanForRoot(ctx context.Context, baseRoot cid.Cid, root
 	}
 
 	plan := &MutationPlan{
-		BucketID: l.bucketID,
 		BaseRoot: baseRoot,
 	}
 	if err := l.appendRootMutationPuts(ctx, plan, root); err != nil {

--- a/core/layout/malt/unixfs/mutation_test.go
+++ b/core/layout/malt/unixfs/mutation_test.go
@@ -24,9 +24,6 @@ func TestSmallFileMutationPlanIncludesMapPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MutationPlanForPath failed: %v", err)
 	}
-	if plan.BucketID == "" {
-		t.Fatal("plan BucketID is empty")
-	}
 	if !plan.BaseRoot.Equals(root) {
 		t.Fatalf("plan BaseRoot = %s, want %s", plan.BaseRoot, root)
 	}

--- a/httpapi/types.go
+++ b/httpapi/types.go
@@ -62,6 +62,12 @@ type BucketSemanticMutationRequest struct {
 	Puts     []SemanticMutationPut `json:"puts"`
 }
 
+// RootSemanticMutationRequest materializes a root-relative semantic mutation
+// without publishing a managed bucket head.
+type RootSemanticMutationRequest struct {
+	Puts []SemanticMutationPut `json:"puts"`
+}
+
 // SemanticMutationPut replaces one semantic object's full canonical arc set.
 type SemanticMutationPut struct {
 	Object  string                  `json:"object,omitempty"`
@@ -80,6 +86,14 @@ type SemanticMutationEntry struct {
 // BucketSemanticMutationResponse returns the gateway write receipt after publication.
 type BucketSemanticMutationResponse struct {
 	Bucket   string `json:"bucket"`
+	BaseRoot string `json:"base_root"`
+	NewRoot  string `json:"new_root"`
+	PutCount int    `json:"put_count"`
+	ArcCount int    `json:"arc_count"`
+}
+
+// RootSemanticMutationResponse returns a root-centric gateway materialization receipt.
+type RootSemanticMutationResponse struct {
 	BaseRoot string `json:"base_root"`
 	NewRoot  string `json:"new_root"`
 	PutCount int    `json:"put_count"`

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -266,7 +266,7 @@ func (s *Server) handleBucketSemanticMutation(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	mut, err := semanticMutationFromRequest(bucketID, baseRoot, &req)
+	mut, err := semanticMutationFromRequest(baseRoot, req.Puts)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -277,9 +277,10 @@ func (s *Server) handleBucketSemanticMutation(w http.ResponseWriter, r *http.Req
 	}
 
 	exec := gateway.Executor{
-		Maps:     g.Semantic(),
-		Lists:    g.ListSemantic(),
-		ArcTable: s.node.ArcTable(),
+		Namespace: bucketID,
+		Maps:      g.Semantic(),
+		Lists:     g.ListSemantic(),
+		ArcTable:  s.node.ArcTable(),
 	}
 	receipt, err := exec.Apply(r.Context(), mut)
 	if err != nil {
@@ -308,7 +309,54 @@ func (s *Server) handleBucketSemanticMutation(w http.ResponseWriter, r *http.Req
 	}
 
 	writeJSON(w, http.StatusCreated, &httpapi.BucketSemanticMutationResponse{
-		Bucket:   receipt.BucketID,
+		Bucket:   bucketID,
+		BaseRoot: receipt.BaseRoot.String(),
+		NewRoot:  receipt.NewRoot.String(),
+		PutCount: receipt.PutCount,
+		ArcCount: receipt.ArcCount,
+	})
+}
+
+func (s *Server) handleRootSemanticMutation(w http.ResponseWriter, r *http.Request) {
+	g, err := s.getGraph(r.Context(), defaultRootGraphID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	baseRoot, err := decodeCID(r.PathValue("root"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var req httpapi.RootSemanticMutationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+
+	mut, err := semanticMutationFromRequest(baseRoot, req.Puts)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	exec := gateway.Executor{
+		Namespace: g.BucketId(),
+		Maps:      g.Semantic(),
+		Lists:     g.ListSemantic(),
+		ArcTable:  s.node.ArcTable(),
+	}
+	receipt, err := exec.Apply(r.Context(), mut)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if lm := s.node.LineageManager(); lm != nil {
+		_ = lm.Record(r.Context(), receipt.NewRoot, receipt.BaseRoot, receipt.ArcCount)
+	}
+
+	writeJSON(w, http.StatusCreated, &httpapi.RootSemanticMutationResponse{
 		BaseRoot: receipt.BaseRoot.String(),
 		NewRoot:  receipt.NewRoot.String(),
 		PutCount: receipt.PutCount,
@@ -1738,7 +1786,6 @@ func (s *Server) applyUnixFSGatewayMutation(ctx context.Context, bucketID string
 		return gateway.WriteReceipt{}, err
 	}
 	mut := gateway.SemanticMutation{
-		BucketID: bucketID,
 		BaseRoot: baseRoot,
 		Puts:     make([]gateway.ArcSetPut, 0, len(plan.Puts)),
 	}
@@ -1753,9 +1800,10 @@ func (s *Server) applyUnixFSGatewayMutation(ctx context.Context, bucketID string
 	}
 
 	exec := gateway.Executor{
-		Maps:     g.Semantic(),
-		Lists:    g.ListSemantic(),
-		ArcTable: s.node.ArcTable(),
+		Namespace: bucketID,
+		Maps:      g.Semantic(),
+		Lists:     g.ListSemantic(),
+		ArcTable:  s.node.ArcTable(),
 	}
 	receipt, err := exec.Apply(ctx, mut)
 	if err != nil {
@@ -2239,13 +2287,9 @@ func parseArcMap(raw map[string]string) (map[string]cid.Cid, error) {
 	return out, nil
 }
 
-func semanticMutationFromRequest(bucketID string, baseRoot cid.Cid, req *httpapi.BucketSemanticMutationRequest) (gateway.SemanticMutation, error) {
-	if req == nil {
-		return gateway.SemanticMutation{}, fmt.Errorf("request is required")
-	}
-
-	puts := make([]gateway.ArcSetPut, 0, len(req.Puts))
-	for i, putReq := range req.Puts {
+func semanticMutationFromRequest(baseRoot cid.Cid, putRequests []httpapi.SemanticMutationPut) (gateway.SemanticMutation, error) {
+	puts := make([]gateway.ArcSetPut, 0, len(putRequests))
+	for i, putReq := range putRequests {
 		put, err := semanticPutFromRequest(putReq)
 		if err != nil {
 			return gateway.SemanticMutation{}, fmt.Errorf("put %d: %w", i, err)
@@ -2254,7 +2298,6 @@ func semanticMutationFromRequest(bucketID string, baseRoot cid.Cid, req *httpapi
 	}
 
 	return gateway.SemanticMutation{
-		BucketID: bucketID,
 		BaseRoot: baseRoot,
 		Puts:     puts,
 	}, nil

--- a/server/server.go
+++ b/server/server.go
@@ -106,6 +106,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/roots/{root}/proof", s.handleRootProof)
 	mux.HandleFunc("GET /api/v1/roots/{root}/prooflist", s.handleRootProofList)
 	mux.HandleFunc("GET /api/v1/roots/{root}/snapshot", s.handleRootSnapshot)
+	mux.HandleFunc("POST /api/v1/roots/{root}/semantic-mutations", s.handleRootSemanticMutation)
 	mux.HandleFunc("POST /api/v1/roots/{root}/update", s.handleRootUpdate)
 	mux.HandleFunc("POST /api/v1/roots/{root}/updates:batch", s.handleRootBatchUpdate)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -914,6 +914,85 @@ func TestServerBucketSemanticMutationRejectsInvalidHead(t *testing.T) {
 	}
 }
 
+func TestServerRootSemanticMutationMaterializesWithoutBucketHead(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{
+			"name": fakeCIDString("initial-name"),
+		}),
+	})
+	resp, err := http.Post(ts.URL+"/api/v1/roots", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create root request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create root status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create root response: %v", err)
+	}
+	resp.Body.Close()
+
+	nextName := fakeCIDString("root-next-name")
+	mutationBody, _ := json.Marshal(map[string]any{
+		"puts": []map[string]any{{
+			"object": createResp.Root,
+			"kind":   "map",
+			"entries": []map[string]string{
+				{"path": "@payload", "target": fakeCIDString("root-next-payload")},
+				{"path": "name", "target": nextName},
+			},
+		}},
+	})
+	resp, err = http.Post(ts.URL+"/api/v1/roots/"+createResp.Root+"/semantic-mutations", "application/json", bytes.NewReader(mutationBody))
+	if err != nil {
+		t.Fatalf("root semantic mutation request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("root semantic mutation status = %d, want %d: %s", resp.StatusCode, http.StatusCreated, string(body))
+	}
+	var mutationResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&mutationResp); err != nil {
+		t.Fatalf("decode root semantic mutation response: %v", err)
+	}
+	resp.Body.Close()
+	if _, ok := mutationResp["bucket"]; ok {
+		t.Fatalf("root semantic mutation response leaked bucket: %+v", mutationResp)
+	}
+	if mutationResp["base_root"] != createResp.Root {
+		t.Fatalf("base_root = %v, want %q", mutationResp["base_root"], createResp.Root)
+	}
+	newRoot, ok := mutationResp["new_root"].(string)
+	if !ok || newRoot == "" || newRoot == createResp.Root {
+		t.Fatalf("new_root = %v, want a new defined root", mutationResp["new_root"])
+	}
+
+	resp, err = http.Get(ts.URL + "/api/v1/roots/" + newRoot + "/resolve?path=name")
+	if err != nil {
+		t.Fatalf("resolve root request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("resolve root status = %d, want %d: %s", resp.StatusCode, http.StatusOK, string(body))
+	}
+	var resolveResp httpapi.ResolveResponse
+	if err := json.NewDecoder(resp.Body).Decode(&resolveResp); err != nil {
+		t.Fatalf("decode resolve response: %v", err)
+	}
+	resp.Body.Close()
+	if resolveResp.Target != nextName {
+		t.Fatalf("resolved target = %q, want %q", resolveResp.Target, nextName)
+	}
+}
+
 func TestServerUnixFSWritesPublishGatewayReadableRoot(t *testing.T) {
 	node := newTestNode(t)
 


### PR DESCRIPTION
## Summary
- remove BucketID from the core gateway SemanticMutation/WriteReceipt surface and move the internal materialization namespace onto the executor
- add root-centric POST /api/v1/roots/{root}/semantic-mutations, client support, and a root-based semantic-mutation CLI path
- keep bucket semantic mutations as a compatibility wrapper and update UnixFS mutation plans/docs around root-centric materialization receipts

## Tests
- env GOCACHE=/tmp/go-build-cache go test ./...