### PR TITLE
[codex] unify path resolution

### DIFF
--- a/core/graph/graph.go
+++ b/core/graph/graph.go
@@ -140,6 +140,9 @@ func (g *Graph) Resolve(ctx context.Context, root cid.Cid, path string) (cid.Cid
 	if err != nil {
 		return cid.Cid{}, nil, fmt.Errorf("resolution failed: %w", err)
 	}
+	if !result.RemainingPath.IsEmpty() {
+		return cid.Cid{}, nil, fmt.Errorf("resolution incomplete: remaining path %q", result.RemainingPath.String())
+	}
 	return result.Target, NewTranscriptProof(result.Transcript), nil
 }
 
@@ -152,6 +155,9 @@ func (g *Graph) BatchResolve(ctx context.Context, root cid.Cid, paths []string) 
 	for _, p := range paths {
 		result, err := g.resolver.Resolve(root, p)
 		if err != nil {
+			continue
+		}
+		if !result.RemainingPath.IsEmpty() {
 			continue
 		}
 		results[p] = result.Target

--- a/core/resolver/resolver.go
+++ b/core/resolver/resolver.go
@@ -45,6 +45,10 @@ type ResolveResult struct {
 	// Target is the final resolved CID
 	Target cid.Cid
 
+	// RemainingPath is non-empty when resolution stopped before consuming the
+	// requested path.
+	RemainingPath arcset.Path
+
 	// Transcript contains the evidence for each step
 	Transcript *Transcript
 }
@@ -64,8 +68,9 @@ func (r *Resolver) ResolveKey(root cid.Cid, path string) (*ResolveResult, error)
 		// Typed list roots are terminal for path traversal.
 		if codec.SemanticKindOf(currentCID) == codec.SemanticKindList {
 			return &ResolveResult{
-				Target:     currentCID,
-				Transcript: transcript,
+				Target:        currentCID,
+				RemainingPath: remainingPath,
+				Transcript:    transcript,
 			}, nil
 		}
 
@@ -79,8 +84,9 @@ func (r *Resolver) ResolveKey(root cid.Cid, path string) (*ResolveResult, error)
 			// Explicit step: use explicit step executor for longest-prefix match.
 			if r.explicitStep == nil {
 				return &ResolveResult{
-					Target:     currentCID,
-					Transcript: transcript,
+					Target:        currentCID,
+					RemainingPath: remainingPath,
+					Transcript:    transcript,
 				}, nil
 			}
 			matchedPath, target, ev, err = r.explicitStep.Resolve(currentCID, remainingPath)
@@ -88,8 +94,9 @@ func (r *Resolver) ResolveKey(root cid.Cid, path string) (*ResolveResult, error)
 			// Implicit step: use implicit step executor for DAG traversal.
 			if r.implicitStep == nil {
 				return &ResolveResult{
-					Target:     currentCID,
-					Transcript: transcript,
+					Target:        currentCID,
+					RemainingPath: remainingPath,
+					Transcript:    transcript,
 				}, nil
 			}
 			matchedPath, target, ev, err = r.implicitStep.Resolve(currentCID, remainingPath)
@@ -102,8 +109,9 @@ func (r *Resolver) ResolveKey(root cid.Cid, path string) (*ResolveResult, error)
 		// If no path was matched, we can't continue.
 		if matchedPath.IsEmpty() {
 			return &ResolveResult{
-				Target:     currentCID,
-				Transcript: transcript,
+				Target:        currentCID,
+				RemainingPath: remainingPath,
+				Transcript:    transcript,
 			}, nil
 		}
 
@@ -126,8 +134,9 @@ func (r *Resolver) ResolveKey(root cid.Cid, path string) (*ResolveResult, error)
 	}
 
 	return &ResolveResult{
-		Target:     currentCID,
-		Transcript: transcript,
+		Target:        currentCID,
+		RemainingPath: remainingPath,
+		Transcript:    transcript,
 	}, nil
 }
 
