### PR TITLE
Add write-amplification Git trace evaluator

### DIFF
--- a/cmd/eval/helper/adapters/hamt/adapter.go
+++ b/cmd/eval/helper/adapters/hamt/adapter.go
@@ -1,0 +1,16 @@
+// Package hamt configures the IPLD UnixFS HAMT baseline adapter.
+package hamt
+
+import (
+	"github.com/dewebprotocol/malt/cmd/eval/helper/adapters/merkledag"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/internal/merkledagimport"
+)
+
+// New creates an IPLD UnixFS + HAMT adapter.
+func New(system *evalstore.System) *merkledag.Adapter {
+	return merkledag.New(system, merkledag.Options{
+		Name:      "hamt",
+		DirLayout: merkledagimport.DirLayoutHAMT,
+	})
+}

--- a/cmd/eval/helper/adapters/hamt/adapter_test.go
+++ b/cmd/eval/helper/adapters/hamt/adapter_test.go
@@ -1,0 +1,26 @@
+package hamt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/adapters/hamt"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+)
+
+func TestNewUsesHAMTSystemName(t *testing.T) {
+	ctx := context.Background()
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{Backend: evalstore.StoreBackendMemory})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	system, err := factory.NewSystem(ctx, "hamt")
+	if err != nil {
+		t.Fatalf("NewSystem: %v", err)
+	}
+	adapter := hamt.New(system)
+	if adapter.Name() != "hamt" {
+		t.Fatalf("adapter name = %q, want hamt", adapter.Name())
+	}
+}

--- a/cmd/eval/helper/adapters/maltflat/adapter.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter.go
@@ -1,0 +1,119 @@
+// Package maltflat replays Git snapshots into the MALT-flat UnixFS layout.
+package maltflat
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/core/arctable/overwrite"
+	"github.com/dewebprotocol/malt/core/commitment/ipa"
+	"github.com/dewebprotocol/malt/core/layout/malt/unixfs"
+	"github.com/dewebprotocol/malt/core/structure/list/tree"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
+	cid "github.com/ipfs/go-cid"
+)
+
+const defaultNamespace = "eval-maltflat"
+
+// Options configures the MALT-flat adapter.
+type Options struct {
+	Namespace string
+	ChunkSize int
+}
+
+// Adapter materializes each commit snapshot as a MALT-flat UnixFS root.
+type Adapter struct {
+	system *evalstore.System
+	layout *unixfs.Layout
+}
+
+// New creates a MALT-flat adapter.
+func New(system *evalstore.System, opts Options) (*Adapter, error) {
+	if system == nil {
+		return nil, fmt.Errorf("system store is nil")
+	}
+	namespace := opts.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	arcs, err := overwrite.NewArcTable(overwrite.WithKVStore(system.StateKV))
+	if err != nil {
+		return nil, fmt.Errorf("create arctable: %w", err)
+	}
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		return nil, fmt.Errorf("create commitment scheme: %w", err)
+	}
+	maps, err := mappingradix.NewMap(scheme, arcs)
+	if err != nil {
+		return nil, fmt.Errorf("create map semantics: %w", err)
+	}
+	lists, err := tree.NewList(scheme, arcs)
+	if err != nil {
+		return nil, fmt.Errorf("create list semantics: %w", err)
+	}
+	layout, err := unixfs.New(unixfs.Options{
+		Namespace: namespace,
+		ChunkSize: opts.ChunkSize,
+		Map:       maps,
+		List:      lists,
+		Blocks:    system.CAS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Adapter{system: system, layout: layout}, nil
+}
+
+func (a *Adapter) Name() string {
+	if a.system != nil && a.system.Name != "" {
+		return a.system.Name
+	}
+	return "maltflat"
+}
+
+// Apply materializes the checked-out live snapshot for this commit. Rebuilding
+// from the live trace keeps delete/rename semantics correct even before the
+// UnixFS layout exposes a delete primitive.
+func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (replay.ApplyResult, error) {
+	if commit.SnapshotRoot == "" {
+		return replay.ApplyResult{}, fmt.Errorf("snapshot root is empty")
+	}
+	files := append([]replay.LiveFile(nil), commit.LiveFiles...)
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+
+	root := cid.Undef
+	var err error
+	if len(files) == 0 {
+		root, err = a.layout.EmptyDirectory(ctx)
+		if err != nil {
+			return replay.ApplyResult{}, err
+		}
+	}
+	for _, file := range files {
+		data, err := os.ReadFile(filepath.Join(commit.SnapshotRoot, filepath.FromSlash(file.Path)))
+		if err != nil {
+			return replay.ApplyResult{}, fmt.Errorf("read %s: %w", file.Path, err)
+		}
+		root, err = a.layout.AddFile(ctx, root, file.Path, data)
+		if err != nil {
+			return replay.ApplyResult{}, fmt.Errorf("materialize %s: %w", file.Path, err)
+		}
+	}
+	if root.Defined() {
+		a.system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(root.Bytes()))
+	}
+	return replay.ApplyResult{
+		Root:              root.String(),
+		AppliedMutations:  len(commit.Mutations),
+		MaterializedPaths: len(files),
+		Accounting:        a.system.Meter.Snapshot(),
+	}, nil
+}
+
+var _ replay.SystemAdapter = (*Adapter)(nil)

--- a/cmd/eval/helper/adapters/maltflat/adapter.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter.go
@@ -4,8 +4,6 @@ package maltflat
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 
 	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
@@ -77,12 +75,12 @@ func (a *Adapter) Name() string {
 	return "maltflat"
 }
 
