### PR TITLE
Fix ProofList verification against branching transcripts

### DIFF
--- a/core/types/prooflist/prooflist.go
+++ b/core/types/prooflist/prooflist.go
@@ -91,7 +91,14 @@ func (p ProofList) ValidateShape(opts ...ValidateOption) error {
 		if !step.From.Equals(current) {
 			return fmt.Errorf("prooflist step %d from CID %s does not continue from current target %s", i, step.From.String(), current.String())
 		}
-		if step.Kind == KindListIndex {
+		listIndexEvidence := step.structureListEvidence()
+		if step.Kind == KindListIndex && !listIndexEvidence {
+			return fmt.Errorf("prooflist step %d list_index kind does not match evidence labels %q/%q", i, step.EvidenceKind, step.EvidenceBackend)
+		}
+		if listIndexEvidence && step.Kind != KindListIndex {
+			return fmt.Errorf("prooflist step %d structure/list evidence does not match kind %q", i, step.Kind)
+		}
+		if listIndexEvidence {
 			listIndexPhase = true
 			continue
 		}
@@ -119,4 +126,8 @@ func (k StepKind) Known() bool {
 	default:
 		return false
 	}
+}
+
+func (s Step) structureListEvidence() bool {
+	return s.EvidenceKind == "structure" && s.EvidenceBackend == "list"
 }

--- a/core/types/prooflist/prooflist.go
+++ b/core/types/prooflist/prooflist.go
@@ -76,7 +76,8 @@ func (p ProofList) ValidateShape(opts ...ValidateOption) error {
 	if cfg.requireSteps && len(p.Steps) == 0 {
 		return fmt.Errorf("prooflist steps are empty")
 	}
-	anchored := map[string]struct{}{p.Root.String(): {}}
+	current := p.Root
+	listIndexPhase := false
 	for i, step := range p.Steps {
 		if !step.Kind.Known() {
 			return fmt.Errorf("prooflist step %d has unknown kind %q", i, step.Kind)
@@ -87,10 +88,17 @@ func (p ProofList) ValidateShape(opts ...ValidateOption) error {
 		if !step.Target.Defined() {
 			return fmt.Errorf("prooflist step %d target CID is undefined", i)
 		}
-		if _, ok := anchored[step.From.String()]; !ok {
-			return fmt.Errorf("prooflist step %d from CID %s is not anchored to the root or an earlier target", i, step.From.String())
+		if !step.From.Equals(current) {
+			return fmt.Errorf("prooflist step %d from CID %s does not continue from current target %s", i, step.From.String(), current.String())
 		}
-		anchored[step.Target.String()] = struct{}{}
+		if step.Kind == KindListIndex {
+			listIndexPhase = true
+			continue
+		}
+		if listIndexPhase {
+			return fmt.Errorf("prooflist step %d traversal step appears after list index evidence", i)
+		}
+		current = step.Target
 	}
 	return nil
 }

--- a/core/types/prooflist/prooflist_test.go
+++ b/core/types/prooflist/prooflist_test.go
@@ -163,18 +163,22 @@ func TestValidateShapeRejectsUnanchoredSteps(t *testing.T) {
 				Target: mid,
 			},
 			{
-				Kind:   KindListIndex,
-				From:   mid,
-				Index:  &index0,
-				Length: &length,
-				Target: chunk0,
+				Kind:            KindListIndex,
+				From:            mid,
+				Index:           &index0,
+				Length:          &length,
+				Target:          chunk0,
+				EvidenceKind:    "structure",
+				EvidenceBackend: "list",
 			},
 			{
-				Kind:   KindListIndex,
-				From:   mid,
-				Index:  &index1,
-				Length: &length,
-				Target: chunk1,
+				Kind:            KindListIndex,
+				From:            mid,
+				Index:           &index1,
+				Length:          &length,
+				Target:          chunk1,
+				EvidenceKind:    "structure",
+				EvidenceBackend: "list",
 			},
 		},
 	}).ValidateShape(RequireSteps()); err != nil {
@@ -205,5 +209,47 @@ func TestValidateShapeRejectsNonLinearTraversalSteps(t *testing.T) {
 		},
 	}).ValidateShape(RequireSteps()); err == nil {
 		t.Fatal("expected a traversal step that branches from an earlier anchor to be rejected")
+	}
+}
+
+func TestValidateShapeRejectsTraversalAfterListEvidence(t *testing.T) {
+	root := testCID(t, "root")
+	listRoot := testCID(t, "list-root")
+	chunk := testCID(t, "chunk")
+	next := testCID(t, "next")
+	index := uint64(0)
+	length := uint64(1)
+
+	if err := (ProofList{
+		Root: root,
+		Steps: []Step{
+			{
+				Kind:            KindMapStep,
+				From:            root,
+				Path:            "large.bin",
+				Target:          listRoot,
+				EvidenceKind:    "structure",
+				EvidenceBackend: "map",
+			},
+			{
+				Kind:            KindMapStep,
+				From:            listRoot,
+				Index:           &index,
+				Length:          &length,
+				Target:          chunk,
+				EvidenceKind:    "structure",
+				EvidenceBackend: "list",
+			},
+			{
+				Kind:            KindMapStep,
+				From:            chunk,
+				Path:            "forged",
+				Target:          next,
+				EvidenceKind:    "structure",
+				EvidenceBackend: "map",
+			},
+		},
+	}).ValidateShape(RequireSteps()); err == nil {
+		t.Fatal("expected traversal after structure/list evidence to be rejected")
 	}
 }