@@ -142,6 +151,9 @@ func (r *Resolver) Resolve(root cid.Cid, path string) (*ResolveResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !keyResult.RemainingPath.IsEmpty() {
+		return keyResult, nil
+	}
 
 	// Terminal materialization is map-only. List roots must remain terminal.
 	if codec.SemanticKindOf(keyResult.Target) == codec.SemanticKindMap && r.explicitStep != nil {
@@ -155,8 +167,9 @@ func (r *Resolver) Resolve(root cid.Cid, path string) (*ResolveResult, error) {
 			Evidence: ev,
 		})
 		return &ResolveResult{
-			Target:     target,
-			Transcript: keyResult.Transcript,
+			Target:        target,
+			RemainingPath: "",
+			Transcript:    keyResult.Transcript,
 		}, nil
 	}
 

--- a/core/resolver/resolver_test.go
+++ b/core/resolver/resolver_test.go
@@ -324,6 +324,20 @@ func TestResolveKeyAndResolve_ListTerminalNoPayloadRedirect(t *testing.T) {
 	if len(resolveResult.Transcript.Steps) != 1 {
 		t.Fatalf("Resolve should not append @payload for list; steps = %d", len(resolveResult.Transcript.Steps))
 	}
+
+	incompleteResult, err := g.Resolve(root, "file/extra")
+	if err != nil {
+		t.Fatalf("Resolve incomplete list path failed: %v", err)
+	}
+	if !incompleteResult.Target.Equals(listRoot) {
+		t.Fatalf("Resolve incomplete list target = %v, want list root %v", incompleteResult.Target, listRoot)
+	}
+	if incompleteResult.RemainingPath != "extra" {
+		t.Fatalf("Resolve incomplete list remaining path = %q, want %q", incompleteResult.RemainingPath, "extra")
+	}
+	if len(incompleteResult.Transcript.Steps) != 1 {
+		t.Fatalf("Resolve incomplete list steps = %d, want 1", len(incompleteResult.Transcript.Steps))
+	}
 }
 
 func TestResolverMissingPayloadBindingFails(t *testing.T) {
@@ -367,5 +381,32 @@ func TestResolverNonMaltEmptyPath(t *testing.T) {
 	}
 	if len(result.Transcript.Steps) != 0 {
 		t.Errorf("Expected 0 steps, got %d", len(result.Transcript.Steps))
+	}
+}
+
+func TestResolverNonMaltUnresolvedPathReportsRemaining(t *testing.T) {
+	e := newTestArcTable()
+	semantic := newSemantic(t, e)
+	c := mock.NewCAS()
+
+	payloadCID, _ := newPayloadCID([]byte("raw-data"))
+	c.AddBlock(payloadCID, []byte("raw-data"))
+
+	explicitR := explicit.NewResolver(e, semantic, testNamespace)
+	implicitR := implicit.NewResolver(c)
+	g := resolver.NewResolver(explicitR, implicitR)
+
+	result, err := g.Resolve(payloadCID, "missing/path")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if !result.Target.Equals(payloadCID) {
+		t.Fatalf("Target = %v, want %v", result.Target, payloadCID)
+	}
+	if result.RemainingPath != "missing/path" {
+		t.Fatalf("RemainingPath = %q, want %q", result.RemainingPath, "missing/path")
+	}
+	if len(result.Transcript.Steps) != 0 {
+		t.Fatalf("Expected 0 steps, got %d", len(result.Transcript.Steps))
 	}
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -34,6 +34,13 @@ import (
 
 const fixedListChunkSize = 262144
 
+type pathResolution struct {
+	queryPath string
+	target    cid.Cid
+	stat      *httpapi.PathStatResponse
+	proofList *prooflist.ProofList
+}
+
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, &httpapi.HealthResponse{Status: "ok"})
 }
@@ -79,8 +86,8 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stat to determine file vs directory
-	stat, err := s.pathStat(r.Context(), g, root, path)
+	wantProof := r.Method != http.MethodHead && !shouldOmitDefaultProof(r)
+	resolved, err := s.resolvePath(r.Context(), g, root, path, wantProof)
 	if err != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(err, errPathNotFound) || errors.Is(err, resolver.ErrResolutionFailed) {
@@ -89,6 +96,7 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, status, err.Error())
 		return
 	}
