### PR TITLE
feat: return proof header on default GET

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,10 +60,14 @@ Conceptually, gateway reads return `result + ProofList`, where the ProofList is
 the vector-commitment proof chain from root to destination. Root-centric
 gateway materialization accepts semantic mutations that have already been
 produced by a layout and returns an operational receipt without publishing a
-managed head. The HTTP gateway may return blob content with ProofList metadata in response
-headers, and may return large-file byte ranges with ProofLists covering the
-selected list entries. File routes are product surfaces around the same
-root-centric materialization namespace.
+managed head. The HTTP gateway returns default `GET /{root}/{path}` file and
+directory reads with `ProofList` metadata in `X-Malt-ProofList` response
+headers encoded as `base64url-json`. Clients can opt out of default proof
+generation with `?proof=false` or `X-Malt-Proof: omit`; default GET responses
+advertise that request-header variance with `Vary: X-Malt-Proof`. Large-file
+byte-range reads include ProofLists covering the selected list entries. File
+routes are product surfaces around the same root-centric materialization
+namespace.
 
 ### List Semantic
 
@@ -360,6 +364,18 @@ mutations accepted by the gateway.
 `ProofList` is the standard verifier-facing read artifact. It should cover map
 step proofs, terminal `@payload` proofs, list index/range proofs, and blob
 target binding proofs from the queried root to the destination.
+
+The current daemon has two HTTP proof-bearing read surfaces:
+
+- default `GET /{root}/{path}` returns content or directory JSON and places the
+  verifier-facing `ProofList` in `X-Malt-ProofList` with
+  `X-Malt-ProofList-Encoding: base64url-json`
+- `GET /{root}/{path}?format=proof` returns the existing JSON
+  `ContentProofResponse` body with embedded content bytes, range metadata, and
+  `prooflist`
+
+`HEAD /{root}/{path}` is intentionally stat-only and returns stat headers
+without generating proof metadata.
 
 ## Flattened UnixFS-Style Layout
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ semantics are owned by `list` and `map`, not by the current runtime `graph`
 object. Root-centric gateway materialization accepts semantic mutations
 produced by layouts and returns an operational receipt. Root publication,
 freshness, and multi-writer arbitration are application or deployment policy,
-not the gateway correctness interface. In the HTTP deployment, blob reads may carry
-`ProofList` in response metadata/header; large-file range reads return selected
-bytes plus the corresponding `ProofList`.
+not the gateway correctness interface. In the HTTP deployment, successful
+default blob and directory `GET /{root}/{path}` reads carry `ProofList`
+metadata in response headers; large-file range reads return selected bytes plus
+the corresponding range-covering `ProofList`.
 
 Current core semantics are:
 
@@ -95,6 +96,30 @@ Current runtime shape:
 
 The file commands are the current product layout built above MALT. They are
 not the definition of the MALT semantic layer.
+
+## HTTP Read Proof Metadata
+
+Default successful `GET /{root}/{path}` responses include verifier-facing proof
+metadata in these response headers:
+
+```text
+X-Malt-ProofList: <base64url(JSON ProofList)>
+X-Malt-ProofList-Encoding: base64url-json
+Vary: X-Malt-Proof
+```
+
+The proof header is generated for file bytes, directory JSON responses, and
+byte-range reads. For list-backed file ranges, the `ProofList` includes the
+touched list-index steps. Clients that only need content bytes can opt out of
+default proof generation with either `?proof=false` or request header
+`X-Malt-Proof: omit`; the `Vary` response header advertises the header-based
+variance to shared HTTP caches.
+
+`HEAD /{root}/{path}` remains a stat-only operation and returns `X-Malt-Kind`,
+`X-Malt-Storage-Kind`, `X-Malt-Key`, optional `X-Malt-Payload`, and optional
+`Content-Length` without generating proof headers. `GET /{root}/{path}?format=proof`
+keeps the JSON-body proof contract for clients that prefer `ContentProofResponse`
+over header metadata.
 
 ## Data Model
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -103,6 +103,22 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 
 	if stat.Kind == "dir" {
 		// Return JSON directory listing
+		if !shouldOmitDefaultProof(r) {
+			queryPath := path
+			if queryPath == "" {
+				queryPath = "@payload"
+			}
+			pl, err := s.contentProofList(r.Context(), g, root, queryPath, stat, 0, 0)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if err := writeProofListHeader(w, *pl); err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			s.node.RecordProofList(*pl)
+		}
 		writeJSON(w, http.StatusOK, stat)
 		return
 	}
