### PR TITLE
Add read benchmark result schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Current runtime shape:
   - verifies a ProofList, including the ProofList emitted by `malt resolve`
 - `malt-eval read`
   - MALT-only read benchmark driver
+  - emits one JSONL record per measured operation; each line follows
+    `cmd/eval/schemas/readbench-result.schema.json`
 - `malt-eval write`
   - Git trace write-amplification replay driver
 - `malt-eval metrics`

--- a/cmd/eval/command/root_test.go
+++ b/cmd/eval/command/root_test.go
@@ -1,6 +1,9 @@
 package command
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestRootCommandExposesEvaluationSubcommands(t *testing.T) {
 	cmd := NewRootCommand()
@@ -12,5 +15,38 @@ func TestRootCommandExposesEvaluationSubcommands(t *testing.T) {
 		if found, _, err := cmd.Find([]string{name}); err != nil || found == nil || found.Name() != name {
 			t.Fatalf("subcommand %q not found: found=%v err=%v", name, found, err)
 		}
+	}
+}
+
+func TestReadCommandExposesArcFlagAndResultSchema(t *testing.T) {
+	cmd := NewRootCommand()
+	readCmd, _, err := cmd.Find([]string{"read"})
+	if err != nil {
+		t.Fatalf("find read command: %v", err)
+	}
+	if readCmd == nil || readCmd.Name() != "read" {
+		t.Fatalf("read command not found: %v", readCmd)
+	}
+
+	arcFlag := readCmd.Flags().Lookup("arc")
+	if arcFlag == nil {
+		t.Fatal("read command should expose repeatable --arc fixture seed flag")
+	}
+	if arcFlag.Value.Type() != "stringArray" {
+		t.Fatalf("--arc flag type = %q, want stringArray", arcFlag.Value.Type())
+	}
+	if err := readCmd.ParseFlags([]string{"--arc", "@payload=bafkqaaa", "--arc", "dummy=bafkqaab"}); err != nil {
+		t.Fatalf("parse read --arc flags: %v", err)
+	}
+	gotArcs, err := readCmd.Flags().GetStringArray("arc")
+	if err != nil {
+		t.Fatalf("read parsed --arc flags: %v", err)
+	}
+	if want := []string{"@payload=bafkqaaa", "dummy=bafkqaab"}; !reflect.DeepEqual(gotArcs, want) {
+		t.Fatalf("parsed --arc flags = %#v, want %#v", gotArcs, want)
+	}
+
+	if got := readCmd.Annotations["malt.result_schema"]; got != "cmd/eval/schemas/readbench-result.schema.json" {
+		t.Fatalf("read result schema annotation = %q", got)
 	}
 }

--- a/cmd/eval/helper/evalread/command.go
+++ b/cmd/eval/helper/evalread/command.go
@@ -39,9 +39,10 @@ func newCommand(use, short string, out io.Writer) *cobra.Command {
 		out:        out,
 	}
 	cmd := &cobra.Command{
-		Use:   use,
-		Short: short,
-		Args:  cobra.NoArgs,
+		Use:         use,
+		Short:       short,
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{"malt.result_schema": readbench.ResultSchemaPath},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return run(cmd, opts)
 		},

--- a/cmd/eval/schemas/readbench-result.schema.json
+++ b/cmd/eval/schemas/readbench-result.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/readbench-result.schema.json",
+  "title": "MALT read benchmark result",
+  "description": "One JSONL record emitted by malt-eval read for a single measured read operation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "operation_kind",
+    "iteration",
+    "fixture",
+    "path",
+    "elapsed_ns",
+    "prooflist_step_count",
+    "cas",
+    "arctable",
+    "proof"
+  ],
+  "properties": {
+    "operation_kind": {
+      "type": "string",
+      "enum": ["resolve_path", "content_range"]
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "fixture": {
+      "type": "string",
+      "minLength": 1
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "range_header": {
+      "type": "string",
+      "description": "HTTP Range header used for content_range records."
+    },
+    "elapsed_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "content_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "prooflist_step_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "target": {
+      "type": "string",
+      "description": "Resolved target CID for resolve_path records."
+    },
+    "cas": {
+      "$ref": "#/$defs/cas_stats"
+    },
+    "arctable": {
+      "$ref": "#/$defs/arctable_stats"
+    },
+    "proof": {
+      "$ref": "#/$defs/proof_stats"
+    }
+  },
+  "$defs": {
+    "counter": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cas_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["put_count", "get_count", "has_count", "bytes_put", "bytes_get"],
+      "properties": {
+        "put_count": { "$ref": "#/$defs/counter" },
+        "get_count": { "$ref": "#/$defs/counter" },
+        "has_count": { "$ref": "#/$defs/counter" },
+        "bytes_put": { "$ref": "#/$defs/counter" },
+        "bytes_get": { "$ref": "#/$defs/counter" }
+      }
+    },
+    "arctable_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "get_count",
+        "batch_get_count",
+        "batch_get_path_count",
+        "update_count",
+        "update_arc_count",
+        "snapshot_count",
+        "snapshot_arc_count",
+        "iterate_count"
+      ],
+      "properties": {
+        "get_count": { "$ref": "#/$defs/counter" },
+        "batch_get_count": { "$ref": "#/$defs/counter" },
+        "batch_get_path_count": { "$ref": "#/$defs/counter" },
+        "update_count": { "$ref": "#/$defs/counter" },
+        "update_arc_count": { "$ref": "#/$defs/counter" },
+        "snapshot_count": { "$ref": "#/$defs/counter" },
+        "snapshot_arc_count": { "$ref": "#/$defs/counter" },
+        "iterate_count": { "$ref": "#/$defs/counter" }
+      }
+    },
+    "proof_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "proof_list_count",
+        "step_count",
+        "evidence_bytes",
+        "proof_bytes",
+        "total_bytes"
+      ],
+      "properties": {
+        "proof_list_count": { "$ref": "#/$defs/counter" },
+        "step_count": { "$ref": "#/$defs/counter" },
+        "evidence_bytes": { "$ref": "#/$defs/counter" },
+        "proof_bytes": { "$ref": "#/$defs/counter" },
+        "total_bytes": { "$ref": "#/$defs/counter" }
+      }
+    }
+  }
+}

