### PR TITLE
docs: align root-centric API docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ repository at `../documents`.
 This repository contains the Go implementation of MALT:
 
 - list/map semantic abstractions over immutable CAS payloads
-- bucket/namespace-scoped ArcTable-backed arcset persistence/materialization
+- namespace-scoped ArcTable-backed arcset persistence/materialization
 - stateless primitive commitment backends
 - the current `core/layout/malt/unixfs` prototype built from list/map/CAS blob composition
 - runtime adapters for current resolver / writer / graph packages
@@ -47,7 +47,7 @@ This repository contains the Go implementation of MALT:
 - `core/layout/malt/unixfs` is the current application-layout prototype; it should not be treated as the core semantic abstraction.
 - unresolved graph-node, arc, resolver, and UnixFS runtime-integration questions should be tracked as TODOs for later design discussion.
 - `bucket` is an operational namespace/collection boundary for runtime state, not a core list/map or arcset semantic.
-- `bucketpath` and `manifest` are current bucket/file layout helpers and should not leak into core semantic rules.
+- `querypath` and `manifest` are current root-relative file-layout helpers and should not leak into core semantic rules.
 - head publication, freshness, merge, and multi-writer arbitration belong to application/deployment policy.
 - overwrite ArcTable is the simple current-state implementation; versioned ArcTable is the default MVCC-style implementation.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,7 @@ List and map are semantic abstractions:
   child references
 - map semantic: authenticated keyed/path-like relations among graph nodes
 
-ArcTable is bucket/namespace-scoped arcset persistence/materialization and does
+ArcTable is namespace-scoped arcset persistence/materialization and does
 not provide correctness by itself. Commitment backends are stateless
 vector-commitment primitives used to authenticate semantic-layer
 representations. Layouts translate source-domain data into semantic mutations;
@@ -42,7 +42,7 @@ The target model has four distinct layers:
 | Layer | Responsibility |
 | --- | --- |
 | Semantic layer | Abstract list/map semantics |
-| ArcTable | Bucket/namespace-scoped arcset persistence/materialization |
+| ArcTable | Namespace-scoped arcset persistence/materialization |
 | Commitment backend | Stateless proof and verification over semantic-layer representations |
 | Gateway | Runtime surface accepting semantic mutations and returning ProofLists |
 | Application layout | Product data model built above list/map/CAS blobs |
@@ -60,11 +60,10 @@ Conceptually, gateway reads return `result + ProofList`, where the ProofList is
 the vector-commitment proof chain from root to destination. Root-centric
 gateway materialization accepts semantic mutations that have already been
 produced by a layout and returns an operational receipt without publishing a
-managed bucket head. The
-HTTP gateway may return blob content with ProofList metadata in response
+managed head. The HTTP gateway may return blob content with ProofList metadata in response
 headers, and may return large-file byte ranges with ProofLists covering the
-selected list entries. Bucket routes remain compatibility/product surfaces
-around the same internal materialization namespace.
+selected list entries. File routes are product surfaces around the same
+root-centric materialization namespace.
 
 ### List Semantic
 
@@ -122,7 +121,7 @@ implicitly redirect through `@payload`.
 List/map semantics need materialized arcset state in order to prove and update
 without reconstructing full payload objects.
 
-In the current implementation this role is served by bucket/namespace-scoped
+In the current implementation this role is served by namespace-scoped
 ArcTable:
 
 - point lookup of materialized structure entries
@@ -134,11 +133,10 @@ ArcTable:
 ArcTable is not the trust root. Incorrect materialized state is rejected by
 proof verification or root recomputation.
 
-The bucket identifier is an operational namespace and collection boundary for
-state placement, replication, migration, GC, bloom/index configuration, and
-optional head publication. It is not part of the mathematical list/map
-semantics, and it does not decide which root should become an application's
-current head.
+The namespace identifier is an operational collection boundary for state
+placement, replication, migration, GC, and bloom/index configuration. It is not
+part of the mathematical list/map semantics, and it does not decide which root
+should become an application's current head.
 
 ### Commitment Backend
 
@@ -179,7 +177,7 @@ as follows:
 - `core/structure/list/tree`
   - primary list implementation
 - `core/arctable`
-  - bucket/namespace-scoped arcset persistence/materialization
+  - namespace-scoped arcset persistence/materialization
 - `core/commitment`
   - stateless primitive commitment backends
 - `core/layout/malt/unixfs`
@@ -195,9 +193,10 @@ as follows:
 - `core/lineage`
   - auxiliary version-history metadata pending integration with versioned
     ArcTable
