### PR TITLE
fix(cas): route malt add through batch staging

### DIFF
--- a/cmd/malt/add.go
+++ b/cmd/malt/add.go
@@ -172,13 +172,6 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	workingRoot := strings.TrimSpace(addRootFlag)
 	if opts.Target == addTargetMALT {
 		daemon = mustDaemonClient()
-		if workingRoot == "" {
-			rootResp, err := daemon.CreatePayloadRoot(ctx, nil)
-			if err != nil {
-				return daemonCommandError(err)
-			}
-			workingRoot = rootResp.Root
-		}
 	}
 
 	result, err := addInputsWithUnixFS(ctx, daemon, casClient, args, workingRoot, opts)
@@ -294,79 +287,39 @@ func normalizeAddToken(raw string) string {
 }
 
 func addInputsWithMALTFlatUnixFS(ctx context.Context, daemon *daemonclient.Client, casClient addCASClient, rawInputs []string, root string, opts addBuildOptions) (*addUnixFSResult, error) {
-	if daemon == nil {
-		return nil, fmt.Errorf("malt target requires daemon client")
-	}
-	inputs, err := collectAddInputs(rawInputs)
-	if err != nil {
-		return nil, err
-	}
-	mounted, err := mountAddInputs(inputs, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &addUnixFSResult{}
-	lastRoot := root
-	for _, item := range mounted {
-		if item.Input.Info.IsDir() {
-			files, bytesUploaded, newRoot, err := addDirectoryWithUnixFS(ctx, daemon, item, lastRoot, opts.Ignore)
-			if err != nil {
-				return nil, err
-			}
-			result.Files += files
-			result.Bytes += bytesUploaded
-			lastRoot = newRoot
-			continue
-		}
-		bytesUploaded, newRoot, err := addFileWithUnixFS(ctx, daemon, item.Input.AbsPath, item.MountBase, lastRoot)
-		if err != nil {
-			return nil, err
-		}
-		result.Files++
-		result.Bytes += bytesUploaded
-		lastRoot = newRoot
-	}
-	result.NewRoot = lastRoot
-	return result, nil
+	return addInputsWithMALTStagedUnixFS(ctx, daemon, casClient, rawInputs, root, opts)
 }
 
 func addInputsWithMALTHierarchicalUnixFS(ctx context.Context, daemon *daemonclient.Client, casClient addCASClient, rawInputs []string, root string, opts addBuildOptions) (*addUnixFSResult, error) {
+	return addInputsWithMALTStagedUnixFS(ctx, daemon, casClient, rawInputs, root, opts)
+}
+
+func addInputsWithMALTStagedUnixFS(ctx context.Context, daemon *daemonclient.Client, casClient addCASClient, rawInputs []string, root string, opts addBuildOptions) (*addUnixFSResult, error) {
 	if daemon == nil {
 		return nil, fmt.Errorf("malt target requires daemon client")
 	}
-	inputs, err := collectAddInputs(rawInputs)
-	if err != nil {
-		return nil, err
-	}
-	mounted, err := mountAddInputs(inputs, opts)
+	staged, err := buildAddStagingTree(ctx, casClient, daemon, rawInputs, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	result := &addUnixFSResult{}
-	lastRoot := root
-	for _, item := range mounted {
-		if item.Input.Info.IsDir() {
-			files, bytesUploaded, newRoot, err := addDirectoryWithUnixFS(ctx, daemon, item, lastRoot, opts.Ignore)
-			if err != nil {
-				return nil, err
-			}
-			result.Files += files
-			result.Bytes += bytesUploaded
-			lastRoot = newRoot
-			continue
-		}
-		bytesUploaded, newRoot, err := addFileWithUnixFS(ctx, daemon, item.Input.AbsPath, item.MountBase, lastRoot)
+	rootNode := staged.Root
+	if strings.TrimSpace(root) != "" {
+		existing, err := loadExistingCurrentTree(ctx, daemon, casClient, root)
 		if err != nil {
 			return nil, err
 		}
-		result.Files++
-		result.Bytes += bytesUploaded
-		lastRoot = newRoot
+		rootNode = mergeAddNodes(existing, staged.Root)
 	}
-	result.NewRoot = lastRoot
-	return result, nil
+	mat, err := materializeDirectory(ctx, daemon, casClient, rootNode)
+	if err != nil {
+		return nil, err
+	}
+	return &addUnixFSResult{
+		Files:   staged.Files,
+		Bytes:   staged.Bytes,
+		NewRoot: mat.Key.String(),
+	}, nil
 }
 
 func addInputsWithMerkleDAGUnixFS(ctx context.Context, casClient addCASClient, rawInputs []string, opts addBuildOptions) (*addUnixFSResult, error) {
@@ -1063,36 +1016,42 @@ func stageSingleFile(ctx context.Context, root *addNode, casClient addCASClient,
 }
 
 func uploadAsList(ctx context.Context, casClient addCASClient, daemon *daemonclient.Client, localPath string) (cid.Cid, error) {
-	data, err := os.ReadFile(localPath)
+	chunks, err := uploadFlatChunks(ctx, casClient, localPath)
 	if err != nil {
-		return cid.Undef, fmt.Errorf("read %s: %w", localPath, err)
+		return cid.Undef, err
 	}
-
-	// Use the daemon's UnixFS API to add the file. This creates a proper
-	// list structure (typed MALT list CID) for chunked content that the
-	// stat handler can recognize as StorageKind "list".
+	if batcher, ok := casClient.(*addCASBatcher); ok {
+		if err := batcher.Flush(ctx); err != nil {
+			return cid.Undef, fmt.Errorf("flush chunks for %s: %w", localPath, err)
+		}
+	}
 	tempRootResp, err := daemon.CreatePayloadRoot(ctx, nil)
 	if err != nil {
 		return cid.Undef, err
 	}
-
-	writeResp, err := daemon.AddUnixFSFile(ctx, tempRootResp.Root, "f", data)
+	entries := make([]httpapi.SemanticMutationEntry, len(chunks))
+	for i, chunk := range chunks {
+		index := uint64(i)
+		entries[i] = httpapi.SemanticMutationEntry{
+			Index:      &index,
+			Target:     chunk.String(),
+			TargetKind: "cas",
+		}
+	}
+	resp, err := daemon.ApplyRootSemanticMutation(ctx, tempRootResp.Root, &httpapi.SemanticMutationRequest{
+		Puts: []httpapi.SemanticMutationPut{{
+			Kind:    "list",
+			Entries: entries,
+		}},
+	})
 	if err != nil {
 		return cid.Undef, err
 	}
-
-	// Extract the file's payload CID (list CID for large files,
-	// raw CID for small). This is what gets stored as the child arc.
-	statResp, err := daemon.Stat(ctx, writeResp.NewRoot, "f")
+	listRoot, err := cid.Decode(resp.NewRoot)
 	if err != nil {
-		return cid.Undef, err
+		return cid.Undef, fmt.Errorf("decode list root CID: %w", err)
 	}
-
-	payloadCID, err := cid.Decode(statResp.Payload)
-	if err != nil {
-		return cid.Undef, fmt.Errorf("decode payload CID: %w", err)
-	}
-	return payloadCID, nil
+	return listRoot, nil
 }
 
 func ensureDirNode(root *addNode, p string) *addNode {

--- a/cmd/malt/add_test.go
+++ b/cmd/malt/add_test.go
@@ -544,9 +544,16 @@ func TestBuildAddStagingTreeFlushesCASBatchBeforeRootMaterialization(t *testing.
 	if len(recorder.batches) == 0 {
 		t.Fatal("expected staged CAS writes to flush through PutBatch")
 	}
-	firstBatchLen := len(recorder.batches[0])
-	if firstBatchLen != 1 {
-		t.Fatalf("first staged batch size = %d, want 1 deduplicated small-file payload", firstBatchLen)
+	payloadCopies := 0
+	for _, batch := range recorder.batches {
+		for _, block := range batch {
+			if string(block.Data) == "duplicate" {
+				payloadCopies++
+			}
+		}
+	}
+	if payloadCopies != 1 {
+		t.Fatalf("deduplicated small-file payload copies = %d, want 1", payloadCopies)
 	}
 
 	mat, err := materializeDirectory(ctx, daemon, recorder, staged.Root)
@@ -571,6 +578,124 @@ func TestBuildAddStagingTreeFlushesCASBatchBeforeRootMaterialization(t *testing.
 		t.Fatalf("get large.bin: %v", err)
 	}
 	if len(largeBody) != len(large) || string(largeBody[:64]) != string(large[:64]) {
+		t.Fatal("large body mismatch")
+	}
+}
+
+func TestAddInputsWithUnixFSUsesCASPutBatch(t *testing.T) {
+	ctx := context.Background()
+	daemon, casClient := newAddTestClients(t)
+	recorder := newRecordingAddCAS(casClient)
+
+	inputRoot := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(inputRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inputRoot, "a.txt"), []byte("hello batch"), 0o644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+
+	result, err := addInputsWithUnixFS(ctx, daemon, recorder, []string{inputRoot}, "", addBuildOptions{})
+	if err != nil {
+		t.Fatalf("add with unixfs: %v", err)
+	}
+	if result.NewRoot == "" {
+		t.Fatal("new root should not be empty")
+	}
+	if len(recorder.batches) == 0 {
+		t.Fatal("expected normal MALT add path to call PutBatch")
+	}
+	body, _, _, err := daemon.GetContent(ctx, result.NewRoot, filepath.Base(inputRoot)+"/a.txt", "")
+	if err != nil {
+		t.Fatalf("get a.txt: %v", err)
+	}
+	if string(body) != "hello batch" {
+		t.Fatalf("body = %q, want hello batch", body)
+	}
+}
+
+func TestAddInputsWithUnixFSDeduplicatesDuplicateSmallPayloads(t *testing.T) {
+	ctx := context.Background()
+	daemon, casClient := newAddTestClients(t)
+	recorder := newRecordingAddCAS(casClient)
+
+	inputRoot := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(inputRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	payload := []byte("same payload")
+	if err := os.WriteFile(filepath.Join(inputRoot, "a.txt"), payload, 0o644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inputRoot, "b.txt"), payload, 0o644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+
+	result, err := addInputsWithUnixFS(ctx, daemon, recorder, []string{inputRoot}, "", addBuildOptions{})
+	if err != nil {
+		t.Fatalf("add with unixfs: %v", err)
+	}
+	payloadCopies := 0
+	for _, batch := range recorder.batches {
+		for _, block := range batch {
+			if string(block.Data) == string(payload) {
+				payloadCopies++
+			}
+		}
+	}
+	if payloadCopies != 1 {
+		t.Fatalf("duplicate payload copies uploaded = %d, want 1", payloadCopies)
+	}
+
+	base := filepath.Base(inputRoot)
+	for _, name := range []string{"a.txt", "b.txt"} {
+		body, _, _, err := daemon.GetContent(ctx, result.NewRoot, base+"/"+name, "")
+		if err != nil {
+			t.Fatalf("get %s: %v", name, err)
+		}
+		if string(body) != string(payload) {
+			t.Fatalf("%s body = %q, want %q", name, body, payload)
+		}
+	}
+}
+
+func TestAddInputsWithUnixFSLargeFileThroughStaging(t *testing.T) {
+	ctx := context.Background()
+	daemon, casClient := newAddTestClients(t)
+	recorder := newRecordingAddCAS(casClient)
+
+	inputRoot := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(inputRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	large := make([]byte, addFixedChunkSize+31)
+	for i := range large {
+		large[i] = byte('a' + (i % 19))
+	}
+	if err := os.WriteFile(filepath.Join(inputRoot, "large.bin"), large, 0o644); err != nil {
+		t.Fatalf("write large: %v", err)
+	}
+
+	result, err := addInputsWithUnixFS(ctx, daemon, recorder, []string{inputRoot}, "", addBuildOptions{})
+	if err != nil {
+		t.Fatalf("add with unixfs: %v", err)
+	}
+	base := filepath.Base(inputRoot)
+	stat, err := daemon.Stat(ctx, result.NewRoot, base+"/large.bin")
+	if err != nil {
+		t.Fatalf("stat large: %v", err)
+	}
+	if stat.Kind != "file" || stat.StorageKind != "list" {
+		t.Fatalf("unexpected large stat: %+v", stat)
+	}
+	if stat.Size == nil || *stat.Size != int64(len(large)) {
+		t.Fatalf("large size = %v, want %d", stat.Size, len(large))
+	}
+	body, _, _, err := daemon.GetContent(ctx, result.NewRoot, base+"/large.bin", "")
+	if err != nil {
+		t.Fatalf("get large: %v", err)
+	}
+	if len(body) != len(large) || string(body[:64]) != string(large[:64]) {
 		t.Fatal("large body mismatch")
 	}
 }

--- a/core/cas/ipfs/ipfs.go
+++ b/core/cas/ipfs/ipfs.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -19,6 +20,8 @@ import (
 	cashttpapi "github.com/dewebprotocol/malt/core/cas/httpapi"
 	cid "github.com/ipfs/go-cid"
 )
+
+var errBatchEndpointUnsupported = errors.New("MALT batch endpoint unsupported")
 
 // Client implements cas.Client using a local IPFS daemon API.
 type Client struct {
@@ -192,7 +195,17 @@ func (c *Client) PutBatch(ctx context.Context, blocks []cas.Block) ([]cas.PutRes
 	for i, item := range unique {
 		uniqueCIDs[i] = item.cid
 	}
-	present, err := c.HasBatch(ctx, uniqueCIDs)
+	present, err := c.hasBatchForPut(ctx, uniqueCIDs)
+	if errors.Is(err, errBatchEndpointUnsupported) {
+		uploaded, err := c.putBatchMissingIndividually(ctx, unique)
+		if err != nil {
+			return nil, err
+		}
+		for i, result := range uploaded {
+			results[unique[i].index] = result
+		}
+		return results, nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -225,6 +238,57 @@ func (c *Client) PutBatch(ctx context.Context, blocks []cas.Block) ([]cas.PutRes
 			return nil, fmt.Errorf("batch put returned CID %s for block %d, want %s", result.CID, item.index, item.cid)
 		}
 		results[item.index] = result
+	}
+	return results, nil
+}
+
+func (c *Client) hasBatchForPut(ctx context.Context, cids []cid.Cid) ([]bool, error) {
+	if len(cids) == 0 {
+		return []bool{}, nil
+	}
+	reqBody := cashttpapi.HasBatchRequest{CIDs: make([]string, len(cids))}
+	for i, blockCID := range cids {
+		reqBody.CIDs[i] = blockCID.String()
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal batch has request: %w", err)
+	}
+	apiURL := fmt.Sprintf("%s/api/v0/malt/block/has-batch", c.apiURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create batch has request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check batch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if isBatchEndpointUnsupported(resp.StatusCode) {
+		io.Copy(io.Discard, resp.Body)
+		return nil, errBatchEndpointUnsupported
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("MALT batch has returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var apiResp cashttpapi.HasBatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("decode batch has response: %w", err)
+	}
+	if len(apiResp.Results) != len(cids) {
+		return nil, fmt.Errorf("batch has returned %d results for %d CIDs", len(apiResp.Results), len(cids))
+	}
+	results := make([]bool, len(cids))
+	for i, item := range apiResp.Results {
+		if item.CID != cids[i].String() {
+			return nil, fmt.Errorf("batch has returned CID %s at index %d, want %s", item.CID, i, cids[i])
+		}
+		results[i] = item.Present
 	}
 	return results, nil
 }

--- a/core/cas/ipfs/ipfs_test.go
+++ b/core/cas/ipfs/ipfs_test.go
@@ -144,12 +144,14 @@ func TestClientPutBatchUploadsOnlyMissingBlocks(t *testing.T) {
 func TestClientPutBatchFallsBackToSingleBlockPut(t *testing.T) {
 	ctx := context.Background()
 	var singlePuts int
+	var statCalls int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v0/malt/block/has-batch", "/api/v0/malt/block/put-batch":
 			http.NotFound(w, r)
 		case "/api/v0/block/stat":
-			http.NotFound(w, r)
+			statCalls++
+			t.Fatalf("PutBatch fallback must not call block/stat")
 		case "/api/v0/block/put":
 			singlePuts++
 			blockCID := cidForMultipartPut(t, r)
@@ -171,10 +173,98 @@ func TestClientPutBatchFallsBackToSingleBlockPut(t *testing.T) {
 	if singlePuts != 2 {
 		t.Fatalf("single puts = %d, want 2", singlePuts)
 	}
+	if statCalls != 0 {
+		t.Fatalf("stat calls = %d, want 0", statCalls)
+	}
 	for i, result := range results {
 		if result.Status != cas.PutStatusStored {
 			t.Fatalf("result[%d] status = %q, want stored", i, result.Status)
 		}
+	}
+}
+
+func TestClientPutBatchUnsupportedFallbackDeduplicates(t *testing.T) {
+	ctx := context.Background()
+	var singlePuts int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/malt/block/has-batch", "/api/v0/malt/block/put-batch":
+			http.NotFound(w, r)
+		case "/api/v0/block/stat":
+			t.Fatalf("PutBatch fallback must not call block/stat")
+		case "/api/v0/block/put":
+			singlePuts++
+			blockCID := cidForMultipartPut(t, r)
+			encodeJSON(t, w, struct {
+				Key  string `json:"Key"`
+				Size int    `json:"Size"`
+			}{Key: blockCID.String()})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL)
+	results, err := client.PutBatch(ctx, []cas.Block{
+		{Data: []byte("same")},
+		{Data: []byte("same")},
+		{Data: []byte("other")},
+	})
+	if err != nil {
+		t.Fatalf("PutBatch fallback duplicates: %v", err)
+	}
+	if singlePuts != 2 {
+		t.Fatalf("single puts = %d, want 2", singlePuts)
+	}
+	if results[0].Status != cas.PutStatusStored || results[2].Status != cas.PutStatusStored {
+		t.Fatalf("stored statuses = %q/%q, want stored", results[0].Status, results[2].Status)
+	}
+	if results[1].Status != cas.PutStatusDuplicate {
+		t.Fatalf("duplicate status = %q, want duplicate", results[1].Status)
+	}
+}
+
+func TestClientPutBatchUnsupportedFallbackPreservesTypedCodec(t *testing.T) {
+	ctx := context.Background()
+	var gotFormat string
+	var gotMHType string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/malt/block/has-batch", "/api/v0/malt/block/put-batch":
+			http.NotFound(w, r)
+		case "/api/v0/block/stat":
+			t.Fatalf("PutBatch fallback must not call block/stat")
+		case "/api/v0/block/put":
+			gotFormat = r.URL.Query().Get("format")
+			gotMHType = r.URL.Query().Get("mhtype")
+			blockCID := cidForMultipartPut(t, r)
+			encodeJSON(t, w, struct {
+				Key  string `json:"Key"`
+				Size int    `json:"Size"`
+			}{Key: blockCID.String()})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL)
+	results, err := client.PutBatch(ctx, []cas.Block{{
+		Data:  []byte(`{"entries":["a.txt"]}`),
+		Codec: codec.CodecMaltManifest,
+	}})
+	if err != nil {
+		t.Fatalf("PutBatch typed fallback: %v", err)
+	}
+	if gotFormat != strconv.FormatUint(codec.CodecMaltManifest, 10) {
+		t.Fatalf("format = %q, want %d", gotFormat, codec.CodecMaltManifest)
+	}
+	if gotMHType != "sha2-256" {
+		t.Fatalf("mhtype = %q, want sha2-256", gotMHType)
+	}
+	if results[0].CID.Prefix().Codec != codec.CodecMaltManifest {
+		t.Fatalf("result codec = %x, want %x", results[0].CID.Prefix().Codec, codec.CodecMaltManifest)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Route the default MALT UnixFS add paths through the client-side staging/materialization flow so normal `malt add` uses the CAS batcher and client-side dedup.
- Stage large files by client-side chunking, flushing queued CAS blocks, then materializing the list root through daemon semantic mutation only after chunks are uploaded.
- Make `ipfs.Client.PutBatch` skip per-block `/api/v0/block/stat` preflight when private MALT batch endpoints are unsupported; fallback now goes directly to deduplicated single-block puts.

## Test Plan
- `go test ./core/cas/ipfs -count=1`
- `go test ./cmd/malt -count=1`
- `go test ./core/cas/... && go test ./core/layout/malt/unixfs && go test ./cmd/malt`
- `go test ./...`

All commands passed locally.

Made with [Cursor](https://cursor.com)