-// Apply materializes the checked-out live snapshot for this commit. Rebuilding
-// from the live trace keeps delete/rename semantics correct even before the
-// UnixFS layout exposes a delete primitive.
+// Apply materializes the object-backed live snapshot for this commit.
+// Rebuilding from the live trace keeps delete/rename semantics correct even
+// before the UnixFS layout exposes a delete primitive.
 func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (replay.ApplyResult, error) {
-	if commit.SnapshotRoot == "" {
-		return replay.ApplyResult{}, fmt.Errorf("snapshot root is empty")
+	if commit.Snapshot == nil {
+		return replay.ApplyResult{}, fmt.Errorf("snapshot reader is nil")
 	}
 	files := append([]replay.LiveFile(nil), commit.LiveFiles...)
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
@@ -96,9 +94,9 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 		}
 	}
 	for _, file := range files {
-		data, err := os.ReadFile(filepath.Join(commit.SnapshotRoot, filepath.FromSlash(file.Path)))
+		data, err := commit.Snapshot.ReadBlob(ctx, file.Hash)
 		if err != nil {
-			return replay.ApplyResult{}, fmt.Errorf("read %s: %w", file.Path, err)
+			return replay.ApplyResult{}, fmt.Errorf("read blob for %s: %w", file.Path, err)
 		}
 		root, err = a.layout.AddFile(ctx, root, file.Path, data)
 		if err != nil {

--- a/cmd/eval/helper/adapters/maltflat/adapter.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter.go
@@ -106,7 +106,7 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 		}
 	}
 	if root.Defined() {
-		a.system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(root.Bytes()))
+		a.system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(root.String()))
 	}
 	return replay.ApplyResult{
 		Root:              root.String(),

--- a/cmd/eval/helper/adapters/maltflat/adapter_test.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter_test.go
@@ -56,8 +56,9 @@ func TestAdapterMaterializesLiveSnapshotWithIndependentStoreAccounting(t *testin
 	if result.Accounting.Categories[evalstore.CategoryArcTable].NewObjectCount == 0 {
 		t.Fatal("expected MALT-flat to charge ArcTable records")
 	}
-	if result.Accounting.Categories[evalstore.CategoryRootHead].NewPersistedBytes == 0 {
-		t.Fatal("expected MALT-flat to charge root/head metadata")
+	rootHead := result.Accounting.Categories[evalstore.CategoryRootHead]
+	if rootHead.NewPersistedBytes != uint64(len(result.Root)) {
+		t.Fatalf("root/head bytes = %d, want emitted root string length %d", rootHead.NewPersistedBytes, len(result.Root))
 	}
 }
 

--- a/cmd/eval/helper/adapters/maltflat/adapter_test.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter_test.go
@@ -2,8 +2,6 @@ package maltflat_test
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/dewebprotocol/malt/cmd/eval/helper/adapters/maltflat"
@@ -13,8 +11,6 @@ import (
 
 func TestAdapterMaterializesLiveSnapshotWithIndependentStoreAccounting(t *testing.T) {
 	ctx := context.Background()
-	snapshotRoot := t.TempDir()
-	writeSnapshotFile(t, snapshotRoot, "docs/readme.txt", "hello malt")
 
 	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
 		Mode:    evalstore.StoreModeIsolated,
@@ -34,14 +30,14 @@ func TestAdapterMaterializesLiveSnapshotWithIndependentStoreAccounting(t *testin
 	}
 
 	result, err := adapter.Apply(ctx, replay.CommitMutation{
-		Repo:         "repo",
-		Commit:       "c1",
-		SnapshotRoot: snapshotRoot,
+		Repo:     "repo",
+		Commit:   "c1",
+		Snapshot: fakeSnapshot{"blob-1": []byte("hello malt")},
 		Mutations: []replay.FileMutation{
-			{Kind: replay.MutationAdd, Path: "docs/readme.txt", Size: int64(len("hello malt"))},
+			{Kind: replay.MutationAdd, Path: "docs/readme.txt", Size: int64(len("hello malt")), Hash: "blob-1"},
 		},
 		LiveFiles: []replay.LiveFile{
-			{Path: "docs/readme.txt", Size: int64(len("hello malt"))},
+			{Path: "docs/readme.txt", Size: int64(len("hello malt")), Hash: "blob-1"},
 		},
 	})
 	if err != nil {
@@ -62,13 +58,18 @@ func TestAdapterMaterializesLiveSnapshotWithIndependentStoreAccounting(t *testin
 	}
 }
 
-func writeSnapshotFile(t *testing.T, root, rel, content string) {
-	t.Helper()
-	path := filepath.Join(root, filepath.FromSlash(rel))
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+type fakeSnapshot map[string][]byte
+
+func (s fakeSnapshot) ReadBlob(_ context.Context, hash string) ([]byte, error) {
+	data, ok := s[hash]
+	if !ok {
+		return nil, errMissingBlob(hash)
 	}
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatalf("write %s: %v", rel, err)
-	}
+	return data, nil
+}
+
+type errMissingBlob string
+
+func (e errMissingBlob) Error() string {
+	return "missing blob " + string(e)
 }

--- a/cmd/eval/helper/adapters/maltflat/adapter_test.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter_test.go
@@ -1,0 +1,73 @@
+package maltflat_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/adapters/maltflat"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+)
+
+func TestAdapterMaterializesLiveSnapshotWithIndependentStoreAccounting(t *testing.T) {
+	ctx := context.Background()
+	snapshotRoot := t.TempDir()
+	writeSnapshotFile(t, snapshotRoot, "docs/readme.txt", "hello malt")
+
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	system, err := factory.NewSystem(ctx, "maltflat")
+	if err != nil {
+		t.Fatalf("NewSystem: %v", err)
+	}
+	adapter, err := maltflat.New(system, maltflat.Options{Namespace: "test-maltflat", ChunkSize: 4})
+	if err != nil {
+		t.Fatalf("New adapter: %v", err)
+	}
+
+	result, err := adapter.Apply(ctx, replay.CommitMutation{
+		Repo:         "repo",
+		Commit:       "c1",
+		SnapshotRoot: snapshotRoot,
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationAdd, Path: "docs/readme.txt", Size: int64(len("hello malt"))},
+		},
+		LiveFiles: []replay.LiveFile{
+			{Path: "docs/readme.txt", Size: int64(len("hello malt"))},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if result.Root == "" {
+		t.Fatal("root is empty")
+	}
+	if result.AppliedMutations != 1 || result.MaterializedPaths != 1 {
+		t.Fatalf("applied/materialized = %d/%d, want 1/1", result.AppliedMutations, result.MaterializedPaths)
+	}
+	if result.Accounting.Categories[evalstore.CategoryArcTable].NewObjectCount == 0 {
+		t.Fatal("expected MALT-flat to charge ArcTable records")
+	}
+	if result.Accounting.Categories[evalstore.CategoryRootHead].NewPersistedBytes == 0 {
+		t.Fatal("expected MALT-flat to charge root/head metadata")
+	}
+}
+
+func writeSnapshotFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}

--- a/cmd/eval/helper/adapters/merkledag/adapter.go
+++ b/cmd/eval/helper/adapters/merkledag/adapter.go
@@ -4,8 +4,8 @@ package merkledag
 import (
 	"context"
 	"fmt"
-	"path/filepath"
-	"strings"
+	"io/fs"
+	"sort"
 
 	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
 	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
@@ -51,17 +51,30 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 	if a.system == nil {
 		return replay.ApplyResult{}, fmt.Errorf("system store is nil")
 	}
-	if commit.SnapshotRoot == "" {
-		return replay.ApplyResult{}, fmt.Errorf("snapshot root is empty")
+	if commit.Snapshot == nil {
+		return replay.ApplyResult{}, fmt.Errorf("snapshot reader is nil")
 	}
-	result, err := merkledagimport.ImportPath(ctx, a.system.CAS, commit.SnapshotRoot, merkledagimport.Options{
+	files := append([]replay.LiveFile(nil), commit.LiveFiles...)
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	importFiles := make([]merkledagimport.File, 0, len(files))
+	for _, file := range files {
+		data, err := commit.Snapshot.ReadBlob(ctx, file.Hash)
+		if err != nil {
+			return replay.ApplyResult{}, fmt.Errorf("read blob for %s: %w", file.Path, err)
+		}
+		importFiles = append(importFiles, merkledagimport.File{
+			Path: file.Path,
+			Data: data,
+			Mode: gitFileMode(file.Mode),
+		})
+	}
+	result, err := merkledagimport.ImportFiles(ctx, a.system.CAS, importFiles, merkledagimport.Options{
 		Model:       merkledagimport.ModelUnixFS,
 		FileLayout:  a.opts.FileLayout,
 		DirLayout:   a.opts.DirLayout,
 		ChunkSize:   a.opts.ChunkSize,
 		HAMTFanout:  a.opts.HAMTFanout,
 		RawFileLeaf: a.opts.RawFileLeaf,
-		Ignore:      newLivePathFilter(commit.SnapshotRoot, commit.LiveFiles),
 	})
 	if err != nil {
 		return replay.ApplyResult{}, err
@@ -75,59 +88,11 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 	}, nil
 }
 
-type livePathFilter struct {
-	root  string
-	files map[string]struct{}
-	dirs  map[string]struct{}
-}
-
-func newLivePathFilter(root string, files []replay.LiveFile) *livePathFilter {
-	filter := &livePathFilter{
-		root:  root,
-		files: make(map[string]struct{}, len(files)),
-		dirs:  make(map[string]struct{}),
+func gitFileMode(mode string) fs.FileMode {
+	if mode == "100755" {
+		return 0o755
 	}
-	for _, file := range files {
-		clean := strings.Trim(filepath.ToSlash(file.Path), "/")
-		if clean == "" {
-			continue
-		}
-		filter.files[clean] = struct{}{}
-		dir := filepath.ToSlash(filepath.Dir(clean))
-		for dir != "." && dir != "" {
-			filter.dirs[dir] = struct{}{}
-			next := filepath.ToSlash(filepath.Dir(dir))
-			if next == dir {
-				break
-			}
-			dir = next
-		}
-	}
-	return filter
-}
-
-func (f *livePathFilter) LoadDirectoryRules(string) error {
-	return nil
-}
-
-func (f *livePathFilter) Ignored(localPath string, isDir bool) (bool, error) {
-	rel, err := filepath.Rel(f.root, localPath)
-	if err != nil {
-		return false, err
-	}
-	rel = filepath.ToSlash(rel)
-	if rel == "." {
-		return false, nil
-	}
-	if rel == ".git" || strings.HasPrefix(rel, ".git/") {
-		return true, nil
-	}
-	if isDir {
-		_, ok := f.dirs[rel]
-		return !ok, nil
-	}
-	_, ok := f.files[rel]
-	return !ok, nil
+	return 0o644
 }
 
 var _ replay.SystemAdapter = (*Adapter)(nil)

--- a/cmd/eval/helper/adapters/merkledag/adapter.go
+++ b/cmd/eval/helper/adapters/merkledag/adapter.go
@@ -1,0 +1,133 @@
+// Package merkledag replays Git snapshots into IPLD UnixFS Merkle DAGs.
+package merkledag
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/internal/merkledagimport"
+)
+
+// Options configures a Merkle DAG baseline adapter.
+type Options struct {
+	Name        string
+	FileLayout  string
+	DirLayout   string
+	ChunkSize   int
+	HAMTFanout  int
+	RawFileLeaf bool
+}
+
+// Adapter materializes each commit snapshot as an IPLD UnixFS DAG.
+type Adapter struct {
+	system *evalstore.System
+	opts   Options
+}
+
+// New creates a Merkle DAG adapter.
+func New(system *evalstore.System, opts Options) *Adapter {
+	if opts.Name == "" {
+		opts.Name = "merkledag"
+	}
+	if opts.DirLayout == "" {
+		opts.DirLayout = merkledagimport.DirLayoutBasic
+	}
+	return &Adapter{system: system, opts: opts}
+}
+
+func (a *Adapter) Name() string {
+	if a.opts.Name != "" {
+		return a.opts.Name
+	}
+	return "merkledag"
+}
+
+// Apply imports only the files listed in the trace's live snapshot.
+func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (replay.ApplyResult, error) {
+	if a.system == nil {
+		return replay.ApplyResult{}, fmt.Errorf("system store is nil")
+	}
+	if commit.SnapshotRoot == "" {
+		return replay.ApplyResult{}, fmt.Errorf("snapshot root is empty")
+	}
+	result, err := merkledagimport.ImportPath(ctx, a.system.CAS, commit.SnapshotRoot, merkledagimport.Options{
+		Model:       merkledagimport.ModelUnixFS,
+		FileLayout:  a.opts.FileLayout,
+		DirLayout:   a.opts.DirLayout,
+		ChunkSize:   a.opts.ChunkSize,
+		HAMTFanout:  a.opts.HAMTFanout,
+		RawFileLeaf: a.opts.RawFileLeaf,
+		Ignore:      newLivePathFilter(commit.SnapshotRoot, commit.LiveFiles),
+	})
+	if err != nil {
+		return replay.ApplyResult{}, err
+	}
+	a.system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(result.Root))
+	return replay.ApplyResult{
+		Root:              result.Root,
+		AppliedMutations:  len(commit.Mutations),
+		MaterializedPaths: len(commit.LiveFiles),
+		Accounting:        a.system.Meter.Snapshot(),
+	}, nil
+}
+
+type livePathFilter struct {
+	root  string
+	files map[string]struct{}
+	dirs  map[string]struct{}
+}
+
+func newLivePathFilter(root string, files []replay.LiveFile) *livePathFilter {
+	filter := &livePathFilter{
+		root:  root,
+		files: make(map[string]struct{}, len(files)),
+		dirs:  make(map[string]struct{}),
+	}
+	for _, file := range files {
+		clean := strings.Trim(filepath.ToSlash(file.Path), "/")
+		if clean == "" {
+			continue
+		}
+		filter.files[clean] = struct{}{}
+		dir := filepath.ToSlash(filepath.Dir(clean))
+		for dir != "." && dir != "" {
+			filter.dirs[dir] = struct{}{}
+			next := filepath.ToSlash(filepath.Dir(dir))
+			if next == dir {
+				break
+			}
+			dir = next
+		}
+	}
+	return filter
+}
+
+func (f *livePathFilter) LoadDirectoryRules(string) error {
+	return nil
+}
+
+func (f *livePathFilter) Ignored(localPath string, isDir bool) (bool, error) {
+	rel, err := filepath.Rel(f.root, localPath)
+	if err != nil {
+		return false, err
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." {
+		return false, nil
+	}
+	if rel == ".git" || strings.HasPrefix(rel, ".git/") {
+		return true, nil
+	}
+	if isDir {
+		_, ok := f.dirs[rel]
+		return !ok, nil
+	}
+	_, ok := f.files[rel]
+	return !ok, nil
+}
+
+var _ replay.SystemAdapter = (*Adapter)(nil)

--- a/cmd/eval/helper/adapters/merkledag/adapter_test.go
+++ b/cmd/eval/helper/adapters/merkledag/adapter_test.go
@@ -1,0 +1,74 @@
+package merkledag_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/adapters/merkledag"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/internal/merkledagimport"
+)
+
+func TestAdapterImportsOnlyTraceLiveFilesAndIgnoresGitDirectory(t *testing.T) {
+	ctx := context.Background()
+	snapshotRoot := t.TempDir()
+	writeFile(t, snapshotRoot, "keep.txt", "keep")
+	writeFile(t, snapshotRoot, ".git/config", "not part of snapshot")
+	writeFile(t, snapshotRoot, "ignored.txt", "not listed in trace")
+
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	system, err := factory.NewSystem(ctx, "merkledag")
+	if err != nil {
+		t.Fatalf("NewSystem: %v", err)
+	}
+	adapter := merkledag.New(system, merkledag.Options{
+		Name:      "merkledag",
+		DirLayout: merkledagimport.DirLayoutBasic,
+	})
+
+	result, err := adapter.Apply(ctx, replay.CommitMutation{
+		Repo:         "repo",
+		Commit:       "c1",
+		SnapshotRoot: snapshotRoot,
+		LiveFiles: []replay.LiveFile{
+			{Path: "keep.txt", Size: int64(len("keep"))},
+		},
+		Mutations: []replay.FileMutation{{Kind: replay.MutationAdd, Path: "keep.txt"}},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if result.Root == "" {
+		t.Fatal("root is empty")
+	}
+	if result.MaterializedPaths != 1 {
+		t.Fatalf("materialized paths = %d, want 1", result.MaterializedPaths)
+	}
+	if result.Accounting.Categories[evalstore.CategoryCASMetadata].NewObjectCount == 0 {
+		t.Fatal("expected Merkle DAG metadata blocks")
+	}
+	if result.Accounting.Categories[evalstore.CategoryRootHead].NewPersistedBytes == 0 {
+		t.Fatal("expected root/head metadata bytes")
+	}
+}
+
+func writeFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}

--- a/cmd/eval/helper/adapters/merkledag/adapter_test.go
+++ b/cmd/eval/helper/adapters/merkledag/adapter_test.go
@@ -2,8 +2,6 @@ package merkledag_test
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/dewebprotocol/malt/cmd/eval/helper/adapters/merkledag"
@@ -12,12 +10,8 @@ import (
 	"github.com/dewebprotocol/malt/internal/merkledagimport"
 )
 
-func TestAdapterImportsOnlyTraceLiveFilesAndIgnoresGitDirectory(t *testing.T) {
+func TestAdapterImportsOnlyTraceLiveFilesFromSnapshot(t *testing.T) {
 	ctx := context.Background()
-	snapshotRoot := t.TempDir()
-	writeFile(t, snapshotRoot, "keep.txt", "keep")
-	writeFile(t, snapshotRoot, ".git/config", "not part of snapshot")
-	writeFile(t, snapshotRoot, "ignored.txt", "not listed in trace")
 
 	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
 		Mode:    evalstore.StoreModeIsolated,
@@ -37,13 +31,16 @@ func TestAdapterImportsOnlyTraceLiveFilesAndIgnoresGitDirectory(t *testing.T) {
 	})
 
 	result, err := adapter.Apply(ctx, replay.CommitMutation{
-		Repo:         "repo",
-		Commit:       "c1",
-		SnapshotRoot: snapshotRoot,
-		LiveFiles: []replay.LiveFile{
-			{Path: "keep.txt", Size: int64(len("keep"))},
+		Repo:   "repo",
+		Commit: "c1",
+		Snapshot: fakeSnapshot{
+			"keep-blob":    []byte("keep"),
+			"ignored-blob": []byte("not listed in trace"),
 		},
-		Mutations: []replay.FileMutation{{Kind: replay.MutationAdd, Path: "keep.txt"}},
+		LiveFiles: []replay.LiveFile{
+			{Path: "keep.txt", Size: int64(len("keep")), Hash: "keep-blob"},
+		},
+		Mutations: []replay.FileMutation{{Kind: replay.MutationAdd, Path: "keep.txt", Hash: "keep-blob"}},
 	})
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -62,13 +59,18 @@ func TestAdapterImportsOnlyTraceLiveFilesAndIgnoresGitDirectory(t *testing.T) {
 	}
 }
 
-func writeFile(t *testing.T, root, rel, content string) {
-	t.Helper()
-	path := filepath.Join(root, filepath.FromSlash(rel))
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+type fakeSnapshot map[string][]byte
+
+func (s fakeSnapshot) ReadBlob(_ context.Context, hash string) ([]byte, error) {
+	data, ok := s[hash]
+	if !ok {
+		return nil, errMissingBlob(hash)
 	}
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatalf("write %s: %v", rel, err)
-	}
+	return data, nil
+}
+
+type errMissingBlob string
+
+func (e errMissingBlob) Error() string {
+	return "missing blob " + string(e)
 }

--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -1,0 +1,319 @@
+// Package git extracts deterministic commit-mutation traces from Git repos.
+package git
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+)
+
+// Source streams checked-out Git commit snapshots as replay.CommitMutation values.
+type Source struct {
+	RepoURL     string
+	RepoPath    string
+	CacheDir    string
+	Ref         string
+	Limit       int
+	FirstParent bool
+}
+
+// Walk visits commits in chronological replay order.
+func (s Source) Walk(ctx context.Context, fn func(replay.CommitMutation) error) error {
+	if fn == nil {
+		return fmt.Errorf("walk callback is nil")
+	}
+	repo, err := s.repositoryPath(ctx)
+	if err != nil {
+		return err
+	}
+	ref := strings.TrimSpace(s.Ref)
+	if ref == "" {
+		ref = "HEAD"
+	}
+	commits, err := s.revList(ctx, repo, ref)
+	if err != nil {
+		return err
+	}
+	for i, commit := range commits {
+		parent, err := firstParent(ctx, repo, commit)
+		if err != nil {
+			return err
+		}
+		mutations, err := mutationsForCommit(ctx, repo, parent, commit)
+		if err != nil {
+			return err
+		}
+		if err := runGit(ctx, repo, "checkout", "--quiet", "--detach", commit); err != nil {
+			return err
+		}
+		liveFiles, liveStats, skipped, err := scanSnapshot(ctx, repo, commit)
+		if err != nil {
+			return err
+		}
+		enrichMutations(mutations, liveFiles)
+		if err := fn(replay.CommitMutation{
+			Repo:         repoName(repo, s.RepoURL),
+			Commit:       commit,
+			Parent:       parent,
+			Index:        i,
+			SnapshotRoot: repo,
+			Mutations:    mutations,
+			LiveStats:    liveStats,
+			LiveFiles:    liveFiles,
+			Skipped:      skipped,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s Source) repositoryPath(ctx context.Context) (string, error) {
+	if strings.TrimSpace(s.RepoPath) != "" {
+		return filepath.Abs(s.RepoPath)
+	}
+	return EnsureClone(ctx, s.RepoURL, s.CacheDir)
+}
+
+// EnsureClone returns a local clone for repoURL under cacheDir.
+func EnsureClone(ctx context.Context, repoURL, cacheDir string) (string, error) {
+	if strings.TrimSpace(repoURL) == "" {
+		return "", fmt.Errorf("repo URL is required")
+	}
+	if cacheDir == "" {
+		cacheDir = filepath.Join(".eval-cache", "repos")
+	}
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return "", err
+	}
+	path := filepath.Join(cacheDir, sanitizeRepoName(repoURL))
+	if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
+		if err := runGit(ctx, path, "fetch", "--prune", "origin"); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+	if err := runGit(ctx, "", "clone", repoURL, path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (s Source) revList(ctx context.Context, repo, ref string) ([]string, error) {
+	args := []string{"rev-list", "--reverse"}
+	if s.FirstParent {
+		args = append(args, "--first-parent")
+	}
+	if s.Limit > 0 {
+		args = append(args, "-n", strconv.Itoa(s.Limit))
+	}
+	args = append(args, ref)
+	out, err := gitOutput(ctx, repo, args...)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Fields(strings.TrimSpace(out))
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("no commits found for ref %q", ref)
+	}
+	return lines, nil
+}
+
+func firstParent(ctx context.Context, repo, commit string) (string, error) {
+	out, err := gitOutput(ctx, repo, "rev-list", "--parents", "-n", "1", commit)
+	if err != nil {
+		return "", err
+	}
+	fields := strings.Fields(out)
+	if len(fields) < 2 {
+		return "", nil
+	}
+	return fields[1], nil
+}
+
+func mutationsForCommit(ctx context.Context, repo, parent, commit string) ([]replay.FileMutation, error) {
+	if parent == "" {
+		out, err := gitOutput(ctx, repo, "ls-tree", "-r", "--name-only", commit)
+		if err != nil {
+			return nil, err
+		}
+		var mutations []replay.FileMutation
+		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			mutations = append(mutations, replay.FileMutation{Kind: replay.MutationAdd, Path: filepath.ToSlash(line)})
+		}
+		return mutations, nil
+	}
+	out, err := gitOutput(ctx, repo, "diff-tree", "--no-commit-id", "--name-status", "-r", "-M", parent, commit)
+	if err != nil {
+		return nil, err
+	}
+	var mutations []replay.FileMutation
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("invalid git diff-tree line %q", line)
+		}
+		status := fields[0]
+		switch status[0] {
+		case 'A', 'C':
+			mutations = append(mutations, replay.FileMutation{Kind: replay.MutationAdd, Path: filepath.ToSlash(fields[len(fields)-1])})
+		case 'M', 'T':
+			mutations = append(mutations, replay.FileMutation{Kind: replay.MutationModify, Path: filepath.ToSlash(fields[1])})
+		case 'D':
+			mutations = append(mutations, replay.FileMutation{Kind: replay.MutationDelete, Path: filepath.ToSlash(fields[1])})
+		case 'R':
+			if len(fields) < 3 {
+				return nil, fmt.Errorf("invalid rename line %q", line)
+			}
+			mutations = append(mutations, replay.FileMutation{
+				Kind:    replay.MutationRename,
+				OldPath: filepath.ToSlash(fields[1]),
+				Path:    filepath.ToSlash(fields[2]),
+			})
+		default:
+			mutations = append(mutations, replay.FileMutation{Kind: replay.MutationModify, Path: filepath.ToSlash(fields[len(fields)-1])})
+		}
+	}
+	return mutations, nil
+}
+
+func scanSnapshot(ctx context.Context, repo, commit string) ([]replay.LiveFile, replay.LiveStats, replay.SkipStats, error) {
+	var (
+		files       []replay.LiveFile
+		stats       replay.LiveStats
+		skipped     replay.SkipStats
+		directories = map[string]struct{}{}
+		depthSum    int
+	)
+	out, err := gitOutput(ctx, repo, "ls-tree", "-r", "--long", commit)
+	if err != nil {
+		return nil, replay.LiveStats{}, replay.SkipStats{}, err
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		head, path, ok := strings.Cut(line, "\t")
+		if !ok {
+			return nil, replay.LiveStats{}, replay.SkipStats{}, fmt.Errorf("invalid ls-tree line %q", line)
+		}
+		fields := strings.Fields(head)
+		if len(fields) < 4 {
+			return nil, replay.LiveStats{}, replay.SkipStats{}, fmt.Errorf("invalid ls-tree metadata %q", head)
+		}
+		mode, objectType, objectHash, sizeText := fields[0], fields[1], fields[2], fields[3]
+		rel := filepath.ToSlash(path)
+		if mode == "120000" {
+			skipped.SymlinkCount++
+			continue
+		}
+		if objectType != "blob" || !strings.HasPrefix(mode, "100") {
+			skipped.OtherCount++
+			continue
+		}
+		size, err := strconv.ParseInt(sizeText, 10, 64)
+		if err != nil {
+			skipped.OtherCount++
+			continue
+		}
+		files = append(files, replay.LiveFile{
+			Path: rel,
+			Mode: mode,
+			Size: size,
+			Hash: objectHash,
+		})
+		stats.LivePayloadBytes += size
+		depth := pathDepth(rel)
+		depthSum += depth
+		if depth > stats.MaxPathDepth {
+			stats.MaxPathDepth = depth
+		}
+		parent := filepath.ToSlash(filepath.Dir(rel))
+		for parent != "." && parent != "" {
+			directories[parent] = struct{}{}
+			next := filepath.ToSlash(filepath.Dir(parent))
+			if next == parent {
+				break
+			}
+			parent = next
+		}
+	}
+	stats.FileCount = len(files)
+	stats.DirectoryCount = len(directories)
+	stats.PathCount = stats.FileCount + stats.DirectoryCount
+	if stats.FileCount > 0 {
+		stats.AveragePathDepth = float64(depthSum) / float64(stats.FileCount)
+	}
+	return files, stats, skipped, nil
+}
+
+func enrichMutations(mutations []replay.FileMutation, files []replay.LiveFile) {
+	byPath := make(map[string]replay.LiveFile, len(files))
+	for _, file := range files {
+		byPath[file.Path] = file
+	}
+	for i := range mutations {
+		file, ok := byPath[mutations[i].Path]
+		if !ok {
+			continue
+		}
+		mutations[i].Mode = file.Mode
+		mutations[i].Size = file.Size
+		mutations[i].Hash = file.Hash
+	}
+}
+
+func pathDepth(path string) int {
+	if path == "" {
+		return 0
+	}
+	return strings.Count(filepath.ToSlash(path), "/") + 1
+}
+
+func repoName(path, repoURL string) string {
+	if repoURL != "" {
+		trimmed := strings.TrimSuffix(repoURL, ".git")
+		parts := strings.FieldsFunc(trimmed, func(r rune) bool {
+			return r == '/' || r == '\\' || r == ':'
+		})
+		if len(parts) > 0 {
+			return parts[len(parts)-1]
+		}
+	}
+	return filepath.Base(path)
+}
+
+func sanitizeRepoName(repoURL string) string {
+	name := repoName(repoURL, repoURL)
+	replacer := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-")
+	return replacer.Replace(name)
+}
+
+func gitOutput(ctx context.Context, repo string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if repo != "" {
+		cmd.Dir = repo
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s failed: %w\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out), nil
+}
+
+func runGit(ctx context.Context, repo string, args ...string) error {
+	_, err := gitOutput(ctx, repo, args...)
+	return err
+}

--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -2,6 +2,7 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -16,7 +17,7 @@ import (
 	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
 )
 
-// Source streams checked-out Git commit snapshots as replay.CommitMutation values.
+// Source streams Git object commit snapshots as replay.CommitMutation values.
 type Source struct {
 	RepoURL     string
 	RepoPath    string
@@ -27,7 +28,7 @@ type Source struct {
 }
 
 // Walk visits commits in chronological replay order.
-func (s Source) Walk(ctx context.Context, fn func(replay.CommitMutation) error) (err error) {
+func (s Source) Walk(ctx context.Context, fn func(replay.CommitMutation) error) error {
 	if fn == nil {
 		return fmt.Errorf("walk callback is nil")
 	}
@@ -43,15 +44,7 @@ func (s Source) Walk(ctx context.Context, fn func(replay.CommitMutation) error) 
 	if err != nil {
 		return err
 	}
-	replayRepo, cleanup, err := createReplayWorktree(ctx, sourceRepo, ref)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if cleanupErr := cleanup(); err == nil && cleanupErr != nil {
-			err = cleanupErr
-		}
-	}()
+	snapshot := objectSnapshot{repo: sourceRepo}
 	for i, commit := range commits {
 		parent, err := firstParent(ctx, sourceRepo, commit)
 		if err != nil {
@@ -61,24 +54,21 @@ func (s Source) Walk(ctx context.Context, fn func(replay.CommitMutation) error) 
 		if err != nil {
 			return err
 		}
-		if err := runGit(ctx, replayRepo, "checkout", "--quiet", "--detach", commit); err != nil {
-			return err
-		}
 		liveFiles, liveStats, skipped, err := scanSnapshot(ctx, sourceRepo, commit)
 		if err != nil {
 			return err
 		}
 		enrichMutations(mutations, liveFiles)
 		if err := fn(replay.CommitMutation{
-			Repo:         repoName(sourceRepo, s.RepoURL),
-			Commit:       commit,
-			Parent:       parent,
-			Index:        i,
-			SnapshotRoot: replayRepo,
-			Mutations:    mutations,
-			LiveStats:    liveStats,
-			LiveFiles:    liveFiles,
-			Skipped:      skipped,
+			Repo:      repoName(sourceRepo, s.RepoURL),
+			Commit:    commit,
+			Parent:    parent,
+			Index:     i,
+			Snapshot:  snapshot,
+			Mutations: mutations,
+			LiveStats: liveStats,
+			LiveFiles: liveFiles,
+			Skipped:   skipped,
 		}); err != nil {
 			return err
 		}
@@ -389,27 +379,15 @@ func sanitizeCachePrefix(value string) string {
 	return strings.Trim(builder.String(), "-")
 }
 
-func createReplayWorktree(ctx context.Context, sourceRepo, ref string) (string, func() error, error) {
-	parent, err := os.MkdirTemp("", "malt-eval-replay-*")
-	if err != nil {
-		return "", nil, err
+type objectSnapshot struct {
+	repo string
+}
+
+func (s objectSnapshot) ReadBlob(ctx context.Context, hash string) ([]byte, error) {
+	if strings.TrimSpace(hash) == "" {
+		return nil, fmt.Errorf("blob hash is empty")
 	}
-	replayRepo := filepath.Join(parent, "checkout")
-	if err := runGit(ctx, sourceRepo, "worktree", "add", "--quiet", "--detach", replayRepo, ref); err != nil {
-		_ = os.RemoveAll(parent)
-		return "", nil, err
-	}
-	cleanup := func() error {
-		var firstErr error
-		if err := runGit(context.Background(), sourceRepo, "worktree", "remove", "--force", replayRepo); err != nil {
-			firstErr = err
-		}
-		if err := os.RemoveAll(parent); err != nil && firstErr == nil {
-			firstErr = err
-		}
-		return firstErr
-	}
-	return replayRepo, cleanup, nil
+	return gitBlob(ctx, s.repo, hash)
 }
 
 func gitOutput(ctx context.Context, repo string, args ...string) (string, error) {
@@ -422,6 +400,20 @@ func gitOutput(ctx context.Context, repo string, args ...string) (string, error)
 		return "", fmt.Errorf("git %s failed: %w\n%s", strings.Join(args, " "), err, out)
 	}
 	return string(out), nil
+}
+
+func gitBlob(ctx context.Context, repo, hash string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", "cat-file", "blob", hash)
+	if repo != "" {
+		cmd.Dir = repo
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git cat-file blob %s failed: %w\n%s", hash, err, stderr.String())
+	}
+	return out, nil
 }
 
 func runGit(ctx context.Context, repo string, args ...string) error {

--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -3,7 +3,10 @@ package git
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,11 +27,11 @@ type Source struct {
 }
 
 // Walk visits commits in chronological replay order.
-func (s Source) Walk(ctx context.Context, fn func(replay.CommitMutation) error) error {
+func (s Source) Walk(ctx context.Context, fn func(replay.CommitMutation) error) (err error) {
 	if fn == nil {
 		return fmt.Errorf("walk callback is nil")
 	}
-	repo, err := s.repositoryPath(ctx)
+	sourceRepo, err := s.repositoryPath(ctx)
 	if err != nil {
 		return err
 	}
@@ -36,33 +39,42 @@ func (s Source) Walk(ctx context.Context, fn func(replay.CommitMutation) error) 
 	if ref == "" {
 		ref = "HEAD"
 	}
-	commits, err := s.revList(ctx, repo, ref)
+	commits, err := s.revList(ctx, sourceRepo, ref)
 	if err != nil {
 		return err
 	}
+	replayRepo, cleanup, err := createReplayWorktree(ctx, sourceRepo, ref)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cleanupErr := cleanup(); err == nil && cleanupErr != nil {
+			err = cleanupErr
+		}
+	}()
 	for i, commit := range commits {
-		parent, err := firstParent(ctx, repo, commit)
+		parent, err := firstParent(ctx, sourceRepo, commit)
 		if err != nil {
 			return err
 		}
-		mutations, err := mutationsForCommit(ctx, repo, parent, commit)
+		mutations, err := mutationsForCommit(ctx, sourceRepo, parent, commit)
 		if err != nil {
 			return err
 		}
-		if err := runGit(ctx, repo, "checkout", "--quiet", "--detach", commit); err != nil {
+		if err := runGit(ctx, replayRepo, "checkout", "--quiet", "--detach", commit); err != nil {
 			return err
 		}
-		liveFiles, liveStats, skipped, err := scanSnapshot(ctx, repo, commit)
+		liveFiles, liveStats, skipped, err := scanSnapshot(ctx, sourceRepo, commit)
 		if err != nil {
 			return err
 		}
 		enrichMutations(mutations, liveFiles)
 		if err := fn(replay.CommitMutation{
-			Repo:         repoName(repo, s.RepoURL),
+			Repo:         repoName(sourceRepo, s.RepoURL),
 			Commit:       commit,
 			Parent:       parent,
 			Index:        i,
-			SnapshotRoot: repo,
+			SnapshotRoot: replayRepo,
 			Mutations:    mutations,
 			LiveStats:    liveStats,
 			LiveFiles:    liveFiles,
@@ -92,8 +104,11 @@ func EnsureClone(ctx context.Context, repoURL, cacheDir string) (string, error) 
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
 		return "", err
 	}
-	path := filepath.Join(cacheDir, sanitizeRepoName(repoURL))
+	path := filepath.Join(cacheDir, CacheNameForURL(repoURL))
 	if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
+		if err := verifyCachedOrigin(ctx, path, repoURL); err != nil {
+			return "", err
+		}
 		if err := runGit(ctx, path, "fetch", "--prune", "origin"); err != nil {
 			return "", err
 		}
@@ -106,14 +121,7 @@ func EnsureClone(ctx context.Context, repoURL, cacheDir string) (string, error) 
 }
 
 func (s Source) revList(ctx context.Context, repo, ref string) ([]string, error) {
-	args := []string{"rev-list", "--reverse"}
-	if s.FirstParent {
-		args = append(args, "--first-parent")
-	}
-	if s.Limit > 0 {
-		args = append(args, "-n", strconv.Itoa(s.Limit))
-	}
-	args = append(args, ref)
+	args := revListArgs(ref, s.Limit, s.FirstParent)
 	out, err := gitOutput(ctx, repo, args...)
 	if err != nil {
 		return nil, err
@@ -123,6 +131,17 @@ func (s Source) revList(ctx context.Context, repo, ref string) ([]string, error)
 		return nil, fmt.Errorf("no commits found for ref %q", ref)
 	}
 	return lines, nil
+}
+
+func revListArgs(ref string, limit int, firstParent bool) []string {
+	args := []string{"rev-list", "--topo-order", "--reverse"}
+	if firstParent {
+		args = append(args, "--first-parent")
+	}
+	if limit > 0 {
+		args = append(args, "-n", strconv.Itoa(limit))
+	}
+	return append(args, ref)
 }
 
 func firstParent(ctx context.Context, repo, commit string) (string, error) {
@@ -295,10 +314,102 @@ func repoName(path, repoURL string) string {
 	return filepath.Base(path)
 }
 
-func sanitizeRepoName(repoURL string) string {
-	name := repoName(repoURL, repoURL)
-	replacer := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-")
-	return replacer.Replace(name)
+const (
+	cacheNameHashLen = 12
+	maxCacheNameLen  = 80
+)
+
+// CacheNameForURL returns a deterministic cache directory name for a full repo URL.
+func CacheNameForURL(repoURL string) string {
+	normalized := normalizeRepoURL(repoURL)
+	sum := sha256.Sum256([]byte(normalized))
+	prefix := sanitizeCachePrefix(normalized)
+	if prefix == "" {
+		prefix = "repo"
+	}
+	hash := hex.EncodeToString(sum[:])[:cacheNameHashLen]
+	maxPrefixLen := maxCacheNameLen - cacheNameHashLen - len("-")
+	if len(prefix) > maxPrefixLen {
+		prefix = strings.Trim(prefix[:maxPrefixLen], "-")
+		if prefix == "" {
+			prefix = "repo"
+		}
+	}
+	return fmt.Sprintf("%s-%s", prefix, hash)
+}
+
+func verifyCachedOrigin(ctx context.Context, path, repoURL string) error {
+	out, err := gitOutput(ctx, path, "remote", "get-url", "origin")
+	if err != nil {
+		return fmt.Errorf("verify cached origin for %s: %w", path, err)
+	}
+	got := normalizeRepoURL(strings.TrimSpace(out))
+	want := normalizeRepoURL(repoURL)
+	if got != want {
+		return fmt.Errorf("cached repo %s origin mismatch: got %q want %q", path, got, want)
+	}
+	return nil
+}
+
+func normalizeRepoURL(repoURL string) string {
+	trimmed := strings.TrimSpace(repoURL)
+	trimmed = strings.TrimRight(trimmed, "/")
+	if strings.HasSuffix(strings.ToLower(trimmed), ".git") {
+		trimmed = trimmed[:len(trimmed)-len(".git")]
+	}
+	if !strings.Contains(trimmed, "://") && strings.Contains(trimmed, "@") {
+		afterUser := strings.SplitN(trimmed, "@", 2)[1]
+		host, path, ok := strings.Cut(afterUser, ":")
+		if ok {
+			return strings.ToLower(host) + "/" + strings.Trim(path, "/")
+		}
+	}
+	if parsed, err := url.Parse(trimmed); err == nil && parsed.Host != "" {
+		return strings.ToLower(parsed.Host) + "/" + strings.Trim(parsed.Path, "/")
+	}
+	return trimmed
+}
+
+func sanitizeCachePrefix(value string) string {
+	lowered := strings.ToLower(value)
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range lowered {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '_'
+		if ok {
+			builder.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			builder.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func createReplayWorktree(ctx context.Context, sourceRepo, ref string) (string, func() error, error) {
+	parent, err := os.MkdirTemp("", "malt-eval-replay-*")
+	if err != nil {
+		return "", nil, err
+	}
+	replayRepo := filepath.Join(parent, "checkout")
+	if err := runGit(ctx, sourceRepo, "worktree", "add", "--quiet", "--detach", replayRepo, ref); err != nil {
+		_ = os.RemoveAll(parent)
+		return "", nil, err
+	}
+	cleanup := func() error {
+		var firstErr error
+		if err := runGit(context.Background(), sourceRepo, "worktree", "remove", "--force", replayRepo); err != nil {
+			firstErr = err
+		}
+		if err := os.RemoveAll(parent); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		return firstErr
+	}
+	return replayRepo, cleanup, nil
 }
 
 func gitOutput(ctx context.Context, repo string, args ...string) (string, error) {

--- a/cmd/eval/helper/git/trace_internal_test.go
+++ b/cmd/eval/helper/git/trace_internal_test.go
@@ -1,0 +1,16 @@
+package git
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestRevListArgsUseTopoOrder(t *testing.T) {
+	args := revListArgs("HEAD", 10, true)
+	if !slices.Contains(args, "--topo-order") {
+		t.Fatalf("rev-list args = %v, want --topo-order", args)
+	}
+	if !slices.Contains(args, "--first-parent") {
+		t.Fatalf("rev-list args = %v, want --first-parent", args)
+	}
+}

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -54,6 +55,85 @@ func TestSourceWalkEmitsFirstParentCommitMutationsAndLiveStats(t *testing.T) {
 	}
 	if len(commits[2].LiveFiles) != 1 || commits[2].LiveFiles[0].Path != "docs/README.md" {
 		t.Fatalf("third live files = %+v, want docs/README.md", commits[2].LiveFiles)
+	}
+}
+
+func TestSourceWalkUsesGitObjectSnapshotWithoutReplayWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	repo := initSingleFileRepo(t, "README.md", "hello\n")
+	initialWorktrees := worktreePaths(t, repo)
+
+	source := gittrace.Source{
+		RepoPath: repo,
+		Ref:      "HEAD",
+		Limit:    1,
+	}
+	var sawCommit bool
+	if err := source.Walk(ctx, func(commit replay.CommitMutation) error {
+		sawCommit = true
+		if got := worktreePaths(t, repo); !slices.Equal(got, initialWorktrees) {
+			t.Fatalf("worktrees during Walk = %v, want unchanged %v", got, initialWorktrees)
+		}
+		if commit.Snapshot == nil {
+			t.Fatal("snapshot reader is nil")
+		}
+		if len(commit.LiveFiles) != 1 || commit.LiveFiles[0].Hash == "" {
+			t.Fatalf("live files = %+v, want one file with blob hash", commit.LiveFiles)
+		}
+		data, err := commit.Snapshot.ReadBlob(ctx, commit.LiveFiles[0].Hash)
+		if err != nil {
+			t.Fatalf("ReadBlob: %v", err)
+		}
+		if string(data) != "hello\n" {
+			t.Fatalf("blob data = %q, want committed contents", string(data))
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if !sawCommit {
+		t.Fatal("Walk did not emit a commit")
+	}
+}
+
+func TestSourceWalkReadsCommittedBlobWhenCheckoutIsDirty(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	repo := initSingleFileRepo(t, "file.txt", "committed\n")
+	writeFile(t, repo, "file.txt", "dirty working tree\n")
+
+	source := gittrace.Source{
+		RepoPath: repo,
+		Ref:      "HEAD",
+		Limit:    1,
+	}
+	var got []byte
+	if err := source.Walk(ctx, func(commit replay.CommitMutation) error {
+		if commit.Snapshot == nil {
+			t.Fatal("snapshot reader is nil")
+		}
+		if len(commit.LiveFiles) != 1 {
+			t.Fatalf("live files = %+v, want one file", commit.LiveFiles)
+		}
+		data, err := commit.Snapshot.ReadBlob(ctx, commit.LiveFiles[0].Hash)
+		if err != nil {
+			return err
+		}
+		got = data
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if string(got) != "committed\n" {
+		t.Fatalf("blob data = %q, want committed contents", string(got))
+	}
+	if branch := currentBranch(t, repo); branch != "main" {
+		t.Fatalf("source repo branch = %q, want main", branch)
 	}
 }
 
@@ -143,6 +223,18 @@ func initTraceRepo(t *testing.T) string {
 	return repo
 }
 
+func initSingleFileRepo(t *testing.T, rel, content string) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-b", "main")
+	runGit(t, repo, "config", "user.email", "bench@example.test")
+	runGit(t, repo, "config", "user.name", "Bench Test")
+	writeFile(t, repo, rel, content)
+	runGit(t, repo, "add", rel)
+	runGit(t, repo, "commit", "-m", "initial")
+	return repo
+}
+
 func writeFile(t *testing.T, repo, rel, content string) {
 	t.Helper()
 	path := filepath.Join(repo, filepath.FromSlash(rel))
@@ -173,6 +265,24 @@ func currentBranch(t *testing.T, repo string) string {
 		t.Fatalf("current branch failed: %v\n%s", err, out)
 	}
 	return string(bytesTrimSpace(out))
+}
+
+func worktreePaths(t *testing.T, repo string) []string {
+	t.Helper()
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("worktree list failed: %v\n%s", err, out)
+	}
+	var paths []string
+	for _, line := range strings.Split(string(out), "\n") {
+		path, ok := strings.CutPrefix(line, "worktree ")
+		if ok {
+			paths = append(paths, filepath.Clean(path))
+		}
+	}
+	return paths
 }
 
 func bytesTrimSpace(in []byte) []byte {

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -1,0 +1,103 @@
+package git_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	gittrace "github.com/dewebprotocol/malt/cmd/eval/helper/git"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+)
+
+func TestSourceWalkEmitsFirstParentCommitMutationsAndLiveStats(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	repo := initTraceRepo(t)
+	writeFile(t, repo, "untracked-output.jsonl", "must not enter trace")
+
+	source := gittrace.Source{
+		RepoPath: repo,
+		Ref:      "HEAD",
+		Limit:    3,
+	}
+	var commits []replay.CommitMutation
+	if err := source.Walk(ctx, func(commit replay.CommitMutation) error {
+		commits = append(commits, commit)
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	if len(commits) != 3 {
+		t.Fatalf("commit count = %d, want 3", len(commits))
+	}
+	if commits[0].Index != 0 || commits[0].Parent != "" {
+		t.Fatalf("first commit index/parent = %d/%q, want 0/empty", commits[0].Index, commits[0].Parent)
+	}
+	if got := commits[0].Mutations[0]; got.Kind != replay.MutationAdd || got.Path != "README.md" {
+		t.Fatalf("first mutation = %s %s, want add README.md", got.Kind, got.Path)
+	}
+	if commits[1].Mutations[0].Kind != replay.MutationModify || commits[1].Mutations[0].Path != "README.md" {
+		t.Fatalf("second mutation = %+v, want modify README.md", commits[1].Mutations[0])
+	}
+	if commits[2].Mutations[0].Kind != replay.MutationRename || commits[2].Mutations[0].OldPath != "README.md" || commits[2].Mutations[0].Path != "docs/README.md" {
+		t.Fatalf("third mutation = %+v, want rename README.md -> docs/README.md", commits[2].Mutations[0])
+	}
+	if commits[2].LiveStats.FileCount != 1 || commits[2].LiveStats.LivePayloadBytes != int64(len("hello world\n")) {
+		t.Fatalf("third live stats = %+v, want one renamed file with current bytes", commits[2].LiveStats)
+	}
+	if len(commits[2].LiveFiles) != 1 || commits[2].LiveFiles[0].Path != "docs/README.md" {
+		t.Fatalf("third live files = %+v, want docs/README.md", commits[2].LiveFiles)
+	}
+}
+
+func initTraceRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-b", "main")
+	runGit(t, repo, "config", "user.email", "bench@example.test")
+	runGit(t, repo, "config", "user.name", "Bench Test")
+
+	writeFile(t, repo, "README.md", "hello\n")
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "initial")
+
+	writeFile(t, repo, "README.md", "hello world\n")
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "modify readme")
+
+	if err := os.MkdirAll(filepath.Join(repo, "docs"), 0755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.Rename(filepath.Join(repo, "README.md"), filepath.Join(repo, "docs", "README.md")); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	runGit(t, repo, "add", "-A")
+	runGit(t, repo, "commit", "-m", "rename readme")
+	return repo
+}
+
+func writeFile(t *testing.T, repo, rel, content string) {
+	t.Helper()
+	path := filepath.Join(repo, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func runGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -2,9 +2,11 @@ package git_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	gittrace "github.com/dewebprotocol/malt/cmd/eval/helper/git"
@@ -55,6 +57,66 @@ func TestSourceWalkEmitsFirstParentCommitMutationsAndLiveStats(t *testing.T) {
 	}
 }
 
+func TestSourceWalkDoesNotMutateRepoPathCheckoutOnFailure(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	repo := initTraceRepo(t)
+	runGit(t, repo, "checkout", "main")
+
+	walkErr := errors.New("stop replay")
+	source := gittrace.Source{
+		RepoPath: repo,
+		Ref:      "HEAD",
+		Limit:    2,
+	}
+	err := source.Walk(ctx, func(commit replay.CommitMutation) error {
+		return walkErr
+	})
+	if !errors.Is(err, walkErr) {
+		t.Fatalf("Walk error = %v, want %v", err, walkErr)
+	}
+
+	if branch := currentBranch(t, repo); branch != "main" {
+		t.Fatalf("source repo branch = %q, want main", branch)
+	}
+}
+
+func TestCacheNameForURLIncludesFullRepositoryIdentity(t *testing.T) {
+	first := gittrace.CacheNameForURL("https://github.com/orgA/project.git")
+	second := gittrace.CacheNameForURL("https://github.com/orgB/project.git")
+	if first == second {
+		t.Fatalf("cache names collide: %q", first)
+	}
+}
+
+func TestCacheNameForURLIsBoundedForLongLocalPaths(t *testing.T) {
+	name := gittrace.CacheNameForURL("C:\\" + strings.Repeat("long-path-segment\\", 20) + "project.git")
+	if len(name) > 80 {
+		t.Fatalf("cache name length = %d, want <= 80: %q", len(name), name)
+	}
+}
+
+func TestEnsureCloneRejectsMismatchedExistingOrigin(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	cacheDir := t.TempDir()
+	url := "https://github.com/orgA/project.git"
+	cachePath := filepath.Join(cacheDir, gittrace.CacheNameForURL(url))
+	if err := os.MkdirAll(cachePath, 0755); err != nil {
+		t.Fatalf("mkdir cache path: %v", err)
+	}
+	runGit(t, cachePath, "init")
+	runGit(t, cachePath, "remote", "add", "origin", "https://github.com/orgB/project.git")
+
+	if _, err := gittrace.EnsureClone(ctx, url, cacheDir); err == nil {
+		t.Fatal("expected mismatched origin error")
+	}
+}
+
 func initTraceRepo(t *testing.T) string {
 	t.Helper()
 	repo := t.TempDir()
@@ -100,4 +162,29 @@ func runGit(t *testing.T, repo string, args ...string) {
 	if err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
+}
+
+func currentBranch(t *testing.T, repo string) string {
+	t.Helper()
+	cmd := exec.Command("git", "symbolic-ref", "--short", "HEAD")
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("current branch failed: %v\n%s", err, out)
+	}
+	return string(bytesTrimSpace(out))
+}
+
+func bytesTrimSpace(in []byte) []byte {
+	for len(in) > 0 && (in[0] == '\r' || in[0] == '\n' || in[0] == ' ' || in[0] == '\t') {
+		in = in[1:]
+	}
+	for len(in) > 0 {
+		last := in[len(in)-1]
+		if last != '\r' && last != '\n' && last != ' ' && last != '\t' {
+			break
+		}
+		in = in[:len(in)-1]
+	}
+	return in
 }

--- a/cmd/eval/helper/replay/runner.go
+++ b/cmd/eval/helper/replay/runner.go
@@ -1,0 +1,58 @@
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// RunJSONL replays commits across systems and writes one JSON record per
+// system per commit.
+func RunJSONL(ctx context.Context, commits []CommitMutation, systems []SystemAdapter, w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("output writer is nil")
+	}
+	if len(systems) == 0 {
+		return fmt.Errorf("at least one system is required")
+	}
+	enc := json.NewEncoder(w)
+	for _, commit := range commits {
+		if err := RunCommit(ctx, commit, systems, enc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunCommit applies one commit to every system and emits JSON records.
+func RunCommit(ctx context.Context, commit CommitMutation, systems []SystemAdapter, enc *json.Encoder) error {
+	if enc == nil {
+		return fmt.Errorf("json encoder is nil")
+	}
+	for _, system := range systems {
+		if system == nil {
+			return fmt.Errorf("system adapter is nil")
+		}
+		result, err := system.Apply(ctx, commit)
+		if err != nil {
+			return fmt.Errorf("%s apply commit %s: %w", system.Name(), commit.Commit, err)
+		}
+		record := ResultRecord{
+			Repo:        commit.Repo,
+			System:      system.Name(),
+			Commit:      commit.Commit,
+			Parent:      commit.Parent,
+			Index:       commit.Index,
+			LiveStats:   commit.LiveStats,
+			MutationSet: commit.Mutations,
+			Skipped:     commit.Skipped,
+			Result:      result,
+			Accounting:  result.Accounting,
+		}
+		if err := enc.Encode(record); err != nil {
+			return fmt.Errorf("encode %s commit %s: %w", system.Name(), commit.Commit, err)
+		}
+	}
+	return nil
+}

--- a/cmd/eval/helper/replay/runner_test.go
+++ b/cmd/eval/helper/replay/runner_test.go
@@ -1,0 +1,86 @@
+package replay_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+)
+
+type fakeAdapter struct {
+	name  string
+	roots []string
+}
+
+func (a *fakeAdapter) Name() string {
+	return a.name
+}
+
+func (a *fakeAdapter) Apply(ctx context.Context, commit replay.CommitMutation) (replay.ApplyResult, error) {
+	a.roots = append(a.roots, commit.Commit)
+	return replay.ApplyResult{
+		Root:              a.name + "-" + commit.Commit,
+		AppliedMutations:  len(commit.Mutations),
+		Accounting:        evalstore.NewMeter().Snapshot(),
+		MaterializedPaths: len(commit.LiveFiles),
+	}, nil
+}
+
+func TestRunJSONLEmitsOneRecordPerSystemPerCommit(t *testing.T) {
+	ctx := context.Background()
+	commits := []replay.CommitMutation{
+		{
+			Repo:   "example",
+			Commit: "c1",
+			Index:  0,
+			Mutations: []replay.FileMutation{
+				{Kind: replay.MutationAdd, Path: "README.md", Size: 5},
+			},
+			LiveStats: replay.LiveStats{FileCount: 1, LivePayloadBytes: 5},
+			LiveFiles: []replay.LiveFile{{Path: "README.md", Size: 5}},
+		},
+		{
+			Repo:   "example",
+			Commit: "c2",
+			Parent: "c1",
+			Index:  1,
+			Mutations: []replay.FileMutation{
+				{Kind: replay.MutationModify, Path: "README.md", Size: 7},
+			},
+			LiveStats: replay.LiveStats{FileCount: 1, LivePayloadBytes: 7},
+			LiveFiles: []replay.LiveFile{{Path: "README.md", Size: 7}},
+		},
+	}
+
+	var out bytes.Buffer
+	err := replay.RunJSONL(ctx, commits, []replay.SystemAdapter{
+		&fakeAdapter{name: "maltflat"},
+		&fakeAdapter{name: "merkledag"},
+	}, &out)
+	if err != nil {
+		t.Fatalf("RunJSONL: %v", err)
+	}
+
+	dec := json.NewDecoder(&out)
+	var records []replay.ResultRecord
+	for dec.More() {
+		var rec replay.ResultRecord
+		if err := dec.Decode(&rec); err != nil {
+			t.Fatalf("Decode record: %v", err)
+		}
+		records = append(records, rec)
+	}
+
+	if len(records) != 4 {
+		t.Fatalf("record count = %d, want 4", len(records))
+	}
+	if records[0].System != "maltflat" || records[1].System != "merkledag" {
+		t.Fatalf("systems for first commit = %q/%q, want maltflat/merkledag", records[0].System, records[1].System)
+	}
+	if records[2].Commit != "c2" || records[2].LiveStats.LivePayloadBytes != 7 {
+		t.Fatalf("second commit record = commit %q live bytes %d, want c2/7", records[2].Commit, records[2].LiveStats.LivePayloadBytes)
+	}
+}

--- a/cmd/eval/helper/replay/types.go
+++ b/cmd/eval/helper/replay/types.go
@@ -27,7 +27,7 @@ type FileMutation struct {
 	Hash    string       `json:"hash,omitempty"`
 }
 
-// LiveFile describes a regular file present in the checked-out commit snapshot.
+// LiveFile describes a regular file present in the commit snapshot.
 type LiveFile struct {
 	Path string `json:"path"`
 	Mode string `json:"mode,omitempty"`
@@ -51,17 +51,22 @@ type SkipStats struct {
 	OtherCount   int `json:"other_count,omitempty"`
 }
 
+// SnapshotReader reads object bytes for files in one immutable source snapshot.
+type SnapshotReader interface {
+	ReadBlob(ctx context.Context, hash string) ([]byte, error)
+}
+
 // CommitMutation is the stable source-domain input shared by all systems.
 type CommitMutation struct {
-	Repo         string         `json:"repo"`
-	Commit       string         `json:"commit"`
-	Parent       string         `json:"parent,omitempty"`
-	Index        int            `json:"index"`
-	SnapshotRoot string         `json:"snapshot_root,omitempty"`
-	Mutations    []FileMutation `json:"mutations"`
-	LiveStats    LiveStats      `json:"live_stats"`
-	LiveFiles    []LiveFile     `json:"live_files,omitempty"`
-	Skipped      SkipStats      `json:"skipped,omitempty"`
+	Repo      string         `json:"repo"`
+	Commit    string         `json:"commit"`
+	Parent    string         `json:"parent,omitempty"`
+	Index     int            `json:"index"`
+	Snapshot  SnapshotReader `json:"-"`
+	Mutations []FileMutation `json:"mutations"`
+	LiveStats LiveStats      `json:"live_stats"`
+	LiveFiles []LiveFile     `json:"live_files,omitempty"`
+	Skipped   SkipStats      `json:"skipped,omitempty"`
 }
 
 // ApplyResult is returned by one evaluated system after applying a commit.

--- a/cmd/eval/helper/replay/types.go
+++ b/cmd/eval/helper/replay/types.go
@@ -1,0 +1,93 @@
+// Package replay defines write-amplification replay contracts and JSONL output.
+package replay
+
+import (
+	"context"
+
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+)
+
+// MutationKind identifies a source-domain file mutation.
+type MutationKind string
+
+const (
+	MutationAdd    MutationKind = "add"
+	MutationModify MutationKind = "modify"
+	MutationDelete MutationKind = "delete"
+	MutationRename MutationKind = "rename"
+)
+
+// FileMutation is one logical file mutation extracted from a Git commit.
+type FileMutation struct {
+	Kind    MutationKind `json:"kind"`
+	Path    string       `json:"path"`
+	OldPath string       `json:"old_path,omitempty"`
+	Mode    string       `json:"mode,omitempty"`
+	Size    int64        `json:"size,omitempty"`
+	Hash    string       `json:"hash,omitempty"`
+}
+
+// LiveFile describes a regular file present in the checked-out commit snapshot.
+type LiveFile struct {
+	Path string `json:"path"`
+	Mode string `json:"mode,omitempty"`
+	Size int64  `json:"size"`
+	Hash string `json:"hash,omitempty"`
+}
+
+// LiveStats describes source-domain live scale after a commit.
+type LiveStats struct {
+	FileCount        int     `json:"file_count"`
+	DirectoryCount   int     `json:"directory_count"`
+	PathCount        int     `json:"path_count"`
+	LivePayloadBytes int64   `json:"live_payload_bytes"`
+	MaxPathDepth     int     `json:"max_path_depth"`
+	AveragePathDepth float64 `json:"average_path_depth"`
+}
+
+// SkipStats records source-domain entries omitted by the evaluator.
+type SkipStats struct {
+	SymlinkCount int `json:"symlink_count,omitempty"`
+	OtherCount   int `json:"other_count,omitempty"`
+}
+
+// CommitMutation is the stable source-domain input shared by all systems.
+type CommitMutation struct {
+	Repo         string         `json:"repo"`
+	Commit       string         `json:"commit"`
+	Parent       string         `json:"parent,omitempty"`
+	Index        int            `json:"index"`
+	SnapshotRoot string         `json:"snapshot_root,omitempty"`
+	Mutations    []FileMutation `json:"mutations"`
+	LiveStats    LiveStats      `json:"live_stats"`
+	LiveFiles    []LiveFile     `json:"live_files,omitempty"`
+	Skipped      SkipStats      `json:"skipped,omitempty"`
+}
+
+// ApplyResult is returned by one evaluated system after applying a commit.
+type ApplyResult struct {
+	Root              string             `json:"root,omitempty"`
+	AppliedMutations  int                `json:"applied_mutations"`
+	MaterializedPaths int                `json:"materialized_paths"`
+	Accounting        evalstore.Snapshot `json:"accounting"`
+}
+
+// ResultRecord is one JSONL measurement point for one system at one commit.
+type ResultRecord struct {
+	Repo        string             `json:"repo"`
+	System      string             `json:"system"`
+	Commit      string             `json:"commit"`
+	Parent      string             `json:"parent,omitempty"`
+	Index       int                `json:"index"`
+	LiveStats   LiveStats          `json:"live_stats"`
+	MutationSet []FileMutation     `json:"mutations"`
+	Skipped     SkipStats          `json:"skipped,omitempty"`
+	Result      ApplyResult        `json:"result"`
+	Accounting  evalstore.Snapshot `json:"accounting"`
+}
+
+// SystemAdapter consumes source-domain commit mutations for one representation.
+type SystemAdapter interface {
+	Name() string
+	Apply(context.Context, CommitMutation) (ApplyResult, error)
+}

--- a/cmd/eval/helper/store/accounting.go
+++ b/cmd/eval/helper/store/accounting.go
@@ -1,0 +1,125 @@
+// Package store provides per-system evaluation storage and write accounting.
+package store
+
+import "sync"
+
+// Category identifies the persisted-data class charged by the evaluator.
+type Category string
+
+const (
+	CategoryCASPayload  Category = "cas_payload"
+	CategoryCASMetadata Category = "cas_metadata"
+	CategoryArcTable    Category = "arctable"
+	CategoryCommitment  Category = "commitment"
+	CategoryRootHead    Category = "root_head"
+)
+
+// Counter captures attempted writes and newly persisted writes for one class.
+type Counter struct {
+	AttemptedPutCount  uint64 `json:"attempted_put_count"`
+	AttemptedPutBytes  uint64 `json:"attempted_put_bytes"`
+	NewObjectCount     uint64 `json:"new_object_count"`
+	NewPersistedBytes  uint64 `json:"new_persisted_bytes"`
+	ChangedRecordCount uint64 `json:"changed_record_count,omitempty"`
+}
+
+// Snapshot is a stable copy of all accounting counters.
+type Snapshot struct {
+	Total      Counter              `json:"total"`
+	Categories map[Category]Counter `json:"categories"`
+}
+
+// Meter records write-accounting counters for one evaluated system.
+type Meter struct {
+	mu         sync.Mutex
+	categories map[Category]Counter
+}
+
+// NewMeter creates an empty write-accounting meter.
+func NewMeter() *Meter {
+	return &Meter{categories: make(map[Category]Counter)}
+}
+
+// RecordCASPut records a CAS put attempt. Only previously absent CAS blocks are
+// charged as newly persisted objects.
+func (m *Meter) RecordCASPut(category Category, bytes int, isNew bool) {
+	if m == nil {
+		return
+	}
+	if bytes < 0 {
+		bytes = 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	counter := m.categories[category]
+	counter.AttemptedPutCount++
+	counter.AttemptedPutBytes += uint64(bytes)
+	if isNew {
+		counter.NewObjectCount++
+		counter.NewPersistedBytes += uint64(bytes)
+	}
+	m.categories[category] = counter
+}
+
+// RecordChangedRecord records a KV-style changed record. KV writes are charged
+// on every successful put because overwrite and delta stores still persist a
+// changed record for the evaluated commit.
+func (m *Meter) RecordChangedRecord(category Category, keyBytes, valueBytes int) {
+	if m == nil {
+		return
+	}
+	if keyBytes < 0 {
+		keyBytes = 0
+	}
+	if valueBytes < 0 {
+		valueBytes = 0
+	}
+	bytes := uint64(keyBytes + valueBytes)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	counter := m.categories[category]
+	counter.AttemptedPutCount++
+	counter.AttemptedPutBytes += bytes
+	counter.NewObjectCount++
+	counter.NewPersistedBytes += bytes
+	counter.ChangedRecordCount++
+	m.categories[category] = counter
+}
+
+// RecordLogicalBytes records non-CAS/KV metadata such as root publication bytes.
+func (m *Meter) RecordLogicalBytes(category Category, bytes int) {
+	if m == nil {
+		return
+	}
+	if bytes < 0 {
+		bytes = 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	counter := m.categories[category]
+	counter.AttemptedPutCount++
+	counter.AttemptedPutBytes += uint64(bytes)
+	counter.NewObjectCount++
+	counter.NewPersistedBytes += uint64(bytes)
+	counter.ChangedRecordCount++
+	m.categories[category] = counter
+}
+
+// Snapshot returns a stable copy of the current counters.
+func (m *Meter) Snapshot() Snapshot {
+	if m == nil {
+		return Snapshot{Categories: map[Category]Counter{}}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := Snapshot{Categories: make(map[Category]Counter, len(m.categories))}
+	for category, counter := range m.categories {
+		out.Categories[category] = counter
+		out.Total.AttemptedPutCount += counter.AttemptedPutCount
+		out.Total.AttemptedPutBytes += counter.AttemptedPutBytes
+		out.Total.NewObjectCount += counter.NewObjectCount
+		out.Total.NewPersistedBytes += counter.NewPersistedBytes
+		out.Total.ChangedRecordCount += counter.ChangedRecordCount
+	}
+	return out
+}

--- a/cmd/eval/helper/store/accounting_test.go
+++ b/cmd/eval/helper/store/accounting_test.go
@@ -2,10 +2,13 @@ package store_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
 	"github.com/dewebprotocol/malt/core/cas"
+	"github.com/dewebprotocol/malt/core/kvstore"
+	cid "github.com/ipfs/go-cid"
 )
 
 func TestIsolatedSystemsCountIdenticalCASBlocksIndependently(t *testing.T) {
@@ -147,3 +150,51 @@ func TestMeteredCASPutBatchReportsStoredAlreadyPresentAndDuplicate(t *testing.T)
 		t.Fatalf("second status = %s, want already_present", results[0].Status)
 	}
 }
+
+func TestMeteredCASGetPreservesUnderlyingKVErrors(t *testing.T) {
+	boom := errors.New("disk failure")
+	metered := evalstore.NewMeteredCAS(errorKV{getErr: boom}, evalstore.NewMeter())
+
+	_, err := metered.Get(context.Background(), cid.Undef)
+	if !errors.Is(err, boom) {
+		t.Fatalf("Get error = %v, want to preserve %v", err, boom)
+	}
+}
+
+type errorKV struct {
+	getErr error
+}
+
+func (e errorKV) Get(context.Context, []byte) ([]byte, error) {
+	return nil, e.getErr
+}
+
+func (e errorKV) BatchGet(context.Context, [][]byte) (map[string][]byte, error) {
+	return nil, e.getErr
+}
+
+func (e errorKV) Put(context.Context, []byte, []byte) error {
+	return e.getErr
+}
+
+func (e errorKV) Delete(context.Context, []byte) error {
+	return e.getErr
+}
+
+func (e errorKV) Has(context.Context, []byte) (bool, error) {
+	return false, e.getErr
+}
+
+func (e errorKV) NewIterator(context.Context, []byte, []byte) kvstore.Iterator {
+	return nil
+}
+
+func (e errorKV) Batch() kvstore.Batch {
+	return nil
+}
+
+func (e errorKV) Close() error {
+	return nil
+}
+
+var _ kvstore.KVStore = errorKV{}

--- a/cmd/eval/helper/store/accounting_test.go
+++ b/cmd/eval/helper/store/accounting_test.go
@@ -1,0 +1,149 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/core/cas"
+)
+
+func TestIsolatedSystemsCountIdenticalCASBlocksIndependently(t *testing.T) {
+	ctx := context.Background()
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+
+	first, err := factory.NewSystem(ctx, "maltflat")
+	if err != nil {
+		t.Fatalf("NewSystem first: %v", err)
+	}
+	second, err := factory.NewSystem(ctx, "merkledag")
+	if err != nil {
+		t.Fatalf("NewSystem second: %v", err)
+	}
+
+	if _, err := first.CAS.Put(ctx, []byte("same payload")); err != nil {
+		t.Fatalf("first put: %v", err)
+	}
+	if _, err := second.CAS.Put(ctx, []byte("same payload")); err != nil {
+		t.Fatalf("second put: %v", err)
+	}
+
+	firstCAS := first.Meter.Snapshot().Categories[evalstore.CategoryCASPayload]
+	secondCAS := second.Meter.Snapshot().Categories[evalstore.CategoryCASPayload]
+	if firstCAS.NewObjectCount != 1 || secondCAS.NewObjectCount != 1 {
+		t.Fatalf("isolated new objects = %d/%d, want 1/1", firstCAS.NewObjectCount, secondCAS.NewObjectCount)
+	}
+	if firstCAS.NewPersistedBytes != uint64(len("same payload")) || secondCAS.NewPersistedBytes != uint64(len("same payload")) {
+		t.Fatalf("isolated new bytes = %d/%d, want payload bytes for both", firstCAS.NewPersistedBytes, secondCAS.NewPersistedBytes)
+	}
+}
+
+func TestSharedSystemsExposeCrossSystemCASDedupAsDiagnosticMode(t *testing.T) {
+	ctx := context.Background()
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeShared,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+
+	first, err := factory.NewSystem(ctx, "maltflat")
+	if err != nil {
+		t.Fatalf("NewSystem first: %v", err)
+	}
+	second, err := factory.NewSystem(ctx, "merkledag")
+	if err != nil {
+		t.Fatalf("NewSystem second: %v", err)
+	}
+
+	if _, err := first.CAS.Put(ctx, []byte("same payload")); err != nil {
+		t.Fatalf("first put: %v", err)
+	}
+	if _, err := second.CAS.Put(ctx, []byte("same payload")); err != nil {
+		t.Fatalf("second put: %v", err)
+	}
+
+	firstCAS := first.Meter.Snapshot().Categories[evalstore.CategoryCASPayload]
+	secondCAS := second.Meter.Snapshot().Categories[evalstore.CategoryCASPayload]
+	if firstCAS.NewObjectCount != 1 {
+		t.Fatalf("first shared new objects = %d, want 1", firstCAS.NewObjectCount)
+	}
+	if secondCAS.AttemptedPutCount != 1 || secondCAS.NewObjectCount != 0 {
+		t.Fatalf("second shared attempted/new objects = %d/%d, want 1/0", secondCAS.AttemptedPutCount, secondCAS.NewObjectCount)
+	}
+}
+
+func TestMeteredKVCountsEveryChangedRecord(t *testing.T) {
+	ctx := context.Background()
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	system, err := factory.NewSystem(ctx, "maltflat")
+	if err != nil {
+		t.Fatalf("NewSystem: %v", err)
+	}
+
+	if err := system.StateKV.Put(ctx, []byte("root"), []byte("v1")); err != nil {
+		t.Fatalf("put v1: %v", err)
+	}
+	if err := system.StateKV.Put(ctx, []byte("root"), []byte("v2")); err != nil {
+		t.Fatalf("put v2: %v", err)
+	}
+
+	arctable := system.Meter.Snapshot().Categories[evalstore.CategoryArcTable]
+	if arctable.NewObjectCount != 2 {
+		t.Fatalf("changed records = %d, want 2", arctable.NewObjectCount)
+	}
+	if arctable.NewPersistedBytes != uint64(len("root")+len("v1")+len("root")+len("v2")) {
+		t.Fatalf("changed bytes = %d, want key+value bytes for both writes", arctable.NewPersistedBytes)
+	}
+}
+
+func TestMeteredCASPutBatchReportsStoredAlreadyPresentAndDuplicate(t *testing.T) {
+	ctx := context.Background()
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	system, err := factory.NewSystem(ctx, "merkledag")
+	if err != nil {
+		t.Fatalf("NewSystem: %v", err)
+	}
+
+	results, err := system.CAS.PutBatch(ctx, []cas.Block{
+		{Data: []byte("new")},
+		{Data: []byte("new")},
+	})
+	if err != nil {
+		t.Fatalf("first PutBatch: %v", err)
+	}
+	if results[0].Status != cas.PutStatusStored || results[1].Status != cas.PutStatusDuplicate {
+		t.Fatalf("first statuses = %s/%s, want stored/duplicate", results[0].Status, results[1].Status)
+	}
+
+	results, err = system.CAS.PutBatch(ctx, []cas.Block{{Data: []byte("new")}})
+	if err != nil {
+		t.Fatalf("second PutBatch: %v", err)
+	}
+	if results[0].Status != cas.PutStatusAlreadyPresent {
+		t.Fatalf("second status = %s, want already_present", results[0].Status)
+	}
+}

--- a/cmd/eval/helper/store/cas_meter.go
+++ b/cmd/eval/helper/store/cas_meter.go
@@ -1,0 +1,118 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dewebprotocol/malt/core/cas"
+	"github.com/dewebprotocol/malt/core/kvstore"
+	cid "github.com/ipfs/go-cid"
+)
+
+// MeteredCAS is a deterministic local CAS with per-system write accounting.
+type MeteredCAS struct {
+	kv    kvstore.KVStore
+	meter *Meter
+}
+
+// NewMeteredCAS creates a CAS backed by kv.
+func NewMeteredCAS(kv kvstore.KVStore, meter *Meter) *MeteredCAS {
+	return &MeteredCAS{kv: kv, meter: meter}
+}
+
+func (c *MeteredCAS) Get(ctx context.Context, block cid.Cid) ([]byte, error) {
+	data, err := c.kv.Get(ctx, casKey(block))
+	if err != nil {
+		return nil, fmt.Errorf("block not found: %s", block)
+	}
+	return data, nil
+}
+
+func (c *MeteredCAS) Has(ctx context.Context, block cid.Cid) (bool, error) {
+	return c.kv.Has(ctx, casKey(block))
+}
+
+func (c *MeteredCAS) HasBatch(ctx context.Context, blocks []cid.Cid) ([]bool, error) {
+	out := make([]bool, len(blocks))
+	for i, block := range blocks {
+		ok, err := c.Has(ctx, block)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = ok
+	}
+	return out, nil
+}
+
+func (c *MeteredCAS) Put(ctx context.Context, data []byte) (cid.Cid, error) {
+	return c.PutWithCodec(ctx, data, cid.Raw)
+}
+
+func (c *MeteredCAS) PutWithCodec(ctx context.Context, data []byte, codec uint64) (cid.Cid, error) {
+	blockCID, err := cas.CIDForBlock(cas.Block{Data: data, Codec: codec})
+	if err != nil {
+		return cid.Undef, err
+	}
+	key := casKey(blockCID)
+	exists, err := c.kv.Has(ctx, key)
+	if err != nil {
+		return cid.Undef, err
+	}
+	if !exists {
+		if err := c.kv.Put(ctx, key, data); err != nil {
+			return cid.Undef, err
+		}
+	}
+	c.meter.RecordCASPut(categoryForCodec(codec), len(data), !exists)
+	return blockCID, nil
+}
+
+func (c *MeteredCAS) PutBatch(ctx context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	results := make([]cas.PutResult, len(blocks))
+	seen := make(map[string]struct{}, len(blocks))
+	for i, block := range blocks {
+		codec := cas.NormalizeCodec(block.Codec)
+		blockCID, err := cas.CIDForBlock(cas.Block{Data: block.Data, Codec: codec})
+		if err != nil {
+			return nil, err
+		}
+		key := casKey(blockCID)
+		keyString := string(key)
+		if _, ok := seen[keyString]; ok {
+			c.meter.RecordCASPut(categoryForCodec(codec), len(block.Data), false)
+			results[i] = cas.PutResult{CID: blockCID, Status: cas.PutStatusDuplicate}
+			continue
+		}
+		seen[keyString] = struct{}{}
+		exists, err := c.kv.Has(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		status := cas.PutStatusAlreadyPresent
+		if !exists {
+			if err := c.kv.Put(ctx, key, block.Data); err != nil {
+				return nil, err
+			}
+			status = cas.PutStatusStored
+		}
+		c.meter.RecordCASPut(categoryForCodec(codec), len(block.Data), !exists)
+		results[i] = cas.PutResult{CID: blockCID, Status: status}
+	}
+	return results, nil
+}
+
+func casKey(block cid.Cid) []byte {
+	return []byte("cas:" + block.String())
+}
+
+func categoryForCodec(codec uint64) Category {
+	if cas.NormalizeCodec(codec) == cid.Raw {
+		return CategoryCASPayload
+	}
+	return CategoryCASMetadata
+}
+
+var _ cas.Client = (*MeteredCAS)(nil)
+var _ cas.TypedWriter = (*MeteredCAS)(nil)
+var _ cas.BatchReader = (*MeteredCAS)(nil)
+var _ cas.BatchWriter = (*MeteredCAS)(nil)

--- a/cmd/eval/helper/store/cas_meter.go
+++ b/cmd/eval/helper/store/cas_meter.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/dewebprotocol/malt/core/cas"
@@ -23,7 +24,10 @@ func NewMeteredCAS(kv kvstore.KVStore, meter *Meter) *MeteredCAS {
 func (c *MeteredCAS) Get(ctx context.Context, block cid.Cid) ([]byte, error) {
 	data, err := c.kv.Get(ctx, casKey(block))
 	if err != nil {
-		return nil, fmt.Errorf("block not found: %s", block)
+		if errors.Is(err, kvstore.ErrNotFound) {
+			return nil, fmt.Errorf("block not found: %s: %w", block, err)
+		}
+		return nil, fmt.Errorf("get block %s: %w", block, err)
 	}
 	return data, nil
 }

--- a/cmd/eval/helper/store/factory.go
+++ b/cmd/eval/helper/store/factory.go
@@ -1,0 +1,158 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dewebprotocol/malt/core/kvstore"
+	kvbadger "github.com/dewebprotocol/malt/core/kvstore/badger"
+	kvfs "github.com/dewebprotocol/malt/core/kvstore/fs"
+	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
+)
+
+// StoreMode controls whether evaluated systems share CAS state.
+type StoreMode string
+
+const (
+	StoreModeIsolated StoreMode = "isolated"
+	StoreModeShared   StoreMode = "shared"
+)
+
+// StoreBackend controls the KV implementation used by evaluator storage.
+type StoreBackend string
+
+const (
+	StoreBackendMemory StoreBackend = "memory"
+	StoreBackendFS     StoreBackend = "fs"
+	StoreBackendBadger StoreBackend = "badger"
+)
+
+// FactoryConfig configures per-system evaluation stores.
+type FactoryConfig struct {
+	Mode    StoreMode
+	Backend StoreBackend
+	RootDir string
+}
+
+// Factory creates system-local KV/CAS environments.
+type Factory struct {
+	cfg          FactoryConfig
+	tempRoot     string
+	sharedCASKV  kvstore.KVStore
+	closeTargets []kvstore.KVStore
+}
+
+// System is one evaluated system's independent storage environment.
+type System struct {
+	Name    string
+	StateKV kvstore.KVStore
+	CAS     *MeteredCAS
+	Meter   *Meter
+}
+
+// NewFactory creates a store factory.
+func NewFactory(cfg FactoryConfig) (*Factory, error) {
+	if cfg.Mode == "" {
+		cfg.Mode = StoreModeIsolated
+	}
+	if cfg.Backend == "" {
+		cfg.Backend = StoreBackendMemory
+	}
+	if cfg.Mode != StoreModeIsolated && cfg.Mode != StoreModeShared {
+		return nil, fmt.Errorf("unsupported store mode %q", cfg.Mode)
+	}
+	if cfg.Backend != StoreBackendMemory && cfg.Backend != StoreBackendFS && cfg.Backend != StoreBackendBadger {
+		return nil, fmt.Errorf("unsupported store backend %q", cfg.Backend)
+	}
+	f := &Factory{cfg: cfg}
+	if cfg.Backend != StoreBackendMemory && cfg.RootDir == "" {
+		root, err := os.MkdirTemp("", "malt-eval-store-*")
+		if err != nil {
+			return nil, err
+		}
+		f.tempRoot = root
+		f.cfg.RootDir = root
+	}
+	return f, nil
+}
+
+// NewSystem creates a storage environment for one evaluated system.
+func (f *Factory) NewSystem(ctx context.Context, name string) (*System, error) {
+	if name == "" {
+		return nil, fmt.Errorf("system name is empty")
+	}
+	meter := NewMeter()
+	stateKV, err := f.newKV(name, "state")
+	if err != nil {
+		return nil, err
+	}
+	var casKV kvstore.KVStore
+	if f.cfg.Mode == StoreModeShared {
+		if f.sharedCASKV == nil {
+			f.sharedCASKV, err = f.newKV("_shared", "cas")
+			if err != nil {
+				_ = stateKV.Close()
+				return nil, err
+			}
+		}
+		casKV = f.sharedCASKV
+	} else {
+		casKV, err = f.newKV(name, "cas")
+		if err != nil {
+			_ = stateKV.Close()
+			return nil, err
+		}
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return &System{
+		Name:    name,
+		StateKV: NewMeteredKV(stateKV, meter, CategoryArcTable),
+		CAS:     NewMeteredCAS(casKV, meter),
+		Meter:   meter,
+	}, nil
+}
+
+// Close releases all stores created by the factory.
+func (f *Factory) Close() error {
+	var firstErr error
+	for _, target := range f.closeTargets {
+		if err := target.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if f.tempRoot != "" {
+		if err := os.RemoveAll(f.tempRoot); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (f *Factory) newKV(system, role string) (kvstore.KVStore, error) {
+	switch f.cfg.Backend {
+	case StoreBackendMemory:
+		kv := kvmemory.New()
+		f.closeTargets = append(f.closeTargets, kv)
+		return kv, nil
+	case StoreBackendFS:
+		kv, err := kvfs.New(filepath.Join(f.cfg.RootDir, system, role))
+		if err != nil {
+			return nil, err
+		}
+		f.closeTargets = append(f.closeTargets, kv)
+		return kv, nil
+	case StoreBackendBadger:
+		kv, err := kvbadger.New(kvbadger.WithPath(filepath.Join(f.cfg.RootDir, system, role)))
+		if err != nil {
+			return nil, err
+		}
+		f.closeTargets = append(f.closeTargets, kv)
+		return kv, nil
+	default:
+		return nil, fmt.Errorf("unsupported store backend %q", f.cfg.Backend)
+	}
+}

--- a/cmd/eval/helper/store/factory.go
+++ b/cmd/eval/helper/store/factory.go
@@ -83,6 +83,9 @@ func (f *Factory) NewSystem(ctx context.Context, name string) (*System, error) {
 	if name == "" {
 		return nil, fmt.Errorf("system name is empty")
 	}
+	if ctx != nil && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	meter := NewMeter()
 	stateKV, err := f.newKV(name, "state")
 	if err != nil {
@@ -104,9 +107,6 @@ func (f *Factory) NewSystem(ctx context.Context, name string) (*System, error) {
 			_ = stateKV.Close()
 			return nil, err
 		}
-	}
-	if ctx != nil && ctx.Err() != nil {
-		return nil, ctx.Err()
 	}
 	return &System{
 		Name:    name,

--- a/cmd/eval/helper/store/factory_internal_test.go
+++ b/cmd/eval/helper/store/factory_internal_test.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestNewSystemChecksCanceledContextBeforeAllocatingStores(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	factory, err := NewFactory(FactoryConfig{Backend: StoreBackendMemory})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+
+	_, err = factory.NewSystem(ctx, "maltflat")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("NewSystem error = %v, want context.Canceled", err)
+	}
+	if len(factory.closeTargets) != 0 {
+		t.Fatalf("close target count = %d, want 0", len(factory.closeTargets))
+	}
+}

--- a/cmd/eval/helper/store/kv_meter.go
+++ b/cmd/eval/helper/store/kv_meter.go
@@ -1,0 +1,107 @@
+package store
+
+import (
+	"context"
+
+	"github.com/dewebprotocol/malt/core/kvstore"
+)
+
+// MeteredKV wraps a KVStore and charges every successful put as a changed record.
+type MeteredKV struct {
+	base     kvstore.KVStore
+	meter    *Meter
+	category Category
+}
+
+// NewMeteredKV wraps base with write accounting.
+func NewMeteredKV(base kvstore.KVStore, meter *Meter, category Category) *MeteredKV {
+	return &MeteredKV{base: base, meter: meter, category: category}
+}
+
+func (m *MeteredKV) Get(ctx context.Context, key []byte) ([]byte, error) {
+	return m.base.Get(ctx, key)
+}
+
+func (m *MeteredKV) BatchGet(ctx context.Context, keys [][]byte) (map[string][]byte, error) {
+	return m.base.BatchGet(ctx, keys)
+}
+
+func (m *MeteredKV) Put(ctx context.Context, key, value []byte) error {
+	if err := m.base.Put(ctx, key, value); err != nil {
+		return err
+	}
+	m.meter.RecordChangedRecord(m.category, len(key), len(value))
+	return nil
+}
+
+func (m *MeteredKV) Delete(ctx context.Context, key []byte) error {
+	if err := m.base.Delete(ctx, key); err != nil {
+		return err
+	}
+	m.meter.RecordChangedRecord(m.category, len(key), 0)
+	return nil
+}
+
+func (m *MeteredKV) Has(ctx context.Context, key []byte) (bool, error) {
+	return m.base.Has(ctx, key)
+}
+
+func (m *MeteredKV) NewIterator(ctx context.Context, start, end []byte) kvstore.Iterator {
+	return m.base.NewIterator(ctx, start, end)
+}
+
+func (m *MeteredKV) Batch() kvstore.Batch {
+	return &meteredBatch{
+		base:     m.base.Batch(),
+		meter:    m.meter,
+		category: m.category,
+	}
+}
+
+func (m *MeteredKV) Close() error {
+	return m.base.Close()
+}
+
+type meteredBatch struct {
+	base     kvstore.Batch
+	meter    *Meter
+	category Category
+	puts     []meteredBatchPut
+}
+
+type meteredBatchPut struct {
+	keyBytes   int
+	valueBytes int
+}
+
+func (b *meteredBatch) Put(key, value []byte) error {
+	if err := b.base.Put(key, value); err != nil {
+		return err
+	}
+	b.puts = append(b.puts, meteredBatchPut{keyBytes: len(key), valueBytes: len(value)})
+	return nil
+}
+
+func (b *meteredBatch) Delete(key []byte) error {
+	if err := b.base.Delete(key); err != nil {
+		return err
+	}
+	b.puts = append(b.puts, meteredBatchPut{keyBytes: len(key)})
+	return nil
+}
+
+func (b *meteredBatch) Commit(ctx context.Context) error {
+	if err := b.base.Commit(ctx); err != nil {
+		return err
+	}
+	for _, put := range b.puts {
+		b.meter.RecordChangedRecord(b.category, put.keyBytes, put.valueBytes)
+	}
+	return nil
+}
+
+func (b *meteredBatch) Cancel() {
+	b.base.Cancel()
+}
+
+var _ kvstore.KVStore = (*MeteredKV)(nil)

--- a/cmd/eval/malt-eval-write/main.go
+++ b/cmd/eval/malt-eval-write/main.go
@@ -1,0 +1,154 @@
+// Package main provides the Git trace write-amplification evaluator.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/adapters/hamt"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/adapters/maltflat"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/adapters/merkledag"
+	gittrace "github.com/dewebprotocol/malt/cmd/eval/helper/git"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/internal/merkledagimport"
+	"github.com/spf13/cobra"
+)
+
+var (
+	repoURL      string
+	repoPath     string
+	repoRef      = "HEAD"
+	commitLimit  int
+	cacheDir     = ".eval-cache/repos"
+	storeDir     = ".eval-cache/write-stores"
+	storeMode    = string(evalstore.StoreModeIsolated)
+	storeBackend = string(evalstore.StoreBackendMemory)
+	systemsCSV   = "maltflat,merkledag,hamt"
+	outPath      string
+	firstParent  = true
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "malt-eval-write",
+	Short: "Replay Git commit traces and emit write-amplification JSONL",
+	Args:  cobra.NoArgs,
+	RunE:  runEvalWrite,
+}
+
+func init() {
+	rootCmd.Flags().StringVar(&repoURL, "repo-url", repoURL, "Git repository URL to clone and replay")
+	rootCmd.Flags().StringVar(&repoPath, "repo-path", repoPath, "Existing local Git repository path to replay")
+	rootCmd.Flags().StringVar(&repoRef, "repo-ref", repoRef, "Git ref to replay")
+	rootCmd.Flags().IntVar(&commitLimit, "limit", commitLimit, "Maximum commits to replay; 0 means all")
+	rootCmd.Flags().StringVar(&cacheDir, "cache-dir", cacheDir, "Repository clone cache directory")
+	rootCmd.Flags().StringVar(&storeDir, "store-dir", storeDir, "Evaluation store directory for fs/badger backends")
+	rootCmd.Flags().StringVar(&storeMode, "store-mode", storeMode, "Store mode: isolated or shared")
+	rootCmd.Flags().StringVar(&storeBackend, "store-backend", storeBackend, "Store backend: memory, fs, or badger")
+	rootCmd.Flags().StringVar(&systemsCSV, "systems", systemsCSV, "Comma-separated systems: maltflat, merkledag, hamt")
+	rootCmd.Flags().StringVar(&outPath, "out", outPath, "Output JSONL file; defaults to stdout")
+	rootCmd.Flags().BoolVar(&firstParent, "first-parent", firstParent, "Replay only the first-parent commit chain")
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func runEvalWrite(cmd *cobra.Command, args []string) error {
+	if strings.TrimSpace(repoURL) == "" && strings.TrimSpace(repoPath) == "" {
+		return fmt.Errorf("one of --repo-url or --repo-path is required")
+	}
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreMode(storeMode),
+		Backend: evalstore.StoreBackend(storeBackend),
+		RootDir: storeDir,
+	})
+	if err != nil {
+		return err
+	}
+	defer factory.Close()
+
+	systems, err := buildSystems(cmd.Context(), factory, systemsCSV)
+	if err != nil {
+		return err
+	}
+	writer, closeWriter, err := outputWriter(outPath)
+	if err != nil {
+		return err
+	}
+	defer closeWriter()
+
+	enc := json.NewEncoder(writer)
+	source := gittrace.Source{
+		RepoURL:     repoURL,
+		RepoPath:    repoPath,
+		CacheDir:    cacheDir,
+		Ref:         repoRef,
+		Limit:       commitLimit,
+		FirstParent: firstParent,
+	}
+	return source.Walk(cmd.Context(), func(commit replay.CommitMutation) error {
+		return replay.RunCommit(cmd.Context(), commit, systems, enc)
+	})
+}
+
+func buildSystems(ctx context.Context, factory *evalstore.Factory, csv string) ([]replay.SystemAdapter, error) {
+	if factory == nil {
+		return nil, fmt.Errorf("store factory is nil")
+	}
+	var systems []replay.SystemAdapter
+	for _, raw := range strings.Split(csv, ",") {
+		name := strings.ToLower(strings.TrimSpace(raw))
+		if name == "" {
+			continue
+		}
+		system, err := factory.NewSystem(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		switch name {
+		case "maltflat":
+			adapter, err := maltflat.New(system, maltflat.Options{})
+			if err != nil {
+				return nil, err
+			}
+			systems = append(systems, adapter)
+		case "merkledag":
+			systems = append(systems, merkledag.New(system, merkledag.Options{
+				Name:      "merkledag",
+				DirLayout: merkledagimport.DirLayoutBasic,
+			}))
+		case "hamt":
+			systems = append(systems, hamt.New(system))
+		default:
+			return nil, fmt.Errorf("unknown system %q", raw)
+		}
+	}
+	if len(systems) == 0 {
+		return nil, fmt.Errorf("no systems selected")
+	}
+	return systems, nil
+}
+
+func outputWriter(path string) (io.Writer, func(), error) {
+	if strings.TrimSpace(path) == "" {
+		return os.Stdout, func() {}, nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+func runWithContext(ctx context.Context, cmd *cobra.Command) error {
+	cmd.SetContext(ctx)
+	return cmd.Execute()
+}

--- a/cmd/eval/malt-eval-write/main_test.go
+++ b/cmd/eval/malt-eval-write/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+)
+
+func TestBuildSystemsUsesIsolatedStoresByDefault(t *testing.T) {
+	ctx := context.Background()
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+
+	systems, err := buildSystems(ctx, factory, "maltflat,merkledag,hamt")
+	if err != nil {
+		t.Fatalf("buildSystems: %v", err)
+	}
+	names := systemNames(systems)
+	want := []string{"maltflat", "merkledag", "hamt"}
+	if len(names) != len(want) {
+		t.Fatalf("names = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("names = %v, want %v", names, want)
+		}
+	}
+}
+
+func TestBuildSystemsRejectsUnknownSystem(t *testing.T) {
+	ctx := context.Background()
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{Backend: evalstore.StoreBackendMemory})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	if _, err := buildSystems(ctx, factory, "maltflat,nope"); err == nil {
+		t.Fatal("expected unknown system error")
+	}
+}
+
+func systemNames(systems []replay.SystemAdapter) []string {
+	names := make([]string, len(systems))
+	for i, system := range systems {
+		names[i] = system.Name()
+	}
+	return names
+}

--- a/internal/merkledagimport/import.go
+++ b/internal/merkledagimport/import.go
@@ -2,11 +2,17 @@
 package merkledagimport
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
+	"sort"
+	"strings"
+	"time"
 
 	chunker "github.com/ipfs/boxo/chunker"
 	merkledag "github.com/ipfs/boxo/ipld/merkledag"
@@ -59,6 +65,13 @@ type Result struct {
 	Bytes int64
 }
 
+// File describes one virtual file to materialize into a UnixFS DAG.
+type File struct {
+	Path string
+	Data []byte
+	Mode fs.FileMode
+}
+
 // Store is the minimal CAS surface needed by the DAGService adapter.
 type Store interface {
 	PutWithCodec(ctx context.Context, data []byte, codec uint64) (cid.Cid, error)
@@ -69,17 +82,8 @@ type Store interface {
 // builders and returns the Merkle DAG root CID.
 func ImportPath(ctx context.Context, store Store, localPath string, opts Options) (*Result, error) {
 	opts = normalizeOptions(opts)
-	if opts.Model != ModelUnixFS {
-		return nil, fmt.Errorf("unsupported merkle-dag model %q", opts.Model)
-	}
-	if opts.Layout != "" {
-		return nil, fmt.Errorf("merkle-dag uses file-layout and dir-layout, not top-level layout %q", opts.Layout)
-	}
-	if opts.FileLayout != FileLayoutBalanced && opts.FileLayout != FileLayoutTrickle {
-		return nil, fmt.Errorf("unsupported merkle-dag unixfs file layout %q", opts.FileLayout)
-	}
-	if opts.DirLayout != DirLayoutBasic && opts.DirLayout != DirLayoutHAMT && opts.DirLayout != DirLayoutAdaptive {
-		return nil, fmt.Errorf("unsupported merkle-dag unixfs directory layout %q", opts.DirLayout)
+	if err := validateOptions(opts); err != nil {
+		return nil, err
 	}
 
 	abs, err := filepath.Abs(localPath)
@@ -103,6 +107,30 @@ func ImportPath(ctx context.Context, store Store, localPath string, opts Options
 	}, nil
 }
 
+// ImportFiles imports a virtual repository snapshot into the supplied CAS using
+// Boxo's UnixFS DAG builders and returns the directory root CID.
+func ImportFiles(ctx context.Context, store Store, files []File, opts Options) (*Result, error) {
+	opts = normalizeOptions(opts)
+	if err := validateOptions(opts); err != nil {
+		return nil, err
+	}
+	importer := &pathImporter{
+		dag:   &casDAGService{store: store},
+		opts:  opts,
+		seen:  make(map[string]struct{}),
+		build: cid.Prefix{Version: 1, Codec: cid.DagProtobuf, MhType: mh.SHA2_256, MhLength: -1},
+	}
+	root, fileCount, bytesUploaded, err := importer.importFiles(ctx, files)
+	if err != nil {
+		return nil, err
+	}
+	return &Result{
+		Root:  root.Cid().String(),
+		Files: fileCount,
+		Bytes: bytesUploaded,
+	}, nil
+}
+
 func normalizeOptions(opts Options) Options {
 	if opts.Model == "" {
 		opts.Model = ModelUnixFS
@@ -120,6 +148,22 @@ func normalizeOptions(opts Options) Options {
 		opts.HAMTFanout = unixfsio.DefaultShardWidth
 	}
 	return opts
+}
+
+func validateOptions(opts Options) error {
+	if opts.Model != ModelUnixFS {
+		return fmt.Errorf("unsupported merkle-dag model %q", opts.Model)
+	}
+	if opts.Layout != "" {
+		return fmt.Errorf("merkle-dag uses file-layout and dir-layout, not top-level layout %q", opts.Layout)
+	}
+	if opts.FileLayout != FileLayoutBalanced && opts.FileLayout != FileLayoutTrickle {
+		return fmt.Errorf("unsupported merkle-dag unixfs file layout %q", opts.FileLayout)
+	}
+	if opts.DirLayout != DirLayoutBasic && opts.DirLayout != DirLayoutHAMT && opts.DirLayout != DirLayoutAdaptive {
+		return fmt.Errorf("unsupported merkle-dag unixfs directory layout %q", opts.DirLayout)
+	}
+	return nil
 }
 
 type pathImporter struct {
@@ -154,17 +198,21 @@ func (i *pathImporter) importFile(ctx context.Context, localPath string, info fs
 	}
 	defer f.Close()
 
+	return i.importFileReader(ctx, localPath, f, info.Mode(), info.ModTime())
+}
+
+func (i *pathImporter) importFileReader(_ context.Context, name string, r io.Reader, mode fs.FileMode, modTime time.Time) (ipld.Node, error) {
 	dbp := helpers.DagBuilderParams{
 		Dagserv:     i.dag,
 		Maxlinks:    helpers.DefaultLinksPerBlock,
 		RawLeaves:   i.opts.RawFileLeaf,
 		CidBuilder:  i.build,
-		FileMode:    info.Mode(),
-		FileModTime: info.ModTime(),
+		FileMode:    mode,
+		FileModTime: modTime,
 	}
-	db, err := dbp.New(chunker.NewSizeSplitter(f, int64(i.opts.ChunkSize)))
+	db, err := dbp.New(chunker.NewSizeSplitter(r, int64(i.opts.ChunkSize)))
 	if err != nil {
-		return nil, fmt.Errorf("create unixfs dag builder for %s: %w", localPath, err)
+		return nil, fmt.Errorf("create unixfs dag builder for %s: %w", name, err)
 	}
 	var root ipld.Node
 	switch i.opts.FileLayout {
@@ -176,9 +224,122 @@ func (i *pathImporter) importFile(ctx context.Context, localPath string, info fs
 		return nil, fmt.Errorf("unsupported merkle-dag unixfs file layout %q", i.opts.FileLayout)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("build unixfs file dag for %s: %w", localPath, err)
+		return nil, fmt.Errorf("build unixfs file dag for %s: %w", name, err)
 	}
 	return root, nil
+}
+
+type virtualDir struct {
+	dirs  map[string]*virtualDir
+	files map[string]File
+}
+
+func newVirtualDir() *virtualDir {
+	return &virtualDir{
+		dirs:  make(map[string]*virtualDir),
+		files: make(map[string]File),
+	}
+}
+
+func (d *virtualDir) add(file File) error {
+	clean, err := cleanVirtualPath(file.Path)
+	if err != nil {
+		return err
+	}
+	parts := strings.Split(clean, "/")
+	dir := d
+	for _, part := range parts[:len(parts)-1] {
+		child := dir.dirs[part]
+		if child == nil {
+			child = newVirtualDir()
+			dir.dirs[part] = child
+		}
+		dir = child
+	}
+	name := parts[len(parts)-1]
+	if _, ok := dir.files[name]; ok {
+		return fmt.Errorf("duplicate virtual file path %q", clean)
+	}
+	file.Path = clean
+	dir.files[name] = file
+	return nil
+}
+
+func cleanVirtualPath(raw string) (string, error) {
+	trimmed := strings.Trim(filepath.ToSlash(strings.TrimSpace(raw)), "/")
+	clean := path.Clean(trimmed)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("invalid virtual file path %q", raw)
+	}
+	return clean, nil
+}
+
+func (i *pathImporter) importFiles(ctx context.Context, files []File) (ipld.Node, int, int64, error) {
+	root := newVirtualDir()
+	for _, file := range files {
+		if err := root.add(file); err != nil {
+			return nil, 0, 0, err
+		}
+	}
+	return i.importVirtualDirectory(ctx, ".", root)
+}
+
+func (i *pathImporter) importVirtualDirectory(ctx context.Context, name string, node *virtualDir) (ipld.Node, int, int64, error) {
+	dir, err := i.newDirectory()
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	var files int
+	var bytesUploaded int64
+	for _, childName := range sortedKeys(node.dirs) {
+		child, childFiles, childBytes, err := i.importVirtualDirectory(ctx, childName, node.dirs[childName])
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		if err := dir.AddChild(ctx, childName, child); err != nil {
+			return nil, 0, 0, fmt.Errorf("add %s to virtual unixfs directory %s: %w", childName, name, err)
+		}
+		files += childFiles
+		bytesUploaded += childBytes
+	}
+	for _, fileName := range sortedKeys(node.files) {
+		file := node.files[fileName]
+		child, err := i.importFileReader(ctx, file.Path, bytes.NewReader(file.Data), virtualFileMode(file.Mode), time.Time{})
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		if err := dir.AddChild(ctx, fileName, child); err != nil {
+			return nil, 0, 0, fmt.Errorf("add %s to virtual unixfs directory %s: %w", fileName, name, err)
+		}
+		files++
+		bytesUploaded += int64(len(file.Data))
+	}
+
+	root, err := dir.GetNode()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("materialize virtual unixfs directory %s: %w", name, err)
+	}
+	if err := i.dag.Add(ctx, root); err != nil {
+		return nil, 0, 0, fmt.Errorf("store virtual unixfs directory %s: %w", name, err)
+	}
+	return root, files, bytesUploaded, nil
+}
+
+func virtualFileMode(mode fs.FileMode) fs.FileMode {
+	if mode == 0 {
+		return 0o644
+	}
+	return mode
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (i *pathImporter) importDirectory(ctx context.Context, localPath string) (ipld.Node, int, int64, error) {

--- a/internal/merkledagimport/import_test.go
+++ b/internal/merkledagimport/import_test.go
@@ -86,6 +86,40 @@ func TestImportDirectoryStoresHAMTUnixFSDAG(t *testing.T) {
 	}
 }
 
+func TestImportFilesStoresVirtualHAMTUnixFSDAG(t *testing.T) {
+	ctx := context.Background()
+	casClient := casmock.NewCAS(casmock.WithoutLatency())
+
+	result, err := ImportFiles(ctx, casClient, []File{
+		{Path: "README.md", Data: []byte("readme"), Mode: 0o644},
+		{Path: "docs/guide.txt", Data: []byte("guide"), Mode: 0o644},
+	}, Options{
+		Model:      ModelUnixFS,
+		FileLayout: FileLayoutBalanced,
+		DirLayout:  DirLayoutHAMT,
+		ChunkSize:  4,
+	})
+	if err != nil {
+		t.Fatalf("import virtual files: %v", err)
+	}
+	if result.Files != 2 {
+		t.Fatalf("files = %d, want 2", result.Files)
+	}
+	if result.Bytes != int64(len("readme")+len("guide")) {
+		t.Fatalf("bytes = %d", result.Bytes)
+	}
+	rootCID, err := cid.Decode(result.Root)
+	if err != nil {
+		t.Fatalf("decode root: %v", err)
+	}
+	if rootCID.Type() != cid.DagProtobuf {
+		t.Fatalf("root codec = %d, want dag-pb", rootCID.Type())
+	}
+	if _, err := casClient.Get(ctx, rootCID); err != nil {
+		t.Fatalf("directory root should be stored in CAS: %v", err)
+	}
+}
+
 func TestImportRejectsTopLevelLayout(t *testing.T) {
 	ctx := context.Background()
 	casClient := casmock.NewCAS(casmock.WithoutLatency())


### PR DESCRIPTION
## Summary

- Add `malt-eval-write` under `cmd/eval` for replaying Git commit traces into write-amplification JSONL output.
- Add helper packages for Git trace extraction, replay result schema, per-system store/CAS accounting, and system adapters.
- Support `maltflat`, `merkledag`, and `hamt` systems with isolated per-system stores by default and optional shared CAS diagnostic mode.
- Replay commit snapshots directly from Git objects by blob hash, without temporary replay worktrees or per-commit checkout.

## Testing

- `go test ./cmd/eval/... -count=1`
- `go test ./... -count=1`
- Manual smoke run against a temporary local Git repo with `maltflat,merkledag,hamt`, `--limit 3`, explicit `--cache-dir`, and two consecutive `--repo-url` runs to verify 9 JSONL records per run and cache reuse.
- Manual smoke run with dirty `--repo-path` to verify 9 JSONL records, branch remains `main`, dirty file contents remain unchanged, and no extra Git worktree is created.
