### PR TITLE
Remove graph manager head state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -413,6 +413,9 @@ Current boundary:
   implemented. Paper-facing formalization, write metadata semantics,
   graph-node terminology, and benchmark-facing proof reporting remain open TODO
   items.
+- Graph manager metadata is limited to lifecycle and runtime profile
+  compatibility. It does not store an authoritative current root or publish
+  freshness.
 
 It also gives the benchmark target:
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Under this terminology:
   definition of MALT.
 - The current `core/graph` package is runtime metadata/composition code; it is
   not the target semantic abstraction.
+- Graph manager metadata tracks lifecycle and backend compatibility only; it
+  does not store or publish a current root.
 
 ## Map Semantic
 

--- a/cmd/malt/shared.go
+++ b/cmd/malt/shared.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dewebprotocol/malt/config"
 	"github.com/dewebprotocol/malt/core/api"
 	"github.com/dewebprotocol/malt/core/graph"
-	"github.com/dewebprotocol/malt/core/types/arcset"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -67,74 +66,6 @@ func mustGraph() *graph.Graph {
 		}
 	}
 	return defaultGraph
-}
-
-func mustManagedGraph(graphID string, requireActive bool) (*graph.Graph, *graph.GraphMeta) {
-	node := mustNode()
-	ctx := context.Background()
-
-	var (
-		meta *graph.GraphMeta
-		err  error
-	)
-	if requireActive {
-		meta, err = node.GraphManager().RequireActive(ctx, graphID)
-	} else {
-		meta, err = node.GraphManager().GetGraph(ctx, graphID)
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading graph %q: %v\n", graphID, err)
-		os.Exit(1)
-	}
-
-	g, err := node.OpenGraph(ctx, graphID)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error opening graph %q: %v\n", graphID, err)
-		os.Exit(1)
-	}
-
-	return g, meta
-}
-
-func managedGraphHeadRoot(meta *graph.GraphMeta) (cid.Cid, error) {
-	if meta == nil {
-		return cid.Undef, fmt.Errorf("graph metadata is nil")
-	}
-	if !meta.Root.Defined() {
-		return cid.Undef, fmt.Errorf("graph %q has no head root", meta.ID)
-	}
-	return meta.Root, nil
-}
-
-func countSnapshotArcs(snapshot arcset.ArcSet) (int, error) {
-	count := 0
-	iter := snapshot.Iterate()
-	for {
-		_, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-		count++
-	}
-	return count, iter.Err()
-}
-
-func updateManagedGraphRoot(graphID string, g *graph.Graph, newRoot cid.Cid) error {
-	node := mustNode()
-	ctx := context.Background()
-
-	snapshot, err := g.Snapshot(ctx, newRoot)
-	if err != nil {
-		return fmt.Errorf("snapshot new root: %w", err)
-	}
-
-	arcCount, err := countSnapshotArcs(snapshot)
-	if err != nil {
-		return fmt.Errorf("count arcs: %w", err)
-	}
-
-	_, err = node.GraphManager().UpdateGraph(ctx, graphID, newRoot, arcCount)
-	return err
 }
 
 // cleanupNode closes the default node if it was created.

--- a/core/graph/graph_test.go
+++ b/core/graph/graph_test.go
@@ -3,19 +3,10 @@ package graph
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/dewebprotocol/malt/core/kvstore/memory"
-	cid "github.com/ipfs/go-cid"
-	mh "github.com/multiformats/go-multihash"
 )
