### PR TITLE
docs: annotate dormant modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,12 @@ This repository contains the Go implementation of MALT:
 - `list` and `map` are semantic abstractions, not merely concrete implementations.
 - `list` describes complex graph nodes with indexed/ranged child references.
 - `map` describes authenticated relations among graph nodes.
+- `core/structure/mapping/indexed` is a baseline comparison map implementation;
+  `core/graph` wires the radix implementation for the current runtime path.
 - current `core/graph` code is runtime metadata/composition, not the target semantic abstraction.
+- `GraphManager` and `GraphMeta` are dormant lifecycle metadata machinery in the
+  current daemon path; daemon startup creates an ad hoc default `Graph` instead
+  of exposing graph lifecycle APIs.
 - current `resolver` and `writer` code is adapter/runtime machinery, not the semantic owner.
 - explicit resolution is a compatibility layer above map reads.
 - list semantics use index/range reads and append/replace/truncate writes, not path resolution.
@@ -50,6 +55,8 @@ This repository contains the Go implementation of MALT:
 - `querypath` and `manifest` are current root-relative file-layout helpers and should not leak into core semantic rules.
 - head publication, freshness, merge, and multi-writer arbitration belong to application/deployment policy.
 - overwrite ArcTable is the simple current-state implementation; versioned ArcTable is the default MVCC-style implementation.
+- `core/arctable/bloom` is an optional ArcTable negative-lookup optimization
+  hook, not semantic state and not deletion-ready dead code.
 
 ## Go Workflow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,6 +111,9 @@ Native writes:
 
 The current public package is `core/structure/mapping`.
 The primary implementation is `core/structure/mapping/radix`.
+`core/structure/mapping/indexed` is retained as a simpler baseline and
+comparison implementation. It is not the production map semantic wired by
+`core/graph`, which constructs `mapping/radix`.
 
 The current explicit resolver is best understood as a compatibility layer above
 map reads. It can implement longest-prefix path policy, but the map semantic
@@ -176,12 +179,17 @@ as follows:
   - target public map semantic abstraction and shared types
 - `core/structure/mapping/radix`
   - primary map implementation
+- `core/structure/mapping/indexed`
+  - baseline comparison implementation, not the current runtime map path
 - `core/structure/list`
   - target public list semantic abstraction and shared types
 - `core/structure/list/tree`
   - primary list implementation
 - `core/arctable`
   - namespace-scoped arcset persistence/materialization
+- `core/arctable/bloom`
+  - optional negative-lookup optimization hook behind ArcTable implementations,
+    disabled unless the ArcTable is constructed with a BloomCache
 - `core/commitment`
   - stateless primitive commitment backends
 - `core/layout/malt/unixfs`
@@ -301,6 +309,10 @@ It owns:
 - commitment proof construction
 - root update computation
 
+`mapping/indexed` is a baseline comparison implementation for the same public
+map interface. It should not be treated as the production map semantic used by
+`core/graph`, resolver adapters, or the current UnixFS-style layout path.
+
 No external writer should redefine map semantics. A layout or write adapter may
 only produce semantic mutations and orchestrate calls into map semantic
 operations.
@@ -415,7 +427,9 @@ Current boundary:
   items.
 - Graph manager metadata is limited to lifecycle and runtime profile
   compatibility. It does not store an authoritative current root or publish
-  freshness.
+  freshness. The current daemon path creates an ad hoc default `Graph` through
+  `Node.NewGraph("default")` and does not expose the managed graph lifecycle as
+  a public API.
 
 It also gives the benchmark target:
 
@@ -470,6 +484,11 @@ The earlier separate lineage index duplicated part of this conceptual space and
 has been removed from the runtime. Version traversal should be derived from the
 versioned ArcTable or from application-level root publication metadata when a
 concrete use case requires it.
+
+`core/arctable/bloom` is retained as the optional negative-lookup optimization
+behind ArcTable implementations. The default root-centric runtime does not make
+it part of read/write semantics or trust, so it is dormant optimization
+machinery rather than deletion-ready dead code.
 
 ## CAS Boundary
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ Under this terminology:
 - The current `core/graph` package is runtime metadata/composition code; it is
   not the target semantic abstraction.
 - Graph manager metadata tracks lifecycle and backend compatibility only; it