--- a/internal/eval/readbench/schema.go
+++ b/internal/eval/readbench/schema.go
@@ -1,0 +1,5 @@
+package readbench
+
+// ResultSchemaPath is the repository-relative JSON Schema for one read
+// benchmark JSONL record.
+const ResultSchemaPath = "cmd/eval/schemas/readbench-result.schema.json"

--- a/internal/eval/readbench/schema_test.go
+++ b/internal/eval/readbench/schema_test.go
@@ -1,0 +1,116 @@
+package readbench
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type jsonSchema struct {
+	Schema               string                  `json:"$schema"`
+	ID                   string                  `json:"$id"`
+	Title                string                  `json:"title"`
+	Type                 string                  `json:"type"`
+	AdditionalProperties bool                    `json:"additionalProperties"`
+	Required             []string                `json:"required"`
+	Properties           map[string]schemaObject `json:"properties"`
+}
+
+type schemaObject struct {
+	Type string `json:"type"`
+	Ref  string `json:"$ref"`
+}
+
+func TestResultSchemaIsCheckedInAndMatchesResultFields(t *testing.T) {
+	schema := readResultSchema(t)
+	if schema.Schema == "" || schema.ID == "" {
+		t.Fatalf("schema must declare $schema and $id: %+v", schema)
+	}
+	if schema.Type != "object" {
+		t.Fatalf("schema type = %q, want object", schema.Type)
+	}
+	if schema.AdditionalProperties {
+		t.Fatal("readbench result schema should reject unknown top-level fields")
+	}
+
+	wantFields, wantRequired := resultJSONFields(t)
+	for fieldName := range wantFields {
+		if _, ok := schema.Properties[fieldName]; !ok {
+			t.Fatalf("schema missing Result field %q", fieldName)
+		}
+	}
+	for fieldName := range schema.Properties {
+		if _, ok := wantFields[fieldName]; !ok {
+			t.Fatalf("schema has unknown top-level field %q", fieldName)
+		}
+	}
+	for fieldName := range wantRequired {
+		if !containsString(schema.Required, fieldName) {
+			t.Fatalf("schema required list missing %q", fieldName)
+		}
+	}
+}
+
+func readResultSchema(t *testing.T) jsonSchema {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", filepath.FromSlash(ResultSchemaPath)))
+	if err != nil {
+		t.Fatalf("read schema %s: %v", ResultSchemaPath, err)
+	}
+	var schema jsonSchema
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("parse schema %s: %v", ResultSchemaPath, err)
+	}
+	return schema
+}
+
+func resultJSONFields(t *testing.T) (map[string]struct{}, map[string]struct{}) {
+	t.Helper()
+
+	fields := make(map[string]struct{})
+	required := make(map[string]struct{})
+	resultType := reflect.TypeOf(Result{})
+	for i := 0; i < resultType.NumField(); i++ {
+		field := resultType.Field(i)
+		name, omitempty := jsonFieldName(field)
+		if name == "" || name == "-" {
+			continue
+		}
+		fields[name] = struct{}{}
+		if !omitempty {
+			required[name] = struct{}{}
+		}
+	}
+	return fields, required
+}
+
+func jsonFieldName(field reflect.StructField) (string, bool) {
+	tag := field.Tag.Get("json")
+	if tag == "" {
+		return field.Name, false
+	}
+	parts := strings.Split(tag, ",")
+	name := parts[0]
+	if name == "" {
+		name = field.Name
+	}
+	for _, opt := range parts[1:] {
+		if opt == "omitempty" {
+			return name, true
+		}
+	}
+	return name, false
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Check in the JSON Schema for one `malt-eval read` JSONL result record.
- Expose the schema path from `internal/eval/readbench` and annotate the Cobra read command with it.
- Add regression coverage for the root Cobra `read --arc` flag path and for schema alignment with the `readbench.Result` JSON fields.

## Test Plan
- `go test ./internal/eval/readbench ./cmd/eval/command ./cmd/eval/helper/evalread`
- `go test ./...`
- `go vet ./...`