-- `core/bucketpath` and `core/manifest`
-  - current file/bucket layout helpers, candidates to move under a dedicated
-    UnixFS-style layout package
+- `core/querypath`
+  - current query-path canonicalization helper for root-relative paths
+- `core/manifest`
+  - current UnixFS directory-manifest helper above the semantic layer
 
 ## Runtime Packaging
 
@@ -209,24 +208,26 @@ Current command model:
   - long-running local process
   - owns hot structure state
   - serves local HTTP/JSON API requests
-- `malt bucket ...`
-  - manages daemon-side buckets and the client-side default bucket
 - `malt add ...`
   - client-side file and directory ingestion
   - uploads payload blocks to CAS
   - commits structure through list/map semantics
+  - writes under `--root` when extending an existing root, or creates a new
+    root when omitted
 - `malt cat ...` and `malt get ...`
-  - product read paths for bucket-local files and directories
+  - product read paths for files and directories under explicit roots
+- `malt semantic-mutation ...`
+  - root-centric semantic mutation materialization
 - lower-level commands
-  - resolve, prove, update, verify, and lineage inspection
+  - resolve, prove, prooflist, update, verify, metrics, eval-read, and lineage
+    inspection
 - `malt cas ...`
   - convenience commands for CAS-oriented workflows
 
 Current runtime invariants:
 
-- a managed bucket head is a directory-shaped map root
-- a list root represents file-content structure and is not a valid managed
-  bucket head
+- a directory root is a directory-shaped map root
+- a list root represents file-content structure and is not a directory root
 - every MALT-native map root carries the reserved `@payload` binding as a map
   semantic invariant
 - materializing a bare map root means resolving `@payload` first
@@ -234,8 +235,8 @@ Current runtime invariants:
   `@payload`
 - bucket-path misses are reported as `not found`
 
-Bucket heads and path-miss behavior are file-layout and product-runtime
-invariants. The reserved `@payload` binding belongs to map semantic objects.
+Path-miss behavior is a file-layout and product-runtime invariant. The reserved
+`@payload` binding belongs to map semantic objects.
 
 ## Code Layout
 
@@ -249,17 +250,20 @@ malt/
 |-- server/          # daemon HTTP server
 |-- core/
 |   |-- api/          # Node: top-level component wiring
-|   |-- arctable/     # bucket/namespace-scoped arcset persistence/materialization
-|   |-- bucketpath/   # current bucket path boundary helper
+|   |-- arctable/     # namespace-scoped arcset persistence/materialization
 |   |-- cas/          # CAS clients and adapters
 |   |-- codec/        # MALT CID codecs and CID utilities
 |   |-- commitment/   # primitive commitment backends
 |   |-- graph/        # current metadata/runtime composition
 |   |-- kvstore/      # KV backends
+|   |-- metrics/      # node-local evaluation counters
+|   |-- querypath/    # root-relative query path canonicalization
 |   |-- layout/
