### PR TITLE
refactor: clean daemon read API

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -370,11 +370,8 @@ The current daemon has two HTTP proof-bearing read surfaces:
 - default `GET /{root}/{path}` returns content or directory JSON and places the
   verifier-facing `ProofList` in `X-Malt-ProofList` with
   `X-Malt-ProofList-Encoding: base64url-json`
-- `GET /{root}/{path}?format=resolve` returns `target` plus `prooflist` by
+- `GET /resolve/{root}/{path}` returns `target` plus `prooflist` by
   default. Clients can opt out with `?proof=false` or `X-Malt-Proof: omit`
-- `GET /{root}/{path}?format=proof` returns the existing JSON
-  `ContentProofResponse` body with embedded content bytes, range metadata, and
-  `prooflist`
 
 `HEAD /{root}/{path}` is intentionally stat-only and returns stat headers
 without generating proof metadata.

--- a/README.md
+++ b/README.md
@@ -118,11 +118,12 @@ variance to shared HTTP caches.
 
 `HEAD /{root}/{path}` remains a stat-only operation and returns `X-Malt-Kind`,
 `X-Malt-Storage-Kind`, `X-Malt-Key`, optional `X-Malt-Payload`, and optional
-`Content-Length` without generating proof headers. `GET /{root}/{path}?format=proof`
-keeps the JSON-body proof contract for clients that prefer `ContentProofResponse`
-over header metadata. `GET /{root}/{path}?format=resolve` returns a JSON
-`ResolveResponse` with `target` and, by default, `prooflist`; clients can opt out
-with `?proof=false` or `X-Malt-Proof: omit`.
+`Content-Length` without generating proof headers.
+
+Path resolution is a separate prefixed API: `GET /resolve/{root}/{path}` returns
+a JSON `ResolveResponse` with `target` and, by default, `prooflist`; clients can
+opt out with `?proof=false` or `X-Malt-Proof: omit`. The content route no longer
+uses `format=resolve` or `format=proof` query modes.
 
 ## Data Model
 

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dewebprotocol/malt/config"
+	"github.com/dewebprotocol/malt/core/types/prooflist"
 	"github.com/dewebprotocol/malt/httpapi"
 )
 
@@ -101,9 +103,8 @@ func (c *Client) ResolveWithProof(ctx context.Context, root, rawPath string, inc
 	if err != nil {
 		return nil, err
 	}
-	u.Path = path.Join(u.Path, "/"+url.PathEscape(root)+"/"+rawPath)
+	u.Path = path.Join(u.Path, "/resolve/"+url.PathEscape(root)+"/"+rawPath)
 	q := u.Query()
-	q.Set("format", "resolve")
 	if !includeProof {
 		q.Set("proof", "false")
 	}
@@ -139,42 +140,22 @@ func (c *Client) ResolveWithProof(ctx context.Context, root, rawPath string, inc
 	return &out, nil
 }
 
-// ProofList resolves a path and returns a verifier-facing ProofList.
-func (c *Client) ProofList(ctx context.Context, root, rawPath string) (*httpapi.ResolveResponse, error) {
-	u, err := url.Parse(c.baseURL)
+// ProofListFromHeaders decodes the verifier-facing ProofList returned by GET
+// content responses in X-Malt-ProofList.
+func ProofListFromHeaders(headers http.Header) (*prooflist.ProofList, error) {
+	raw := headers.Get("X-Malt-ProofList")
+	if raw == "" {
+		return nil, fmt.Errorf("missing X-Malt-ProofList header")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(raw)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode X-Malt-ProofList: %w", err)
 	}
-	u.Path = path.Join(u.Path, "/"+url.PathEscape(root)+"/"+rawPath)
-	q := u.Query()
-	q.Set("format", "resolve")
-	u.RawQuery = q.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, err
+	var pl prooflist.ProofList
+	if err := json.Unmarshal(payload, &pl); err != nil {
+		return nil, fmt.Errorf("decode X-Malt-ProofList JSON: %w", err)
 	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		var apiErr httpapi.ErrorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&apiErr); err == nil && apiErr.Error != "" {
-			return nil, &Error{StatusCode: resp.StatusCode, Message: apiErr.Error}
-		}
-		payload, _ := io.ReadAll(resp.Body)
-		return nil, &Error{StatusCode: resp.StatusCode, Message: strings.TrimSpace(string(payload))}
-	}
-
-	var out httpapi.ResolveResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return nil, err
-	}
-	return &out, nil
+	return &pl, nil
 }
 
 // Stat returns the locked stat contract for a path under a root CID.
@@ -265,47 +246,6 @@ func (c *Client) GetContent(ctx context.Context, root, rawPath, rangeHeader stri
 		return nil, status, headers, err
 	}
 	return data, status, headers, nil
