### PR TITLE
feat(cas): batch write, preflight, and add staging flush

### DIFF
--- a/cmd/malt/add.go
+++ b/cmd/malt/add.go
@@ -831,6 +831,7 @@ func buildAddStagingTree(ctx context.Context, casClient addCASClient, daemon *da
 		return nil, err
 	}
 
+	batcher := asAddCASBatcher(casClient)
 	root := newDirNode()
 	var files int
 	var bytesUploaded int64
@@ -838,7 +839,7 @@ func buildAddStagingTree(ctx context.Context, casClient addCASClient, daemon *da
 	for _, item := range mounted {
 		if item.Input.Info.IsDir() {
 			if item.Input.Symlink {
-				key, dirFiles, dirBytes, err := materializeSymlinkDirectoryBoundary(ctx, daemon, casClient, item.Input.AbsPath)
+				key, dirFiles, dirBytes, err := materializeSymlinkDirectoryBoundary(ctx, daemon, batcher, item.Input.AbsPath)
 				if err != nil {
 					return nil, err
 				}
@@ -849,7 +850,7 @@ func buildAddStagingTree(ctx context.Context, casClient addCASClient, daemon *da
 				bytesUploaded += dirBytes
 				continue
 			}
-			dirFiles, dirBytes, err := stageDirectoryInput(ctx, root, casClient, daemon, item, opts.Ignore)
+			dirFiles, dirBytes, err := stageDirectoryInput(ctx, root, batcher, daemon, item, opts.Ignore)
 			if err != nil {
 				return nil, err
 			}
@@ -857,12 +858,15 @@ func buildAddStagingTree(ctx context.Context, casClient addCASClient, daemon *da
 			bytesUploaded += dirBytes
 			continue
 		}
-		fileBytes, err := stageSingleFile(ctx, root, casClient, daemon, item.Input.AbsPath, item.MountBase)
+		fileBytes, err := stageSingleFile(ctx, root, batcher, daemon, item.Input.AbsPath, item.MountBase)
 		if err != nil {
 			return nil, err
 		}
 		files++
 		bytesUploaded += fileBytes
+	}
+	if err := batcher.Flush(ctx); err != nil {
+		return nil, fmt.Errorf("flush staged CAS batch: %w", err)
 	}
 
 	return &addBuildResult{
@@ -1288,6 +1292,10 @@ func loadCurrentDirRecursive(ctx context.Context, daemon *daemonclient.Client, c
 }
 
 func materializeDirectory(ctx context.Context, daemon *daemonclient.Client, casClient addCASClient, node *addNode) (*addMaterializeResult, error) {
+	return materializeDirectoryWithBatcher(ctx, daemon, asAddCASBatcher(casClient), node)
+}
+
+func materializeDirectoryWithBatcher(ctx context.Context, daemon *daemonclient.Client, casClient *addCASBatcher, node *addNode) (*addMaterializeResult, error) {
 	if node == nil || node.Kind != "dir" {
 		return nil, fmt.Errorf("materializeDirectory requires a directory node")
 	}
@@ -1306,7 +1314,7 @@ func materializeDirectory(ctx context.Context, daemon *daemonclient.Client, casC
 			continue
 		}
 		if child.Kind == "dir" {
-			mat, err := materializeDirectory(ctx, daemon, casClient, child)
+			mat, err := materializeDirectoryWithBatcher(ctx, daemon, casClient, child)
 			if err != nil {
 				return nil, err
 			}
@@ -1338,6 +1346,9 @@ func materializeDirectory(ctx context.Context, daemon *daemonclient.Client, casC
 	payloadCID, err := casClient.Put(ctx, payloadBytes)
 	if err != nil {
 		return nil, fmt.Errorf("upload directory manifest: %w", err)
+	}
+	if err := casClient.Flush(ctx); err != nil {
+		return nil, fmt.Errorf("flush directory manifest: %w", err)
 	}
 
 	bindings := make(map[string]string, 1+len(childKeys)+len(desc))

--- a/cmd/malt/add_cas_batch.go
+++ b/cmd/malt/add_cas_batch.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dewebprotocol/malt/core/cas"
+	cid "github.com/ipfs/go-cid"
+)
+
+type addCASBatcher struct {
+	inner  addCASClient
+	blocks []cas.Block
+	seen   map[string]cid.Cid
+}
+
+func newAddCASBatcher(inner addCASClient) *addCASBatcher {
+	return &addCASBatcher{
+		inner: inner,
+		seen:  make(map[string]cid.Cid),
+	}
+}
+
+func asAddCASBatcher(client addCASClient) *addCASBatcher {
+	if batcher, ok := client.(*addCASBatcher); ok {
+		return batcher
+	}
+	return newAddCASBatcher(client)
+}
+
+func (b *addCASBatcher) Put(ctx context.Context, data []byte) (cid.Cid, error) {
+	return b.PutWithCodec(ctx, data, cid.Raw)
+}
+
+func (b *addCASBatcher) PutWithCodec(_ context.Context, data []byte, codec uint64) (cid.Cid, error) {
+	block := cas.Block{Data: data, Codec: codec}
+	blockCID, err := cas.CIDForBlock(block)
+	if err != nil {
+		return cid.Undef, err
+	}
+	if b.seen == nil {
+		b.seen = make(map[string]cid.Cid)
+	}
+	key := blockCID.String()
+	if _, ok := b.seen[key]; !ok {
+		b.seen[key] = blockCID
+		b.blocks = append(b.blocks, cas.Block{
+			Data:  append([]byte(nil), data...),
+			Codec: codec,
+		})
+	}
+	return blockCID, nil
+}
+
+func (b *addCASBatcher) Get(ctx context.Context, c cid.Cid) ([]byte, error) {
+	return b.inner.Get(ctx, c)
+}
+
+func (b *addCASBatcher) Flush(ctx context.Context) error {
+	if len(b.blocks) == 0 {
+		return nil
+	}
+	results, err := cas.PutBlocks(ctx, b.inner, b.blocks)
+	if err != nil {
+		return err
+	}
+	if len(results) != len(b.blocks) {
+		return fmt.Errorf("CAS batch flush returned %d results for %d blocks", len(results), len(b.blocks))
+	}
+	for i, result := range results {
+		want, err := cas.CIDForBlock(b.blocks[i])
+		if err != nil {
+			return err
+		}
+		if !result.CID.Equals(want) {
+			return fmt.Errorf("CAS batch flush returned CID %s for block %d, want %s", result.CID, i, want)
+		}
+	}
+	b.blocks = nil
+	b.seen = make(map[string]cid.Cid)
+	return nil
+}

--- a/cmd/malt/add_test.go
+++ b/cmd/malt/add_test.go
@@ -10,8 +10,10 @@ import (
 	daemonclient "github.com/dewebprotocol/malt/client"
 	"github.com/dewebprotocol/malt/config"
 	"github.com/dewebprotocol/malt/core/api"
+	"github.com/dewebprotocol/malt/core/cas"
 	"github.com/dewebprotocol/malt/core/cas/ipfs"
 	casmock "github.com/dewebprotocol/malt/core/cas/mock"
+	"github.com/dewebprotocol/malt/core/codec"
 	"github.com/dewebprotocol/malt/server"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -475,6 +477,104 @@ func TestAddWorkflowMaterializesSmallLargeAndEmptyDir(t *testing.T) {
 	}
 }
 
+func TestAddCASBatcherDeduplicatesBlocks(t *testing.T) {
+	ctx := context.Background()
+	recorder := newRecordingAddCAS(casmock.NewCAS(casmock.WithoutLatency()))
+	batcher := newAddCASBatcher(recorder)
+
+	first, err := batcher.Put(ctx, []byte("same"))
+	if err != nil {
+		t.Fatalf("Put first: %v", err)
+	}
+	second, err := batcher.Put(ctx, []byte("same"))
+	if err != nil {
+		t.Fatalf("Put duplicate: %v", err)
+	}
+	if !first.Equals(second) {
+		t.Fatalf("duplicate CID = %s, want %s", second, first)
+	}
+	typed, err := batcher.PutWithCodec(ctx, []byte(`{"entries":["a.txt"]}`), codec.CodecMaltManifest)
+	if err != nil {
+		t.Fatalf("PutWithCodec: %v", err)
+	}
+	if typed.Prefix().Codec != codec.CodecMaltManifest {
+		t.Fatalf("typed codec = %x, want %x", typed.Prefix().Codec, codec.CodecMaltManifest)
+	}
+	if err := batcher.Flush(ctx); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if len(recorder.batches) != 1 {
+		t.Fatalf("batch calls = %d, want 1", len(recorder.batches))
+	}
+	if len(recorder.batches[0]) != 2 {
+		t.Fatalf("batched blocks = %d, want 2", len(recorder.batches[0]))
+	}
+}
+
+func TestBuildAddStagingTreeFlushesCASBatchBeforeRootMaterialization(t *testing.T) {
+	ctx := context.Background()
+	daemon, casClient := newAddTestClients(t)
+	recorder := newRecordingAddCAS(casClient)
+
+	inputRoot := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(inputRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inputRoot, "a.txt"), []byte("duplicate"), 0o644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inputRoot, "b.txt"), []byte("duplicate"), 0o644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	large := make([]byte, addFixedChunkSize+11)
+	for i := range large {
+		large[i] = byte('a' + (i % 17))
+	}
+	if err := os.WriteFile(filepath.Join(inputRoot, "large.bin"), large, 0o644); err != nil {
+		t.Fatalf("write large: %v", err)
+	}
+
+	staged, err := buildAddStagingTree(ctx, recorder, daemon, []string{inputRoot}, addBuildOptions{})
+	if err != nil {
+		t.Fatalf("build staging: %v", err)
+	}
+	if staged.Files != 3 {
+		t.Fatalf("files = %d, want 3", staged.Files)
+	}
+	if len(recorder.batches) == 0 {
+		t.Fatal("expected staged CAS writes to flush through PutBatch")
+	}
+	firstBatchLen := len(recorder.batches[0])
+	if firstBatchLen != 1 {
+		t.Fatalf("first staged batch size = %d, want 1 deduplicated small-file payload", firstBatchLen)
+	}
+
+	mat, err := materializeDirectory(ctx, daemon, recorder, staged.Root)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	base := filepath.Base(inputRoot)
+	for _, p := range []string{base + "/a.txt", base + "/b.txt", base + "/large.bin"} {
+		if _, err := daemon.Stat(ctx, mat.Key.String(), p); err != nil {
+			t.Fatalf("stat %q: %v", p, err)
+		}
+	}
+	body, _, _, err := daemon.GetContent(ctx, mat.Key.String(), base+"/a.txt", "")
+	if err != nil {
+		t.Fatalf("get a.txt: %v", err)
+	}
+	if string(body) != "duplicate" {
+		t.Fatalf("a.txt body = %q, want duplicate", body)
+	}
+	largeBody, _, _, err := daemon.GetContent(ctx, mat.Key.String(), base+"/large.bin", "")
+	if err != nil {
+		t.Fatalf("get large.bin: %v", err)
+	}
+	if len(largeBody) != len(large) || string(largeBody[:64]) != string(large[:64]) {
+		t.Fatal("large body mismatch")
+	}
+}
+
 func TestAddInputsWithUnixFSWorkflow(t *testing.T) {
 	ctx := context.Background()
 	daemon, casClient := newAddTestClients(t)
@@ -726,6 +826,39 @@ func newAddTestClients(t *testing.T) (*daemonclient.Client, *ipfs.Client) {
 	ts := httptest.NewServer(server.New(node, "127.0.0.1:0").Handler())
 	t.Cleanup(ts.Close)
 	return daemonclient.NewWithBaseURL(ts.URL), ipfs.NewClient(casTS.URL)
+}
+
+type recordingAddCAS struct {
+	inner   addCASClient
+	batches [][]cas.Block
+}
+
+func newRecordingAddCAS(inner addCASClient) *recordingAddCAS {
+	return &recordingAddCAS{inner: inner}
+}
+
+func (r *recordingAddCAS) Put(ctx context.Context, data []byte) (cid.Cid, error) {
+	return r.inner.Put(ctx, data)
+}
+
+func (r *recordingAddCAS) PutWithCodec(ctx context.Context, data []byte, codec uint64) (cid.Cid, error) {
+	return r.inner.PutWithCodec(ctx, data, codec)
+}
+
+func (r *recordingAddCAS) Get(ctx context.Context, c cid.Cid) ([]byte, error) {
+	return r.inner.Get(ctx, c)
+}
+
+func (r *recordingAddCAS) PutBatch(ctx context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	cloned := make([]cas.Block, len(blocks))
+	for i, block := range blocks {
+		cloned[i] = cas.Block{Data: append([]byte(nil), block.Data...), Codec: block.Codec}
+	}
+	r.batches = append(r.batches, cloned)
+	if batch, ok := r.inner.(cas.BatchWriter); ok {
+		return batch.PutBatch(ctx, blocks)
+	}
+	return cas.PutBlocks(ctx, r.inner, blocks)
 }
 
 func mustAddNodeAtPath(t *testing.T, root *addNode, p string) *addNode {

--- a/core/cas/cas.go
+++ b/core/cas/cas.go
@@ -3,9 +3,32 @@ package cas
 
 import (
 	"context"
+	"fmt"
 
 	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
 )
+
+// Block is a CAS block to write. Codec 0 means cid.Raw.
+type Block struct {
+	Data  []byte
+	Codec uint64
+}
+
+// PutStatus describes how a block write was handled.
+type PutStatus string
+
+const (
+	PutStatusStored         PutStatus = "stored"
+	PutStatusAlreadyPresent PutStatus = "already_present"
+	PutStatusDuplicate      PutStatus = "duplicate"
+)
+
+// PutResult is the ordered result for a block write.
+type PutResult struct {
+	CID    cid.Cid
+	Status PutStatus
+}
 
 // Reader provides read-side access to content-addressable storage.
 type Reader interface {
@@ -27,8 +50,75 @@ type TypedWriter interface {
 	PutWithCodec(ctx context.Context, data []byte, codec uint64) (cid.Cid, error)
 }
 
+// BatchReader provides batch existence checks.
+type BatchReader interface {
+	HasBatch(ctx context.Context, cids []cid.Cid) ([]bool, error)
+}
+
+// BatchWriter provides batch block writes.
+type BatchWriter interface {
+	PutBatch(ctx context.Context, blocks []Block) ([]PutResult, error)
+}
+
 // Client provides full read/write access to content-addressable storage.
 type Client interface {
 	Reader
 	Writer
+}
+
+// NormalizeCodec returns the effective codec for a block.
+func NormalizeCodec(codec uint64) uint64 {
+	if codec == 0 {
+		return cid.Raw
+	}
+	return codec
+}
+
+// CIDForBlock computes the CID for block bytes and codec.
+func CIDForBlock(block Block) (cid.Cid, error) {
+	mhash, err := mh.Sum(block.Data, mh.SHA2_256, -1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(NormalizeCodec(block.Codec), mhash), nil
+}
+
+// PutBlocks stores blocks, using batch writes when supported.
+func PutBlocks(ctx context.Context, writer Writer, blocks []Block) ([]PutResult, error) {
+	if len(blocks) == 0 {
+		return []PutResult{}, nil
+	}
+	if batch, ok := writer.(BatchWriter); ok {
+		results, err := batch.PutBatch(ctx, blocks)
+		if err != nil {
+			return nil, err
+		}
+		if len(results) != len(blocks) {
+			return nil, fmt.Errorf("batch writer returned %d results for %d blocks", len(results), len(blocks))
+		}
+		return results, nil
+	}
+
+	results := make([]PutResult, len(blocks))
+	for i, block := range blocks {
+		codec := NormalizeCodec(block.Codec)
+		var (
+			blockCID cid.Cid
+			err      error
+		)
+		if codec == cid.Raw {
+			blockCID, err = writer.Put(ctx, block.Data)
+		} else {
+			typed, ok := writer.(TypedWriter)
+			if !ok {
+				return nil, fmt.Errorf("block %d requests codec %d but writer does not implement cas.TypedWriter", i, codec)
+			}
+			blockCID, err = typed.PutWithCodec(ctx, block.Data, codec)
+		}
+		if err != nil {
+			return nil, err
+		}
+		results[i] = PutResult{CID: blockCID, Status: PutStatusStored}
+	}
+	return results, nil
 }

--- a/core/cas/cas_test.go
+++ b/core/cas/cas_test.go
@@ -1,0 +1,107 @@
+package cas_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/cas"
+	"github.com/dewebprotocol/malt/core/codec"
+	cid "github.com/ipfs/go-cid"
+)
+
+type fallbackWriter struct {
+	raw   [][]byte
+	typed []cas.Block
+}
+
+func (w *fallbackWriter) Put(_ context.Context, data []byte) (cid.Cid, error) {
+	w.raw = append(w.raw, append([]byte(nil), data...))
+	return cas.CIDForBlock(cas.Block{Data: data})
+}
+
+func (w *fallbackWriter) PutWithCodec(_ context.Context, data []byte, codec uint64) (cid.Cid, error) {
+	w.typed = append(w.typed, cas.Block{Data: append([]byte(nil), data...), Codec: codec})
+	return cas.CIDForBlock(cas.Block{Data: data, Codec: codec})
+}
+
+type rawOnlyWriter struct{}
+
+func (rawOnlyWriter) Put(_ context.Context, data []byte) (cid.Cid, error) {
+	return cas.CIDForBlock(cas.Block{Data: data})
+}
+
+func TestCIDForBlockRaw(t *testing.T) {
+	got, err := cas.CIDForBlock(cas.Block{Data: []byte("hello")})
+	if err != nil {
+		t.Fatalf("CIDForBlock: %v", err)
+	}
+	want, err := newPayloadCID([]byte("hello"))
+	if err != nil {
+		t.Fatalf("newPayloadCID: %v", err)
+	}
+	if !got.Equals(want) {
+		t.Fatalf("raw CID = %s, want %s", got, want)
+	}
+}
+
+func TestCIDForBlockTypedCodec(t *testing.T) {
+	got, err := cas.CIDForBlock(cas.Block{Data: []byte(`{"entries":["a.txt"]}`), Codec: codec.CodecMaltManifest})
+	if err != nil {
+		t.Fatalf("CIDForBlock: %v", err)
+	}
+	if got.Prefix().Codec != codec.CodecMaltManifest {
+		t.Fatalf("codec = %x, want %x", got.Prefix().Codec, codec.CodecMaltManifest)
+	}
+}
+
+func TestPutBlocksFallbackPreservesOrder(t *testing.T) {
+	ctx := context.Background()
+	writer := &fallbackWriter{}
+	blocks := []cas.Block{
+		{Data: []byte("first")},
+		{Data: []byte("second"), Codec: codec.CodecMaltManifest},
+		{Data: []byte("third")},
+	}
+
+	results, err := cas.PutBlocks(ctx, writer, blocks)
+	if err != nil {
+		t.Fatalf("PutBlocks: %v", err)
+	}
+	if len(results) != len(blocks) {
+		t.Fatalf("results = %d, want %d", len(results), len(blocks))
+	}
+	for i, block := range blocks {
+		want, err := cas.CIDForBlock(block)
+		if err != nil {
+			t.Fatalf("CIDForBlock(%d): %v", i, err)
+		}
+		if !results[i].CID.Equals(want) {
+			t.Fatalf("result[%d] CID = %s, want %s", i, results[i].CID, want)
+		}
+		if results[i].Status != cas.PutStatusStored {
+			t.Fatalf("result[%d] status = %q, want stored", i, results[i].Status)
+		}
+	}
+	if len(writer.raw) != 2 || len(writer.typed) != 1 {
+		t.Fatalf("raw writes = %d typed writes = %d, want 2/1", len(writer.raw), len(writer.typed))
+	}
+}
+
+func TestPutBlocksNonRawWithoutTypedWriterReturnsError(t *testing.T) {
+	_, err := cas.PutBlocks(context.Background(), rawOnlyWriter{}, []cas.Block{
+		{Data: []byte("typed"), Codec: codec.CodecMaltManifest},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestPutBlocksEmptyBatch(t *testing.T) {
+	results, err := cas.PutBlocks(context.Background(), rawOnlyWriter{}, nil)
+	if err != nil {
+		t.Fatalf("PutBlocks empty: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("empty results = %d, want 0", len(results))
+	}
+}

--- a/core/cas/httpapi/types.go
+++ b/core/cas/httpapi/types.go
@@ -1,0 +1,32 @@
+package httpapi
+
+type HasBatchRequest struct {
+	CIDs []string `json:"cids"`
+}
+
+type HasBatchResult struct {
+	CID     string `json:"cid"`
+	Present bool   `json:"present"`
+}
+
+type HasBatchResponse struct {
+	Results []HasBatchResult `json:"results"`
+}
+
+type PutBatchRequest struct {
+	Blocks []PutBatchBlock `json:"blocks"`
+}
+
+type PutBatchBlock struct {
+	Codec uint64 `json:"codec,omitempty"`
+	Data  string `json:"data"`
+}
+
+type PutBatchResult struct {
+	CID    string `json:"cid"`
+	Status string `json:"status"`
+}
+
+type PutBatchResponse struct {
+	Results []PutBatchResult `json:"results"`
+}

--- a/core/cas/ipfs/ipfs.go
+++ b/core/cas/ipfs/ipfs.go
@@ -5,6 +5,7 @@ package ipfs
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dewebprotocol/malt/core/cas"
+	cashttpapi "github.com/dewebprotocol/malt/core/cas/httpapi"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -22,6 +24,12 @@ import (
 type Client struct {
 	apiURL string
 	client *http.Client
+}
+
+type uniqueBlock struct {
+	index int
+	cid   cid.Cid
+	block cas.Block
 }
 
 // Option configures an IPFS client.
@@ -156,6 +164,141 @@ func (c *Client) putWithFormat(ctx context.Context, data []byte, format string) 
 	return cID, nil
 }
 
+// PutBatch stores blocks with local deduplication and batch preflight.
+func (c *Client) PutBatch(ctx context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	if len(blocks) == 0 {
+		return []cas.PutResult{}, nil
+	}
+
+	results := make([]cas.PutResult, len(blocks))
+	unique := make([]uniqueBlock, 0, len(blocks))
+	seen := make(map[string]int, len(blocks))
+	for i, block := range blocks {
+		blockCID, err := cas.CIDForBlock(block)
+		if err != nil {
+			return nil, err
+		}
+		results[i].CID = blockCID
+		key := blockCID.String()
+		if _, ok := seen[key]; ok {
+			results[i].Status = cas.PutStatusDuplicate
+			continue
+		}
+		seen[key] = i
+		unique = append(unique, uniqueBlock{index: i, cid: blockCID, block: block})
+	}
+
+	uniqueCIDs := make([]cid.Cid, len(unique))
+	for i, item := range unique {
+		uniqueCIDs[i] = item.cid
+	}
+	present, err := c.HasBatch(ctx, uniqueCIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(present) != len(unique) {
+		return nil, fmt.Errorf("batch has returned %d results for %d blocks", len(present), len(unique))
+	}
+
+	missing := make([]uniqueBlock, 0, len(unique))
+	for i, item := range unique {
+		if present[i] {
+			results[item.index].Status = cas.PutStatusAlreadyPresent
+			continue
+		}
+		missing = append(missing, item)
+	}
+	if len(missing) == 0 {
+		return results, nil
+	}
+
+	uploaded, err := c.putBatchMissing(ctx, missing)
+	if err != nil {
+		return nil, err
+	}
+	if len(uploaded) != len(missing) {
+		return nil, fmt.Errorf("batch put returned %d results for %d blocks", len(uploaded), len(missing))
+	}
+	for i, result := range uploaded {
+		item := missing[i]
+		if !result.CID.Equals(item.cid) {
+			return nil, fmt.Errorf("batch put returned CID %s for block %d, want %s", result.CID, item.index, item.cid)
+		}
+		results[item.index] = result
+	}
+	return results, nil
+}
+
+func (c *Client) putBatchMissing(ctx context.Context, missing []uniqueBlock) ([]cas.PutResult, error) {
+	reqBody := cashttpapi.PutBatchRequest{Blocks: make([]cashttpapi.PutBatchBlock, len(missing))}
+	for i, item := range missing {
+		reqBody.Blocks[i] = cashttpapi.PutBatchBlock{
+			Codec: item.block.Codec,
+			Data:  base64.StdEncoding.EncodeToString(item.block.Data),
+		}
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal batch put request: %w", err)
+	}
+	apiURL := fmt.Sprintf("%s/api/v0/malt/block/put-batch", c.apiURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create batch put request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to put batch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if isBatchEndpointUnsupported(resp.StatusCode) {
+		io.Copy(io.Discard, resp.Body)
+		return c.putBatchMissingIndividually(ctx, missing)
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("MALT batch put returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var apiResp cashttpapi.PutBatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("decode batch put response: %w", err)
+	}
+	results := make([]cas.PutResult, len(apiResp.Results))
+	for i, item := range apiResp.Results {
+		blockCID, err := cid.Decode(item.CID)
+		if err != nil {
+			return nil, fmt.Errorf("decode batch put CID at index %d: %w", i, err)
+		}
+		results[i] = cas.PutResult{CID: blockCID, Status: cas.PutStatus(item.Status)}
+	}
+	return results, nil
+}
+
+func (c *Client) putBatchMissingIndividually(ctx context.Context, missing []uniqueBlock) ([]cas.PutResult, error) {
+	results := make([]cas.PutResult, len(missing))
+	for i, item := range missing {
+		codec := cas.NormalizeCodec(item.block.Codec)
+		var (
+			blockCID cid.Cid
+			err      error
+		)
+		if codec == cid.Raw {
+			blockCID, err = c.Put(ctx, item.block.Data)
+		} else {
+			blockCID, err = c.PutWithCodec(ctx, item.block.Data, codec)
+		}
+		if err != nil {
+			return nil, err
+		}
+		results[i] = cas.PutResult{CID: blockCID, Status: cas.PutStatusStored}
+	}
+	return results, nil
+}
+
 // Has checks if a block exists in the local IPFS node.
 func (c *Client) Has(ctx context.Context, cID cid.Cid) (bool, error) {
 	url := fmt.Sprintf("%s/api/v0/block/stat?arg=%s", c.apiURL, cID.String())
@@ -176,5 +319,75 @@ func (c *Client) Has(ctx context.Context, cID cid.Cid) (bool, error) {
 	return resp.StatusCode == http.StatusOK, nil
 }
 
+// HasBatch checks if blocks exist, falling back to individual Has when needed.
+func (c *Client) HasBatch(ctx context.Context, cids []cid.Cid) ([]bool, error) {
+	if len(cids) == 0 {
+		return []bool{}, nil
+	}
+	reqBody := cashttpapi.HasBatchRequest{CIDs: make([]string, len(cids))}
+	for i, blockCID := range cids {
+		reqBody.CIDs[i] = blockCID.String()
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal batch has request: %w", err)
+	}
+	apiURL := fmt.Sprintf("%s/api/v0/malt/block/has-batch", c.apiURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create batch has request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check batch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if isBatchEndpointUnsupported(resp.StatusCode) {
+		io.Copy(io.Discard, resp.Body)
+		return c.hasBatchIndividually(ctx, cids)
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("MALT batch has returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var apiResp cashttpapi.HasBatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("decode batch has response: %w", err)
+	}
+	if len(apiResp.Results) != len(cids) {
+		return nil, fmt.Errorf("batch has returned %d results for %d CIDs", len(apiResp.Results), len(cids))
+	}
+	results := make([]bool, len(cids))
+	for i, item := range apiResp.Results {
+		if item.CID != cids[i].String() {
+			return nil, fmt.Errorf("batch has returned CID %s at index %d, want %s", item.CID, i, cids[i])
+		}
+		results[i] = item.Present
+	}
+	return results, nil
+}
+
+func (c *Client) hasBatchIndividually(ctx context.Context, cids []cid.Cid) ([]bool, error) {
+	results := make([]bool, len(cids))
+	for i, blockCID := range cids {
+		present, err := c.Has(ctx, blockCID)
+		if err != nil {
+			return nil, err
+		}
+		results[i] = present
+	}
+	return results, nil
+}
+
+func isBatchEndpointUnsupported(status int) bool {
+	return status == http.StatusNotFound || status == http.StatusMethodNotAllowed
+}
+
 // Ensure Client implements cas.Client.
 var _ cas.Client = (*Client)(nil)
+var _ cas.BatchReader = (*Client)(nil)
+var _ cas.BatchWriter = (*Client)(nil)

--- a/core/cas/ipfs/ipfs_test.go
+++ b/core/cas/ipfs/ipfs_test.go
@@ -2,8 +2,17 @@ package ipfs
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 
+	"github.com/dewebprotocol/malt/core/cas"
+	cashttpapi "github.com/dewebprotocol/malt/core/cas/httpapi"
+	"github.com/dewebprotocol/malt/core/codec"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -69,4 +78,242 @@ func TestClientImplementsInterface(t *testing.T) {
 		Put(ctx context.Context, data []byte) (cid.Cid, error)
 		Has(ctx context.Context, c cid.Cid) (bool, error)
 	} = NewClient("http://localhost:5001")
+}
+
+func TestClientPutBatchUploadsOnlyMissingBlocks(t *testing.T) {
+	ctx := context.Background()
+	presentBlock := cas.Block{Data: []byte("present")}
+	presentCID, err := cas.CIDForBlock(presentBlock)
+	if err != nil {
+		t.Fatalf("CIDForBlock present: %v", err)
+	}
+	uploadedBlocks := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/malt/block/has-batch":
+			var req cashttpapi.HasBatchRequest
+			decodeJSON(t, r, &req)
+			resp := cashttpapi.HasBatchResponse{Results: make([]cashttpapi.HasBatchResult, len(req.CIDs))}
+			for i, raw := range req.CIDs {
+				resp.Results[i] = cashttpapi.HasBatchResult{
+					CID:     raw,
+					Present: raw == presentCID.String(),
+				}
+			}
+			encodeJSON(t, w, resp)
+		case "/api/v0/malt/block/put-batch":
+			var req cashttpapi.PutBatchRequest
+			decodeJSON(t, r, &req)
+			uploadedBlocks += len(req.Blocks)
+			resp := cashttpapi.PutBatchResponse{Results: make([]cashttpapi.PutBatchResult, len(req.Blocks))}
+			for i, block := range req.Blocks {
+				c := cidForHTTPBlock(t, block)
+				resp.Results[i] = cashttpapi.PutBatchResult{CID: c.String(), Status: string(cas.PutStatusStored)}
+			}
+			encodeJSON(t, w, resp)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL)
+	results, err := client.PutBatch(ctx, []cas.Block{
+		presentBlock,
+		{Data: []byte("missing-a")},
+		{Data: []byte("missing-a")},
+		{Data: []byte("missing-b")},
+	})
+	if err != nil {
+		t.Fatalf("PutBatch: %v", err)
+	}
+	if uploadedBlocks != 2 {
+		t.Fatalf("uploaded blocks = %d, want 2", uploadedBlocks)
+	}
+	if results[0].Status != cas.PutStatusAlreadyPresent {
+		t.Fatalf("present status = %q, want already_present", results[0].Status)
+	}
+	if results[1].Status != cas.PutStatusStored || results[3].Status != cas.PutStatusStored {
+		t.Fatalf("stored statuses = %q/%q, want stored", results[1].Status, results[3].Status)
+	}
+	if results[2].Status != cas.PutStatusDuplicate {
+		t.Fatalf("duplicate status = %q, want duplicate", results[2].Status)
+	}
+}
+
+func TestClientPutBatchFallsBackToSingleBlockPut(t *testing.T) {
+	ctx := context.Background()
+	var singlePuts int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/malt/block/has-batch", "/api/v0/malt/block/put-batch":
+			http.NotFound(w, r)
+		case "/api/v0/block/stat":
+			http.NotFound(w, r)
+		case "/api/v0/block/put":
+			singlePuts++
+			blockCID := cidForMultipartPut(t, r)
+			encodeJSON(t, w, struct {
+				Key  string `json:"Key"`
+				Size int    `json:"Size"`
+			}{Key: blockCID.String()})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL)
+	results, err := client.PutBatch(ctx, []cas.Block{{Data: []byte("a")}, {Data: []byte("b")}})
+	if err != nil {
+		t.Fatalf("PutBatch fallback: %v", err)
+	}
+	if singlePuts != 2 {
+		t.Fatalf("single puts = %d, want 2", singlePuts)
+	}
+	for i, result := range results {
+		if result.Status != cas.PutStatusStored {
+			t.Fatalf("result[%d] status = %q, want stored", i, result.Status)
+		}
+	}
+}
+
+func TestClientPutBatchUploadsDuplicatePayloadOnce(t *testing.T) {
+	ctx := context.Background()
+	uploadedBlocks := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/malt/block/has-batch":
+			var req cashttpapi.HasBatchRequest
+			decodeJSON(t, r, &req)
+			resp := cashttpapi.HasBatchResponse{Results: make([]cashttpapi.HasBatchResult, len(req.CIDs))}
+			for i, raw := range req.CIDs {
+				resp.Results[i] = cashttpapi.HasBatchResult{CID: raw}
+			}
+			encodeJSON(t, w, resp)
+		case "/api/v0/malt/block/put-batch":
+			var req cashttpapi.PutBatchRequest
+			decodeJSON(t, r, &req)
+			uploadedBlocks += len(req.Blocks)
+			resp := cashttpapi.PutBatchResponse{Results: make([]cashttpapi.PutBatchResult, len(req.Blocks))}
+			for i, block := range req.Blocks {
+				c := cidForHTTPBlock(t, block)
+				resp.Results[i] = cashttpapi.PutBatchResult{CID: c.String(), Status: string(cas.PutStatusStored)}
+			}
+			encodeJSON(t, w, resp)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL)
+	results, err := client.PutBatch(ctx, []cas.Block{
+		{Data: []byte("same")},
+		{Data: []byte("same")},
+		{Data: []byte("other")},
+	})
+	if err != nil {
+		t.Fatalf("PutBatch duplicates: %v", err)
+	}
+	if uploadedBlocks != 2 {
+		t.Fatalf("uploaded blocks = %d, want 2", uploadedBlocks)
+	}
+	if results[1].Status != cas.PutStatusDuplicate {
+		t.Fatalf("duplicate status = %q, want duplicate", results[1].Status)
+	}
+}
+
+func TestClientPutBatchPreservesTypedCodecInBatchRequest(t *testing.T) {
+	ctx := context.Background()
+	var gotCodec uint64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/malt/block/has-batch":
+			var req cashttpapi.HasBatchRequest
+			decodeJSON(t, r, &req)
+			resp := cashttpapi.HasBatchResponse{Results: make([]cashttpapi.HasBatchResult, len(req.CIDs))}
+			for i, raw := range req.CIDs {
+				resp.Results[i] = cashttpapi.HasBatchResult{CID: raw}
+			}
+			encodeJSON(t, w, resp)
+		case "/api/v0/malt/block/put-batch":
+			var req cashttpapi.PutBatchRequest
+			decodeJSON(t, r, &req)
+			gotCodec = req.Blocks[0].Codec
+			blockCID := cidForHTTPBlock(t, req.Blocks[0])
+			encodeJSON(t, w, cashttpapi.PutBatchResponse{Results: []cashttpapi.PutBatchResult{{
+				CID:    blockCID.String(),
+				Status: string(cas.PutStatusStored),
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL)
+	results, err := client.PutBatch(ctx, []cas.Block{{Data: []byte(`{"entries":["a.txt"]}`), Codec: codec.CodecMaltManifest}})
+	if err != nil {
+		t.Fatalf("PutBatch typed: %v", err)
+	}
+	if gotCodec != codec.CodecMaltManifest {
+		t.Fatalf("request codec = %x, want %x", gotCodec, codec.CodecMaltManifest)
+	}
+	if results[0].CID.Prefix().Codec != codec.CodecMaltManifest {
+		t.Fatalf("result codec = %x, want %x", results[0].CID.Prefix().Codec, codec.CodecMaltManifest)
+	}
+}
+
+func decodeJSON(t *testing.T, r *http.Request, out any) {
+	t.Helper()
+	if err := json.NewDecoder(r.Body).Decode(out); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+}
+
+func encodeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}
+
+func cidForHTTPBlock(t *testing.T, block cashttpapi.PutBatchBlock) cid.Cid {
+	t.Helper()
+	data, err := base64.StdEncoding.DecodeString(block.Data)
+	if err != nil {
+		t.Fatalf("decode block base64: %v", err)
+	}
+	c, err := cas.CIDForBlock(cas.Block{Data: data, Codec: block.Codec})
+	if err != nil {
+		t.Fatalf("CIDForBlock: %v", err)
+	}
+	return c
+}
+
+func cidForMultipartPut(t *testing.T, r *http.Request) cid.Cid {
+	t.Helper()
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		t.Fatalf("FormFile: %v", err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("read multipart: %v", err)
+	}
+	codecValue := uint64(cid.Raw)
+	if raw := r.URL.Query().Get("format"); raw != "" {
+		codecValue, err = strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			t.Fatalf("parse format: %v", err)
+		}
+	}
+	c, err := cas.CIDForBlock(cas.Block{Data: data, Codec: codecValue})
+	if err != nil {
+		t.Fatalf("CIDForBlock multipart: %v", err)
+	}
+	return c
 }

--- a/core/cas/mock/batch_test.go
+++ b/core/cas/mock/batch_test.go
@@ -1,0 +1,109 @@
+package mock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/cas"
+	"github.com/dewebprotocol/malt/core/codec"
+	cid "github.com/ipfs/go-cid"
+)
+
+func TestCASPutBatchStoresBlocks(t *testing.T) {
+	ctx := context.Background()
+	store := NewCAS(WithoutLatency())
+	blocks := []cas.Block{
+		{Data: []byte("first")},
+		{Data: []byte("second")},
+	}
+
+	results, err := store.PutBatch(ctx, blocks)
+	if err != nil {
+		t.Fatalf("PutBatch: %v", err)
+	}
+	for i, result := range results {
+		if result.Status != cas.PutStatusStored {
+			t.Fatalf("result[%d] status = %q, want stored", i, result.Status)
+		}
+		data, err := store.Get(ctx, result.CID)
+		if err != nil {
+			t.Fatalf("Get result[%d]: %v", i, err)
+		}
+		if string(data) != string(blocks[i].Data) {
+			t.Fatalf("data[%d] = %q, want %q", i, data, blocks[i].Data)
+		}
+	}
+	stats := store.SnapshotStats()
+	if stats.PutCount != 2 || stats.BytesPut != uint64(len("first")+len("second")) {
+		t.Fatalf("stats = %+v, want PutCount 2 and batch bytes", stats)
+	}
+}
+
+func TestCASPutBatchReportsAlreadyPresent(t *testing.T) {
+	ctx := context.Background()
+	store := NewCAS(WithoutLatency())
+	block := cas.Block{Data: []byte("same")}
+	if _, err := store.PutBatch(ctx, []cas.Block{block}); err != nil {
+		t.Fatalf("initial PutBatch: %v", err)
+	}
+
+	results, err := store.PutBatch(ctx, []cas.Block{block})
+	if err != nil {
+		t.Fatalf("second PutBatch: %v", err)
+	}
+	if results[0].Status != cas.PutStatusAlreadyPresent {
+		t.Fatalf("status = %q, want already_present", results[0].Status)
+	}
+}
+
+func TestCASHasBatchPreservesOrder(t *testing.T) {
+	ctx := context.Background()
+	store := NewCAS(WithoutLatency())
+	present, err := cas.CIDForBlock(cas.Block{Data: []byte("present")})
+	if err != nil {
+		t.Fatalf("CIDForBlock present: %v", err)
+	}
+	missing, err := cas.CIDForBlock(cas.Block{Data: []byte("missing")})
+	if err != nil {
+		t.Fatalf("CIDForBlock missing: %v", err)
+	}
+	if _, err := store.PutBatch(ctx, []cas.Block{{Data: []byte("present")}}); err != nil {
+		t.Fatalf("PutBatch present: %v", err)
+	}
+
+	results, err := store.HasBatch(ctx, []cid.Cid{missing, present, missing})
+	if err != nil {
+		t.Fatalf("HasBatch: %v", err)
+	}
+	want := []bool{false, true, false}
+	for i := range want {
+		if results[i] != want[i] {
+			t.Fatalf("results[%d] = %v, want %v", i, results[i], want[i])
+		}
+	}
+	stats := store.SnapshotStats()
+	if stats.HasCount != 3 {
+		t.Fatalf("HasCount = %d, want 3", stats.HasCount)
+	}
+}
+
+func TestCASPutBatchSupportsTypedCodecs(t *testing.T) {
+	ctx := context.Background()
+	store := NewCAS(WithoutLatency())
+	payload := []byte(`{"entries":["a.txt"]}`)
+
+	results, err := store.PutBatch(ctx, []cas.Block{{Data: payload, Codec: codec.CodecMaltManifest}})
+	if err != nil {
+		t.Fatalf("PutBatch typed: %v", err)
+	}
+	if results[0].CID.Prefix().Codec != codec.CodecMaltManifest {
+		t.Fatalf("codec = %x, want %x", results[0].CID.Prefix().Codec, codec.CodecMaltManifest)
+	}
+	data, err := store.Get(ctx, results[0].CID)
+	if err != nil {
+		t.Fatalf("Get typed: %v", err)
+	}
+	if string(data) != string(payload) {
+		t.Fatalf("typed data = %q, want %q", data, payload)
+	}
+}

--- a/core/cas/mock/http.go
+++ b/core/cas/mock/http.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dewebprotocol/malt/core/cas"
+	cashttpapi "github.com/dewebprotocol/malt/core/cas/httpapi"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -34,6 +36,8 @@ func (s *HTTPServer) Handler() http.Handler {
 	mux.HandleFunc("POST /api/v0/block/get", s.handleBlockGet)
 	mux.HandleFunc("POST /api/v0/block/put", s.handleBlockPut)
 	mux.HandleFunc("POST /api/v0/block/stat", s.handleBlockStat)
+	mux.HandleFunc("POST /api/v0/malt/block/has-batch", s.handleHasBatch)
+	mux.HandleFunc("POST /api/v0/malt/block/put-batch", s.handlePutBatch)
 	return mux
 }
 
@@ -113,6 +117,91 @@ func (s *HTTPServer) handleBlockPut(w http.ResponseWriter, r *http.Request) {
 	}{
 		Key:  blockCID.String(),
 		Size: len(data),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (s *HTTPServer) handleHasBatch(w http.ResponseWriter, r *http.Request) {
+	var req cashttpapi.HasBatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid json: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	cids := make([]cid.Cid, len(req.CIDs))
+	for i, raw := range req.CIDs {
+		blockCID, err := cid.Decode(raw)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("invalid cid at index %d: %v", i, err), http.StatusBadRequest)
+			return
+		}
+		cids[i] = blockCID
+	}
+
+	var (
+		present []bool
+		err     error
+	)
+	if batch, ok := s.cas.(cas.BatchReader); ok {
+		present, err = batch.HasBatch(r.Context(), cids)
+	} else {
+		present = make([]bool, len(cids))
+		for i, blockCID := range cids {
+			present[i], err = s.cas.Has(r.Context(), blockCID)
+			if err != nil {
+				break
+			}
+		}
+	}
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(present) != len(cids) {
+		http.Error(w, "batch reader returned wrong result count", http.StatusInternalServerError)
+		return
+	}
+
+	resp := cashttpapi.HasBatchResponse{Results: make([]cashttpapi.HasBatchResult, len(cids))}
+	for i, blockCID := range cids {
+		resp.Results[i] = cashttpapi.HasBatchResult{
+			CID:     blockCID.String(),
+			Present: present[i],
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (s *HTTPServer) handlePutBatch(w http.ResponseWriter, r *http.Request) {
+	var req cashttpapi.PutBatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid json: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	blocks := make([]cas.Block, len(req.Blocks))
+	for i, block := range req.Blocks {
+		data, err := base64.StdEncoding.DecodeString(block.Data)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("invalid base64 at index %d: %v", i, err), http.StatusBadRequest)
+			return
+		}
+		blocks[i] = cas.Block{Data: data, Codec: block.Codec}
+	}
+
+	results, err := cas.PutBlocks(r.Context(), s.cas, blocks)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	resp := cashttpapi.PutBatchResponse{Results: make([]cashttpapi.PutBatchResult, len(results))}
+	for i, result := range results {
+		resp.Results[i] = cashttpapi.PutBatchResult{
+			CID:    result.CID.String(),
+			Status: string(result.Status),
+		}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)

--- a/core/cas/mock/http_test.go
+++ b/core/cas/mock/http_test.go
@@ -1,13 +1,20 @@
 package mock
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/dewebprotocol/malt/core/cas"
+	cashttpapi "github.com/dewebprotocol/malt/core/cas/httpapi"
 	"github.com/dewebprotocol/malt/core/cas/ipfs"
 	"github.com/dewebprotocol/malt/core/codec"
+	cid "github.com/ipfs/go-cid"
 )
 
 func TestHTTPServerKuboCompatibleBlockAPI(t *testing.T) {
@@ -62,5 +69,121 @@ func TestHTTPServerSupportsTypedBlockPut(t *testing.T) {
 	}
 	if string(data) != string(payload) {
 		t.Fatalf("typed block data = %q", string(data))
+	}
+}
+
+func TestHTTPServerSupportsHasBatch(t *testing.T) {
+	mockCAS := NewCAS(WithoutLatency())
+	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
+	defer ts.Close()
+
+	ctx := context.Background()
+	present, err := mockCAS.Put(ctx, []byte("present"))
+	if err != nil {
+		t.Fatalf("put present: %v", err)
+	}
+	missing, err := cas.CIDForBlock(cas.Block{Data: []byte("missing")})
+	if err != nil {
+		t.Fatalf("CIDForBlock missing: %v", err)
+	}
+
+	req := cashttpapi.HasBatchRequest{CIDs: []string{missing.String(), present.String()}}
+	var resp cashttpapi.HasBatchResponse
+	postJSON(t, ts.URL+"/api/v0/malt/block/has-batch", req, &resp, http.StatusOK)
+	if len(resp.Results) != 2 {
+		t.Fatalf("results = %d, want 2", len(resp.Results))
+	}
+	if resp.Results[0].Present || !resp.Results[1].Present {
+		t.Fatalf("presence results = %+v, want false/true", resp.Results)
+	}
+}
+
+func TestHTTPServerSupportsPutBatch(t *testing.T) {
+	mockCAS := NewCAS(WithoutLatency())
+	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
+	defer ts.Close()
+
+	req := cashttpapi.PutBatchRequest{Blocks: []cashttpapi.PutBatchBlock{
+		{Data: base64.StdEncoding.EncodeToString([]byte("raw"))},
+		{Codec: codec.CodecMaltManifest, Data: base64.StdEncoding.EncodeToString([]byte(`{"entries":["a.txt"]}`))},
+	}}
+	var resp cashttpapi.PutBatchResponse
+	postJSON(t, ts.URL+"/api/v0/malt/block/put-batch", req, &resp, http.StatusOK)
+	if len(resp.Results) != 2 {
+		t.Fatalf("results = %d, want 2", len(resp.Results))
+	}
+	if resp.Results[0].Status != string(cas.PutStatusStored) || resp.Results[1].Status != string(cas.PutStatusStored) {
+		t.Fatalf("statuses = %+v, want stored/stored", resp.Results)
+	}
+	typed, err := cid.Decode(resp.Results[1].CID)
+	if err != nil {
+		t.Fatalf("decode typed CID: %v", err)
+	}
+	if typed.Prefix().Codec != codec.CodecMaltManifest {
+		t.Fatalf("codec = %x, want %x", typed.Prefix().Codec, codec.CodecMaltManifest)
+	}
+}
+
+func TestHTTPServerPutBatchRejectsInvalidBase64(t *testing.T) {
+	mockCAS := NewCAS(WithoutLatency())
+	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
+	defer ts.Close()
+
+	req := cashttpapi.PutBatchRequest{Blocks: []cashttpapi.PutBatchBlock{{Data: "not base64 %%%"}}}
+	postJSON(t, ts.URL+"/api/v0/malt/block/put-batch", req, nil, http.StatusBadRequest)
+}
+
+func TestHTTPServerPutBatchPreservesResultOrder(t *testing.T) {
+	mockCAS := NewCAS(WithoutLatency())
+	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
+	defer ts.Close()
+
+	blocks := []cas.Block{
+		{Data: []byte("first")},
+		{Data: []byte("second")},
+		{Data: []byte("first")},
+	}
+	req := cashttpapi.PutBatchRequest{Blocks: make([]cashttpapi.PutBatchBlock, len(blocks))}
+	for i, block := range blocks {
+		req.Blocks[i] = cashttpapi.PutBatchBlock{
+			Codec: block.Codec,
+			Data:  base64.StdEncoding.EncodeToString(block.Data),
+		}
+	}
+
+	var resp cashttpapi.PutBatchResponse
+	postJSON(t, ts.URL+"/api/v0/malt/block/put-batch", req, &resp, http.StatusOK)
+	if len(resp.Results) != len(blocks) {
+		t.Fatalf("results = %d, want %d", len(resp.Results), len(blocks))
+	}
+	for i, block := range blocks {
+		want, err := cas.CIDForBlock(block)
+		if err != nil {
+			t.Fatalf("CIDForBlock(%d): %v", i, err)
+		}
+		if resp.Results[i].CID != want.String() {
+			t.Fatalf("result[%d] CID = %s, want %s", i, resp.Results[i].CID, want)
+		}
+	}
+}
+
+func postJSON(t *testing.T, url string, req any, out any, wantStatus int) {
+	t.Helper()
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post json: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != wantStatus {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, wantStatus)
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
 	}
 }

--- a/core/cas/mock/mock.go
+++ b/core/cas/mock/mock.go
@@ -20,7 +20,6 @@ import (
 	"github.com/dewebprotocol/malt/core/kvstore/memory"
 	"github.com/dewebprotocol/malt/core/metrics"
 	cid "github.com/ipfs/go-cid"
-	mh "github.com/multiformats/go-multihash"
 )
 
 // Default latency values based on ProbeLab Kubo v0.39.0 e2e measurements
@@ -163,17 +162,51 @@ func (m *CAS) PutWithCodec(ctx context.Context, data []byte, codec uint64) (cid.
 	m.stats.RecordPutCall()
 	simulateLatency(m.putLatency, m.jitter)
 
-	mhash, err := mh.Sum(data, mh.SHA2_256, -1)
+	c, err := cas.CIDForBlock(cas.Block{Data: data, Codec: codec})
 	if err != nil {
 		return cid.Cid{}, err
 	}
-	c := cid.NewCidV1(codec, mhash)
 
 	if err := m.kv.Put(ctx, blockKey(c), data); err != nil {
 		return cid.Cid{}, fmt.Errorf("failed to store block: %w", err)
 	}
 	m.stats.RecordPutBytes(len(data))
 	return c, nil
+}
+
+// PutBatch stores a batch of blocks in mock storage.
+func (m *CAS) PutBatch(ctx context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	if len(blocks) == 0 {
+		return []cas.PutResult{}, nil
+	}
+	for range blocks {
+		m.stats.RecordPutCall()
+	}
+	simulateLatency(m.putLatency, m.jitter)
+
+	results := make([]cas.PutResult, len(blocks))
+	for i, block := range blocks {
+		blockCID, err := cas.CIDForBlock(block)
+		if err != nil {
+			return nil, err
+		}
+		exists, err := m.kv.Has(ctx, blockKey(blockCID))
+		if err != nil {
+			return nil, fmt.Errorf("failed to check block: %w", err)
+		}
+		status := cas.PutStatusStored
+		if exists {
+			status = cas.PutStatusAlreadyPresent
+		}
+		if !exists {
+			if err := m.kv.Put(ctx, blockKey(blockCID), block.Data); err != nil {
+				return nil, fmt.Errorf("failed to store block: %w", err)
+			}
+		}
+		m.stats.RecordPutBytes(len(block.Data))
+		results[i] = cas.PutResult{CID: blockCID, Status: status}
+	}
+	return results, nil
 }
 
 // Has checks if a block exists in mock storage.
@@ -186,6 +219,27 @@ func (m *CAS) Has(ctx context.Context, c cid.Cid) (bool, error) {
 		return false, fmt.Errorf("failed to check block: %w", err)
 	}
 	return exists, nil
+}
+
+// HasBatch checks if each block exists in mock storage.
+func (m *CAS) HasBatch(ctx context.Context, cids []cid.Cid) ([]bool, error) {
+	if len(cids) == 0 {
+		return []bool{}, nil
+	}
+	for range cids {
+		m.stats.RecordHasCall()
+	}
+	simulateLatency(m.hasLatency, m.jitter)
+
+	results := make([]bool, len(cids))
+	for i, c := range cids {
+		exists, err := m.kv.Has(ctx, blockKey(c))
+		if err != nil {
+			return nil, fmt.Errorf("failed to check block: %w", err)
+		}
+		results[i] = exists
+	}
+	return results, nil
 }
 
 // AddBlock adds a pre-existing block to mock storage without latency.
@@ -205,3 +259,5 @@ func (m *CAS) ResetStats() {
 
 // Ensure CAS implements cas.Client.
 var _ cas.Client = (*CAS)(nil)
+var _ cas.BatchReader = (*CAS)(nil)
+var _ cas.BatchWriter = (*CAS)(nil)

--- a/core/layout/malt/unixfs/layout.go
+++ b/core/layout/malt/unixfs/layout.go
@@ -417,17 +417,21 @@ func (l *Layout) commitPayload(ctx context.Context, data []byte) (cid.Cid, error
 		return l.blocks.Put(ctx, data)
 	}
 
-	chunks := make([]cid.Cid, 0, (len(data)+l.chunkSize-1)/l.chunkSize)
+	blocks := make([]cas.Block, 0, (len(data)+l.chunkSize-1)/l.chunkSize)
 	for start := 0; start < len(data); start += l.chunkSize {
 		end := start + l.chunkSize
 		if end > len(data) {
 			end = len(data)
 		}
-		chunkCID, err := l.blocks.Put(ctx, data[start:end])
-		if err != nil {
-			return cid.Undef, err
-		}
-		chunks = append(chunks, chunkCID)
+		blocks = append(blocks, cas.Block{Data: data[start:end]})
+	}
+	results, err := cas.PutBlocks(ctx, l.blocks, blocks)
+	if err != nil {
+		return cid.Undef, err
+	}
+	chunks := make([]cid.Cid, len(results))
+	for i, result := range results {
+		chunks[i] = result.CID
 	}
 	return l.lists.Commit(ctx, l.namespace, list.NewViewFromSlice(chunks))
 }

--- a/core/layout/malt/unixfs/layout_test.go
+++ b/core/layout/malt/unixfs/layout_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/dewebprotocol/malt/core/arctable/overwrite"
+	"github.com/dewebprotocol/malt/core/cas"
 	casmock "github.com/dewebprotocol/malt/core/cas/mock"
 	"github.com/dewebprotocol/malt/core/codec"
 	"github.com/dewebprotocol/malt/core/commitment/ipa"
@@ -18,6 +19,11 @@ import (
 )
 
 func newLayout(t *testing.T, chunkSize int) *unixfs.Layout {
+	t.Helper()
+	return newLayoutWithBlocks(t, chunkSize, casmock.NewCAS(casmock.WithoutLatency()))
+}
+
+func newLayoutWithBlocks(t *testing.T, chunkSize int, blocks cas.Client) *unixfs.Layout {
 	t.Helper()
 
 	kv := kvmemory.New()
@@ -43,12 +49,42 @@ func newLayout(t *testing.T, chunkSize int) *unixfs.Layout {
 		ChunkSize: chunkSize,
 		Map:       maps,
 		List:      lists,
-		Blocks:    casmock.NewCAS(casmock.WithoutLatency()),
+		Blocks:    blocks,
 	})
 	if err != nil {
 		t.Fatalf("unixfs.New failed: %v", err)
 	}
 	return layout
+}
+
+type spyBatchCAS struct {
+	inner   *casmock.CAS
+	batches [][]cas.Block
+}
+
+func newSpyBatchCAS() *spyBatchCAS {
+	return &spyBatchCAS{inner: casmock.NewCAS(casmock.WithoutLatency())}
+}
+
+func (s *spyBatchCAS) Get(ctx context.Context, c cid.Cid) ([]byte, error) {
+	return s.inner.Get(ctx, c)
+}
+
+func (s *spyBatchCAS) Has(ctx context.Context, c cid.Cid) (bool, error) {
+	return s.inner.Has(ctx, c)
+}
+
+func (s *spyBatchCAS) Put(ctx context.Context, data []byte) (cid.Cid, error) {
+	return s.inner.Put(ctx, data)
+}
+
+func (s *spyBatchCAS) PutBatch(ctx context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	cloned := make([]cas.Block, len(blocks))
+	for i, block := range blocks {
+		cloned[i] = cas.Block{Data: append([]byte(nil), block.Data...), Codec: block.Codec}
+	}
+	s.batches = append(s.batches, cloned)
+	return s.inner.PutBatch(ctx, blocks)
 }
 
 func TestAddAndReadSmallFile(t *testing.T) {
@@ -112,6 +148,46 @@ func TestAddAndReadLargeFileRange(t *testing.T) {
 	}
 	if !bytes.Equal(ranged, data[3:14]) {
 		t.Fatalf("ReadFileRange mismatch: got %q want %q", ranged, data[3:14])
+	}
+}
+
+func TestAddLargeFileUsesCASPutBatch(t *testing.T) {
+	ctx := context.Background()
+	blocks := newSpyBatchCAS()
+	layout := newLayoutWithBlocks(t, 4, blocks)
+	data := []byte("abcdefghijklmnopqrstuvwxyz")
+
+	root, err := layout.AddFile(ctx, cid.Undef, "blob.bin", data)
+	if err != nil {
+		t.Fatalf("AddFile failed: %v", err)
+	}
+	if len(blocks.batches) != 1 {
+		t.Fatalf("PutBatch calls = %d, want 1", len(blocks.batches))
+	}
+	if len(blocks.batches[0]) != 7 {
+		t.Fatalf("batched chunks = %d, want 7", len(blocks.batches[0]))
+	}
+
+	stat, err := layout.Stat(ctx, root, "blob.bin")
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	if stat.StorageKind != "list" || stat.Size != uint64(len(data)) {
+		t.Fatalf("stat = %+v, want list storage and original size", stat)
+	}
+	full, err := layout.ReadFile(ctx, root, "blob.bin")
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if !bytes.Equal(full, data) {
+		t.Fatalf("ReadFile mismatch: got %q want %q", full, data)
+	}
+	resolution, err := layout.Resolve(ctx, root, "blob.bin")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if len(resolution.Steps) != 2 {
+		t.Fatalf("resolution steps = %d, want 2", len(resolution.Steps))
 	}
 }
 


### PR DESCRIPTION
This PR adds CAS batch write and has/preflight support, preserves Kubo-compatible single-block APIs, and uses batch paths where available with fallback.

## What's included
- `cas`: `BatchReader` / `BatchWriter`, `CIDForBlock`, `NormalizeCodec`, `PutBlocks`.
- Mock CAS: native `HasBatch` / `PutBatch` with per-batch latency and per-block metrics.
- Mock HTTP: `POST /api/v0/malt/block/has-batch` and `put-batch` (Kubo `/api/v0/block/*` unchanged).
- IPFS client: local CID dedup, `HasBatch` preflight, missing-only upload, 404/405 fallback.
- UnixFS layout: large file chunks via `cas.PutBlocks`.
- `malt add`: CAS batcher for staging/materialization paths; flush before `CreateRootStructure`.

## Tests
`go test ./core/cas/...`, `go test ./core/layout/malt/unixfs`, `go test ./cmd/malt`, and `go test ./...` were run locally and passed.

Made with [Cursor](https://cursor.com)