-|   |   `-- unixfs/    # current map/list-based UnixFS layout prototype
+|   |   |-- ipld/      # Merkle DAG UnixFS import helpers
+|   |   `-- malt/
+|   |       `-- unixfs/ # current map/list-based UnixFS layout prototype
 |   |-- lineage/      # auxiliary version-history metadata
-|   |-- manifest/     # current directory-manifest helper
+|   |-- manifest/     # UnixFS directory-manifest helper
 |   |-- resolver/     # current read compatibility adapters
 |   |-- structure/    # list/map semantic abstractions and implementations
 |   |-- types/        # arc sets, evidence, proof-related types
@@ -381,9 +385,9 @@ Current boundary:
 - The package remains the direct map/list/CAS library layer for the
   UnixFS-style layout and translates source-domain file/directory data into
   MALT semantic mutations.
-- Managed buckets now expose this layout through daemon routes for UnixFS file
-  and directory writes, path stat, and content reads. The `malt add`,
-  `malt cat`, and `malt get` commands use those bucket APIs.
+- Root-centric daemon routes expose this layout for UnixFS file and directory
+  writes, path stat, and content reads. The `malt add`, `malt cat`, and
+  `malt get` commands use those root APIs.
 - The package still directly injects `mapping.Semantics`, `list.Semantics`,
   and `cas.Client`; current `core/graph`, `core/writer`, and `core/resolver`
   remain runtime and compatibility adapters rather than semantic owners.
@@ -414,8 +418,8 @@ Open TODOs for the next discussion:
 - define the `ProofList` schema for path lookup, terminal `@payload`, blob
   bindings, and list range reads
 - decide how UnixFS reads should map onto gateway read queries and `ProofList`
-- define the final UnixFS write receipt, bucket-head advancement, and
-  concurrency contract for the already-wired managed bucket APIs
+- define the final UnixFS write receipt and application-level concurrency
+  contract for the already-wired root APIs
 - decide whether list needs a first-class range proof API or whether composed
   index proofs are sufficient for the first benchmark
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ VerifyRead(root, query, result, ProofList) -> valid / invalid
 A structure root exposes authenticated read/write semantics, but those
 semantics are owned by `list` and `map`, not by the current runtime `graph`
 object. Root-centric gateway materialization accepts semantic mutations
-produced by layouts and returns an operational receipt; managed bucket heads
-remain product/runtime publication pointers, not the gateway correctness
-interface. In the HTTP deployment, blob reads may carry
+produced by layouts and returns an operational receipt. Root publication,
+freshness, and multi-writer arbitration are application or deployment policy,
+not the gateway correctness interface. In the HTTP deployment, blob reads may carry
 `ProofList` in response metadata/header; large-file range reads return selected
 bytes plus the corresponding `ProofList`.
 
@@ -45,7 +45,7 @@ Current core semantics are:
   - use case: directory-like metadata, object fields, path indexes
   - every map semantic object carries the reserved `@payload` binding
 
-Both semantics use ArcTable for bucket/namespace-scoped arcset persistence/materialization
+Both semantics use ArcTable for namespace-scoped arcset persistence/materialization
 and stateless commitment backends for proofs.
 
 ## What MALT Changes
@@ -73,25 +73,28 @@ Current runtime shape:
 - `malt daemon`
   - long-running local process
   - owns hot proving/index state
-- `malt bucket`
-  - manages daemon-side buckets and the client-side default bucket
 - `malt add`
   - uploads payload directly to CAS
   - commits file and directory structure through MALT list/map semantics
+  - writes under `--root` when extending an existing root, or creates a new
+    root when omitted
 - `malt cat`, `malt get`
-  - product file and directory read commands over bucket paths
-- `malt resolve`, `malt prove`, `malt update`, `malt verify`, `malt lineage`
+  - product file and directory read commands over explicit roots
+- `malt semantic-mutation`
+  - materializes root-centric semantic mutation requests
+- `malt resolve`, `malt prove`, `malt prooflist`, `malt update`,
+  `malt verify`, `malt lineage`, `malt metrics`, `malt eval-read`
   - lower-level thin HTTP clients against the local daemon
 - `malt cas`
   - direct convenience commands against the configured CAS endpoint
 - daemon API
-  - fixed HTTP/JSON surface at `/api/v1`
+  - root-centric HTTP/JSON surface rooted at `/`
 - embedded mock CAS
   - optional same-process second-port service
   - fixed Kubo-compatible API at `/api/v0`
 
-The bucket/file commands are the current product layout built above MALT. They
-are not the definition of the MALT semantic layer.
+The file commands are the current product layout built above MALT. They are
+not the definition of the MALT semantic layer.
 
 ## Data Model
 
@@ -103,32 +106,30 @@ MALT separates:
 Payload CIDs identify immutable CAS blocks.
 Structure roots identify committed list/map semantic state.
 
-In the current bucket-first prototype:
+In the current root-centric prototype:
 
-- a managed bucket head is a directory-shaped `map` root
+- a directory root is a directory-shaped `map` root
 - large files are represented by `list` roots referenced from map bindings
 - every MALT-native `map` root carries a reserved `@payload` binding as a map
   semantic invariant
 - empty payloads should use a defined empty-block CID rather than omitting
   `@payload`
 
-The managed bucket head is a product/runtime pointer. The `@payload` binding is
-not merely a bucket rule: it is reserved by map semantic objects for terminal
+The `@payload` binding is reserved by map semantic objects for terminal
 materialization. List roots are terminal typed keys and do not auto-redirect
 through `@payload`.
 
-Bucket is an operational namespace and collection boundary for state placement,
-replication, migration, GC, indexing configuration, and optional head pointers.
-It is not part of the core list/map semantics. Applications decide which root
-becomes a published head, how freshness is communicated, and whether concurrent
-roots are merged.
+The daemon still uses an internal namespace for local state placement and
+materialization. That namespace is not part of the core list/map semantics.
+Applications decide which root becomes a published head, how freshness is
+communicated, and whether concurrent roots are merged.
 
 ## Terminology and Layers
 
 | Layer | Role | Examples |
 | --- | --- | --- |
 | Semantic Layer | Abstract list/map semantics | `list`, `map` |
-| ArcTable | Bucket/namespace-scoped arcset persistence/materialization | overwrite, versioned |
+| ArcTable | Namespace-scoped arcset persistence/materialization | overwrite, versioned |
 | Commitment Backend | Stateless primitive authentication | KZG, IPA |
 | Gateway | Deployment surface for semantic mutations and verifiable reads | daemon HTTP API |
 | Application Layout | Product data model built above semantic layer | flattened UnixFS-style bucket layout |
@@ -211,9 +212,9 @@ Current boundary:
 - `core/layout/malt/unixfs` remains the direct map/list/CAS library layer for the
   UnixFS-style layout and translates source-domain file/directory data into
   MALT semantic mutations.
-- The managed bucket runtime now exposes this layout through daemon routes for
-  UnixFS file and directory writes, path stat, and content reads, and the
-  `malt add`, `malt cat`, and `malt get` commands use those bucket APIs.
+- The root-centric daemon exposes this layout through routes for UnixFS file
+  and directory writes, path stat, and content reads, and the `malt add`,
+  `malt cat`, and `malt get` commands use those root APIs.
 - The layout still depends directly on `mapping.Semantics`, `list.Semantics`,
   and `cas.Client`; it does not make current `core/graph`, `core/writer`, or
   `core/resolver` the semantic owners.
@@ -270,7 +271,7 @@ Verification is local to the client:
 - `core/commitment`
   - stateless primitive commitment backends
 - `core/arctable`
-  - bucket/namespace-scoped arcset persistence/materialization
+  - namespace-scoped arcset persistence/materialization
 - `core/layout/malt/unixfs`
   - current pure MALT UnixFS-style layout prototype over map/list semantics
 - `core/resolver`
@@ -282,9 +283,10 @@ Verification is local to the client:
 - `core/lineage`
   - auxiliary version-history metadata; pending redesign with MVCC and
     versioned ArcTable
-- `core/bucketpath` and `core/manifest`
-  - current bucket/file layout helpers; candidates to move under a dedicated
-    UnixFS or bucket layout package
+- `core/querypath`
+  - current query-path canonicalization helper for root-relative paths
+- `core/manifest`
+  - current UnixFS directory-manifest helper above the semantic layer
 
 ## Config
 
@@ -294,7 +296,6 @@ Current operator flow:
 2. create `~/.malt/malt.json`
 3. choose a local state root
 4. run `malt daemon`
-5. optionally set `client.default_bucket_id` or use `malt bucket default`
 
 Current schema:
 
@@ -310,7 +311,7 @@ Current schema:
 - `cas.timeout`
 - `cas.embedded_mock`
 - `logging`
-- `client.default_bucket_id`
+- `client`
 
 Current defaults:
 
@@ -318,6 +319,7 @@ Current defaults:
 - embedded mock CAS listen: `127.0.0.1:4318`
 - structure backend: `kzg`
 - ArcTable type: `versioned`
+- CAS mode: `embedded-mock`
 
 ## Repo Layout
 
@@ -330,15 +332,16 @@ malt/
 |-- httpapi/         # shared daemon request/response payload types
 |-- core/
 |   |-- api/          # top-level wiring via Node
-|   |-- arctable/     # bucket/namespace-scoped arcset persistence/materialization
-|   |-- bucketpath/   # current bucket path boundary helper
+|   |-- arctable/     # namespace-scoped arcset persistence/materialization
 |   |-- cas/          # CAS clients and adapters
 |   |-- codec/        # MALT CID codecs and CID utilities
 |   |-- commitment/   # primitive commitment backends
 |   |-- graph/        # current runtime metadata/composition
 |   |-- kvstore/      # KV backends
+|   |-- metrics/      # node-local evaluation counters
+|   |-- querypath/    # root-relative query path canonicalization
 |   |-- lineage/      # auxiliary version-history metadata
-|   |-- manifest/     # current directory-manifest helper
+|   |-- manifest/     # UnixFS directory-manifest helper
 |   |-- resolver/     # current read compatibility adapters
 |   |-- structure/    # list/map semantic abstractions and implementations
 |   |-- types/        # arc sets, evidence, proof-related types


### PR DESCRIPTION
## Summary

- remove stale managed-bucket/default-bucket language from README and ARCHITECTURE
- document explicit-root CLI/API behavior after the root-centric API activation
- clarify that ArcTable state is namespace-scoped implementation state and that querypath/manifest are file-layout helpers above core semantics

## Verification

- `rg -n "managed bucket|malt bucket|/api/v1|bucket/file|bucket APIs|bucket routes|bucketpath|client.default_bucket_id|default bucket|bucket head|bucket heads|bucket/namespace|Bucket is|Bucket routes" README.md ARCHITECTURE.md AGENTS.md` returns no matches
- documentation-only change; Go tests not run