### PR TITLE
Refactor write mutation boundary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -398,10 +398,13 @@ Current boundary:
 - The package remains the direct map/list/CAS library layer for the
   UnixFS-style layout and translates source-domain file/directory data into
   MALT semantic mutations.
-- Root-centric daemon routes expose this layout for UnixFS file and directory
-  writes, path stat, and content reads. The public CLI exposes ingestion through
-  `malt add`; reads are available through the daemon API and proof-bearing
-  resolve/content endpoints.
+- `POST /{root}/_mutate` is the gateway write boundary. Root-centric daemon
+  routes also expose `POST /{root}/{path}` as a UnixFS layout convenience: it
+  stages a file or directory operation, converts the resulting layout state into
+  a semantic mutation, and then uses the same gateway materialization path as
+  `_mutate`.
+- The public CLI exposes ingestion through `malt add`; reads are available
+  through the daemon API and proof-bearing resolve/content endpoints.
 - The package still directly injects `mapping.Semantics`, `list.Semantics`,
   and `cas.Client`; current `core/graph`, `core/writer`, and `core/resolver`
   remain runtime and compatibility adapters rather than semantic owners.
@@ -432,8 +435,9 @@ Open TODOs for the next discussion:
 - define graph node and arc terminology precisely enough to map onto current
   map/list semantics
 - formalize the current gateway semantic-mutation schema
-- formalize how `core/layout/malt/unixfs` exposes and consumes semantic
-  mutations
+- formalize how `core/layout/malt/unixfs` exposes semantic mutations for
+  gateway materialization and how much of the current UnixFS convenience route
+  remains public API versus test/demo scaffolding
 - formalize the current `ProofList` schema and verification semantics for path
   lookup, terminal `@payload`, blob bindings, and list range reads
 - decide how UnixFS reads should map onto gateway read queries and `ProofList`

--- a/README.md
+++ b/README.md
@@ -246,10 +246,14 @@ Current boundary:
 - `core/layout/malt/unixfs` remains the direct map/list/CAS library layer for the
   UnixFS-style layout and translates source-domain file/directory data into
   MALT semantic mutations.