+	stat := resolved.stat
 
 	// HEAD request — return stat headers without body
 	if r.Method == http.MethodHead {
@@ -107,21 +115,12 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 
 	if stat.Kind == "dir" {
 		// Return JSON directory listing
-		if !shouldOmitDefaultProof(r) {
-			queryPath := path
-			if queryPath == "" {
-				queryPath = "@payload"
-			}
-			pl, err := s.contentProofList(r.Context(), g, root, queryPath, stat, 0, 0)
-			if err != nil {
+		if resolved.proofList != nil {
+			if err := writeProofListHeader(w, *resolved.proofList); err != nil {
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
-			if err := writeProofListHeader(w, *pl); err != nil {
-				writeError(w, http.StatusInternalServerError, err.Error())
-				return
-			}
-			s.node.RecordProofList(*pl)
+			s.node.RecordProofList(*resolved.proofList)
 		}
 		addVaryHeader(w, "X-Malt-Proof")
 		writeJSON(w, http.StatusOK, stat)
@@ -150,12 +149,8 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Generate and write proof headers before response headers
-	if !shouldOmitDefaultProof(r) {
-		queryPath := path
-		if queryPath == "" {
-			queryPath = "@payload"
-		}
-		pl, err := s.contentProofList(r.Context(), g, root, queryPath, stat, start, endExclusive)
+	if resolved.proofList != nil {
+		pl, err := s.readProofList(r.Context(), g, resolved, start, endExclusive)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
@@ -180,47 +175,7 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) serveResolve(w http.ResponseWriter, r *http.Request, g *graph.Graph, root cid.Cid, queryPath string) {
-	result, err := g.Resolver().Resolve(root, queryPath)
-	if err != nil {
-		status := http.StatusInternalServerError
-		if errors.Is(err, resolver.ErrResolutionFailed) {
-			status = http.StatusNotFound
-		}
-		writeError(w, status, err.Error())
-		return
-	}
-	if resolveMiss(root, queryPath, result) {
-		writeError(w, http.StatusNotFound, errPathNotFound.Error())
-		return
-	}
-	addVaryHeader(w, "X-Malt-Proof")
-	resp := &httpapi.ResolveResponse{Target: result.Target.String()}
-	if !shouldOmitDefaultProof(r) {
-		pl, err := resolver.ProofListFromTranscript(root, result.Transcript)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
-		}
-		pl.Query = querypath.CanonicalizeQueryPath(queryPath)
-		resp.ProofList = pl
-		s.node.RecordProofList(*pl)
-	}
-	writeJSON(w, http.StatusOK, resp)
-}
-
-func (s *Server) handleStat(w http.ResponseWriter, r *http.Request) {
-	g, err := s.getOrCreateGraph(r.Context())
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	root, err := decodeCID(r.PathValue("root"))
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid root CID: "+err.Error())
-		return
-	}
-	path := r.PathValue("path")
-	stat, err := s.pathStat(r.Context(), g, root, path)
+	resolved, err := s.resolvePath(r.Context(), g, root, queryPath, !shouldOmitDefaultProof(r))
 	if err != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(err, errPathNotFound) || errors.Is(err, resolver.ErrResolutionFailed) {
@@ -229,13 +184,13 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request) {
 		writeError(w, status, err.Error())
 		return
 	}
-	w.Header().Set("X-Malt-Kind", stat.Kind)
-	w.Header().Set("X-Malt-Storage-Kind", stat.StorageKind)
-	w.Header().Set("X-Malt-Key", stat.Key)
-	if stat.Size != nil {
-		w.Header().Set("Content-Length", strconv.FormatInt(*stat.Size, 10))
+	addVaryHeader(w, "X-Malt-Proof")
+	resp := &httpapi.ResolveResponse{Target: resolved.target.String()}
+	if resolved.proofList != nil {
+		resp.ProofList = resolved.proofList
+		s.node.RecordProofList(*resolved.proofList)
 	}
-	w.WriteHeader(http.StatusOK)
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) handleSemanticMutation(w http.ResponseWriter, r *http.Request) {
@@ -430,122 +385,186 @@ func (s *Server) verifyProofList(g *graph.Graph, pl prooflist.ProofList) (bool, 
 	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
 		return false, err
 	}
-	if proofListUsesResolverEvidence(pl) {
-		return s.verifyResolverProofList(g, pl)
-	}
-	return s.verifyStructureProofList(g, pl)
-}
-
-func proofListUsesResolverEvidence(pl prooflist.ProofList) bool {
-	for _, step := range pl.Steps {
-		switch step.EvidenceKind {
-		case "explicit", "implicit", "hamt":
-			return true
-		}
-	}
-	return false
-}
-
-func (s *Server) verifyResolverProofList(g *graph.Graph, pl prooflist.ProofList) (bool, error) {
-	steps := make([]resolver.StepEvidence, len(pl.Steps))
 	for i, step := range pl.Steps {
-		ev, err := decodeEvidence(step.EvidenceKind, step.Evidence)
-		if err != nil {
-			return false, fmt.Errorf("invalid evidence at step %d: %w", i, err)
-		}
-		steps[i] = resolver.StepEvidence{
-			Path:     arcset.CanonicalizePath(step.Path),
-			Target:   step.Target,
-			Evidence: ev,
-		}
-	}
-	return g.Resolver().VerifyTranscript(pl.Root, &resolver.Transcript{Steps: steps})
-}
-
-func (s *Server) verifyStructureProofList(g *graph.Graph, pl prooflist.ProofList) (bool, error) {
-	for i, step := range pl.Steps {
-		switch {
-		case step.EvidenceKind == "structure" && step.EvidenceBackend == "map":
-			key := arcset.CanonicalizePath(step.Path)
-			ok, err := g.Semantic().Verify(step.From, key, mapping.Binding{Value: step.Target, Present: true}, structure.Proof(step.Proof))
-			if err != nil || !ok {
-				return ok, err
-			}
-		case step.EvidenceKind == "structure" && step.EvidenceBackend == "list":
-			if step.Index == nil {
-				return false, fmt.Errorf("prooflist step %d list index is missing", i)
-			}
-			if step.Length == nil {
-				return false, fmt.Errorf("prooflist step %d list length is missing", i)
-			}
-			ok, err := g.ListSemantic().Verify(step.From, *step.Index, list.Query{Key: step.Target, Length: *step.Length}, structure.Proof(step.Proof))
-			if err != nil || !ok {
-				return ok, err
-			}
-		default:
-			return false, fmt.Errorf("prooflist step %d has unsupported evidence labels %q/%q", i, step.EvidenceKind, step.EvidenceBackend)
+		ok, err := s.verifyProofListStep(g, i, step)
+		if err != nil || !ok {
+			return ok, err
 		}
 	}
 	return true, nil
 }
 
+func (s *Server) verifyProofListStep(g *graph.Graph, index int, step prooflist.Step) (bool, error) {
+	switch step.EvidenceKind {
+	case "explicit", "implicit", "hamt":
+		ev, err := decodeEvidence(step.EvidenceKind, step.Evidence)
+		if err != nil {
+			return false, fmt.Errorf("invalid evidence at step %d: %w", index, err)
+		}
+		return g.Resolver().VerifyTranscript(step.From, &resolver.Transcript{Steps: []resolver.StepEvidence{{
+			Path:     arcset.CanonicalizePath(step.Path),
+			Target:   step.Target,
+			Evidence: ev,
+		}}})
+	case "structure":
+		switch step.EvidenceBackend {
+		case "map":
+			key := arcset.CanonicalizePath(step.Path)
+			return g.Semantic().Verify(step.From, key, mapping.Binding{Value: step.Target, Present: true}, structure.Proof(step.Proof))
+		case "list":
+			if step.Index == nil {
+				return false, fmt.Errorf("prooflist step %d list index is missing", index)
+			}
+			if step.Length == nil {
+				return false, fmt.Errorf("prooflist step %d list length is missing", index)
+			}
+			return g.ListSemantic().Verify(step.From, *step.Index, list.Query{Key: step.Target, Length: *step.Length}, structure.Proof(step.Proof))
+		default:
+			return false, fmt.Errorf("prooflist step %d has unsupported structure evidence backend %q", index, step.EvidenceBackend)
+		}
+	default:
+		return false, fmt.Errorf("prooflist step %d has unsupported evidence labels %q/%q", index, step.EvidenceKind, step.EvidenceBackend)
+	}
+}
+
 var (
-	errPathNotFound  = errors.New("path not found")
-	errNotFlatUnixFS = errors.New("not a flat unixfs root")
+	errPathNotFound = errors.New("path not found")
 )
 
-func (s *Server) pathStat(ctx context.Context, g *graph.Graph, root cid.Cid, path string) (*httpapi.PathStatResponse, error) {
-	if stat, err := s.flatUnixFSPathStat(ctx, g, root, path); err == nil {
-		return stat, nil
-	} else if errors.Is(err, errPathNotFound) {
+func (s *Server) resolvePath(ctx context.Context, g *graph.Graph, root cid.Cid, rawPath string, wantProof bool) (*pathResolution, error) {
+	cleanPath := querypath.CanonicalizeQueryPath(rawPath)
+	keyResult, err := g.Resolver().ResolveKey(root, cleanPath)
+	if err != nil {
 		return nil, err
 	}
-	if stat, err := s.unixFSPathStat(ctx, g, root, path); err == nil {
-		return stat, nil
-	}
-	return s.legacyPathStat(ctx, g, root, path)
-}
-
-func (s *Server) flatUnixFSPathStat(ctx context.Context, g *graph.Graph, root cid.Cid, p string) (*httpapi.PathStatResponse, error) {
-	if codec.SemanticKindOf(root) != codec.SemanticKindMap {
-		return nil, errNotFlatUnixFS
-	}
-	rootPayload, payloadErr := s.node.ArcTable().Get(ctx, g.Namespace(), root, explicit.PayloadArc)
-	if payloadErr != nil || codec.SemanticKindOf(rootPayload) != codec.SemanticKindManifest {
-		return nil, errNotFlatUnixFS
-	}
-	var target cid.Cid
-	var err error
-	if querypath.CanonicalizeQueryPath(p) == "" {
-		target = rootPayload
-	} else {
-		target, err = s.node.ArcTable().Get(ctx, g.Namespace(), root, arcset.CanonicalizePath(p))
-	}
-	if err != nil || !target.Defined() {
-		return s.flatUnixFSMapBoundaryStat(ctx, g, root, p)
-	}
-	return s.statFromFlatTarget(ctx, g, target)
-}
-
-func (s *Server) flatUnixFSMapBoundaryStat(ctx context.Context, g *graph.Graph, root cid.Cid, p string) (*httpapi.PathStatResponse, error) {
-	clean := querypath.CanonicalizeQueryPath(p)
-	if clean == "" {
+	if resolveMiss(root, cleanPath, keyResult) {
 		return nil, errPathNotFound
 	}
-	parts := strings.Split(clean, "/")
-	for i := len(parts) - 1; i > 0; i-- {
-		prefix := strings.Join(parts[:i], "/")
-		suffix := strings.Join(parts[i:], "/")
-		target, err := s.node.ArcTable().Get(ctx, g.Namespace(), root, arcset.CanonicalizePath(prefix))
-		if err != nil || codec.SemanticKindOf(target) != codec.SemanticKindMap {
-			continue
-		}
-		if stat, statErr := s.unixFSPathStat(ctx, g, target, suffix); statErr == nil {
-			return stat, nil
-		}
-		return s.legacyPathStat(ctx, g, target, suffix)
+	key := keyResult.Target
+	if !key.Defined() {
+		return nil, errPathNotFound
 	}
-	return nil, errPathNotFound
+
+	stat, target, err := s.statForResolvedKey(ctx, g, key)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved := &pathResolution{
+		queryPath: cleanPath,
+		target:    target,
+		stat:      stat,
+	}
+	if !wantProof {
+		return resolved, nil
+	}
+
+	transcript := keyResult.Transcript
+	if codec.SemanticKindOf(key) == codec.SemanticKindMap {
+		payloadResult, err := g.Resolver().ResolveKey(key, explicit.PayloadArc.String())
+		if err != nil {
+			return nil, err
+		}
+		if resolveMiss(key, explicit.PayloadArc.String(), payloadResult) {
+			return nil, errPathNotFound
+		}
+		if !payloadResult.Target.Equals(target) {
+			return nil, fmt.Errorf("%w: resolved target %s does not match projected target %s", resolver.ErrResolutionFailed, payloadResult.Target, target)
+		}
+		transcript.Steps = append(transcript.Steps, payloadResult.Transcript.Steps...)
+	}
+
+	pl, err := resolver.ProofListFromTranscript(root, transcript)
+	if err != nil {
+		return nil, err
+	}
+	pl.Query = cleanPath
+	resolved.proofList = pl
+	return resolved, nil
+}
+
+func (s *Server) statForResolvedKey(ctx context.Context, g *graph.Graph, key cid.Cid) (*httpapi.PathStatResponse, cid.Cid, error) {
+	switch codec.SemanticKindOf(key) {
+	case codec.SemanticKindManifest:
+		stat, err := s.statFromFlatTarget(ctx, g, key)
+		return stat, key, err
+	case codec.SemanticKindMap:
+		if stat, err := s.unixFSPathStat(ctx, g, key, ""); err == nil {
+			target, err := statReadTarget(stat)
+			if err != nil {
+				return nil, cid.Undef, err
+			}
+			return stat, target, nil
+		}
+		payload, err := mandatoryMapPayload(ctx, g, key)
+		if err != nil {
+			return nil, cid.Undef, err
+		}
+		return &httpapi.PathStatResponse{
+			Kind:        "dir",
+			StorageKind: "map",
+			Key:         key.String(),
+			Payload:     payload.String(),
+		}, payload, nil
+	case codec.SemanticKindList:
+		size, _, err := s.listFileSize(ctx, g, key)
+		if err != nil {
+			return nil, cid.Undef, err
+		}
+		return &httpapi.PathStatResponse{
+			Kind:        "file",
+			StorageKind: "list",
+			Key:         key.String(),
+			Size:        &size,
+		}, key, nil
+	default:
+		resp := &httpapi.PathStatResponse{
+			Kind:        "file",
+			StorageKind: "raw",
+			Key:         key.String(),
+		}
+		if data, err := s.node.CAS().Get(ctx, key); err == nil {
+			size := int64(len(data))
+			resp.Size = &size
+		}
+		return resp, key, nil
+	}
+}
+
+func statReadTarget(stat *httpapi.PathStatResponse) (cid.Cid, error) {
+	if stat == nil {
+		return cid.Undef, fmt.Errorf("resolved stat is nil")
+	}
+	target := stat.Key
+	if stat.Payload != "" {
+		target = stat.Payload
+	}
+	if target == "" {
+		return cid.Undef, errPathNotFound
+	}
+	return decodeCID(target)
+}
+
+func (s *Server) readProofList(ctx context.Context, g *graph.Graph, resolved *pathResolution, start, endExclusive int64) (*prooflist.ProofList, error) {
+	if resolved == nil || resolved.proofList == nil {
+		return nil, fmt.Errorf("resolution prooflist is missing")
+	}
+	pl := *resolved.proofList
+	pl.Steps = append([]prooflist.Step(nil), resolved.proofList.Steps...)
+	if resolved.stat.StorageKind == "list" && endExclusive > start {
+		listRoot, err := decodeCID(resolved.stat.Key)
+		if err != nil {
+			return nil, err
+		}
+		steps, err := s.listIndexStepsForRange(ctx, g, listRoot, start, endExclusive)
+		if err != nil {
+			return nil, err
+		}
+		if err := unixfs.AppendListIndexSteps(&pl, resolved.queryPath, steps); err != nil {
+			return nil, err
+		}
+	}
+	return &pl, nil
 }
 
 func (s *Server) statFromFlatTarget(ctx context.Context, g *graph.Graph, target cid.Cid) (*httpapi.PathStatResponse, error) {
@@ -858,65 +877,6 @@ func (s *Server) readContentPayload(ctx context.Context, g *graph.Graph, stat *h
 	}
 }
 
-func (s *Server) contentProofList(ctx context.Context, g *graph.Graph, root cid.Cid, queryPath string, stat *httpapi.PathStatResponse, start, endExclusive int64) (*prooflist.ProofList, error) {
-	if layout, err := s.unixFSLayout(g); err == nil {
-		if unixStat, statErr := layout.Stat(ctx, root, queryPath); statErr == nil && unixStat.Kind == "file" {
-			return s.unixFSContentProofList(ctx, layout, root, queryPath, stat, start, endExclusive)
-		}
-	}
-	return s.legacyContentProofList(ctx, g, root, queryPath, stat, start, endExclusive)
-}
-
-func (s *Server) unixFSContentProofList(ctx context.Context, layout *unixfs.Layout, root cid.Cid, queryPath string, stat *httpapi.PathStatResponse, start, endExclusive int64) (*prooflist.ProofList, error) {
-	resolution, err := layout.Resolve(ctx, root, queryPath)
-	if err != nil {
-		return nil, err
-	}
-	pl, err := unixfs.ProofListFromSteps(root, queryPath, resolution.Steps)
-	if err != nil {
-		return nil, err
-	}
-	if stat.StorageKind == "list" && endExclusive > start {
-		steps, err := layout.ListIndexStepsForFileRange(ctx, root, queryPath, uint64(start), uint64(endExclusive-start))
-		if err != nil {
-			return nil, err
-		}
-		if err := unixfs.AppendListIndexSteps(pl, queryPath, steps); err != nil {
-			return nil, err
-		}
-	}
-	return pl, nil
-}
-
-func (s *Server) legacyContentProofList(ctx context.Context, g *graph.Graph, root cid.Cid, queryPath string, stat *httpapi.PathStatResponse, start, endExclusive int64) (*prooflist.ProofList, error) {
-	result, err := g.Resolver().Resolve(root, queryPath)
-	if err != nil {
-		return nil, err
-	}
-	if resolveMiss(root, queryPath, result) {
-		return nil, errPathNotFound
-	}
-	pl, err := resolver.ProofListFromTranscript(root, result.Transcript)
-	if err != nil {
-		return nil, err
-	}
-	pl.Query = queryPath
-	if stat.StorageKind == "list" && endExclusive > start {
-		listRoot, err := decodeCID(stat.Key)
-		if err != nil {
-			return nil, err
-		}
-		steps, err := s.listIndexStepsForRange(ctx, g, listRoot, start, endExclusive)
-		if err != nil {
-			return nil, err
-		}
-		if err := unixfs.AppendListIndexSteps(pl, queryPath, steps); err != nil {
-			return nil, err
-		}
-	}
-	return pl, nil
-}
-
 func (s *Server) unixFSPathStat(ctx context.Context, g *graph.Graph, root cid.Cid, p string) (*httpapi.PathStatResponse, error) {
 	layout, err := s.unixFSLayout(g)
 	if err != nil {
@@ -948,25 +908,6 @@ func (s *Server) unixFSPathStat(ctx context.Context, g *graph.Graph, root cid.Ci
 	default:
 		return nil, fmt.Errorf("unsupported unixfs node kind %q", stat.Kind)
 	}
-}
-
-func (s *Server) unixFSResolve(ctx context.Context, g *graph.Graph, root cid.Cid, rawPath string) (*httpapi.ResolveResponse, error) {
-	layout, err := s.unixFSLayout(g)
-	if err != nil {
-		return nil, err
-	}
-	resolution, err := layout.Resolve(ctx, root, querypath.CanonicalizeQueryPath(rawPath))
-	if err != nil {
-		return nil, err
-	}
-	pl, err := unixfs.ProofListFromSteps(root, querypath.CanonicalizeQueryPath(rawPath), resolution.Steps)
-	if err != nil {
-		return nil, err
-	}
-	return &httpapi.ResolveResponse{
-		Target:    resolution.Payload.String(),
-		ProofList: pl,
-	}, nil
 }
 
 func (s *Server) unixFSArcCount(ctx context.Context, layout *unixfs.Layout, root cid.Cid) int {
@@ -1299,12 +1240,11 @@ func buildCreateSnapshot(arcs map[string]cid.Cid) (arcset.ArcSet, int, error) {
 	return snapshot, arcCount, nil
 }
 
-func resolveMiss(root cid.Cid, requestedPath string, result *resolver.ResolveResult) bool {
+func resolveMiss(_ cid.Cid, _ string, result *resolver.ResolveResult) bool {
 	if result == nil {
 		return false
 	}
-	path := arcset.CanonicalizePath(requestedPath)
-	return !path.IsEmpty() && result.Target.Equals(root) && len(result.Transcript.Steps) == 0
+	return !result.RemainingPath.IsEmpty()
 }
 
 func mandatoryMapPayload(ctx context.Context, g *graph.Graph, root cid.Cid) (cid.Cid, error) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1118,6 +1118,103 @@ func TestServerUnixFSWritesPublishGatewayReadableRoot(t *testing.T) {
 	if resp.StatusCode != http.StatusOK || !bytes.Equal(got, fileBody) {
 		t.Fatalf("content status/body = %d %q, want %d %q", resp.StatusCode, string(got), http.StatusOK, string(fileBody))
 	}
+
+	resp, err = http.Get(ts.URL + "/" + writeResp.NewRoot + "/docs/readme.txt/extra")
+	if err != nil {
+		t.Fatalf("partial content path request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("partial content path status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestServerResolveHeadAndReadShareUnixFSDirectoryTarget(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"dummy": fakeCIDString("dummy")}),
+	})
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create structure status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+
+	resp, err = http.Post(ts.URL+"/"+createResp.Root+"/docs?type=dir", "application/json", nil)
+	if err != nil {
+		t.Fatalf("create unixfs directory request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create unixfs directory status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var dirResp httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dirResp); err != nil {
+		t.Fatalf("decode unixfs directory response: %v", err)
+	}
+	resp.Body.Close()
+
+	headReq, _ := http.NewRequest(http.MethodHead, ts.URL+"/"+dirResp.NewRoot+"/docs", nil)
+	resp, err = http.DefaultClient.Do(headReq)
+	if err != nil {
+		t.Fatalf("directory HEAD request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("directory HEAD status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	headKey := resp.Header.Get("X-Malt-Key")
+	if headKey == "" {
+		t.Fatal("directory HEAD X-Malt-Key is missing")
+	}
+	headTarget := resp.Header.Get("X-Malt-Payload")
+	if headTarget == "" {
+		headTarget = headKey
+	}
+
+	resp, err = http.Get(ts.URL + "/resolve/" + dirResp.NewRoot + "/docs")
+	if err != nil {
+		t.Fatalf("directory resolve request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("directory resolve status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var resolveResp httpapi.ResolveResponse
+	if err := json.NewDecoder(resp.Body).Decode(&resolveResp); err != nil {
+		t.Fatalf("decode directory resolve response: %v", err)
+	}
+	resp.Body.Close()
+	if resolveResp.Target != headTarget {
+		t.Fatalf("resolve target = %q, HEAD target = %q; want shared resolution target", resolveResp.Target, headTarget)
+	}
+
+	resp, err = http.Get(ts.URL + "/" + dirResp.NewRoot + "/docs")
+	if err != nil {
+		t.Fatalf("directory read request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("directory read status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	readProof := requireProofListHeader(t, resp)
+	resp.Body.Close()
+	readTarget, err := readProof.LastStepTarget()
+	if err != nil {
+		t.Fatalf("directory read proof target: %v", err)
+	}
+	if readTarget.String() != resolveResp.Target {
+		t.Fatalf("read proof target = %q, resolve target = %q; want shared resolution target", readTarget.String(), resolveResp.Target)
+	}
 }
 
 func TestServerUnixFSGatewayRootDoesNotSelfParent(t *testing.T) {


### PR DESCRIPTION
## Summary

- route daemon `read`, `HEAD`, and `resolve` through one shared path resolution pipeline
- expose `RemainingPath` from the core resolver so callers can reject partial path resolution
- keep `PathStatResponse.Key` as the terminal key CID while using `Payload` as the read/resolve materialization target
- add regression coverage for directory target consistency and unresolved suffix handling

## Why

`read` and `resolve` had diverged: they could resolve UnixFS directory paths to different terminal concepts, and partial path resolution could be mistaken for success when traversal stopped at a terminal object. The shared pipeline makes the operations differ only at the last step: `HEAD` returns stat metadata, `resolve` returns target plus ProofList, and `read` fetches content after resolution.

## Validation

- `go test ./...`