@@ -127,6 +143,25 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	// Generate and write proof headers before response headers
+	if !shouldOmitDefaultProof(r) {
+		queryPath := path
+		if queryPath == "" {
+			queryPath = "@payload"
+		}
+		pl, err := s.contentProofList(r.Context(), g, root, queryPath, stat, start, endExclusive)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if err := writeProofListHeader(w, *pl); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		s.node.RecordProofList(*pl)
+	}
+
 	w.Header().Set("Accept-Ranges", "bytes")
 	if partial {
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, endExclusive-1, totalSize))
@@ -1530,4 +1565,28 @@ func nonEmpty(primary string, fallback string) string {
 		return primary
 	}
 	return fallback
+}
+
+// shouldOmitDefaultProof returns true when the request opts out of default proof
+// generation via query parameter or request header.
+func shouldOmitDefaultProof(r *http.Request) bool {
+	if r.URL.Query().Get("proof") == "false" {
+		return true
+	}
+	if r.Header.Get("X-Malt-Proof") == "omit" {
+		return true
+	}
+	return false
+}
+
+// writeProofListHeader encodes and writes the ProofList as base64url-json headers.
+func writeProofListHeader(w http.ResponseWriter, pl prooflist.ProofList) error {
+	data, err := json.Marshal(pl)
+	if err != nil {
+		return err
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+	w.Header().Set("X-Malt-ProofList", encoded)
+	w.Header().Set("X-Malt-ProofList-Encoding", "base64url-json")
+	return nil
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -119,6 +119,7 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 			}
 			s.node.RecordProofList(*pl)
 		}
+		addVaryHeader(w, "X-Malt-Proof")
 		writeJSON(w, http.StatusOK, stat)
 		return
 	}
@@ -162,6 +163,8 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 		s.node.RecordProofList(*pl)
 	}
 