-- The root-centric daemon exposes this layout through routes for UnixFS file
-  and directory writes, path stat, and content reads. The public CLI currently
-  exposes write ingestion through `malt add`; reads are available through the
-  daemon API and proof-bearing resolve/content endpoints.
+- `POST /{root}/_mutate` is the gateway write boundary. The root-centric daemon
+  also exposes `POST /{root}/{path}` as a UnixFS layout convenience: it stages a
+  file or directory operation, converts the resulting layout state into a
+  semantic mutation, and then uses the same gateway materialization path as
+  `_mutate`.
+- The public CLI currently exposes write ingestion through `malt add`; reads
+  are available through the daemon API and proof-bearing resolve/content
+  endpoints.
 - The layout still depends directly on `mapping.Semantics`, `list.Semantics`,
   and `cas.Client`; it does not make current `core/graph`, `core/writer`, or
   `core/resolver` the semantic owners.

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -217,13 +217,7 @@ func (s *Server) handleSemanticMutation(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	exec := gateway.Executor{
-		Namespace: g.Namespace(),
-		Maps:      g.Semantic(),
-		Lists:     g.ListSemantic(),
-		ArcTable:  s.node.ArcTable(),
-	}
-	receipt, err := exec.Apply(r.Context(), mut)
+	receipt, err := s.applyGatewaySemanticMutation(r.Context(), g, mut)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -278,7 +272,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		receipt, err := s.applyUnixFSGatewayMutation(r.Context(), g, layout, root, newRoot)
+		receipt, err := s.applyUnixFSLayoutMutation(r.Context(), g, layout, root, newRoot)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
@@ -306,7 +300,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	receipt, err := s.applyUnixFSGatewayMutation(r.Context(), g, layout, root, newRoot)
+	receipt, err := s.applyUnixFSLayoutMutation(r.Context(), g, layout, root, newRoot)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -771,16 +765,38 @@ func (s *Server) prepareUnixFSRoot(ctx context.Context, g *graph.Graph, layout *
 	return cid.Undef, nil
 }
 
-func (s *Server) applyUnixFSGatewayMutation(ctx context.Context, g *graph.Graph, layout *unixfs.Layout, oldRoot cid.Cid, newRoot cid.Cid) (gateway.WriteReceipt, error) {
-	baseRoot := oldRoot
-	if !baseRoot.Defined() {
-		baseRoot = newRoot
-	}
-
+func (s *Server) applyUnixFSLayoutMutation(ctx context.Context, g *graph.Graph, layout *unixfs.Layout, oldRoot cid.Cid, newRoot cid.Cid) (gateway.WriteReceipt, error) {
 	plan, err := layout.MutationPlanForRoot(ctx, oldRoot, newRoot)
 	if err != nil {
 		return gateway.WriteReceipt{}, err
 	}
+	mut := semanticMutationFromUnixFSPlan(plan, newRoot)
+	receipt, err := s.applyGatewaySemanticMutation(ctx, g, mut)
+	if err != nil {
+		return gateway.WriteReceipt{}, err
+	}
+	if codec.SemanticKindOf(receipt.NewRoot) != codec.SemanticKindMap {
+		return gateway.WriteReceipt{}, fmt.Errorf("unixfs mutation result must be a map current root")
+	}
+	return receipt, nil
+}
+
+func (s *Server) applyGatewaySemanticMutation(ctx context.Context, g *graph.Graph, mut gateway.SemanticMutation) (gateway.WriteReceipt, error) {
+	exec := gateway.Executor{
+		Namespace: g.Namespace(),
+		Maps:      g.Semantic(),
+		Lists:     g.ListSemantic(),
+		ArcTable:  s.node.ArcTable(),
+	}
+	return exec.Apply(ctx, mut)
+}
+
+func semanticMutationFromUnixFSPlan(plan *unixfs.MutationPlan, fallbackRoot cid.Cid) gateway.SemanticMutation {
+	baseRoot := plan.BaseRoot
+	if !baseRoot.Defined() {
+		baseRoot = fallbackRoot
+	}
+
 	mut := gateway.SemanticMutation{
 		BaseRoot: baseRoot,
 		Puts:     make([]gateway.ArcSetPut, 0, len(plan.Puts)),
@@ -794,21 +810,7 @@ func (s *Server) applyUnixFSGatewayMutation(ctx context.Context, g *graph.Graph,
 			ArcSet: put.ArcSet,
 		})
 	}
-
-	exec := gateway.Executor{
-		Namespace: g.Namespace(),
-		Maps:      g.Semantic(),
-		Lists:     g.ListSemantic(),
-		ArcTable:  s.node.ArcTable(),
-	}
-	receipt, err := exec.Apply(ctx, mut)
-	if err != nil {
-		return gateway.WriteReceipt{}, err
-	}
-	if codec.SemanticKindOf(receipt.NewRoot) != codec.SemanticKindMap {
-		return gateway.WriteReceipt{}, fmt.Errorf("unixfs mutation result must be a map current root")
-	}
-	return receipt, nil
+	return mut
 }
 
 func (s *Server) migrateLegacyTreeToUnixFS(ctx context.Context, g *graph.Graph, layout *unixfs.Layout, legacyRoot cid.Cid) (cid.Cid, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -84,14 +84,16 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /lineage/{root}/descendants", s.handleRemovedPublicRoute)
 	mux.HandleFunc("POST /{root}/_batch-update", s.handleRemovedPublicRoute)
 
-	// Write - specific pattern first
+	// Semantic mutation is the gateway write boundary.
 	mux.HandleFunc("POST /{root}/_mutate", s.handleSemanticMutation)
 
 	// Resolve - explicit proof-producing path resolution.
 	mux.HandleFunc("GET /resolve/{root}", s.handleResolve)
 	mux.HandleFunc("GET /resolve/{root}/{path...}", s.handleResolve)
 
-	// Core read/write (/{root}/{path...} format)
+	// Core read/write (/{root}/{path...} format). POST is a UnixFS layout
+	// convenience that converts file operations into semantic mutations before
+	// gateway materialization.
 	mux.HandleFunc("GET /{root}", s.handleContent)
 	mux.HandleFunc("GET /{root}/{path...}", s.handleContent)
 	mux.HandleFunc("POST /{root}/{path...}", s.handleWrite)


### PR DESCRIPTION
## Summary
- Route the explicit semantic mutation endpoint and UnixFS convenience writes through one gateway semantic mutation applicator.
- Rename the UnixFS write helper to describe it as a layout mutation adapter.
- Clarify README/ARCHITECTURE/server route comments that `POST /{root}/{path}` is a UnixFS convenience path over `_mutate`, not a separate core write boundary.

## Test Plan
- `go test ./server ./client ./core/gateway ./core/layout/malt/unixfs`
- `go test ./...`
- `go vet ./...`