--- a/core/types/prooflist/prooflist_test.go
+++ b/core/types/prooflist/prooflist_test.go
@@ -181,3 +181,29 @@ func TestValidateShapeRejectsUnanchoredSteps(t *testing.T) {
 		t.Fatalf("expected sibling list-index steps anchored at a prior target to pass: %v", err)
 	}
 }
+
+func TestValidateShapeRejectsNonLinearTraversalSteps(t *testing.T) {
+	root := testCID(t, "root")
+	first := testCID(t, "first")
+	sibling := testCID(t, "sibling")
+
+	if err := (ProofList{
+		Root: root,
+		Steps: []Step{
+			{
+				Kind:   KindMapStep,
+				From:   root,
+				Path:   "a",
+				Target: first,
+			},
+			{
+				Kind:   KindMapStep,
+				From:   root,
+				Path:   "b",
+				Target: sibling,
+			},
+		},
+	}).ValidateShape(RequireSteps()); err == nil {
+		t.Fatal("expected a traversal step that branches from an earlier anchor to be rejected")
+	}
+}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -385,28 +385,32 @@ func (s *Server) verifyProofList(g *graph.Graph, pl prooflist.ProofList) (bool, 
 	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
 		return false, err
 	}
-	if err := validateProofListQuery(pl); err != nil {
-		return false, err
-	}
+	var verifiedPath proofListVerifiedPath
 	for i, step := range pl.Steps {
 		ok, err := s.verifyProofListStep(g, i, step)
 		if err != nil || !ok {
 			return ok, err
 		}
+		if err := verifiedPath.addStep(step); err != nil {
+			return false, err
+		}
+	}
+	if err := validateProofListQuery(pl, verifiedPath); err != nil {
+		return false, err
 	}
 	return true, nil
 }
 