-}
-
-// ContentProof reads content with a content-range and ProofList for a root CID path.
-func (c *Client) ContentProof(ctx context.Context, root, rawPath, rangeHeader string) (*httpapi.ContentProofResponse, error) {
-	u, err := url.Parse(c.baseURL)
-	if err != nil {
-		return nil, err
-	}
-	u.Path = path.Join(u.Path, fmt.Sprintf("/%s/%s", url.PathEscape(root), rawPath))
-	q := u.Query()
-	q.Set("format", "proof")
-	u.RawQuery = q.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	if rangeHeader != "" {
-		req.Header.Set("Range", rangeHeader)
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		var apiErr httpapi.ErrorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&apiErr); err == nil && apiErr.Error != "" {
-			return nil, &Error{StatusCode: resp.StatusCode, Message: apiErr.Error}
-		}
-		payload, _ := io.ReadAll(resp.Body)
-		return nil, &Error{StatusCode: resp.StatusCode, Message: strings.TrimSpace(string(payload))}
-	}
-
-	var out httpapi.ContentProofResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return nil, err
-	}
-	return &out, nil
 }
 
 // ApplyRootSemanticMutation materializes a semantic mutation under an explicit root.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -115,7 +115,7 @@ func TestClientProofListReads(t *testing.T) {
 		t.Fatalf("create root structure: %v", err)
 	}
 