-
-func newTestCID(data []byte) cid.Cid {
-	h, err := mh.Sum(data, mh.SHA2_256, -1)
-	if err != nil {
-		panic(err)
-	}
-	return cid.NewCidV1(cid.Raw, h)
-}
 
 func newTestStore() *Store {
 	return NewStore(memory.New())
@@ -31,7 +22,6 @@ func TestStoreCreateAndGet(t *testing.T) {
 
 	g := &GraphMeta{
 		ID:           "test-graph",
-		Root:         newTestCID([]byte("root1")),
 		State:        StateActive,
 		Backend:      "kzg",
 		ArcTableType: "overwrite",
@@ -128,14 +118,19 @@ func TestStoreUpdate(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore()
 
-	root := newTestCID([]byte("root1"))
-	g := &GraphMeta{ID: "update-test", Root: root, State: StateActive, ArcCount: 1}
+	g := &GraphMeta{
+		ID:           "update-test",
+		State:        StateActive,
+		Backend:      "kzg",
+		ArcTableType: "overwrite",
+		UpdatedAt:    time.Now(),
+	}
 	if err := s.Create(ctx, g); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
-	newRoot := newTestCID([]byte("root2"))
-	g.UpdateRoot(newRoot, 5)
+	g.Backend = "ipa"
+	g.UpdatedAt = g.UpdatedAt.Add(time.Second)
 
 	if err := s.Update(ctx, g); err != nil {
 		t.Fatalf("Update failed: %v", err)
@@ -145,11 +140,8 @@ func TestStoreUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
-	if !got.Root.Equals(newRoot) {
-		t.Error("root was not updated")
-	}
-	if got.ArcCount != 5 {
-		t.Errorf("expected ArcCount=5, got %d", got.ArcCount)
+	if got.Backend != "ipa" {
+		t.Errorf("expected backend ipa, got %q", got.Backend)
 	}
 }
 
@@ -167,9 +159,6 @@ func TestManagerCreateGraph(t *testing.T) {
 	}
 	if g.State != StateActive {
 		t.Errorf("expected StateActive, got %q", g.State)
-	}
-	if g.ArcCount != 0 {
-		t.Errorf("expected ArcCount=0, got %d", g.ArcCount)
 	}
 }
 
@@ -219,39 +208,6 @@ func TestManagerGetDeletedGraph(t *testing.T) {
 	_, err := m.GetGraph(ctx, "to-del")
 	if err != ErrDeleted {
 		t.Errorf("expected ErrDeleted, got %v", err)
-	}
-}
-
-func TestManagerUpdateGraph(t *testing.T) {
-	ctx := context.Background()
-	m := newTestManager()
-
-	m.CreateGraph(ctx, "up", "kzg", "overwrite")
-
-	root := newTestCID([]byte("root1"))
-	g, err := m.UpdateGraph(ctx, "up", root, 3)
-	if err != nil {
-		t.Fatalf("UpdateGraph failed: %v", err)
-	}
-	if !g.Root.Equals(root) {
-		t.Error("root not updated")
-	}
-	if g.ArcCount != 3 {
-		t.Errorf("expected ArcCount=3, got %d", g.ArcCount)
-	}
-}
-
-func TestManagerUpdateFrozenGraph(t *testing.T) {
-	ctx := context.Background()
-	m := newTestManager()
-
-	m.CreateGraph(ctx, "frozen", "kzg", "overwrite")
-	m.FreezeGraph(ctx, "frozen")
-
-	root := newTestCID([]byte("root1"))
-	_, err := m.UpdateGraph(ctx, "frozen", root, 1)
-	if err != ErrFrozen {
-		t.Errorf("expected ErrFrozen, got %v", err)
 	}
 }
 
@@ -339,21 +295,5 @@ func TestGraphStateTransitions(t *testing.T) {
 	g.State = StateDeleted
 	if !g.IsDeleted() {
 		t.Error("expected deleted after state change")
-	}
-}
-
-func TestGraphUpdateRoot(t *testing.T) {
-	root1 := newTestCID([]byte("root1"))
-	root2 := newTestCID([]byte("root2"))
-
-	g := &GraphMeta{ID: "update-root", Root: root1, ArcCount: 1}
-
-	g.UpdateRoot(root2, 5)
-
-	if !g.Root.Equals(root2) {
-		t.Error("root not updated")
-	}
-	if g.ArcCount != 5 {
-		t.Errorf("expected ArcCount=5, got %d", g.ArcCount)
 	}
 }

--- a/core/graph/manager.go
+++ b/core/graph/manager.go
@@ -1,6 +1,6 @@
 // Package graph provides graph lifecycle management for MALT.
-// A graph represents a scoped collection of arcs authenticated by structure commitments.
-// Each graph has metadata (root CID, arc count, creation time) and a lifecycle state.
+// A graph is runtime metadata for reopening a namespace with a compatible
+// backend profile. It does not own a current root or freshness policy.
 // This file contains the Store and Manager types.
 package graph
 
@@ -13,16 +13,13 @@ import (
 	"time"
 
 	"github.com/dewebprotocol/malt/core/kvstore"
-	cid "github.com/ipfs/go-cid"
 )
 
 // GraphMeta represents a MALT graph with metadata.
 type GraphMeta struct {
 	ID           string     `json:"id"`
-	Root         cid.Cid    `json:"root"`
 	CreatedAt    time.Time  `json:"created_at"`
 	UpdatedAt    time.Time  `json:"updated_at"`
-	ArcCount     int        `json:"arc_count"`
 	Backend      string     `json:"backend"`       // per-graph commitment scheme used when reopening the graph
 	ArcTableType string     `json:"arctable_type"` // node-scoped ArcTable compatibility requirement for this graph
 	State        GraphState `json:"state"`
@@ -41,13 +38,6 @@ func (g *GraphMeta) IsFrozen() bool {
 // IsDeleted returns true if the graph is deleted.
 func (g *GraphMeta) IsDeleted() bool {
 	return g.State == StateDeleted
-}
-
-// UpdateRoot updates the root CID and arc count, recording the update time.
-func (g *GraphMeta) UpdateRoot(root cid.Cid, arcCount int) {
-	g.Root = root
-	g.ArcCount = arcCount
-	g.UpdatedAt = time.Now()
 }
 
 // graphKey returns the KVStore key for a graph by ID.
@@ -189,8 +179,9 @@ func (s *Store) List(ctx context.Context) ([]*GraphMeta, error) {
 	return graphs, nil
 }
 
-// Manager manages graph lifecycle: creation, access, state transitions.
-// It coordinates graph metadata with ArcTable namespaces and commitment backend selection.
+// Manager manages graph lifecycle: creation, access, and state transitions.
+// It coordinates graph metadata with ArcTable namespaces and commitment backend
+// selection, but it intentionally does not track an authoritative head root.
 type Manager struct {
 	store  *Store
 	mu     sync.RWMutex
@@ -206,7 +197,7 @@ func NewManager(store *Store) *Manager {
 }
 
 // CreateGraph creates a new graph metadata entry with the given runtime profile.
-// The graph starts in the "active" state with an undefined root.
+// The graph starts in the "active" state without publishing any root.
 func (m *Manager) CreateGraph(ctx context.Context, id string, backend string, arcTableType string) (*GraphMeta, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -228,10 +219,8 @@ func (m *Manager) CreateGraph(ctx context.Context, id string, backend string, ar
 	now := time.Now()
 	g := &GraphMeta{
 		ID:           id,
-		Root:         cid.Undef,
 		CreatedAt:    now,
 		UpdatedAt:    now,
-		ArcCount:     0,
 		Backend:      backend,
 		ArcTableType: arcTableType,
 		State:        StateActive,
@@ -271,39 +260,6 @@ func (m *Manager) GetGraph(ctx context.Context, id string) (*GraphMeta, error) {
 	m.graphs[id] = g
 	m.mu.Unlock()
 
-	return g, nil
-}
-
-// UpdateGraph updates a graph's root and arc count after a mutation.
-// Only active graphs can be updated.
-func (m *Manager) UpdateGraph(ctx context.Context, id string, root cid.Cid, arcCount int) (*GraphMeta, error) {
-	m.mu.Lock()
-	g, ok := m.graphs[id]
-	m.mu.Unlock()
-
-	if !ok {
-		var err error
-		g, err = m.store.Get(ctx, id)
-		if err != nil {
-			return nil, err
-		}
-		m.mu.Lock()
-		m.graphs[id] = g
-		m.mu.Unlock()
-	}
-
-	if !g.IsActive() {
-		if g.IsFrozen() {
-			return nil, ErrFrozen
-		}
-		return nil, ErrDeleted
-	}
-
-	g.UpdateRoot(root, arcCount)
-
-	if err := m.store.Update(ctx, g); err != nil {
-		return nil, err
-	}
 	return g, nil
 }
 


### PR DESCRIPTION
## Summary
- Remove `GraphMeta.Root`, `GraphMeta.ArcCount`, and `GraphManager.UpdateGraph` so graph metadata no longer acts as an authoritative head store.
- Delete unused CLI helpers that read or update a managed graph head.
- Keep command flows rooted in explicit root arguments or `--root`.
- Document that graph manager metadata is lifecycle/runtime-profile metadata only; root publication and freshness remain client/application policy.

## Verification
- `go test ./core/graph ./core/api ./cmd/malt -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`