-func validateProofListQuery(pl prooflist.ProofList) error {
+func validateProofListQuery(pl prooflist.ProofList, verifiedPath proofListVerifiedPath) error {
 	want := arcset.CanonicalizePath(querypath.CanonicalizeQueryPath(pl.Query)).String()
 	if want == "" {
 		return nil
 	}
-	got, hasPayloadBinding := proofListLogicalQueryPath(pl)
+	got := verifiedPath.logicalQueryPath()
 	if got == want {
 		return nil
 	}
-	if hasPayloadBinding {
+	if verifiedPath.hasPayloadBinding {
 		payloadQuery := "@payload"
 		if got != "" {
 			payloadQuery = got + "/@payload"
@@ -418,20 +422,29 @@ func validateProofListQuery(pl prooflist.ProofList) error {
 	return fmt.Errorf("prooflist query %q does not match ordered traversal path %q", want, got)
 }
 
-func proofListLogicalQueryPath(pl prooflist.ProofList) (string, bool) {
-	parts := make([]string, 0, len(pl.Steps))
-	hasPayloadBinding := false
-	for _, step := range pl.Steps {
-		switch step.Kind {
-		case prooflist.KindMapStep, prooflist.KindBlobBinding, prooflist.KindImplicitBlock, prooflist.KindLegacyUnknown:
-			if path := arcset.CanonicalizePath(step.Path).String(); path != "" {
-				parts = append(parts, path)
-			}
-		case prooflist.KindPayloadBinding:
-			hasPayloadBinding = true
-		}
+type proofListVerifiedPath struct {
+	parts             []string
+	hasPayloadBinding bool
+}
+
+func (p *proofListVerifiedPath) addStep(step prooflist.Step) error {
+	path := arcset.CanonicalizePath(step.Path).String()
+	if path == "" || step.EvidenceKind == "structure" && step.EvidenceBackend == "list" {
+		return nil
 	}
-	return strings.Join(parts, "/"), hasPayloadBinding
+	if p.hasPayloadBinding {
+		return fmt.Errorf("prooflist traversal step %q appears after terminal @payload binding", path)
+	}
+	if path == "@payload" {
+		p.hasPayloadBinding = true
+		return nil
+	}
+	p.parts = append(p.parts, path)
+	return nil
+}
+
+func (p proofListVerifiedPath) logicalQueryPath() string {
+	return strings.Join(p.parts, "/")
 }
 
 func (s *Server) verifyProofListStep(g *graph.Graph, index int, step prooflist.Step) (bool, error) {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -385,6 +385,9 @@ func (s *Server) verifyProofList(g *graph.Graph, pl prooflist.ProofList) (bool, 
 	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
 		return false, err
 	}
+	if err := validateProofListQuery(pl); err != nil {
+		return false, err
+	}
 	for i, step := range pl.Steps {
 		ok, err := s.verifyProofListStep(g, i, step)
 		if err != nil || !ok {
@@ -392,6 +395,43 @@ func (s *Server) verifyProofList(g *graph.Graph, pl prooflist.ProofList) (bool, 
 		}
 	}
 	return true, nil
+}
+
+func validateProofListQuery(pl prooflist.ProofList) error {
+	want := arcset.CanonicalizePath(querypath.CanonicalizeQueryPath(pl.Query)).String()
+	if want == "" {
+		return nil
+	}
+	got, hasPayloadBinding := proofListLogicalQueryPath(pl)
+	if got == want {
+		return nil
+	}
+	if hasPayloadBinding {
+		payloadQuery := "@payload"
+		if got != "" {
+			payloadQuery = got + "/@payload"
+		}
+		if want == payloadQuery {
+			return nil
+		}
+	}
+	return fmt.Errorf("prooflist query %q does not match ordered traversal path %q", want, got)
+}
+
+func proofListLogicalQueryPath(pl prooflist.ProofList) (string, bool) {
+	parts := make([]string, 0, len(pl.Steps))
+	hasPayloadBinding := false
+	for _, step := range pl.Steps {
+		switch step.Kind {
+		case prooflist.KindMapStep, prooflist.KindBlobBinding, prooflist.KindImplicitBlock, prooflist.KindLegacyUnknown:
+			if path := arcset.CanonicalizePath(step.Path).String(); path != "" {
+				parts = append(parts, path)
+			}
+		case prooflist.KindPayloadBinding:
+			hasPayloadBinding = true
+		}
+	}
+	return strings.Join(parts, "/"), hasPayloadBinding
 }
 
 func (s *Server) verifyProofListStep(g *graph.Graph, index int, step prooflist.Step) (bool, error) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -738,6 +738,90 @@ func TestServerVerifyRejectsBranchingProofList(t *testing.T) {
 	verifyRejects("branching", forged)
 }
 
+func TestServerVerifyRejectsForgedPayloadBindingKind(t *testing.T) {
+	node := newTestNode(t)
+	mockCAS, ok := node.CAS().(*casmock.CAS)
+	if !ok {
+		t.Fatal("expected mock CAS")
+	}
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	targetCID, err := mockCAS.Put(t.Context(), []byte("verify forged payload binding"))
+	if err != nil {
+		t.Fatalf("put target: %v", err)
+	}
+	createBody, err := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"name": targetCID.String()}),
+	})
+	if err != nil {
+		t.Fatalf("marshal create request: %v", err)
+	}
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create root status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create root: %v", err)
+	}
+	resp.Body.Close()
+
+	resp, err = http.Get(ts.URL + "/resolve/" + createResp.Root + "/name")
+	if err != nil {
+		t.Fatalf("resolve name: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("resolve name status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var resolveResp httpapi.ResolveResponse
+	if err := json.NewDecoder(resp.Body).Decode(&resolveResp); err != nil {
+		t.Fatalf("decode resolve response: %v", err)
+	}
+	resp.Body.Close()
+	if resolveResp.ProofList == nil {
+		t.Fatal("resolve response missing ProofList")
+	}
+	if len(resolveResp.ProofList.Steps) != 1 {
+		t.Fatalf("prooflist steps = %d, want 1", len(resolveResp.ProofList.Steps))
+	}
+	if got := resolveResp.ProofList.Steps[0].Path; got != "name" {
+		t.Fatalf("prooflist step path = %q, want name", got)
+	}
+
+	forged := *resolveResp.ProofList
+	forged.Query = "@payload"
+	forged.Steps = append([]prooflist.Step(nil), resolveResp.ProofList.Steps...)
+	forged.Steps[0].Kind = prooflist.KindPayloadBinding
+
+	verifyBody, err := json.Marshal(&httpapi.VerifyRequest{ProofList: forged})
+	if err != nil {
+		t.Fatalf("marshal verify request: %v", err)
+	}
+	resp, err = http.Post(ts.URL+"/verify", "application/json", bytes.NewReader(verifyBody))
+	if err != nil {
+		t.Fatalf("verify forged prooflist: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		var verifyResp httpapi.VerifyResponse
+		if err := json.NewDecoder(resp.Body).Decode(&verifyResp); err != nil {
+			t.Fatalf("decode verify response: %v", err)
+		}
+		if verifyResp.Valid {
+			t.Fatal("forged payload_binding kind verified; want rejection")
+		}
+		return
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("verify forged prooflist status = %d, want %d or invalid response", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
 func TestServerProofListReadEndpoints(t *testing.T) {
 	node := newTestNode(t)
 	mockCAS, ok := node.CAS().(*casmock.CAS)
@@ -1558,6 +1642,25 @@ func TestServerDefaultGETSmallUnixFSFileIncludesPayloadProof(t *testing.T) {
 	last := proofResp.Steps[len(proofResp.Steps)-1]
 	if last.Kind != prooflist.KindPayloadBinding || last.Path != "@payload" {
 		t.Fatalf("last proof step = %q/%q, want payload binding @payload", last.Kind, last.Path)
+	}
+	verifyBody, err := json.Marshal(&httpapi.VerifyRequest{ProofList: proofResp})
+	if err != nil {
+		t.Fatalf("marshal verify request: %v", err)
+	}
+	verifyRespHTTP, err := http.Post(ts.URL+"/verify", "application/json", bytes.NewReader(verifyBody))
+	if err != nil {
+		t.Fatalf("verify payload-binding prooflist request: %v", err)
+	}
+	defer verifyRespHTTP.Body.Close()
+	if verifyRespHTTP.StatusCode != http.StatusOK {
+		t.Fatalf("verify payload-binding prooflist status = %d, want %d", verifyRespHTTP.StatusCode, http.StatusOK)
+	}
+	var verifyResp httpapi.VerifyResponse
+	if err := json.NewDecoder(verifyRespHTTP.Body).Decode(&verifyResp); err != nil {
+		t.Fatalf("decode verify payload-binding response: %v", err)
+	}
+	if !verifyResp.Valid {
+		t.Fatal("expected payload-binding prooflist verification to succeed")
 	}
 	for i, step := range proofResp.Steps {
 		if step.Kind == prooflist.KindListIndex {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -635,6 +635,109 @@ func TestServerVerifyAcceptsProofList(t *testing.T) {
 	}
 }
 
+func TestServerVerifyRejectsBranchingProofList(t *testing.T) {
+	node := newTestNode(t)
+	mockCAS, ok := node.CAS().(*casmock.CAS)
+	if !ok {
+		t.Fatal("expected mock CAS")
+	}
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	payloadCID, err := mockCAS.Put(t.Context(), []byte("verify branch payload"))
+	if err != nil {
+		t.Fatalf("put payload: %v", err)
+	}
+	aCID, err := mockCAS.Put(t.Context(), []byte("verify branch a"))
+	if err != nil {
+		t.Fatalf("put a: %v", err)
+	}
+	bCID, err := mockCAS.Put(t.Context(), []byte("verify branch b"))
+	if err != nil {
+		t.Fatalf("put b: %v", err)
+	}
+	createBody, err := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: map[string]string{
+			"@payload": payloadCID.String(),
+			"a":        aCID.String(),
+			"b":        bCID.String(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal create request: %v", err)
+	}
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create root status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create root: %v", err)
+	}
+	resp.Body.Close()
+
+	resolve := func(path string) prooflist.ProofList {
+		t.Helper()
+		resp, err := http.Get(ts.URL + "/resolve/" + createResp.Root + "/" + path)
+		if err != nil {
+			t.Fatalf("resolve %s: %v", path, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("resolve %s status = %d, want %d", path, resp.StatusCode, http.StatusOK)
+		}
+		var resolveResp httpapi.ResolveResponse
+		if err := json.NewDecoder(resp.Body).Decode(&resolveResp); err != nil {
+			t.Fatalf("decode resolve %s: %v", path, err)
+		}
+		if resolveResp.ProofList == nil {
+			t.Fatalf("resolve %s missing ProofList", path)
+		}
+		return *resolveResp.ProofList
+	}
+
+	aProof := resolve("a")
+	bProof := resolve("b")
+	verifyRejects := func(name string, pl prooflist.ProofList) {
+		t.Helper()
+		verifyBody, err := json.Marshal(&httpapi.VerifyRequest{ProofList: pl})
+		if err != nil {
+			t.Fatalf("marshal %s verify request: %v", name, err)
+		}
+		resp, err := http.Post(ts.URL+"/verify", "application/json", bytes.NewReader(verifyBody))
+		if err != nil {
+			t.Fatalf("verify %s prooflist: %v", name, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			var verifyResp httpapi.VerifyResponse
+			if err := json.NewDecoder(resp.Body).Decode(&verifyResp); err != nil {
+				t.Fatalf("decode %s verify response: %v", name, err)
+			}
+			if verifyResp.Valid {
+				t.Fatalf("%s ProofList verified; want rejection", name)
+			}
+			return
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("verify %s proof status = %d, want %d or invalid response", name, resp.StatusCode, http.StatusBadRequest)
+		}
+	}
+
+	mismatchedQuery := aProof
+	mismatchedQuery.Query = "b"
+	verifyRejects("query-mismatched", mismatchedQuery)
+
+	forged := aProof
+	forged.Query = "a/b"
+	forged.Steps = append(append([]prooflist.Step(nil), aProof.Steps...), bProof.Steps...)
+	verifyRejects("branching", forged)
+}
+
 func TestServerProofListReadEndpoints(t *testing.T) {
 	node := newTestNode(t)
 	mockCAS, ok := node.CAS().(*casmock.CAS)


### PR DESCRIPTION
## Summary
- Reject non-linear ProofList traversal steps instead of accepting any previously anchored target.
- Keep list-index range evidence as a terminal fan-out from the current list root.
- Bind `/verify` ProofList queries to the ordered verified traversal path, with explicit support for terminal `@payload` queries.
- Add regression coverage for forged sibling/branch ProofLists and query mismatch.

## Verification
- `go test ./server ./core/types/prooflist ./core/resolver ./cmd/malt -count=1`
- `go test ./... -count=1`
- `go vet ./...`