### PR TITLE
Add readbench IPLD baselines

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -221,7 +221,8 @@ Current command model:
 - `malt verify ...`
   - verifies a ProofList
 - `malt-eval read`
-  - MALT-only read benchmark driver
+  - read benchmark driver for `maltflat`, IPLD UnixFS, and IPLD UnixFS+HAMT
+    baselines
 - `malt-eval write`
   - Git trace write-amplification replay driver
 - `malt-eval metrics`
@@ -425,6 +426,8 @@ Metrics:
 
 - path lookup latency
 - range read latency
+- evidence item count (`ProofList` steps for MALT, CAS block fetches for IPLD
+  baselines)
 - chunk update cost
 - directory mutation cost
 - proof size

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Current runtime shape:
 - `malt verify`
   - verifies a ProofList, including the ProofList emitted by `malt resolve`
 - `malt-eval read`
-  - MALT-only read benchmark driver
+  - read benchmark driver for `maltflat`, IPLD UnixFS, and IPLD UnixFS+HAMT
+    baselines
   - emits one JSONL record per measured operation; each line follows
     `cmd/eval/schemas/readbench-result.schema.json`
 - `malt-eval write`

--- a/cmd/eval/helper/evalread/command.go
+++ b/cmd/eval/helper/evalread/command.go
@@ -14,6 +14,7 @@ import (
 
 type options struct {
 	cfgFile    string
+	systemsCSV string
 	fixture    string
 	depth      int
 	smallBytes int
@@ -26,11 +27,12 @@ type options struct {
 
 // NewCommand creates the unified `malt-eval read` subcommand.
 func NewCommand() *cobra.Command {
-	return newCommand("read", "Run a MALT-only read benchmark and emit JSONL", os.Stdout)
+	return newCommand("read", "Run a read benchmark across MALT and IPLD UnixFS baselines", os.Stdout)
 }
 
 func newCommand(use, short string, out io.Writer) *cobra.Command {
 	opts := &options{
+		systemsCSV: readbench.DefaultSystemsCSV,
 		depth:      readbench.DefaultDirectoryDepth,
 		smallBytes: readbench.DefaultSmallFileBytes,
 		largeBytes: readbench.DefaultLargeFileBytes,
@@ -48,6 +50,7 @@ func newCommand(use, short string, out io.Writer) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVarP(&opts.cfgFile, "config", "c", "", "config file (default: ~/.malt/malt.json)")
+	cmd.Flags().StringVar(&opts.systemsCSV, "systems", opts.systemsCSV, "Comma-separated systems: maltflat, merkledag, hamt")
 	cmd.Flags().StringVar(&opts.fixture, "fixture", opts.fixture, "name for the deterministic read fixture (defaults to a fresh readbench-* fixture)")
 	cmd.Flags().IntVar(&opts.depth, "depth", opts.depth, "directory depth for fixture paths")
 	cmd.Flags().IntVar(&opts.smallBytes, "small-bytes", opts.smallBytes, "small raw file size in bytes")
@@ -59,23 +62,32 @@ func newCommand(use, short string, out io.Writer) *cobra.Command {
 }
 
 func run(cmd *cobra.Command, opts *options) error {
-	cfg, err := loadConfig(opts.cfgFile)
-	if err != nil {
-		return err
-	}
 	arcs, err := ParseArcFlags(opts.arcFlags)
 	if err != nil {
 		return err
 	}
-	if len(arcs) == 0 {
-		return fmt.Errorf("--arc is required at least once and must include @payload")
+	systems, err := ParseSystemsCSV(opts.systemsCSV)
+	if err != nil {
+		return err
 	}
-	if _, ok := arcs["@payload"]; !ok {
-		return fmt.Errorf("--arc is required at least once and must include @payload")
+	var apiBaseURL string
+	if systemsInclude(systems, readbench.SystemMALTFlat) {
+		cfg, err := loadConfig(opts.cfgFile)
+		if err != nil {
+			return err
+		}
+		apiBaseURL = cfg.APIBaseURL()
+		if len(arcs) == 0 {
+			return fmt.Errorf("--arc is required at least once and must include @payload")
+		}
+		if _, ok := arcs["@payload"]; !ok {
+			return fmt.Errorf("--arc is required at least once and must include @payload")
+		}
 	}
 
-	runner := readbench.NewRunner(cfg.APIBaseURL())
+	runner := readbench.NewRunner(apiBaseURL)
 	return runner.RunJSONL(cmd.Context(), readbench.RunConfig{
+		Systems: systems,
 		Fixture: readbench.FixtureConfig{
 			FixtureName:    opts.fixture,
 			DirectoryDepth: opts.depth,
@@ -86,6 +98,20 @@ func run(cmd *cobra.Command, opts *options) error {
 		RangeHeader: opts.rangeValue,
 		Iterations:  opts.iterations,
 	}, opts.out)
+}
+
+// ParseSystemsCSV parses comma-separated read benchmark system names.
+func ParseSystemsCSV(raw string) ([]readbench.SystemName, error) {
+	return readbench.ParseSystemsCSV(raw)
+}
+
+func systemsInclude(systems []readbench.SystemName, target readbench.SystemName) bool {
+	for _, system := range systems {
+		if system == target {
+			return true
+		}
+	}
+	return false
 }
 
 func loadConfig(path string) (*config.Config, error) {

--- a/cmd/eval/helper/evalread/command_test.go
+++ b/cmd/eval/helper/evalread/command_test.go
@@ -49,3 +49,9 @@ func TestParseSystemsCSVRejectsUnknownSystem(t *testing.T) {
 		t.Fatal("expected unknown system to fail")
 	}
 }
+
+func TestParseSystemsCSVRejectsDuplicateSystem(t *testing.T) {
+	if _, err := ParseSystemsCSV("maltflat,merkledag,maltflat"); err == nil {
+		t.Fatal("expected duplicate system to fail")
+	}
+}

--- a/cmd/eval/helper/evalread/command_test.go
+++ b/cmd/eval/helper/evalread/command_test.go
@@ -1,6 +1,11 @@
 package evalread
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dewebprotocol/malt/internal/eval/readbench"
+)
 
 func TestParseArcFlagsRequiresPathAndCID(t *testing.T) {
 	if _, err := ParseArcFlags([]string{"missing-separator"}); err == nil {
@@ -21,5 +26,26 @@ func TestParseArcFlagsReturnsMap(t *testing.T) {
 	}
 	if got["@payload"] != "bafyroot" || got["name"] != "bafyname" {
 		t.Fatalf("arcs = %#v", got)
+	}
+}
+
+func TestParseSystemsCSVReturnsOrderedSystems(t *testing.T) {
+	got, err := ParseSystemsCSV("maltflat, merkledag, hamt")
+	if err != nil {
+		t.Fatalf("parse systems: %v", err)
+	}
+	want := []readbench.SystemName{
+		readbench.SystemMALTFlat,
+		readbench.SystemMerkleDAG,
+		readbench.SystemHAMT,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("systems = %q, want %q", got, want)
+	}
+}
+
+func TestParseSystemsCSVRejectsUnknownSystem(t *testing.T) {
+	if _, err := ParseSystemsCSV("maltflat,unknown"); err == nil {
+		t.Fatal("expected unknown system to fail")
 	}
 }

--- a/cmd/eval/schemas/readbench-result.schema.json
+++ b/cmd/eval/schemas/readbench-result.schema.json
@@ -1,22 +1,29 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/readbench-result.schema.json",
-  "title": "MALT read benchmark result",
+  "title": "Read benchmark result",
   "description": "One JSONL record emitted by malt-eval read for a single measured read operation.",
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "system",
     "operation_kind",
     "iteration",
     "fixture",
     "path",
     "elapsed_ns",
     "prooflist_step_count",
+    "evidence_item_count",
     "cas",
     "arctable",
     "proof"
   ],
   "properties": {
+    "system": {
+      "type": "string",
+      "enum": ["maltflat", "merkledag", "hamt"],
+      "description": "Evaluated read implementation."
+    },
     "operation_kind": {
       "type": "string",
       "enum": ["resolve_path", "content_range"]
@@ -48,6 +55,11 @@
     "prooflist_step_count": {
       "type": "integer",
       "minimum": 0
+    },
+    "evidence_item_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Comparable evidence count: ProofList steps for MALT, CAS block fetches for IPLD UnixFS baselines."
     },
     "target": {
       "type": "string",

--- a/internal/eval/readbench/baseline.go
+++ b/internal/eval/readbench/baseline.go
@@ -1,0 +1,240 @@
+package readbench
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	casmock "github.com/dewebprotocol/malt/core/cas/mock"
+	"github.com/dewebprotocol/malt/core/metrics"
+	"github.com/dewebprotocol/malt/internal/merkledagimport"
+	unixfsio "github.com/ipfs/boxo/ipld/unixfs/io"
+	cid "github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+type fixtureData struct {
+	fixtureName string
+	smallPath   string
+	largePath   string
+	smallData   []byte
+	largeData   []byte
+}
+
+type baselineSystem struct {
+	system SystemName
+	store  *casmock.CAS
+	dag    ipld.DAGService
+	root   string
+}
+
+func newFixtureData(cfg FixtureConfig) fixtureData {
+	return fixtureData{
+		fixtureName: cfg.FixtureName,
+		smallPath:   fixturePath(cfg.DirectoryDepth, "small.txt"),
+		largePath:   fixturePath(cfg.DirectoryDepth, "large.bin"),
+		smallData:   deterministicBytes("small", cfg.SmallFileBytes),
+		largeData:   deterministicBytes("large", cfg.LargeFileBytes),
+	}
+}
+
+func newBaselineSystem(ctx context.Context, system SystemName, fixture fixtureData) (*baselineSystem, error) {
+	dirLayout, err := baselineDirLayout(system)
+	if err != nil {
+		return nil, err
+	}
+	store := casmock.NewCAS(casmock.WithoutLatency())
+	dag := merkledagimport.NewDAGService(store)
+	result, err := merkledagimport.ImportFiles(ctx, store, []merkledagimport.File{
+		{Path: fixture.smallPath, Data: fixture.smallData, Mode: 0o644},
+		{Path: fixture.largePath, Data: fixture.largeData, Mode: 0o644},
+	}, merkledagimport.Options{
+		Model:      merkledagimport.ModelUnixFS,
+		FileLayout: merkledagimport.FileLayoutBalanced,
+		DirLayout:  dirLayout,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s prepare fixture: %w", system, err)
+	}
+	return &baselineSystem{
+		system: system,
+		store:  store,
+		dag:    dag,
+		root:   result.Root,
+	}, nil
+}
+
+func baselineDirLayout(system SystemName) (string, error) {
+	switch system {
+	case SystemMerkleDAG:
+		return merkledagimport.DirLayoutBasic, nil
+	case SystemHAMT:
+		return merkledagimport.DirLayoutHAMT, nil
+	default:
+		return "", fmt.Errorf("system %q is not an IPLD UnixFS baseline", system)
+	}
+}
+
+func (b *baselineSystem) measureOperation(ctx context.Context, iteration int, fixture string, op operation) (*Result, error) {
+	if b == nil || b.store == nil || b.dag == nil {
+		return nil, fmt.Errorf("baseline system is nil")
+	}
+	b.store.ResetStats()
+
+	start := time.Now()
+	var (
+		target       string
+		contentBytes *int
+	)
+	switch op.kind {
+	case OperationResolvePath:
+		node, err := b.resolvePath(ctx, op.path)
+		if err != nil {
+			return nil, fmt.Errorf("%s resolve path %q: %w", b.system, op.path, err)
+		}
+		target = node.Cid().String()
+	case OperationContentRange:
+		node, err := b.resolvePath(ctx, op.path)
+		if err != nil {
+			return nil, fmt.Errorf("%s resolve content path %q: %w", b.system, op.path, err)
+		}
+		count, err := readUnixFSRange(ctx, b.dag, node, op.rangeHeader)
+		if err != nil {
+			return nil, fmt.Errorf("%s content range read %q: %w", b.system, op.path, err)
+		}
+		contentBytes = &count
+	default:
+		return nil, fmt.Errorf("unsupported operation kind %q", op.kind)
+	}
+	elapsed := time.Since(start).Nanoseconds()
+	casStats := b.store.SnapshotStats()
+
+	return &Result{
+		System:            b.system,
+		OperationKind:     op.kind,
+		Iteration:         iteration,
+		FixtureName:       fixture,
+		Path:              op.path,
+		RangeHeader:       op.rangeHeader,
+		ElapsedNS:         elapsed,
+		ContentBytes:      contentBytes,
+		EvidenceItemCount: int(casStats.GetCount),
+		Target:            target,
+		CAS:               casStats,
+		ArcTable:          metrics.ArcTableStats{},
+		Proof:             metrics.ProofStats{},
+	}, nil
+}
+
+func (b *baselineSystem) resolvePath(ctx context.Context, queryPath string) (ipld.Node, error) {
+	root, err := cid.Parse(b.root)
+	if err != nil {
+		return nil, fmt.Errorf("parse baseline root %q: %w", b.root, err)
+	}
+	node, err := b.dag.Get(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	clean := path.Clean(strings.Trim(queryPath, "/"))
+	if clean == "." {
+		return node, nil
+	}
+	for _, segment := range strings.Split(clean, "/") {
+		dir, err := unixfsio.NewDirectoryFromNode(b.dag, node)
+		if err != nil {
+			return nil, err
+		}
+		node, err = dir.Find(ctx, segment)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return node, nil
+}
+
+func readUnixFSRange(ctx context.Context, dag ipld.NodeGetter, node ipld.Node, rawRange string) (int, error) {
+	reader, err := unixfsio.NewDagReader(ctx, node, dag)
+	if err != nil {
+		return 0, err
+	}
+	defer reader.Close()
+
+	start, endExclusive, err := parseReadRangeHeader(rawRange, int64(reader.Size()))
+	if err != nil {
+		return 0, err
+	}
+	length := endExclusive - start
+	if length == 0 {
+		return 0, nil
+	}
+	if length > int64(int(length)) {
+		return 0, fmt.Errorf("range length overflows int")
+	}
+	if _, err := reader.Seek(start, io.SeekStart); err != nil {
+		return 0, err
+	}
+	buf := make([]byte, int(length))
+	n, err := io.ReadFull(reader, buf)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func parseReadRangeHeader(raw string, size int64) (int64, int64, error) {
+	if size < 0 {
+		return 0, 0, fmt.Errorf("invalid size")
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, size, nil
+	}
+	if !strings.HasPrefix(raw, "bytes=") {
+		return 0, 0, fmt.Errorf("invalid range")
+	}
+	spec := strings.TrimPrefix(raw, "bytes=")
+	if strings.Contains(spec, ",") {
+		return 0, 0, fmt.Errorf("multiple ranges are not supported")
+	}
+	parts := strings.SplitN(spec, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid range")
+	}
+	if parts[0] == "" {
+		suffix, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil || suffix <= 0 {
+			return 0, 0, fmt.Errorf("invalid range")
+		}
+		if size == 0 {
+			return 0, 0, fmt.Errorf("unsatisfiable range")
+		}
+		if suffix > size {
+			suffix = size
+		}
+		return size - suffix, size, nil
+	}
+
+	start, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil || start < 0 {
+		return 0, 0, fmt.Errorf("invalid range")
+	}
+	if start >= size {
+		return 0, 0, fmt.Errorf("unsatisfiable range")
+	}
+	if parts[1] == "" {
+		return start, size, nil
+	}
+	end, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil || end < start {
+		return 0, 0, fmt.Errorf("invalid range")
+	}
+	if end >= size {
+		end = size - 1
+	}
+	return start, end + 1, nil
+}

--- a/internal/eval/readbench/runner.go
+++ b/internal/eval/readbench/runner.go
@@ -151,6 +151,9 @@ func (r *Runner) RunJSONL(ctx context.Context, cfg RunConfig, w io.Writer) error
 	if err != nil {
 		return err
 	}
+	if normalized.Iterations == 0 {
+		return nil
+	}
 
 	data := newFixtureData(normalized.Fixture)
 	fixture := &Fixture{

--- a/internal/eval/readbench/runner.go
+++ b/internal/eval/readbench/runner.go
@@ -1,4 +1,4 @@
-// Package readbench provides a MALT-only read benchmark runner.
+// Package readbench provides read benchmark runners for MALT and IPLD UnixFS baselines.
 package readbench
 
 import (
@@ -50,12 +50,13 @@ type FixtureConfig struct {
 
 // RunConfig controls one JSONL benchmark run.
 type RunConfig struct {
+	Systems     []SystemName
 	Fixture     FixtureConfig
 	RangeHeader string
 	Iterations  int
 }
 
-// Fixture describes the deterministic MALT-only dataset.
+// Fixture describes the deterministic read benchmark dataset.
 type Fixture struct {
 	FixtureName string
 	SmallPath   string
@@ -65,6 +66,7 @@ type Fixture struct {
 
 // Result is one benchmark JSONL record.
 type Result struct {
+	System             SystemName            `json:"system"`
 	OperationKind      OperationKind         `json:"operation_kind"`
 	Iteration          int                   `json:"iteration"`
 	FixtureName        string                `json:"fixture"`
@@ -73,6 +75,7 @@ type Result struct {
 	ElapsedNS          int64                 `json:"elapsed_ns"`
 	ContentBytes       *int                  `json:"content_bytes,omitempty"`
 	ProofListStepCount int                   `json:"prooflist_step_count"`
+	EvidenceItemCount  int                   `json:"evidence_item_count"`
 	Target             string                `json:"target,omitempty"`
 	CAS                metrics.CASStats      `json:"cas"`
 	ArcTable           metrics.ArcTableStats `json:"arctable"`
@@ -99,7 +102,7 @@ func NewRunner(baseURL string) *Runner {
 	}
 }
 
-// PrepareFixture creates a deterministic MALT-only read fixture under an explicit root.
+// PrepareFixture creates a deterministic MALT read fixture under an explicit root.
 func (r *Runner) PrepareFixture(ctx context.Context, cfg FixtureConfig) (*Fixture, error) {
 	if r == nil || r.client == nil {
 		return nil, fmt.Errorf("read benchmark runner is nil")
@@ -108,6 +111,7 @@ func (r *Runner) PrepareFixture(ctx context.Context, cfg FixtureConfig) (*Fixtur
 	if err != nil {
 		return nil, err
 	}
+	data := newFixtureData(normalized)
 
 	if len(cfg.Arcs) == 0 {
 		return nil, fmt.Errorf("create root structure: Arcs is required in FixtureConfig")
@@ -118,23 +122,21 @@ func (r *Runner) PrepareFixture(ctx context.Context, cfg FixtureConfig) (*Fixtur
 	}
 	r.root = rootResp.Root
 
-	smallPath := fixturePath(normalized.DirectoryDepth, "small.txt")
-	largePath := fixturePath(normalized.DirectoryDepth, "large.bin")
-	if writeResp, err := r.client.AddUnixFSFile(ctx, r.root, smallPath, deterministicBytes("small", normalized.SmallFileBytes)); err != nil {
+	if writeResp, err := r.client.AddUnixFSFile(ctx, r.root, data.smallPath, data.smallData); err != nil {
 		return nil, fmt.Errorf("write small fixture: %w", err)
 	} else {
 		r.root = writeResp.NewRoot
 	}
-	if writeResp, err := r.client.AddUnixFSFile(ctx, r.root, largePath, deterministicBytes("large", normalized.LargeFileBytes)); err != nil {
+	if writeResp, err := r.client.AddUnixFSFile(ctx, r.root, data.largePath, data.largeData); err != nil {
 		return nil, fmt.Errorf("write large fixture: %w", err)
 	} else {
 		r.root = writeResp.NewRoot
 	}
 
 	return &Fixture{
-		FixtureName: normalized.FixtureName,
-		SmallPath:   smallPath,
-		LargePath:   largePath,
+		FixtureName: data.fixtureName,
+		SmallPath:   data.smallPath,
+		LargePath:   data.largePath,
 		Root:        r.root,
 	}, nil
 }
@@ -150,9 +152,35 @@ func (r *Runner) RunJSONL(ctx context.Context, cfg RunConfig, w io.Writer) error
 		return err
 	}
 
-	fixture, err := r.PrepareFixture(ctx, normalized.Fixture)
-	if err != nil {
-		return err
+	data := newFixtureData(normalized.Fixture)
+	fixture := &Fixture{
+		FixtureName: data.fixtureName,
+		SmallPath:   data.smallPath,
+		LargePath:   data.largePath,
+	}
+	baselines := make(map[SystemName]*baselineSystem)
+	for _, system := range normalized.Systems {
+		switch system {
+		case SystemMALTFlat:
+			if fixture.Root == "" {
+				prepared, err := r.PrepareFixture(ctx, normalized.Fixture)
+				if err != nil {
+					return err
+				}
+				fixture = prepared
+			}
+		case SystemMerkleDAG, SystemHAMT:
+			if _, ok := baselines[system]; ok {
+				continue
+			}
+			baseline, err := newBaselineSystem(ctx, system, data)
+			if err != nil {
+				return err
+			}
+			baselines[system] = baseline
+		default:
+			return fmt.Errorf("unknown system %q", system)
+		}
 	}
 
 	ops := []operation{
@@ -162,13 +190,26 @@ func (r *Runner) RunJSONL(ctx context.Context, cfg RunConfig, w io.Writer) error
 
 	enc := json.NewEncoder(w)
 	for iteration := 0; iteration < normalized.Iterations; iteration++ {
-		for _, op := range ops {
-			result, err := r.measureOperation(ctx, iteration, fixture.FixtureName, op)
-			if err != nil {
-				return err
-			}
-			if err := enc.Encode(result); err != nil {
-				return fmt.Errorf("write JSONL result: %w", err)
+		for _, system := range normalized.Systems {
+			for _, op := range ops {
+				var (
+					result *Result
+					err    error
+				)
+				switch system {
+				case SystemMALTFlat:
+					result, err = r.measureOperation(ctx, iteration, fixture.FixtureName, op)
+				case SystemMerkleDAG, SystemHAMT:
+					result, err = baselines[system].measureOperation(ctx, iteration, fixture.FixtureName, op)
+				default:
+					return fmt.Errorf("unknown system %q", system)
+				}
+				if err != nil {
+					return err
+				}
+				if err := enc.Encode(result); err != nil {
+					return fmt.Errorf("write JSONL result: %w", err)
+				}
 			}
 		}
 	}
@@ -217,6 +258,7 @@ func (r *Runner) measureOperation(ctx context.Context, iteration int, fixture st
 	}
 
 	return &Result{
+		System:             SystemMALTFlat,
 		OperationKind:      op.kind,
 		Iteration:          iteration,
 		FixtureName:        fixture,
@@ -225,6 +267,7 @@ func (r *Runner) measureOperation(ctx context.Context, iteration int, fixture st
 		ElapsedNS:          elapsed,
 		ContentBytes:       contentBytes,
 		ProofListStepCount: stepCount,
+		EvidenceItemCount:  stepCount,
 		Target:             target,
 		CAS:                snapshot.CAS,
 		ArcTable:           snapshot.ArcTable,
@@ -253,6 +296,10 @@ func (r *Runner) metricsSnapshot(ctx context.Context) (metrics.Snapshot, error) 
 }
 
 func normalizeRunConfig(cfg RunConfig) (RunConfig, error) {
+	systems, err := normalizeSystems(cfg.Systems)
+	if err != nil {
+		return RunConfig{}, err
+	}
 	fixture, err := normalizeFixtureConfig(cfg.Fixture)
 	if err != nil {
 		return RunConfig{}, err
@@ -263,6 +310,7 @@ func normalizeRunConfig(cfg RunConfig) (RunConfig, error) {
 	if strings.TrimSpace(cfg.RangeHeader) == "" {
 		cfg.RangeHeader = DefaultRangeHeader
 	}
+	cfg.Systems = systems
 	cfg.Fixture = fixture
 	return cfg, nil
 }

--- a/internal/eval/readbench/runner_test.go
+++ b/internal/eval/readbench/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/dewebprotocol/malt/config"
 	"github.com/dewebprotocol/malt/core/api"
 	casmock "github.com/dewebprotocol/malt/core/cas/mock"
+	"github.com/dewebprotocol/malt/core/metrics"
 	"github.com/dewebprotocol/malt/server"
 )
 
@@ -166,6 +168,7 @@ func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 
 	var out bytes.Buffer
 	err := runner.RunJSONL(ctx, RunConfig{
+		Systems: []SystemName{SystemMALTFlat},
 		Fixture: FixtureConfig{
 			FixtureName:    "readbench-run",
 			DirectoryDepth: 2,
@@ -186,6 +189,9 @@ func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 	}
 
 	proofRead := got[0]
+	if proofRead.System != SystemMALTFlat {
+		t.Fatalf("first system = %q, want %q", proofRead.System, SystemMALTFlat)
+	}
 	if proofRead.OperationKind != OperationResolvePath {
 		t.Fatalf("first operation = %q, want %q", proofRead.OperationKind, OperationResolvePath)
 	}
@@ -204,6 +210,9 @@ func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 	if proofRead.ProofListStepCount == 0 {
 		t.Fatal("prooflist step count should be recorded")
 	}
+	if proofRead.EvidenceItemCount != proofRead.ProofListStepCount {
+		t.Fatalf("prooflist evidence items = %d, want prooflist step count %d", proofRead.EvidenceItemCount, proofRead.ProofListStepCount)
+	}
 	if proofRead.Proof.ProofListCount != 1 {
 		t.Fatalf("prooflist proof metric count = %d, want 1", proofRead.Proof.ProofListCount)
 	}
@@ -215,6 +224,9 @@ func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 	}
 
 	rangeRead := got[1]
+	if rangeRead.System != SystemMALTFlat {
+		t.Fatalf("second system = %q, want %q", rangeRead.System, SystemMALTFlat)
+	}
 	if rangeRead.OperationKind != OperationContentRange {
 		t.Fatalf("second operation = %q, want %q", rangeRead.OperationKind, OperationContentRange)
 	}
@@ -230,11 +242,120 @@ func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 	if rangeRead.ProofListStepCount == 0 {
 		t.Fatal("content range prooflist step count should be recorded")
 	}
+	if rangeRead.EvidenceItemCount != rangeRead.ProofListStepCount {
+		t.Fatalf("content range evidence items = %d, want prooflist step count %d", rangeRead.EvidenceItemCount, rangeRead.ProofListStepCount)
+	}
 	if rangeRead.Proof.ProofListCount != 1 {
 		t.Fatalf("content proof metric count = %d, want reset per operation", rangeRead.Proof.ProofListCount)
 	}
 	if rangeRead.CAS.GetCount == 0 || rangeRead.CAS.BytesGet == 0 {
 		t.Fatalf("content range CAS metrics should include bytes fetched: %+v", rangeRead.CAS)
+	}
+}
+
+func TestRunJSONLEmitsUnixFSBaselines(t *testing.T) {
+	ctx := context.Background()
+	runner := NewRunner("http://127.0.0.1:0")
+
+	var out bytes.Buffer
+	err := runner.RunJSONL(ctx, RunConfig{
+		Systems: []SystemName{SystemMerkleDAG, SystemHAMT},
+		Fixture: FixtureConfig{
+			FixtureName:    "readbench-baseline",
+			DirectoryDepth: 2,
+			SmallFileBytes: 48,
+			LargeFileBytes: 300 * 1024,
+		},
+		RangeHeader: "bytes=7-19",
+		Iterations:  1,
+	}, &out)
+	if err != nil {
+		t.Fatalf("RunJSONL() error = %v", err)
+	}
+
+	got := decodeJSONLResults(t, out.Bytes())
+	if len(got) != 4 {
+		t.Fatalf("result count = %d, want 4\n%s", len(got), out.String())
+	}
+
+	wantSystems := []SystemName{SystemMerkleDAG, SystemMerkleDAG, SystemHAMT, SystemHAMT}
+	for i, result := range got {
+		if result.System != wantSystems[i] {
+			t.Fatalf("record %d system = %q, want %q", i, result.System, wantSystems[i])
+		}
+		if result.FixtureName != "readbench-baseline" {
+			t.Fatalf("record %d fixture = %q", i, result.FixtureName)
+		}
+		if result.CAS.GetCount == 0 || result.CAS.BytesGet == 0 {
+			t.Fatalf("record %d should include baseline CAS reads: %+v", i, result.CAS)
+		}
+		if result.EvidenceItemCount != int(result.CAS.GetCount) {
+			t.Fatalf("record %d evidence items = %d, want CAS get count %d", i, result.EvidenceItemCount, result.CAS.GetCount)
+		}
+		if result.ProofListStepCount != 0 {
+			t.Fatalf("record %d prooflist steps = %d, want 0 for IPLD baseline", i, result.ProofListStepCount)
+		}
+		if result.ArcTable != (metrics.ArcTableStats{}) {
+			t.Fatalf("record %d arctable metrics = %+v, want zero baseline metrics", i, result.ArcTable)
+		}
+		if result.Proof != (metrics.ProofStats{}) {
+			t.Fatalf("record %d proof metrics = %+v, want zero baseline metrics", i, result.Proof)
+		}
+	}
+
+	resolveRecords := []Result{got[0], got[2]}
+	for _, result := range resolveRecords {
+		if result.OperationKind != OperationResolvePath {
+			t.Fatalf("%s first operation = %q, want %q", result.System, result.OperationKind, OperationResolvePath)
+		}
+		if result.Path != "dir00/dir01/small.txt" {
+			t.Fatalf("%s resolve path = %q", result.System, result.Path)
+		}
+		if result.Target == "" {
+			t.Fatalf("%s resolve target should be recorded", result.System)
+		}
+		if result.ContentBytes != nil {
+			t.Fatalf("%s resolve content bytes = %v, want omitted", result.System, *result.ContentBytes)
+		}
+	}
+
+	rangeRecords := []Result{got[1], got[3]}
+	for _, result := range rangeRecords {
+		if result.OperationKind != OperationContentRange {
+			t.Fatalf("%s second operation = %q, want %q", result.System, result.OperationKind, OperationContentRange)
+		}
+		if result.Path != "dir00/dir01/large.bin" {
+			t.Fatalf("%s range path = %q", result.System, result.Path)
+		}
+		if result.RangeHeader != "bytes=7-19" {
+			t.Fatalf("%s range header = %q", result.System, result.RangeHeader)
+		}
+		if result.ContentBytes == nil || *result.ContentBytes != 13 {
+			t.Fatalf("%s content bytes = %v, want 13", result.System, result.ContentBytes)
+		}
+	}
+}
+
+func TestNormalizeRunConfigDefaultsToAllSystems(t *testing.T) {
+	got, err := normalizeRunConfig(RunConfig{
+		Fixture: FixtureConfig{LargeFileBytes: 300 * 1024},
+	})
+	if err != nil {
+		t.Fatalf("normalizeRunConfig() error = %v", err)
+	}
+	want := []SystemName{SystemMALTFlat, SystemMerkleDAG, SystemHAMT}
+	if !reflect.DeepEqual(got.Systems, want) {
+		t.Fatalf("systems = %q, want %q", got.Systems, want)
+	}
+}
+
+func TestNormalizeRunConfigRejectsUnknownSystem(t *testing.T) {
+	_, err := normalizeRunConfig(RunConfig{
+		Systems: []SystemName{"unknown"},
+		Fixture: FixtureConfig{LargeFileBytes: 300 * 1024},
+	})
+	if err == nil {
+		t.Fatal("expected unknown system to fail")
 	}
 }
 

--- a/internal/eval/readbench/runner_test.go
+++ b/internal/eval/readbench/runner_test.go
@@ -359,6 +359,36 @@ func TestNormalizeRunConfigRejectsUnknownSystem(t *testing.T) {
 	}
 }
 
+func TestNormalizeRunConfigRejectsDuplicateSystem(t *testing.T) {
+	_, err := normalizeRunConfig(RunConfig{
+		Systems: []SystemName{SystemMALTFlat, SystemMALTFlat},
+		Fixture: FixtureConfig{LargeFileBytes: 300 * 1024},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate system to fail")
+	}
+}
+
+func TestRunJSONLZeroIterationsSkipsFixtureSetup(t *testing.T) {
+	ctx := context.Background()
+	runner := NewRunner("http://127.0.0.1:0")
+
+	var out bytes.Buffer
+	err := runner.RunJSONL(ctx, RunConfig{
+		Fixture: FixtureConfig{
+			FixtureName:    "readbench-zero-setup",
+			LargeFileBytes: 300 * 1024,
+		},
+		Iterations: 0,
+	}, &out)
+	if err != nil {
+		t.Fatalf("RunJSONL() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("RunJSONL() wrote %q, want no records", out.String())
+	}
+}
+
 func TestRunJSONLAllowsZeroIterations(t *testing.T) {
 	ctx := context.Background()
 	baseURL, mockCAS := newTestDaemonWithCAS(t)

--- a/internal/eval/readbench/systems.go
+++ b/internal/eval/readbench/systems.go
@@ -29,6 +29,7 @@ func ParseSystemsCSV(raw string) ([]SystemName, error) {
 	}
 	parts := strings.Split(raw, ",")
 	systems := make([]SystemName, 0, len(parts))
+	seen := make(map[SystemName]struct{}, len(parts))
 	for _, part := range parts {
 		system := SystemName(strings.TrimSpace(part))
 		if system == "" {
@@ -37,6 +38,10 @@ func ParseSystemsCSV(raw string) ([]SystemName, error) {
 		if !knownSystem(system) {
 			return nil, fmt.Errorf("unknown system %q", system)
 		}
+		if _, ok := seen[system]; ok {
+			return nil, fmt.Errorf("duplicate system %q", system)
+		}
+		seen[system] = struct{}{}
 		systems = append(systems, system)
 	}
 	if len(systems) == 0 {
@@ -50,10 +55,15 @@ func normalizeSystems(systems []SystemName) ([]SystemName, error) {
 		return DefaultSystems(), nil
 	}
 	normalized := make([]SystemName, 0, len(systems))
+	seen := make(map[SystemName]struct{}, len(systems))
 	for _, system := range systems {
 		if !knownSystem(system) {
 			return nil, fmt.Errorf("unknown system %q", system)
 		}
+		if _, ok := seen[system]; ok {
+			return nil, fmt.Errorf("duplicate system %q", system)
+		}
+		seen[system] = struct{}{}
 		normalized = append(normalized, system)
 	}
 	return normalized, nil

--- a/internal/eval/readbench/systems.go
+++ b/internal/eval/readbench/systems.go
@@ -1,0 +1,69 @@
+package readbench
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SystemName identifies a read benchmark implementation under test.
+type SystemName string
+
+const (
+	SystemMALTFlat  SystemName = "maltflat"
+	SystemMerkleDAG SystemName = "merkledag"
+	SystemHAMT      SystemName = "hamt"
+)
+
+// DefaultSystemsCSV is the default comma-separated read benchmark system list.
+const DefaultSystemsCSV = "maltflat,merkledag,hamt"
+
+// DefaultSystems returns the default read benchmark system order.
+func DefaultSystems() []SystemName {
+	return []SystemName{SystemMALTFlat, SystemMerkleDAG, SystemHAMT}
+}
+
+// ParseSystemsCSV parses a comma-separated system list.
+func ParseSystemsCSV(raw string) ([]SystemName, error) {
+	if strings.TrimSpace(raw) == "" {
+		return DefaultSystems(), nil
+	}
+	parts := strings.Split(raw, ",")
+	systems := make([]SystemName, 0, len(parts))
+	for _, part := range parts {
+		system := SystemName(strings.TrimSpace(part))
+		if system == "" {
+			continue
+		}
+		if !knownSystem(system) {
+			return nil, fmt.Errorf("unknown system %q", system)
+		}
+		systems = append(systems, system)
+	}
+	if len(systems) == 0 {
+		return nil, fmt.Errorf("no systems selected")
+	}
+	return systems, nil
+}
+
+func normalizeSystems(systems []SystemName) ([]SystemName, error) {
+	if len(systems) == 0 {
+		return DefaultSystems(), nil
+	}
+	normalized := make([]SystemName, 0, len(systems))
+	for _, system := range systems {
+		if !knownSystem(system) {
+			return nil, fmt.Errorf("unknown system %q", system)
+		}
+		normalized = append(normalized, system)
+	}
+	return normalized, nil
+}
+
+func knownSystem(system SystemName) bool {
+	switch system {
+	case SystemMALTFlat, SystemMerkleDAG, SystemHAMT:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/merkledagimport/import.go
+++ b/internal/merkledagimport/import.go
@@ -78,6 +78,11 @@ type Store interface {
 	Get(ctx context.Context, c cid.Cid) ([]byte, error)
 }
 
+// NewDAGService adapts a CAS store to the Boxo UnixFS DAGService interfaces.
+func NewDAGService(store Store) ipld.DAGService {
+	return &casDAGService{store: store}
+}
+
 // ImportPath imports localPath into the supplied CAS using Boxo's UnixFS DAG
 // builders and returns the Merkle DAG root CID.
 func ImportPath(ctx context.Context, store Store, localPath string, opts Options) (*Result, error) {
@@ -91,7 +96,7 @@ func ImportPath(ctx context.Context, store Store, localPath string, opts Options
 		return nil, fmt.Errorf("resolve path %q: %w", localPath, err)
 	}
 	importer := &pathImporter{
-		dag:   &casDAGService{store: store},
+		dag:   NewDAGService(store),
 		opts:  opts,
 		seen:  make(map[string]struct{}),
 		build: cid.Prefix{Version: 1, Codec: cid.DagProtobuf, MhType: mh.SHA2_256, MhLength: -1},
@@ -115,7 +120,7 @@ func ImportFiles(ctx context.Context, store Store, files []File, opts Options) (
 		return nil, err
 	}
 	importer := &pathImporter{
-		dag:   &casDAGService{store: store},
+		dag:   NewDAGService(store),
 		opts:  opts,
 		seen:  make(map[string]struct{}),
 		build: cid.Prefix{Version: 1, Codec: cid.DagProtobuf, MhType: mh.SHA2_256, MhLength: -1},


### PR DESCRIPTION
## Summary
- Extend `malt-eval read` with a `--systems` selector defaulting to `maltflat,merkledag,hamt`.
- Add IPLD UnixFS Basic and UnixFS+HAMT read baselines that import the same deterministic fixture and measure actual path resolve and content range reads.
- Add `system` and `evidence_item_count` to the readbench JSONL schema, with evidence items defined as ProofList steps for MALT and CAS block fetches for IPLD baselines.
- Reject duplicate `--systems` entries and short-circuit zero-iteration runs before fixture setup.
- Update README/ARCHITECTURE wording and tests for the expanded benchmark contract.

## Verification
- `go test ./internal/eval/readbench ./cmd/eval/helper/evalread`
- `go test ./internal/eval/readbench ./internal/merkledagimport ./cmd/eval/helper/evalread ./cmd/eval/command`
- `go test ./...`
- `go run ./cmd/eval/malt-eval read --systems merkledag,hamt --fixture cli-baseline --iterations 1 --large-bytes 307200 --range bytes=7-19`