-	rootProof, err := client.ProofList(ctx, createResp.Root, "name")
+	rootProof, err := client.ResolveRoot(ctx, createResp.Root, "name")
 	if err != nil {
 		t.Fatalf("ProofList: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestClientProofListReads(t *testing.T) {
 		t.Fatalf("create root structure: %v", err)
 	}
 
-	rootProof, err = client.ProofList(ctx, rootCreateResp.Root, "")
+	rootProof, err = client.ResolveRoot(ctx, rootCreateResp.Root, "")
 	if err != nil {
 		t.Fatalf("ProofList: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestClientProofListPreservesRootPath(t *testing.T) {
 		t.Fatalf("create root structure: %v", err)
 	}
 
-	proof, err := client.ProofList(ctx, createResp.Root, "name")
+	proof, err := client.ResolveRoot(ctx, createResp.Root, "name")
 	if err != nil {
 		t.Fatalf("ProofList: %v", err)
 	}
@@ -534,7 +534,7 @@ func TestClientResolveRootReturnsProofListSteps(t *testing.T) {
 	}
 }
 
-func TestClientContentProofReadReturnsContentRangeAndProofList(t *testing.T) {
+func TestClientContentRangeReadReturnsProofListHeader(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := api.NewNode(api.WithConfig(cfg))
 	if err != nil {
@@ -560,23 +560,24 @@ func TestClientContentProofReadReturnsContentRangeAndProofList(t *testing.T) {
 		t.Fatalf("add unixfs file: %v", err)
 	}
 
-	resp, err := client.ContentProof(ctx, writeResp.NewRoot, "f.txt", "bytes=1-3")
+	content, status, headers, err := client.GetContent(ctx, writeResp.NewRoot, "f.txt", "bytes=1-3")
 	if err != nil {
-		t.Fatalf("ContentProof: %v", err)
+		t.Fatalf("GetContent: %v", err)
 	}
-	if string(resp.Content) != "bcd" {
-		t.Fatalf("content = %q, want bcd", resp.Content)
+	if string(content) != "bcd" {
+		t.Fatalf("content = %q, want bcd", content)
 	}
-	if resp.Range.StatusCode != http.StatusPartialContent || resp.Range.ContentRange != "bytes 1-3/6" {
-		t.Fatalf("range metadata = %+v, want status 206 content-range bytes 1-3/6", resp.Range)
+	if status != http.StatusPartialContent || headers.Get("Content-Range") != "bytes 1-3/6" {
+		t.Fatalf("range metadata = status %d content-range %q, want status 206 content-range bytes 1-3/6", status, headers.Get("Content-Range"))
 	}
-	if resp.Range.Start != 1 || resp.Range.EndExclusive != 4 || resp.Range.ContentLength != 3 || resp.Range.TotalSize != 6 {
-		t.Fatalf("unexpected byte range metadata: %+v", resp.Range)
+	proof, err := ProofListFromHeaders(headers)
+	if err != nil {
+		t.Fatalf("prooflist header: %v", err)
 	}
-	if err := resp.ProofList.ValidateShape(prooflist.RequireSteps()); err != nil {
+	if err := proof.ValidateShape(prooflist.RequireSteps()); err != nil {
 		t.Fatalf("prooflist shape: %v", err)
 	}
-	last := resp.ProofList.Steps[len(resp.ProofList.Steps)-1]
+	last := proof.Steps[len(proof.Steps)-1]
 	if last.Kind != prooflist.KindPayloadBinding || last.Path != "@payload" {
 		t.Fatalf("last proof step = %q/%q, want payload binding @payload", last.Kind, last.Path)
 	}

--- a/httpapi/types.go
+++ b/httpapi/types.go
@@ -97,30 +97,6 @@ type PathStatResponse struct {
 	Entries     []string `json:"entries,omitempty"` // directory entries when available
 }
 
-// ContentRange describes the HTTP-equivalent byte range metadata for a
-// proof-bearing JSON content read.
-type ContentRange struct {
-	Start         int64  `json:"start"`
-	EndExclusive  int64  `json:"end_exclusive"`
-	ContentLength int64  `json:"content_length"`
-	TotalSize     int64  `json:"total_size"`
-	Partial       bool   `json:"partial"`
-	StatusCode    int    `json:"status_code"`
-	AcceptRanges  string `json:"accept_ranges"`
-	ContentRange  string `json:"content_range,omitempty"`
-}
-
-// ContentProofResponse returns content bytes with range metadata and the
-// verifier-facing ProofList for the same read.
-type ContentProofResponse struct {
-	Path        string              `json:"path,omitempty"`
-	StorageKind string              `json:"storage_kind"`
-	Key         string              `json:"key"`
-	Content     []byte              `json:"content"`
-	Range       ContentRange        `json:"range"`
-	ProofList   prooflist.ProofList `json:"prooflist"`
-}
-
 // UnixFSWriteResponse returns the result of a UnixFS layout mutation.
 type UnixFSWriteResponse struct {
 	Path     string `json:"path"`

--- a/internal/eval/readbench/runner.go
+++ b/internal/eval/readbench/runner.go
@@ -33,8 +33,8 @@ var generatedFixtureCounter atomic.Uint64
 type OperationKind string
 
 const (
-	OperationProofListPath OperationKind = "prooflist_path"
-	OperationContentRange  OperationKind = "content_range"
+	OperationResolvePath  OperationKind = "resolve_path"
+	OperationContentRange OperationKind = "content_range"
 )
 
 // FixtureConfig controls the deterministic fixture fixture.
@@ -156,7 +156,7 @@ func (r *Runner) RunJSONL(ctx context.Context, cfg RunConfig, w io.Writer) error
 	}
 
 	ops := []operation{
-		{kind: OperationProofListPath, path: fixture.SmallPath},
+		{kind: OperationResolvePath, path: fixture.SmallPath},
 		{kind: OperationContentRange, path: fixture.LargePath, rangeHeader: normalized.RangeHeader},
 	}
 
@@ -187,22 +187,25 @@ func (r *Runner) measureOperation(ctx context.Context, iteration int, fixture st
 		stepCount    int
 	)
 	switch op.kind {
-	case OperationProofListPath:
-		resp, err := r.client.ProofList(ctx, r.root, op.path)
+	case OperationResolvePath:
+		resp, err := r.client.ResolveRoot(ctx, r.root, op.path)
 		if err != nil {
-			return nil, fmt.Errorf("prooflist read %q: %w", op.path, err)
+			return nil, fmt.Errorf("resolve path %q: %w", op.path, err)
 		}
 		target = resp.Target
 		stepCount = len(resp.ProofList.Steps)
 	case OperationContentRange:
-		resp, err := r.client.ContentProof(ctx, r.root, op.path, op.rangeHeader)
+		content, _, headers, err := r.client.GetContent(ctx, r.root, op.path, op.rangeHeader)
 		if err != nil {
 			return nil, fmt.Errorf("content range read %q: %w", op.path, err)
 		}
-		count := len(resp.Content)
+		pl, err := daemonclient.ProofListFromHeaders(headers)
+		if err != nil {
+			return nil, fmt.Errorf("content range prooflist %q: %w", op.path, err)
+		}
+		count := len(content)
 		contentBytes = &count
-		target = resp.Key
-		stepCount = len(resp.ProofList.Steps)
+		stepCount = len(pl.Steps)
 	default:
 		return nil, fmt.Errorf("unsupported operation kind %q", op.kind)
 	}

--- a/internal/eval/readbench/runner_test.go
+++ b/internal/eval/readbench/runner_test.go
@@ -158,7 +158,7 @@ func TestPrepareFixtureGeneratesUniqueFixtureNameWhenOmitted(t *testing.T) {
 	}
 }
 
-func TestRunJSONLMeasuresProofListAndContentRange(t *testing.T) {
+func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 	ctx := context.Background()
 	baseURL, mockCAS := newTestDaemonWithCAS(t)
 	runner := NewRunner(baseURL)
@@ -186,8 +186,8 @@ func TestRunJSONLMeasuresProofListAndContentRange(t *testing.T) {
 	}
 
 	proofRead := got[0]
-	if proofRead.OperationKind != OperationProofListPath {
-		t.Fatalf("first operation = %q, want %q", proofRead.OperationKind, OperationProofListPath)
+	if proofRead.OperationKind != OperationResolvePath {
+		t.Fatalf("first operation = %q, want %q", proofRead.OperationKind, OperationResolvePath)
 	}
 	if proofRead.FixtureName != "readbench-run" || proofRead.Path != "dir00/dir01/small.txt" {
 		t.Fatalf("proof read target = fixture %q path %q", proofRead.FixtureName, proofRead.Path)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -47,6 +47,20 @@ func (s *Server) handleMetricsReset(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, &httpapi.MetricsResponse{Snapshot: s.node.MetricsSnapshot()})
 }
 
+func (s *Server) handleResolve(w http.ResponseWriter, r *http.Request) {
+	g, err := s.getOrCreateGraph(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	root, err := decodeCID(r.PathValue("root"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid root CID: "+err.Error())
+		return
+	}
+	s.serveResolve(w, r, g, root, r.PathValue("path"))
+}
+
 func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 	g, err := s.getOrCreateGraph(r.Context())
 	if err != nil {
@@ -60,18 +74,8 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 	}
 	path := r.PathValue("path")
 
-	// Format negotiation
-	if r.URL.Query().Get("format") == "resolve" {
-		s.serveResolve(w, r, g, root, path)
-		return
-	}
-	if r.URL.Query().Get("format") == "proof" {
-		// Empty path means root-level proof — resolve @payload instead
-		queryPath := path
-		if queryPath == "" {
-			queryPath = "@payload"
-		}
-		s.serveContentProof(w, r, g, root, queryPath)
+	if _, ok := r.URL.Query()["format"]; ok {
+		writeError(w, http.StatusBadRequest, "format query is not supported; use /resolve/{root}/{path} for path resolution or GET /{root}/{path} for content reads")
 		return
 	}
 
@@ -202,62 +206,6 @@ func (s *Server) serveResolve(w http.ResponseWriter, r *http.Request, g *graph.G
 		s.node.RecordProofList(*pl)
 	}
 	writeJSON(w, http.StatusOK, resp)
-}
-
-func (s *Server) serveContentProof(w http.ResponseWriter, r *http.Request, g *graph.Graph, root cid.Cid, queryPath string) {
-	stat, err := s.pathStat(r.Context(), g, root, queryPath)
-	if err != nil {
-		status := http.StatusInternalServerError
-		if errors.Is(err, errPathNotFound) || errors.Is(err, resolver.ErrResolutionFailed) {
-			status = http.StatusNotFound
-		}
-		writeError(w, status, err.Error())
-		return
-	}
-	if stat.Kind != "file" {
-		writeError(w, httpapi.StatusContentIsDirectory, "content proof is only valid for file targets")
-		return
-	}
-	key, err := decodeCID(stat.Key)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	totalSize := int64(0)
-	if stat.Size != nil {
-		totalSize = *stat.Size
-	}
-
-	start, endExclusive, partial, err := parseRangeHeader(r.Header.Get("Range"), totalSize)
-	if err != nil {
-		writeError(w, httpapi.StatusRangeNotSatisfiable, err.Error())
-		return
-	}
-	payload, err := s.readContentPayload(r.Context(), g, stat, key, start, endExclusive)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	pl, err := s.contentProofList(r.Context(), g, root, queryPath, stat, start, endExclusive)
-	if err != nil {
-		status := http.StatusInternalServerError
-		if errors.Is(err, errPathNotFound) || errors.Is(err, resolver.ErrResolutionFailed) || errors.Is(err, unixfs.ErrNotFound) {
-			status = http.StatusNotFound
-		}
-		writeError(w, status, err.Error())
-		return
-	}
-
-	w.Header().Set("Accept-Ranges", "bytes")
-	s.node.RecordProofList(*pl)
-	writeJSON(w, http.StatusOK, &httpapi.ContentProofResponse{
-		Path:        queryPath,
-		StorageKind: stat.StorageKind,
-		Key:         stat.Key,
-		Content:     payload,
-		Range:       contentRangeMetadata(start, endExclusive, totalSize, partial),
-		ProofList:   *pl,
-	})
 }
 
 func (s *Server) handleStat(w http.ResponseWriter, r *http.Request) {
@@ -1144,25 +1092,6 @@ func (s *Server) listIndexStepsForRange(ctx context.Context, g *graph.Graph, lis
 		})
 	}
 	return steps, nil
-}
-
-func contentRangeMetadata(start, endExclusive, totalSize int64, partial bool) httpapi.ContentRange {
-	statusCode := http.StatusOK
-	contentRange := ""
-	if partial {
-		statusCode = http.StatusPartialContent
-		contentRange = fmt.Sprintf("bytes %d-%d/%d", start, endExclusive-1, totalSize)
-	}
-	return httpapi.ContentRange{
-		Start:         start,
-		EndExclusive:  endExclusive,
-		ContentLength: endExclusive - start,
-		TotalSize:     totalSize,
-		Partial:       partial,
-		StatusCode:    statusCode,
-		AcceptRanges:  "bytes",
-		ContentRange:  contentRange,
-	}
 }
 
 func parseRangeHeader(raw string, size int64) (start int64, endExclusive int64, partial bool, err error) {

--- a/server/server.go
+++ b/server/server.go
@@ -87,7 +87,12 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// Write - specific pattern first
 	mux.HandleFunc("POST /{root}/_mutate", s.handleSemanticMutation)
 
+	// Resolve - explicit proof-producing path resolution.
+	mux.HandleFunc("GET /resolve/{root}", s.handleResolve)
+	mux.HandleFunc("GET /resolve/{root}/{path...}", s.handleResolve)
+
 	// Core read/write (/{root}/{path...} format)
+	mux.HandleFunc("GET /{root}", s.handleContent)
 	mux.HandleFunc("GET /{root}/{path...}", s.handleContent)
 	mux.HandleFunc("POST /{root}/{path...}", s.handleWrite)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -23,6 +23,26 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
+func requireProofListHeader(t *testing.T, resp *http.Response) prooflist.ProofList {
+	t.Helper()
+	proofListHeader := resp.Header.Get("X-Malt-ProofList")
+	if proofListHeader == "" {
+		t.Fatal("X-Malt-ProofList header is missing")
+	}
+	if got := resp.Header.Get("X-Malt-ProofList-Encoding"); got != "base64url-json" {
+		t.Fatalf("X-Malt-ProofList-Encoding = %q, want %q", got, "base64url-json")
+	}
+	proofData, err := base64.RawURLEncoding.DecodeString(proofListHeader)
+	if err != nil {
+		t.Fatalf("decode proof list header: %v", err)
+	}
+	var pl prooflist.ProofList
+	if err := json.Unmarshal(proofData, &pl); err != nil {
+		t.Fatalf("unmarshal proof list: %v", err)
+	}
+	return pl
+}
+
 func TestServerHealthAndRootLifecycle(t *testing.T) {
 	node := newTestNode(t)
 
@@ -235,7 +255,7 @@ func TestServerMetricsSnapshotAndResetEndpoints(t *testing.T) {
 		t.Fatalf("content status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
-	resp, err = http.Get(ts.URL + "/" + root + "/file.txt?format=proof")
+	resp, err = http.Get(ts.URL + "/" + root + "/file.txt")
 	if err != nil {
 		t.Fatalf("prooflist request failed: %v", err)
 	}
@@ -244,7 +264,7 @@ func TestServerMetricsSnapshotAndResetEndpoints(t *testing.T) {
 		t.Fatalf("prooflist status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
-	resp, err = http.Get(ts.URL + "/" + root + "/file.txt?format=proof")
+	resp, err = http.Get(ts.URL + "/" + root + "/file.txt")
 	if err != nil {
 		t.Fatalf("content proof request failed: %v", err)
 	}
@@ -378,8 +398,8 @@ func TestServerRootCreateResolveAndVerify(t *testing.T) {
 		t.Fatalf("resolved target = %q, want %q", got, target)
 	}
 
-	// Verify using the proof endpoint
-	proofResp, err := http.Get(ts.URL + "/" + createResp.Root + "/name?format=proof")
+	// Verify the proof header returned by the default read endpoint.
+	proofResp, err := http.Get(ts.URL + "/" + createResp.Root + "/name")
 	if err != nil {
 		t.Fatalf("proof request failed: %v", err)
 	}
@@ -389,16 +409,18 @@ func TestServerRootCreateResolveAndVerify(t *testing.T) {
 		t.Fatalf("proof status = %d, want %d", proofResp.StatusCode, http.StatusOK)
 	}
 
-	var contentProof httpapi.ContentProofResponse
-	if err := json.NewDecoder(proofResp.Body).Decode(&contentProof); err != nil {
-		t.Fatalf("decode proof response: %v", err)
+	_, _ = io.Copy(io.Discard, proofResp.Body)
+	contentProof := requireProofListHeader(t, proofResp)
+	proofTarget, err := contentProof.LastStepTarget()
+	if err != nil {
+		t.Fatalf("proof target: %v", err)
 	}
-	if contentProof.Key != target {
-		t.Fatalf("proof target = %q, want %q", contentProof.Key, target)
+	if proofTarget.String() != target {
+		t.Fatalf("proof target = %q, want %q", proofTarget.String(), target)
 	}
 }
 
-func TestServerResolveFormatReturnsProofListByDefault(t *testing.T) {
+func TestServerResolvePrefixReturnsProofListByDefault(t *testing.T) {
 	node := newTestNode(t)
 	mockCAS, ok := node.CAS().(*casmock.CAS)
 	if !ok {
@@ -431,7 +453,7 @@ func TestServerResolveFormatReturnsProofListByDefault(t *testing.T) {
 		t.Fatalf("decode create root: %v", err)
 	}
 
-	resp, err = http.Get(ts.URL + "/" + createResp.Root + "/name?format=resolve")
+	resp, err = http.Get(ts.URL + "/resolve/" + createResp.Root + "/name")
 	if err != nil {
 		t.Fatalf("resolve request: %v", err)
 	}
@@ -456,7 +478,7 @@ func TestServerResolveFormatReturnsProofListByDefault(t *testing.T) {
 		t.Fatalf("resolve Vary header = %q, want to contain X-Malt-Proof", vary)
 	}
 
-	resp, err = http.Get(ts.URL + "/" + createResp.Root + "/name?format=resolve&proof=false")
+	resp, err = http.Get(ts.URL + "/resolve/" + createResp.Root + "/name?proof=false")
 	if err != nil {
 		t.Fatalf("resolve proof=false request: %v", err)
 	}
@@ -475,7 +497,7 @@ func TestServerResolveFormatReturnsProofListByDefault(t *testing.T) {
 		t.Fatalf("prooflist should be absent when proof=false: %#v", noProof["prooflist"])
 	}
 
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/"+createResp.Root+"/name?format=resolve", nil)
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/resolve/"+createResp.Root+"/name", nil)
 	if err != nil {
 		t.Fatalf("build resolve omit request: %v", err)
 	}
@@ -494,6 +516,52 @@ func TestServerResolveFormatReturnsProofListByDefault(t *testing.T) {
 	}
 	if _, ok := noProof["prooflist"]; ok {
 		t.Fatalf("prooflist should be absent when X-Malt-Proof: omit: %#v", noProof["prooflist"])
+	}
+}
+
+func TestServerContentRouteRejectsLegacyFormatModes(t *testing.T) {
+	node := newTestNode(t)
+	mockCAS, ok := node.CAS().(*casmock.CAS)
+	if !ok {
+		t.Fatal("expected mock CAS")
+	}
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	targetCID, err := mockCAS.Put(t.Context(), []byte("legacy format target"))
+	if err != nil {
+		t.Fatalf("put target: %v", err)
+	}
+	createBody, err := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"name": targetCID.String()}),
+	})
+	if err != nil {
+		t.Fatalf("marshal create request: %v", err)
+	}
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create root status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create root: %v", err)
+	}
+
+	for _, format := range []string{"resolve", "proof"} {
+		resp, err := http.Get(ts.URL + "/" + createResp.Root + "/name?format=" + format)
+		if err != nil {
+			t.Fatalf("format=%s request: %v", format, err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("format=%s status = %d, want %d", format, resp.StatusCode, http.StatusBadRequest)
+		}
 	}
 }
 
@@ -530,7 +598,7 @@ func TestServerVerifyAcceptsProofList(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	resp, err = http.Get(ts.URL + "/" + createResp.Root + "/name?format=resolve")
+	resp, err = http.Get(ts.URL + "/resolve/" + createResp.Root + "/name")
 	if err != nil {
 		t.Fatalf("resolve request: %v", err)
 	}
@@ -611,22 +679,24 @@ func TestServerProofListReadEndpoints(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	resp, err = http.Get(ts.URL + "/" + createResp.Root + "/name?format=proof")
+	resp, err = http.Get(ts.URL + "/" + createResp.Root + "/name")
 	if err != nil {
 		t.Fatalf("prooflist request failed: %v", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("prooflist status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
-	var proofResp httpapi.ContentProofResponse
-	if err := json.NewDecoder(resp.Body).Decode(&proofResp); err != nil {
-		t.Fatalf("decode prooflist response: %v", err)
-	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	proofResp := requireProofListHeader(t, resp)
 	resp.Body.Close()
-	if proofResp.Key != target {
-		t.Fatalf("prooflist target = %q, want %q", proofResp.Key, target)
+	proofTarget, err := proofResp.LastStepTarget()
+	if err != nil {
+		t.Fatalf("prooflist target: %v", err)
 	}
-	if len(proofResp.ProofList.Steps) == 0 {
+	if proofTarget.String() != target {
+		t.Fatalf("prooflist target = %q, want %q", proofTarget.String(), target)
+	}
+	if len(proofResp.Steps) == 0 {
 		t.Fatal("expected non-empty prooflist")
 	}
 
@@ -657,26 +727,28 @@ func TestServerProofListReadEndpoints(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	resp, err = http.Get(ts.URL + "/" + rootCreateResp.Root + "/?format=proof")
+	resp, err = http.Get(ts.URL + "/" + rootCreateResp.Root)
 	if err != nil {
 		t.Fatalf("root prooflist request failed: %v", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("root prooflist status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
-	var rootProofResp httpapi.ContentProofResponse
-	if err := json.NewDecoder(resp.Body).Decode(&rootProofResp); err != nil {
-		t.Fatalf("decode root prooflist response: %v", err)
-	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	rootProofResp := requireProofListHeader(t, resp)
 	resp.Body.Close()
-	if rootProofResp.Key != rootPayload {
-		t.Fatalf("root prooflist target = %q, want %q", rootProofResp.Key, rootPayload)
+	rootProofTarget, err := rootProofResp.LastStepTarget()
+	if err != nil {
+		t.Fatalf("root prooflist target: %v", err)
 	}
-	if len(rootProofResp.ProofList.Steps) != 1 {
-		t.Fatalf("root prooflist steps = %d, want 1", len(rootProofResp.ProofList.Steps))
+	if rootProofTarget.String() != rootPayload {
+		t.Fatalf("root prooflist target = %q, want %q", rootProofTarget.String(), rootPayload)
 	}
-	if rootProofResp.ProofList.Steps[0].Kind != prooflist.KindPayloadBinding {
-		t.Fatalf("root prooflist step kind = %q, want %q", rootProofResp.ProofList.Steps[0].Kind, prooflist.KindPayloadBinding)
+	if len(rootProofResp.Steps) != 1 {
+		t.Fatalf("root prooflist steps = %d, want 1", len(rootProofResp.Steps))
+	}
+	if rootProofResp.Steps[0].Kind != prooflist.KindPayloadBinding {
+		t.Fatalf("root prooflist step kind = %q, want %q", rootProofResp.Steps[0].Kind, prooflist.KindPayloadBinding)
 	}
 }
 
@@ -1008,19 +1080,17 @@ func TestServerUnixFSWritesPublishGatewayReadableRoot(t *testing.T) {
 		t.Fatalf("root @payload from arctable = %s, err %v; want defined", payload, err)
 	}
 
-	resp, err = http.Get(ts.URL + "/" + writeResp.NewRoot + "/docs/readme.txt?format=proof")
+	resp, err = http.Get(ts.URL + "/" + writeResp.NewRoot + "/docs/readme.txt")
 	if err != nil {
 		t.Fatalf("prooflist request failed: %v", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("prooflist status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
-	var contentProofResp httpapi.ContentProofResponse
-	if err := json.NewDecoder(resp.Body).Decode(&contentProofResp); err != nil {
-		t.Fatalf("decode prooflist response: %v", err)
-	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	contentProofResp := requireProofListHeader(t, resp)
 	resp.Body.Close()
-	if contentProofResp.Key == "" || len(contentProofResp.ProofList.Steps) == 0 {
+	if len(contentProofResp.Steps) == 0 {
 		t.Fatalf("unexpected prooflist response: %+v", contentProofResp)
 	}
 
@@ -1212,7 +1282,7 @@ func TestServerStatAndContentContracts(t *testing.T) {
 	}
 }
 
-func TestServerContentProofReadSmallUnixFSFileIncludesPayloadProof(t *testing.T) {
+func TestServerDefaultGETSmallUnixFSFileIncludesPayloadProof(t *testing.T) {
 	node := newTestNode(t)
 
 	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
@@ -1259,7 +1329,7 @@ func TestServerContentProofReadSmallUnixFSFileIncludesPayloadProof(t *testing.T)
 		t.Fatalf("raw content status/body = %d %q, want %d %q", resp.StatusCode, rawBody, http.StatusOK, fileBody)
 	}
 
-	resp, err = http.Get(ts.URL + "/" + writeResp.NewRoot + "/docs/readme.txt?format=proof")
+	resp, err = http.Get(ts.URL + "/" + writeResp.NewRoot + "/docs/readme.txt")
 	if err != nil {
 		t.Fatalf("content proof request: %v", err)
 	}
@@ -1268,40 +1338,35 @@ func TestServerContentProofReadSmallUnixFSFileIncludesPayloadProof(t *testing.T)
 		t.Fatalf("content proof status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
-	var proofResp httpapi.ContentProofResponse
-	if err := json.NewDecoder(resp.Body).Decode(&proofResp); err != nil {
-		t.Fatalf("decode content proof response: %v", err)
+	proofBody, _ := io.ReadAll(resp.Body)
+	if !bytes.Equal(proofBody, fileBody) {
+		t.Fatalf("content = %q, want %q", proofBody, fileBody)
 	}
-	if !bytes.Equal(proofResp.Content, fileBody) {
-		t.Fatalf("content = %q, want %q", proofResp.Content, fileBody)
+	if resp.Header.Get("Accept-Ranges") != "bytes" {
+		t.Fatalf("Accept-Ranges = %q, want bytes", resp.Header.Get("Accept-Ranges"))
 	}
-	if proofResp.Range.StatusCode != http.StatusOK || proofResp.Range.ContentLength != int64(len(fileBody)) || proofResp.Range.TotalSize != int64(len(fileBody)) {
-		t.Fatalf("unexpected range metadata: %+v", proofResp.Range)
+	proofResp := requireProofListHeader(t, resp)
+	if proofResp.Query != "docs/readme.txt" {
+		t.Fatalf("proof query = %q, want docs/readme.txt", proofResp.Query)
 	}
-	if proofResp.Range.Partial || proofResp.Range.ContentRange != "" || proofResp.Range.AcceptRanges != "bytes" {
-		t.Fatalf("unexpected full-read range metadata: %+v", proofResp.Range)
-	}
-	if proofResp.ProofList.Query != "docs/readme.txt" {
-		t.Fatalf("proof query = %q, want docs/readme.txt", proofResp.ProofList.Query)
-	}
-	if err := proofResp.ProofList.ValidateShape(prooflist.RequireSteps()); err != nil {
+	if err := proofResp.ValidateShape(prooflist.RequireSteps()); err != nil {
 		t.Fatalf("prooflist shape: %v", err)
 	}
-	if len(proofResp.ProofList.Steps) == 0 {
+	if len(proofResp.Steps) == 0 {
 		t.Fatal("expected prooflist steps")
 	}
-	last := proofResp.ProofList.Steps[len(proofResp.ProofList.Steps)-1]
+	last := proofResp.Steps[len(proofResp.Steps)-1]
 	if last.Kind != prooflist.KindPayloadBinding || last.Path != "@payload" {
 		t.Fatalf("last proof step = %q/%q, want payload binding @payload", last.Kind, last.Path)
 	}
-	for i, step := range proofResp.ProofList.Steps {
+	for i, step := range proofResp.Steps {
 		if step.Kind == prooflist.KindListIndex {
 			t.Fatalf("small raw file included list-index step at %d: %+v", i, step)
 		}
 	}
 }
 
-func TestServerContentProofReadUnixFSRangeIncludesTouchedListIndexes(t *testing.T) {
+func TestServerDefaultGETRangeIncludesTouchedListIndexes(t *testing.T) {
 	node := newTestNode(t)
 
 	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
@@ -1338,37 +1403,32 @@ func TestServerContentProofReadUnixFSRangeIncludesTouchedListIndexes(t *testing.
 	}
 	resp.Body.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/"+writeResp.NewRoot+"/large.bin?format=proof", nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/"+writeResp.NewRoot+"/large.bin", nil)
 	req.Header.Set("Range", "bytes=262142-262145")
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("content proof range request: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("content proof status = %d, want %d", resp.StatusCode, http.StatusOK)
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("content proof status = %d, want %d", resp.StatusCode, http.StatusPartialContent)
 	}
 
-	var proofResp httpapi.ContentProofResponse
-	if err := json.NewDecoder(resp.Body).Decode(&proofResp); err != nil {
-		t.Fatalf("decode content proof response: %v", err)
-	}
-	if string(proofResp.Content) != "aabc" {
-		t.Fatalf("content range = %q, want aabc", proofResp.Content)
+	content, _ := io.ReadAll(resp.Body)
+	if string(content) != "aabc" {
+		t.Fatalf("content range = %q, want aabc", content)
 	}
 	wantContentRange := "bytes 262142-262145/262149"
-	if proofResp.Range.StatusCode != http.StatusPartialContent || proofResp.Range.ContentRange != wantContentRange {
-		t.Fatalf("range metadata = %+v, want status 206 content-range %q", proofResp.Range, wantContentRange)
+	if got := resp.Header.Get("Content-Range"); got != wantContentRange {
+		t.Fatalf("content range header = %q, want %q", got, wantContentRange)
 	}
-	if proofResp.Range.Start != 262142 || proofResp.Range.EndExclusive != 262146 || proofResp.Range.ContentLength != 4 || !proofResp.Range.Partial {
-		t.Fatalf("unexpected byte range metadata: %+v", proofResp.Range)
-	}
-	if err := proofResp.ProofList.ValidateShape(prooflist.RequireSteps()); err != nil {
+	proofResp := requireProofListHeader(t, resp)
+	if err := proofResp.ValidateShape(prooflist.RequireSteps()); err != nil {
 		t.Fatalf("prooflist shape: %v", err)
 	}
 
 	var indexes []uint64
-	for _, step := range proofResp.ProofList.Steps {
+	for _, step := range proofResp.Steps {
 		if step.Kind == prooflist.KindListIndex {
 			if step.Index == nil {
 				t.Fatalf("list-index step missing index: %+v", step)
@@ -1386,7 +1446,7 @@ func TestServerContentProofReadUnixFSRangeIncludesTouchedListIndexes(t *testing.
 		t.Fatalf("list-index steps = %v, want [0 1]", indexes)
 	}
 
-	verifyBody, err := json.Marshal(&httpapi.VerifyRequest{ProofList: proofResp.ProofList})
+	verifyBody, err := json.Marshal(&httpapi.VerifyRequest{ProofList: proofResp})
 	if err != nil {
 		t.Fatalf("marshal verify request: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add explicit `GET /resolve/{root}/{path}` resolution endpoints with ProofList responses by default
- keep content/stat reads on root-relative `GET`/`HEAD /{root}/{path}` and reject legacy `format=` modes on the content route
- remove the JSON `ContentProofResponse` API and update client/readbench callers to consume resolve responses or `X-Malt-ProofList` headers
- update README and architecture docs to describe the new public surface

## Tests
- `go test ./...`