+	// Advertise X-Malt-Proof as a variance header since proof generation depends on it
+	addVaryHeader(w, "X-Malt-Proof")
 	w.Header().Set("Accept-Ranges", "bytes")
 	if partial {
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, endExclusive-1, totalSize))
@@ -1589,4 +1592,17 @@ func writeProofListHeader(w http.ResponseWriter, pl prooflist.ProofList) error {
 	w.Header().Set("X-Malt-ProofList", encoded)
 	w.Header().Set("X-Malt-ProofList-Encoding", "base64url-json")
 	return nil
+}
+
+// addVaryHeader adds a Vary header value if not already present, preserving existing values.
+func addVaryHeader(w http.ResponseWriter, value string) {
+	values := w.Header().Values("Vary")
+	for _, existing := range values {
+		for _, part := range strings.Split(existing, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), value) {
+				return
+			}
+		}
+	}
+	w.Header().Add("Vary", value)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -241,8 +242,8 @@ func TestServerMetricsSnapshotAndResetEndpoints(t *testing.T) {
 	if snapshot.ArcTable.GetCount == 0 {
 		t.Fatalf("ArcTable GetCount = %d, want > 0", snapshot.ArcTable.GetCount)
 	}
-	if snapshot.Proof.ProofListCount != 2 {
-		t.Fatalf("ProofListCount = %d, want 2", snapshot.Proof.ProofListCount)
+	if snapshot.Proof.ProofListCount != 3 {
+		t.Fatalf("ProofListCount = %d, want 3", snapshot.Proof.ProofListCount)
 	}
 	if snapshot.Proof.StepCount == 0 || snapshot.Proof.TotalBytes == 0 {
 		t.Fatalf("Proof stats = %+v, want steps and byte accounting", snapshot.Proof)
@@ -1168,6 +1169,355 @@ func TestServerContentProofReadUnixFSRangeIncludesTouchedListIndexes(t *testing.
 			if step.EvidenceBackend != "list" {
 				t.Fatalf("list-index evidence backend = %q, want list", step.EvidenceBackend)
 			}
+		}
+	}
+	if len(indexes) != 2 || indexes[0] != 0 || indexes[1] != 1 {
+		t.Fatalf("list-index steps = %v, want [0 1]", indexes)
+	}
+}
+
+func TestServerDefaultGETReturnsProofHeader(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	// Create a structure with a small raw file
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"dummy": fakeCIDString("dummy")}),
+	})
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure: %v", err)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+	root := createResp.Root
+
+	// Write a small file via UnixFS
+	fileBody := []byte("hello proof header")
+	resp, err = http.Post(ts.URL+"/"+root+"/readme.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	if err != nil {
+		t.Fatalf("create unixfs file: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create unixfs file status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var writeResp httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&writeResp); err != nil {
+		t.Fatalf("decode unixfs write: %v", err)
+	}
+	resp.Body.Close()
+
+	// Default GET should include proof headers
+	resp, err = http.Get(ts.URL + "/" + writeResp.NewRoot + "/readme.txt")
+	if err != nil {
+		t.Fatalf("default GET request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("default GET status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Equal(body, fileBody) {
+		t.Fatalf("default GET body = %q, want %q", string(body), string(fileBody))
+	}
+
+	proofListHeader := resp.Header.Get("X-Malt-ProofList")
+	encodingHeader := resp.Header.Get("X-Malt-ProofList-Encoding")
+	if proofListHeader == "" {
+		t.Fatal("X-Malt-ProofList header is missing")
+	}
+	if encodingHeader != "base64url-json" {
+		t.Fatalf("X-Malt-ProofList-Encoding = %q, want %q", encodingHeader, "base64url-json")
+	}
+
+	// Decode and validate the proof list
+	proofData, err := base64.RawURLEncoding.DecodeString(proofListHeader)
+	if err != nil {
+		t.Fatalf("decode proof list header: %v", err)
+	}
+	var pl prooflist.ProofList
+	if err := json.Unmarshal(proofData, &pl); err != nil {
+		t.Fatalf("unmarshal proof list: %v", err)
+	}
+	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("proof list validation: %v", err)
+	}
+}
+
+func TestServerDefaultGETProofHeaderWithProofFalse(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"dummy": fakeCIDString("dummy")}),
+	})
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure: %v", err)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+	root := createResp.Root
+
+	fileBody := []byte("opt-out proof")
+	resp, err = http.Post(ts.URL+"/"+root+"/file.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	if err != nil {
+		t.Fatalf("create unixfs file: %v", err)
+	}
+	var writeResp httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&writeResp); err != nil {
+		t.Fatalf("decode write response: %v", err)
+	}
+	resp.Body.Close()
+
+	// GET with ?proof=false should omit proof headers
+	resp, err = http.Get(ts.URL + "/" + writeResp.NewRoot + "/file.txt?proof=false")
+	if err != nil {
+		t.Fatalf("GET with proof=false: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Equal(body, fileBody) {
+		t.Fatalf("GET body = %q, want %q", string(body), string(fileBody))
+	}
+
+	if resp.Header.Get("X-Malt-ProofList") != "" {
+		t.Fatal("X-Malt-ProofList header should be absent when proof=false")
+	}
+}
+
+func TestServerDefaultGETProofHeaderWithXMaltProofOmit(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"dummy": fakeCIDString("dummy")}),
+	})
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure: %v", err)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+	root := createResp.Root
+
+	fileBody := []byte("header opt-out proof")
+	resp, err = http.Post(ts.URL+"/"+root+"/file2.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	if err != nil {
+		t.Fatalf("create unixfs file: %v", err)
+	}
+	var writeResp httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&writeResp); err != nil {
+		t.Fatalf("decode write response: %v", err)
+	}
+	resp.Body.Close()
+
+	// GET with X-Malt-Proof: omit should omit proof headers
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/"+writeResp.NewRoot+"/file2.txt", nil)
+	req.Header.Set("X-Malt-Proof", "omit")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET with X-Malt-Proof: omit: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Equal(body, fileBody) {
+		t.Fatalf("GET body = %q, want %q", string(body), string(fileBody))
+	}
+
+	if resp.Header.Get("X-Malt-ProofList") != "" {
+		t.Fatal("X-Malt-ProofList header should be absent when X-Malt-Proof: omit")
+	}
+}
+
+func TestServerDefaultGETDirectoryProofHeader(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"dummy": fakeCIDString("dummy")}),
+	})
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure: %v", err)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+	root := createResp.Root
+
+	// Create a directory
+	resp, err = http.Post(ts.URL+"/"+root+"/docs?type=dir", "application/json", nil)
+	if err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	var dirResp httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dirResp); err != nil {
+		t.Fatalf("decode dir response: %v", err)
+	}
+	resp.Body.Close()
+
+	// Default GET on directory should include proof header
+	resp, err = http.Get(ts.URL + "/" + dirResp.NewRoot + "/docs")
+	if err != nil {
+		t.Fatalf("GET directory: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET directory status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var dirStat httpapi.PathStatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dirStat); err != nil {
+		t.Fatalf("decode directory response: %v", err)
+	}
+	if dirStat.Kind != "dir" {
+		t.Fatalf("dir stat kind = %q, want %q", dirStat.Kind, "dir")
+	}
+
+	proofListHeader := resp.Header.Get("X-Malt-ProofList")
+	if proofListHeader == "" {
+		t.Fatal("X-Malt-ProofList header is missing for directory GET")
+	}
+
+	proofData, err := base64.RawURLEncoding.DecodeString(proofListHeader)
+	if err != nil {
+		t.Fatalf("decode proof list header: %v", err)
+	}
+	var pl prooflist.ProofList
+	if err := json.Unmarshal(proofData, &pl); err != nil {
+		t.Fatalf("unmarshal proof list: %v", err)
+	}
+	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("proof list validation: %v", err)
+	}
+
+	// Directory proofs should include a terminal @payload binding step
+	var hasPayloadBinding bool
+	for _, step := range pl.Steps {
+		if step.Kind == prooflist.KindPayloadBinding && step.Path == "@payload" {
+			hasPayloadBinding = true
+			break
+		}
+	}
+	if !hasPayloadBinding {
+		t.Fatalf("directory proof missing terminal @payload binding step, steps: %+v", pl.Steps)
+	}
+}
+
+func TestServerDefaultGETRangeProofHeader(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"dummy": fakeCIDString("dummy")}),
+	})
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure: %v", err)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+	root := createResp.Root
+
+	// Create a large file that spans multiple chunks
+	fileBody := append(bytes.Repeat([]byte{'a'}, fixedListChunkSize), []byte("bcdef")...)
+	resp, err = http.Post(ts.URL+"/"+root+"/large.bin", "application/octet-stream", bytes.NewReader(fileBody))
+	if err != nil {
+		t.Fatalf("create unixfs large file: %v", err)
+	}
+	var writeResp httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&writeResp); err != nil {
+		t.Fatalf("decode write response: %v", err)
+	}
+	resp.Body.Close()
+
+	// Range GET should include proof header with list index steps
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/"+writeResp.NewRoot+"/large.bin", nil)
+	req.Header.Set("Range", "bytes=262142-262145")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("range GET request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("range GET status = %d, want %d (Partial Content)", resp.StatusCode, http.StatusPartialContent)
+	}
+
+	contentRange := resp.Header.Get("Content-Range")
+	wantContentRange := "bytes 262142-262145/262149"
+	if contentRange != wantContentRange {
+		t.Fatalf("Content-Range = %q, want %q", contentRange, wantContentRange)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "aabc" {
+		t.Fatalf("range GET body = %q, want %q", string(body), "aabc")
+	}
+
+	proofListHeader := resp.Header.Get("X-Malt-ProofList")
+	if proofListHeader == "" {
+		t.Fatal("X-Malt-ProofList header is missing for range GET")
+	}
+
+	proofData, err := base64.RawURLEncoding.DecodeString(proofListHeader)
+	if err != nil {
+		t.Fatalf("decode proof list header: %v", err)
+	}
+	var pl prooflist.ProofList
+	if err := json.Unmarshal(proofData, &pl); err != nil {
+		t.Fatalf("unmarshal proof list: %v", err)
+	}
+	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("proof list validation: %v", err)
+	}
+
+	// Range GET proof should include list index steps for the touched chunks
+	var indexes []uint64
+	for _, step := range pl.Steps {
+		if step.Kind == prooflist.KindListIndex {
+			if step.Index == nil {
+				t.Fatalf("list-index step missing index: %+v", step)
+			}
+			indexes = append(indexes, *step.Index)
 		}
 	}
 	if len(indexes) != 2 || indexes[0] != 0 || indexes[1] != 1 {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/dewebprotocol/malt/config"
@@ -1237,6 +1238,12 @@ func TestServerDefaultGETReturnsProofHeader(t *testing.T) {
 		t.Fatalf("X-Malt-ProofList-Encoding = %q, want %q", encodingHeader, "base64url-json")
 	}
 
+	// Vary header should be present
+	varyHeader := resp.Header.Get("Vary")
+	if !strings.Contains(varyHeader, "X-Malt-Proof") {
+		t.Fatalf("Vary header = %q, want to contain X-Malt-Proof", varyHeader)
+	}
+
 	// Decode and validate the proof list
 	proofData, err := base64.RawURLEncoding.DecodeString(proofListHeader)
 	if err != nil {
@@ -1301,6 +1308,12 @@ func TestServerDefaultGETProofHeaderWithProofFalse(t *testing.T) {
 	if resp.Header.Get("X-Malt-ProofList") != "" {
 		t.Fatal("X-Malt-ProofList header should be absent when proof=false")
 	}
+
+	// Vary header should still be present since response varies based on X-Malt-Proof
+	varyHeader := resp.Header.Get("Vary")
+	if !strings.Contains(varyHeader, "X-Malt-Proof") {
+		t.Fatalf("Vary header = %q, want to contain X-Malt-Proof", varyHeader)
+	}
 }
 
 func TestServerDefaultGETProofHeaderWithXMaltProofOmit(t *testing.T) {
@@ -1354,6 +1367,12 @@ func TestServerDefaultGETProofHeaderWithXMaltProofOmit(t *testing.T) {
 
 	if resp.Header.Get("X-Malt-ProofList") != "" {
 		t.Fatal("X-Malt-ProofList header should be absent when X-Malt-Proof: omit")
+	}
+
+	// Vary header should still be present since response varies based on X-Malt-Proof
+	varyHeader := resp.Header.Get("Vary")
+	if !strings.Contains(varyHeader, "X-Malt-Proof") {
+		t.Fatalf("Vary header = %q, want to contain X-Malt-Proof", varyHeader)
 	}
 }
 
@@ -1410,6 +1429,12 @@ func TestServerDefaultGETDirectoryProofHeader(t *testing.T) {
 	proofListHeader := resp.Header.Get("X-Malt-ProofList")
 	if proofListHeader == "" {
 		t.Fatal("X-Malt-ProofList header is missing for directory GET")
+	}
+
+	// Vary header should be present
+	varyHeader := resp.Header.Get("Vary")
+	if !strings.Contains(varyHeader, "X-Malt-Proof") {
+		t.Fatalf("Vary header = %q, want to contain X-Malt-Proof", varyHeader)
 	}
 
 	proofData, err := base64.RawURLEncoding.DecodeString(proofListHeader)
@@ -1498,6 +1523,12 @@ func TestServerDefaultGETRangeProofHeader(t *testing.T) {
 		t.Fatal("X-Malt-ProofList header is missing for range GET")
 	}
 
+	// Vary header should be present
+	varyHeader := resp.Header.Get("Vary")
+	if !strings.Contains(varyHeader, "X-Malt-Proof") {
+		t.Fatalf("Vary header = %q, want to contain X-Malt-Proof", varyHeader)
+	}
+
 	proofData, err := base64.RawURLEncoding.DecodeString(proofListHeader)
 	if err != nil {
 		t.Fatalf("decode proof list header: %v", err)
@@ -1522,6 +1553,57 @@ func TestServerDefaultGETRangeProofHeader(t *testing.T) {
 	}
 	if len(indexes) != 2 || indexes[0] != 0 || indexes[1] != 1 {
 		t.Fatalf("list-index steps = %v, want [0 1]", indexes)
+	}
+}
+
+func TestServerHEADDoesNotReturnProofHeaders(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"dummy": fakeCIDString("dummy")}),
+	})
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure: %v", err)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+	root := createResp.Root
+
+	fileBody := []byte("head test file")
+	resp, err = http.Post(ts.URL+"/"+root+"/head.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	if err != nil {
+		t.Fatalf("create unixfs file: %v", err)
+	}
+	var writeResp httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&writeResp); err != nil {
+		t.Fatalf("decode write response: %v", err)
+	}
+	resp.Body.Close()
+
+	// HEAD request should not return proof headers
+	req, _ := http.NewRequest(http.MethodHead, ts.URL+"/"+writeResp.NewRoot+"/head.txt", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("HEAD request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("HEAD status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	if resp.Header.Get("X-Malt-ProofList") != "" {
+		t.Fatal("X-Malt-ProofList header should be absent for HEAD request")
+	}
+	if resp.Header.Get("X-Malt-ProofList-Encoding") != "" {
+		t.Fatal("X-Malt-ProofList-Encoding header should be absent for HEAD request")
 	}
 }
 


### PR DESCRIPTION
Adds default GET ProofList response headers with query/header opt-out. Keeps format=proof JSON behavior compatible.

## Summary
- Default successful GET reads now generate verifier-facing ProofList metadata returned in response headers
- Response headers: `X-Malt-ProofList` (base64url-json encoded) and `X-Malt-ProofList-Encoding`
- Opt-out controls: `?proof=false` query parameter or `X-Malt-Proof: omit` request header
- Existing `?format=proof` behavior unchanged (returns JSON body with `prooflist`)
- HEAD requests remain stat-only with no proof headers

## Test plan
- [x] Default GET small file returns proof headers and validates shape
- [x] Default GET directory/MALT map object returns proof headers with terminal @payload binding
- [x] Default GET with ?proof=false omits proof headers
- [x] Default GET with X-Malt-Proof: omit omits proof headers  
- [x] Range GET for large/list-backed file returns proof headers with list index steps
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)