### PR TITLE
fix: clean up root-centric API behavior

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dewebprotocol/malt/config"
+	"github.com/dewebprotocol/malt/core/types/prooflist"
 	"github.com/dewebprotocol/malt/httpapi"
 )
 
@@ -84,12 +86,19 @@ func (c *Client) ResolveRoot(ctx context.Context, root string, p string) (*httpa
 
 // ProveRoot returns the transcript for an explicit root path.
 func (c *Client) ProveRoot(ctx context.Context, root string, p string) (*httpapi.ResolveResponse, error) {
-	return c.Resolve(ctx, root, p)
+	proof, err := c.ProofList(ctx, root, p)
+	if err != nil {
+		return nil, err
+	}
+	return &httpapi.ResolveResponse{
+		Target:     proof.Target,
+		Transcript: transcriptFromProofList(proof.ProofList),
+	}, nil
 }
 
 // ProofListRoot returns a ProofList read result from an explicit root.
-func (c *Client) ProofListRoot(ctx context.Context, root string, _ string) (*httpapi.ProofListResponse, error) {
-	return c.ProofList(ctx, root, "")
+func (c *Client) ProofListRoot(ctx context.Context, root string, p string) (*httpapi.ProofListResponse, error) {
+	return c.ProofList(ctx, root, p)
 }
 
 // Resolve resolves a path relative to a root CID. Uses HEAD /{root}/{path}
@@ -160,6 +169,27 @@ func (c *Client) ProofList(ctx context.Context, root, rawPath string) (*httpapi.
 		return nil, err
 	}
 	return &httpapi.ProofListResponse{Target: out.Key, ProofList: out.ProofList}, nil
+}
+
+func transcriptFromProofList(pl prooflist.ProofList) []httpapi.StepEvidence {
+	steps := make([]httpapi.StepEvidence, 0, len(pl.Steps))
+	for _, step := range pl.Steps {
+		evidence := step.Evidence
+		if len(evidence) == 0 {
+			evidence = step.Proof
+		}
+		stepPath := step.Path
+		if stepPath == "" {
+			stepPath = step.Coordinate
+		}
+		steps = append(steps, httpapi.StepEvidence{
+			Path:     stepPath,
+			Target:   step.Target.String(),
+			Evidence: base64.StdEncoding.EncodeToString(evidence),
+			Kind:     string(step.Kind),
+		})
+	}
+	return steps
 }
 
 // Stat returns the locked stat contract for a path under a root CID.

--- a/client/client.go
+++ b/client/client.go
@@ -4,7 +4,6 @@ package client
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,7 +15,6 @@ import (
 	"time"
 
 	"github.com/dewebprotocol/malt/config"
-	"github.com/dewebprotocol/malt/core/types/prooflist"
 	"github.com/dewebprotocol/malt/httpapi"
 )
 
@@ -86,14 +84,11 @@ func (c *Client) ResolveRoot(ctx context.Context, root string, p string) (*httpa
 
 // ProveRoot returns the transcript for an explicit root path.
 func (c *Client) ProveRoot(ctx context.Context, root string, p string) (*httpapi.ResolveResponse, error) {
-	proof, err := c.ProofList(ctx, root, p)
-	if err != nil {
+	var resp httpapi.ResolveResponse
+	if err := c.do(ctx, http.MethodGet, "/"+url.PathEscape(root)+"/"+p, map[string]string{"format": "resolve"}, nil, &resp); err != nil {
 		return nil, err
 	}
-	return &httpapi.ResolveResponse{
-		Target:     proof.Target,
-		Transcript: transcriptFromProofList(proof.ProofList),
-	}, nil
+	return &resp, nil
 }
 
 // ProofListRoot returns a ProofList read result from an explicit root.
@@ -169,27 +164,6 @@ func (c *Client) ProofList(ctx context.Context, root, rawPath string) (*httpapi.
 		return nil, err
 	}
 	return &httpapi.ProofListResponse{Target: out.Key, ProofList: out.ProofList}, nil
-}
-
-func transcriptFromProofList(pl prooflist.ProofList) []httpapi.StepEvidence {
-	steps := make([]httpapi.StepEvidence, 0, len(pl.Steps))
-	for _, step := range pl.Steps {
-		evidence := step.Evidence
-		if len(evidence) == 0 {
-			evidence = step.Proof
-		}
-		stepPath := step.Path
-		if stepPath == "" {
-			stepPath = step.Coordinate
-		}
-		steps = append(steps, httpapi.StepEvidence{
-			Path:     stepPath,
-			Target:   step.Target.String(),
-			Evidence: base64.StdEncoding.EncodeToString(evidence),
-			Kind:     string(step.Kind),
-		})
-	}
-	return steps
 }
 
 // Stat returns the locked stat contract for a path under a root CID.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -259,6 +259,52 @@ func TestClientProveRootReturnsTranscript(t *testing.T) {
 	if len(proof.Transcript) == 0 {
 		t.Fatalf("transcript is empty")
 	}
+	verifyResp, err := client.Verify(ctx, &httpapi.VerifyRequest{
+		Root:       createResp.Root,
+		Transcript: toVerifySteps(proof.Transcript),
+	})
+	if err != nil {
+		t.Fatalf("Verify ProveRoot transcript: %v", err)
+	}
+	if !verifyResp.Valid {
+		t.Fatalf("ProveRoot transcript did not verify")
+	}
+}
+
+func TestClientProveRootDoesNotRequireTargetContent(t *testing.T) {
+	cfg := testConfig(t)
+	node, err := api.NewNode(api.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = node.Close()
+	})
+
+	ts := httptest.NewServer(server.New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	client := NewWithBaseURL(ts.URL)
+	ctx := context.Background()
+
+	target := fakeCIDString("missing-content-target")
+	createResp, err := client.CreateRootStructure(ctx, withPayloadBinding(map[string]string{
+		"name": target,
+	}))
+	if err != nil {
+		t.Fatalf("create root structure: %v", err)
+	}
+
+	proof, err := client.ProveRoot(ctx, createResp.Root, "name")
+	if err != nil {
+		t.Fatalf("ProveRoot: %v", err)
+	}
+	if proof.Target != target {
+		t.Fatalf("target = %q, want %q", proof.Target, target)
+	}
+	if len(proof.Transcript) == 0 {
+		t.Fatalf("transcript is empty")
+	}
 }
 
 func TestClientRootPathMethodsPreserveNestedPath(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dewebprotocol/malt/config"
@@ -164,6 +165,121 @@ func TestClientProofListReads(t *testing.T) {
 	}
 	if rootProof.ProofList.Steps[0].Kind != prooflist.KindPayloadBinding {
 		t.Fatalf("root prooflist step kind = %q, want %q", rootProof.ProofList.Steps[0].Kind, prooflist.KindPayloadBinding)
+	}
+}
+
+func TestClientProofListRootPreservesPath(t *testing.T) {
+	cfg := testConfig(t)
+	node, err := api.NewNode(api.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = node.Close()
+	})
+	mockCAS, ok := node.CAS().(*casmock.CAS)
+	if !ok {
+		t.Fatal("expected mock CAS")
+	}
+
+	ts := httptest.NewServer(server.New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	client := NewWithBaseURL(ts.URL)
+	ctx := context.Background()
+
+	targetData := []byte("named-target")
+	targetCID, err := mockCAS.Put(ctx, targetData)
+	if err != nil {
+		t.Fatalf("put target: %v", err)
+	}
+	rootPayloadData := []byte("root-payload")
+	rootPayloadCID, err := mockCAS.Put(ctx, rootPayloadData)
+	if err != nil {
+		t.Fatalf("put root payload: %v", err)
+	}
+
+	createResp, err := client.CreateRootStructure(ctx, withPayloadBinding(map[string]string{
+		"@payload": rootPayloadCID.String(),
+		"name":     targetCID.String(),
+	}))
+	if err != nil {
+		t.Fatalf("create root structure: %v", err)
+	}
+
+	proof, err := client.ProofListRoot(ctx, createResp.Root, "name")
+	if err != nil {
+		t.Fatalf("ProofListRoot: %v", err)
+	}
+	if proof.Target != targetCID.String() {
+		t.Fatalf("ProofListRoot target = %q, want %q", proof.Target, targetCID.String())
+	}
+}
+
+func TestClientProveRootReturnsTranscript(t *testing.T) {
+	cfg := testConfig(t)
+	node, err := api.NewNode(api.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = node.Close()
+	})
+	mockCAS, ok := node.CAS().(*casmock.CAS)
+	if !ok {
+		t.Fatal("expected mock CAS")
+	}
+
+	ts := httptest.NewServer(server.New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	client := NewWithBaseURL(ts.URL)
+	ctx := context.Background()
+
+	targetData := []byte("prove-target")
+	targetCID, err := mockCAS.Put(ctx, targetData)
+	if err != nil {
+		t.Fatalf("put target: %v", err)
+	}
+
+	createResp, err := client.CreateRootStructure(ctx, withPayloadBinding(map[string]string{
+		"name": targetCID.String(),
+	}))
+	if err != nil {
+		t.Fatalf("create root structure: %v", err)
+	}
+
+	proof, err := client.ProveRoot(ctx, createResp.Root, "name")
+	if err != nil {
+		t.Fatalf("ProveRoot: %v", err)
+	}
+	if proof.Target != targetCID.String() {
+		t.Fatalf("target = %q, want %q", proof.Target, targetCID.String())
+	}
+	if len(proof.Transcript) == 0 {
+		t.Fatalf("transcript is empty")
+	}
+}
+
+func TestClientRootPathMethodsPreserveNestedPath(t *testing.T) {
+	seen := make(chan string, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.Method + " " + r.URL.RequestURI()
+		w.Header().Set("X-Malt-Key", fakeCIDString("target"))
+		w.Header().Set("X-Malt-Kind", "file")
+		w.Header().Set("X-Malt-Storage-Kind", "raw")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := NewWithBaseURL(ts.URL)
+	root := fakeCIDString("root")
+
+	if _, err := client.Resolve(context.Background(), root, "a/b/c"); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := <-seen; !strings.Contains(got, "/"+root+"/a/b/c") {
+		t.Fatalf("request = %q, want nested root path", got)
 	}
 }
 

--- a/cmd/malt/eval_read.go
+++ b/cmd/malt/eval_read.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/dewebprotocol/malt/internal/eval/readbench"
@@ -14,6 +15,7 @@ var (
 	evalReadLargeBytes = readbench.DefaultLargeFileBytes
 	evalReadRange      = readbench.DefaultRangeHeader
 	evalReadIterations = readbench.DefaultIterations
+	evalReadArcFlags   []string
 	evalReadArcs       map[string]string
 )
 
@@ -25,6 +27,7 @@ func init() {
 	evalReadCmd.Flags().IntVar(&evalReadLargeBytes, "large-bytes", evalReadLargeBytes, "large list-backed file size in bytes")
 	evalReadCmd.Flags().StringVar(&evalReadRange, "range", evalReadRange, "HTTP Range header for content_range reads")
 	evalReadCmd.Flags().IntVar(&evalReadIterations, "iterations", evalReadIterations, "number of prooflist/content-range operation pairs")
+	evalReadCmd.Flags().StringArrayVar(&evalReadArcFlags, "arc", nil, "Initial fixture arc as path=cid; repeatable and must include @payload")
 }
 
 var evalReadCmd = &cobra.Command{
@@ -47,12 +50,30 @@ func runEvalRead(cmd *cobra.Command, args []string) error {
 		SmallFileBytes: evalReadSmallBytes,
 		LargeFileBytes: evalReadLargeBytes,
 	}
-	if len(evalReadArcs) > 0 {
-		fixtureConfig.Arcs = evalReadArcs
+	arcs, err := evalReadFixtureArcs()
+	if err != nil {
+		return err
+	}
+	if len(arcs) == 0 {
+		return fmt.Errorf("--arc is required at least once and must include @payload")
+	}
+	fixtureConfig.Arcs = arcs
+	if _, ok := fixtureConfig.Arcs["@payload"]; !ok {
+		return fmt.Errorf("--arc is required at least once and must include @payload")
 	}
 	return runner.RunJSONL(cmd.Context(), readbench.RunConfig{
 		Fixture:     fixtureConfig,
 		RangeHeader: evalReadRange,
 		Iterations:  evalReadIterations,
 	}, os.Stdout)
+}
+
+func evalReadFixtureArcs() (map[string]string, error) {
+	if len(evalReadArcFlags) > 0 {
+		return parseCreatePairs(evalReadArcFlags)
+	}
+	if len(evalReadArcs) > 0 {
+		return evalReadArcs, nil
+	}
+	return nil, nil
 }

--- a/cmd/malt/eval_read_test.go
+++ b/cmd/malt/eval_read_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dewebprotocol/malt/config"
@@ -15,11 +16,12 @@ import (
 	casmock "github.com/dewebprotocol/malt/core/cas/mock"
 	"github.com/dewebprotocol/malt/internal/eval/readbench"
 	"github.com/dewebprotocol/malt/server"
+	cid "github.com/ipfs/go-cid"
 )
 
 func TestEvalReadPrintsBenchmarkJSONL(t *testing.T) {
 	ctx := context.Background()
-	apiBaseURL, cfgPath := newEvalReadTestConfig(t)
+	apiBaseURL, cfgPath, manifestCID, dummyCID := newEvalReadTestConfigWithCIDs(t)
 	if apiBaseURL == "" {
 		t.Fatal("test API base URL should not be empty")
 	}
@@ -35,6 +37,10 @@ func TestEvalReadPrintsBenchmarkJSONL(t *testing.T) {
 	evalReadLargeBytes = 300 * 1024
 	evalReadRange = "bytes=3-8"
 	evalReadIterations = 1
+	evalReadArcFlags = []string{
+		"@payload=" + manifestCID.String(),
+		"dummy=" + dummyCID.String(),
+	}
 
 	out := captureStdout(t, func() {
 		if err := runEvalRead(testCommandWithContext(ctx), nil); err != nil {
@@ -57,6 +63,54 @@ func TestEvalReadPrintsBenchmarkJSONL(t *testing.T) {
 	}
 	if results[0].Proof.ProofListCount != 1 || results[1].Proof.ProofListCount != 1 {
 		t.Fatalf("proof metrics should be reset per operation: %+v %+v", results[0].Proof, results[1].Proof)
+	}
+}
+
+func TestEvalReadAcceptsArcFlags(t *testing.T) {
+	ctx := context.Background()
+	_, cfgPath, manifestCID, dummyCID := newEvalReadTestConfigWithCIDs(t)
+
+	oldCfgFile := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfgFile })
+
+	resetEvalReadFlags(t)
+	evalReadFixture = "eval-read-cli-arc"
+	evalReadDepth = 0
+	evalReadSmallBytes = 40
+	evalReadLargeBytes = 300 * 1024
+	evalReadIterations = 1
+	evalReadArcFlags = []string{
+		"@payload=" + manifestCID.String(),
+		"dummy=" + dummyCID.String(),
+	}
+
+	out := captureStdout(t, func() {
+		if err := runEvalRead(testCommandWithContext(ctx), nil); err != nil {
+			t.Fatalf("run eval-read with --arc flags: %v", err)
+		}
+	})
+	results := decodeEvalReadJSONL(t, out)
+	if len(results) != 2 {
+		t.Fatalf("result count = %d, want 2\n%s", len(results), out)
+	}
+}
+
+func TestEvalReadRequiresArcFlags(t *testing.T) {
+	ctx := context.Background()
+	_, cfgPath := newEvalReadTestConfig(t)
+
+	oldCfgFile := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfgFile })
+
+	resetEvalReadFlags(t)
+	err := runEvalRead(testCommandWithContext(ctx), nil)
+	if err == nil {
+		t.Fatal("expected eval-read without --arc to fail")
+	}
+	if !strings.Contains(err.Error(), "--arc is required") {
+		t.Fatalf("error = %q, want --arc is required", err.Error())
 	}
 }
 
@@ -87,6 +141,8 @@ func resetEvalReadFlags(t *testing.T) {
 	oldLargeBytes := evalReadLargeBytes
 	oldRange := evalReadRange
 	oldIterations := evalReadIterations
+	oldArcFlags := evalReadArcFlags
+	oldArcs := evalReadArcs
 	t.Cleanup(func() {
 		evalReadFixture = oldFixture
 		evalReadDepth = oldDepth
@@ -94,10 +150,21 @@ func resetEvalReadFlags(t *testing.T) {
 		evalReadLargeBytes = oldLargeBytes
 		evalReadRange = oldRange
 		evalReadIterations = oldIterations
+		evalReadArcFlags = oldArcFlags
+		evalReadArcs = oldArcs
 	})
+	evalReadArcFlags = nil
+	evalReadArcs = nil
 }
 
 func newEvalReadTestConfig(t *testing.T) (string, string) {
+	t.Helper()
+
+	apiBaseURL, cfgPath, _, _ := newEvalReadTestConfigWithCIDs(t)
+	return apiBaseURL, cfgPath
+}
+
+func newEvalReadTestConfigWithCIDs(t *testing.T) (string, string, cid.Cid, cid.Cid) {
 	t.Helper()
 
 	mockCAS := casmock.NewCAS(casmock.WithoutLatency())
@@ -115,12 +182,6 @@ func newEvalReadTestConfig(t *testing.T) (string, string) {
 	if err != nil {
 		t.Fatalf("put dummy: %v", err)
 	}
-	oldArcs := evalReadArcs
-	evalReadArcs = map[string]string{
-		"@payload": manifestCID.String(),
-		"dummy":    dummyCID.String(),
-	}
-	t.Cleanup(func() { evalReadArcs = oldArcs })
 
 	cfg := config.DefaultConfig()
 	cfg.RPC.Listen = ""
@@ -146,5 +207,5 @@ func newEvalReadTestConfig(t *testing.T) (string, string) {
 	if _, err := os.Stat(cfgPath); err != nil {
 		t.Fatalf("stat test config: %v", err)
 	}
-	return ts.URL, cfgPath
+	return ts.URL, cfgPath, manifestCID, dummyCID
 }

--- a/cmd/malt/prove_test.go
+++ b/cmd/malt/prove_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestProvePrintsTranscriptSteps(t *testing.T) {
+	ctx := context.Background()
+	daemon, casClient := newAddTestClients(t)
+	defaultClient = daemon
+	t.Cleanup(func() { defaultClient = nil })
+
+	targetData := []byte("prove-target")
+	targetCID, err := casClient.Put(ctx, targetData)
+	if err != nil {
+		t.Fatalf("put target content: %v", err)
+	}
+	target := targetCID.String()
+	createResp, err := daemon.CreateRootStructure(ctx, map[string]string{"@payload": target, "name": target})
+	if err != nil {
+		t.Fatalf("create root structure: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runProve(testCommandWithContext(ctx), []string{createResp.Root, "name"}); err != nil {
+			t.Fatalf("run prove: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "[0]") || !strings.Contains(out, "evidence:") {
+		t.Fatalf("prove output missing transcript step:\n%s", out)
+	}
+	if !strings.Contains(out, "target: "+target) {
+		t.Fatalf("prove output target mismatch:\n%s", out)
+	}
+}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -308,12 +308,16 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		writeJSON(w, http.StatusCreated, &httpapi.UnixFSWriteResponse{
+		resp := &httpapi.UnixFSWriteResponse{
 			Path:     p,
 			Kind:     "dir",
 			NewRoot:  receipt.NewRoot.String(),
 			ArcCount: receipt.ArcCount,
-		})
+		}
+		if root.Defined() {
+			resp.OldRoot = root.String()
+		}
+		writeJSON(w, http.StatusCreated, resp)
 		return
 	}
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -61,6 +61,10 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 	path := r.PathValue("path")
 
 	// Format negotiation
+	if r.URL.Query().Get("format") == "resolve" {
+		s.serveResolve(w, r, g, root, path)
+		return
+	}
 	if r.URL.Query().Get("format") == "proof" {
 		// Empty path means root-level proof — resolve @payload instead
 		queryPath := path
@@ -131,6 +135,26 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}
 	_, _ = io.Copy(w, bytes.NewReader(payload))
+}
+
+func (s *Server) serveResolve(w http.ResponseWriter, r *http.Request, g *graph.Graph, root cid.Cid, queryPath string) {
+	result, err := g.Resolver().Resolve(root, queryPath)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, resolver.ErrResolutionFailed) {
+			status = http.StatusNotFound
+		}
+		writeError(w, status, err.Error())
+		return
+	}
+	if resolveMiss(root, queryPath, result) {
+		writeError(w, http.StatusNotFound, errPathNotFound.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, &httpapi.ResolveResponse{
+		Target:     result.Target.String(),
+		Transcript: encodeTranscript(result.Transcript),
+	})
 }
 
 func (s *Server) serveContentProof(w http.ResponseWriter, r *http.Request, g *graph.Graph, root cid.Cid, queryPath string) {

--- a/server/server.go
+++ b/server/server.go
@@ -85,7 +85,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /{root}/{path...}", s.handleUpdate)
 
 	// Root creation
-	mux.HandleFunc("POST /{root}", s.handleCreateStructure)
+	mux.HandleFunc("POST /_", s.handleCreateStructure)
 }
 
 func (s *Server) getOrCreateGraph(ctx context.Context) (*graph.Graph, error) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -78,6 +78,37 @@ func TestServerHealthAndRootLifecycle(t *testing.T) {
 	}
 }
 
+func TestServerCreateRootOnlyAcceptsUnderscoreRoute(t *testing.T) {
+	node := newTestNode(t)
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	body, err := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"name": fakeCIDString("name")}),
+	})
+	if err != nil {
+		t.Fatalf("marshal create request: %v", err)
+	}
+
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /_: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST /_ status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	resp.Body.Close()
+
+	resp, err = http.Post(ts.URL+"/not-a-create-route", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /not-a-create-route: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusCreated {
+		t.Fatalf("POST /not-a-create-route unexpectedly created a root")
+	}
+}
+
 func TestServerLegacyGraphRoutesRemoved(t *testing.T) {
 	node := newTestNode(t)
 
@@ -731,7 +762,14 @@ func TestServerUnixFSWritesPublishGatewayReadableRoot(t *testing.T) {
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("create unixfs directory status = %d, want %d", resp.StatusCode, http.StatusCreated)
 	}
+	var dirResp httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dirResp); err != nil {
+		t.Fatalf("decode unixfs directory response: %v", err)
+	}
 	resp.Body.Close()
+	if dirResp.OldRoot != root {
+		t.Fatalf("directory write old_root = %q, want %q", dirResp.OldRoot, root)
+	}
 
 	fileBody := []byte("hello from gateway unixfs")
 	resp, err = http.Post(ts.URL+"/"+root+"/docs/readme.txt", "application/octet-stream", bytes.NewReader(fileBody))


### PR DESCRIPTION
## Summary
- Restore root-centric proof behavior so `malt prove <root> <path>` prints non-empty transcript steps and `ProofListRoot(root, path)` proves the requested path.
- Add user-facing `malt eval-read --arc path=cid` fixture creation input and require an `@payload` arc.
- Narrow root creation to `POST /_` and make UnixFS directory write receipts include `old_root` like file writes.

## Test plan
- [x] `go test ./client -run "TestClientProofListRootPreservesPath|TestClientProveRootReturnsTranscript|TestClientRootPathMethodsPreserveNestedPath" -count=1`
- [x] `go test ./server -run "TestServerCreateRootOnlyAcceptsUnderscoreRoute|TestServerUnixFSWritesPublishGatewayReadableRoot" -count=1`
- [x] `go test ./cmd/malt -run "EvalRead|Prove" -count=1`
- [x] `go test ./client ./cmd/malt ./server -count=1`
- [x] `go test ./...`

## Acceptance Checklist
- [x] `malt prove <root> <path>` returns non-empty transcript again.
- [x] `ProofListRoot(root, path)` proves the requested path.
- [x] `malt eval-read` has a user-facing fixture arc path, e.g. `--arc path=cid`.
- [x] Root creation is only `POST /_`.
- [x] Directory and file UnixFS write receipts both include `old_root`.
- [x] `go test ./...` passes.

Made with [Cursor](https://cursor.com)