### PR TITLE
docs: align runtime docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -214,6 +214,8 @@ evaluation binary named `malt-eval` with workload-specific subcommands.
 
 Current command model:
 
+- `malt init`
+  - creates the local configuration file and state-root directory
 - `malt daemon`
   - long-running local process
   - owns hot structure state

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ subcommands.
 
 Current runtime shape:
 
+- `malt init`
+  - creates the local configuration file and state-root directory
 - `malt daemon`
   - long-running local process
   - owns hot proving/index state

--- a/core/manifest/directory.go
+++ b/core/manifest/directory.go
@@ -1,4 +1,5 @@
-// Package manifest implements the locked directory manifest JSON for bucket trees.
+// Package manifest implements the locked directory manifest JSON used by the
+// UnixFS application layout.
 //
 // Wire shape (locked):
 //
@@ -6,7 +7,8 @@
 //
 // Rules: top-level object with required "entries"; entries sorted lexicographically;
 // each entry is one immediate child name; empty directory is {"entries":[]}.
-// Child type and key are not stored; they are derived via bucket root + path resolution.
+// Child type and key are not stored; root-relative path resolution derives them
+// from the current MALT structure.
 package manifest
 
 import (


### PR DESCRIPTION
## Summary

- list `malt init` with the other public runtime commands in `README.md` and `ARCHITECTURE.md`
- reword the `core/manifest` package comment around the UnixFS application-layout boundary instead of bucket-tree terminology

## Validation

- `go test ./...`
- `git diff --check`