-  does not store or publish a current root.
+  does not store or publish a current root. The daemon currently creates an ad
+  hoc default `Graph` and does not expose GraphManager lifecycle APIs as the
+  public runtime path.
 
 ## Map Semantic
 
@@ -198,7 +200,9 @@ Native operations:
 
 The current default implementation is `core/structure/mapping/radix`, a
 digest-keyed radix map over an index commitment backend. The older
-`core/structure/mapping/indexed` package remains as a simpler comparison path.
+`core/structure/mapping/indexed` package remains as a simpler baseline and
+comparison implementation. It is not the production map semantic wired by
+`core/graph`.
 
 The explicit path resolver should be understood as a compatibility layer above
 map reads. It may implement longest-prefix path matching, but map itself
@@ -306,6 +310,8 @@ Verification is local to the client:
   - public map semantic abstraction and shared map types
 - `core/structure/mapping/radix`
   - primary map implementation
+- `core/structure/mapping/indexed`
+  - baseline comparison map implementation, not the current runtime map path
 - `core/structure/list`
   - public list semantic abstraction and shared list types
 - `core/structure/list/tree`
@@ -314,6 +320,9 @@ Verification is local to the client:
   - stateless primitive commitment backends
 - `core/arctable`
   - namespace-scoped arcset persistence/materialization
+- `core/arctable/bloom`
+  - optional ArcTable negative-lookup optimization hook, disabled unless an
+    ArcTable is constructed with a BloomCache
 - `core/layout/malt/unixfs`
   - current pure MALT UnixFS-style layout prototype over map/list semantics
 - `core/resolver`

--- a/core/arctable/bloom/bloom.go
+++ b/core/arctable/bloom/bloom.go
@@ -1,5 +1,7 @@
 // Package bloom provides Bloom Filter implementations for ArcTable.
 // Bloom filters provide fast negative membership tests.
+// They are optional optimization hooks behind ArcTable implementations, not
+// semantic state or part of the root-centric trust boundary.
 //
 // Bloom Filter properties:
 //   - False negative: If Test returns false, the item is definitely not in the set

--- a/core/graph/manager.go
+++ b/core/graph/manager.go
@@ -1,6 +1,8 @@
 // Package graph provides graph lifecycle management for MALT.
 // A graph is runtime metadata for reopening a namespace with a compatible
 // backend profile. It does not own a current root or freshness policy.
+// The current daemon path creates an ad hoc default Graph instead of exposing
+// this lifecycle manager as a public API.
 // This file contains the Store and Manager types.
 package graph
 

--- a/core/structure/mapping/indexed/indexed.go
+++ b/core/structure/mapping/indexed/indexed.go
@@ -1,4 +1,6 @@
 // Package indexed implements the canonical-path ordered baseline map semantic.
+// It is retained for comparison; core/graph wires mapping/radix in the current
+// runtime path.
 package indexed
 
 import (
@@ -34,9 +36,9 @@ type entry struct {
 	value cid.Cid
 }
 
-// NewMap creates the default keyed-map semantic over an index-addressed
-// commitment backend. The default placement rule orders bindings by canonical
-// path and authenticates binding cells rather than bare values.
+// NewMap creates the baseline keyed-map semantic over an index-addressed
+// commitment backend. Its placement rule orders bindings by canonical path and
+// authenticates binding cells rather than bare values.
 func NewMap(scheme commitment.IndexCommitment, e arctable.ArcTable) (*Map, error) {
 	if scheme == nil {
 		return nil, fmt.Errorf("scheme is nil")


### PR DESCRIPTION
## Summary

- Clarify that `core/structure/mapping/indexed` is a baseline comparison implementation, while the current runtime path wires `mapping/radix` through `core/graph`.
- Mark `GraphManager` and `GraphMeta` as dormant lifecycle metadata machinery; the daemon currently creates an ad hoc default `Graph` instead of exposing lifecycle APIs.
- Document `core/arctable/bloom` as an optional ArcTable negative-lookup optimization hook, not semantic state or deletion-ready dead code.

## Validation

- `go test ./core/structure/mapping/indexed ./core/graph ./core/arctable/...`