### PR TITLE
Add unified evaluation framework

### DIFF
--- a/cmd/eval/command/root.go
+++ b/cmd/eval/command/root.go
@@ -4,6 +4,8 @@ package command
 import (
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalmetrics"
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalread"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/evalrun"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/evalsuites"
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalwrite"
 	"github.com/spf13/cobra"
 )
@@ -15,6 +17,7 @@ func NewRootCommand() *cobra.Command {
 		Short: "Run MALT evaluation workloads",
 	}
 	cmd.AddCommand(
+		evalrun.NewCommand(evalsuites.NewRegistry()),
 		evalread.NewCommand(),
 		evalwrite.NewCommand(),
 		evalmetrics.NewCommand(),

--- a/cmd/eval/command/root.go
+++ b/cmd/eval/command/root.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalmetrics"
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalread"
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalrun"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/evalschema"
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalsuites"
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalwrite"
 	"github.com/spf13/cobra"
@@ -18,6 +19,7 @@ func NewRootCommand() *cobra.Command {
 	}
 	cmd.AddCommand(
 		evalrun.NewCommand(evalsuites.NewRegistry()),
+		evalschema.NewCommand(),
 		evalread.NewCommand(),
 		evalwrite.NewCommand(),
 		evalmetrics.NewCommand(),

--- a/cmd/eval/command/root.go
+++ b/cmd/eval/command/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalrun"
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalschema"
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalsuites"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/evalsummary"
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalwrite"
 	"github.com/spf13/cobra"
 )
@@ -20,6 +21,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(
 		evalrun.NewCommand(evalsuites.NewRegistry()),
 		evalschema.NewCommand(),
+		evalsummary.NewCommand(),
 		evalread.NewCommand(),
 		evalwrite.NewCommand(),
 		evalmetrics.NewCommand(),

--- a/cmd/eval/command/root_test.go
+++ b/cmd/eval/command/root_test.go
@@ -11,7 +11,7 @@ func TestRootCommandExposesEvaluationSubcommands(t *testing.T) {
 		t.Fatalf("root command Use = %q, want malt-eval", cmd.Use)
 	}
 
-	for _, name := range []string{"run", "read", "write", "metrics"} {
+	for _, name := range []string{"run", "schema", "read", "write", "metrics"} {
 		if found, _, err := cmd.Find([]string{name}); err != nil || found == nil || found.Name() != name {
 			t.Fatalf("subcommand %q not found: found=%v err=%v", name, found, err)
 		}

--- a/cmd/eval/command/root_test.go
+++ b/cmd/eval/command/root_test.go
@@ -11,7 +11,7 @@ func TestRootCommandExposesEvaluationSubcommands(t *testing.T) {
 		t.Fatalf("root command Use = %q, want malt-eval", cmd.Use)
 	}
 
-	for _, name := range []string{"read", "write", "metrics"} {
+	for _, name := range []string{"run", "read", "write", "metrics"} {
 		if found, _, err := cmd.Find([]string{name}); err != nil || found == nil || found.Name() != name {
 			t.Fatalf("subcommand %q not found: found=%v err=%v", name, found, err)
 		}

--- a/cmd/eval/command/root_test.go
+++ b/cmd/eval/command/root_test.go
@@ -11,7 +11,7 @@ func TestRootCommandExposesEvaluationSubcommands(t *testing.T) {
 		t.Fatalf("root command Use = %q, want malt-eval", cmd.Use)
 	}
 
-	for _, name := range []string{"run", "schema", "read", "write", "metrics"} {
+	for _, name := range []string{"run", "schema", "summarize", "read", "write", "metrics"} {
 		if found, _, err := cmd.Find([]string{name}); err != nil || found == nil || found.Name() != name {
 			t.Fatalf("subcommand %q not found: found=%v err=%v", name, found, err)
 		}

--- a/cmd/eval/helper/adapters/maltflat/adapter.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter.go
@@ -5,11 +5,17 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
 	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/core/arctable"
 	"github.com/dewebprotocol/malt/core/arctable/overwrite"
+	"github.com/dewebprotocol/malt/core/arctable/versioned"
+	"github.com/dewebprotocol/malt/core/commitment"
 	"github.com/dewebprotocol/malt/core/commitment/ipa"
+	"github.com/dewebprotocol/malt/core/commitment/kzg"
+	"github.com/dewebprotocol/malt/core/kvstore"
 	"github.com/dewebprotocol/malt/core/layout/malt/unixfs"
 	"github.com/dewebprotocol/malt/core/structure/list/tree"
 	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
@@ -18,10 +24,30 @@ import (
 
 const defaultNamespace = "eval-maltflat"
 
+// ArcTableMode selects the ArcTable persistence strategy used by MALT-flat.
+type ArcTableMode string
+
+const (
+	ArcTableModeOverwrite ArcTableMode = "overwrite"
+	ArcTableModeVersioned ArcTableMode = "versioned"
+)
+
+// CommitmentBackend selects the primitive commitment scheme used by map/list semantics.
+type CommitmentBackend string
+
+const (
+	CommitmentBackendIPA CommitmentBackend = "ipa"
+	CommitmentBackendKZG CommitmentBackend = "kzg"
+)
+
+const MaterializationStrategyLiveSnapshotRebuild = "live_snapshot_rebuild"
+
 // Options configures the MALT-flat adapter.
 type Options struct {
-	Namespace string
-	ChunkSize int
+	Namespace         string
+	ChunkSize         int
+	ArcTableMode      ArcTableMode
+	CommitmentBackend CommitmentBackend
 }
 
 // Adapter materializes each commit snapshot as a MALT-flat UnixFS root.
@@ -30,20 +56,27 @@ type Adapter struct {
 	layout *unixfs.Layout
 }
 
+// DefaultOptions returns the paper-aligned MALT-flat evaluation configuration.
+func DefaultOptions() Options {
+	return Options{
+		Namespace:         defaultNamespace,
+		ChunkSize:         unixfs.DefaultChunkSize,
+		ArcTableMode:      ArcTableModeVersioned,
+		CommitmentBackend: CommitmentBackendKZG,
+	}
+}
+
 // New creates a MALT-flat adapter.
 func New(system *evalstore.System, opts Options) (*Adapter, error) {
 	if system == nil {
 		return nil, fmt.Errorf("system store is nil")
 	}
-	namespace := opts.Namespace
-	if namespace == "" {
-		namespace = defaultNamespace
-	}
-	arcs, err := overwrite.NewArcTable(overwrite.WithKVStore(system.StateKV))
+	opts = applyDefaults(opts)
+	arcs, err := newArcTable(system.StateKV, opts.ArcTableMode)
 	if err != nil {
 		return nil, fmt.Errorf("create arctable: %w", err)
 	}
-	scheme, err := ipa.NewScheme()
+	scheme, err := newCommitmentBackend(opts.CommitmentBackend)
 	if err != nil {
 		return nil, fmt.Errorf("create commitment scheme: %w", err)
 	}
@@ -56,7 +89,7 @@ func New(system *evalstore.System, opts Options) (*Adapter, error) {
 		return nil, fmt.Errorf("create list semantics: %w", err)
 	}
 	layout, err := unixfs.New(unixfs.Options{
-		Namespace: namespace,
+		Namespace: opts.Namespace,
 		ChunkSize: opts.ChunkSize,
 		Map:       maps,
 		List:      lists,
@@ -107,11 +140,51 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 		a.system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(root.String()))
 	}
 	return replay.ApplyResult{
-		Root:              root.String(),
-		AppliedMutations:  len(commit.Mutations),
-		MaterializedPaths: len(files),
-		Accounting:        a.system.Meter.Snapshot(),
+		Root:                    root.String(),
+		AppliedMutations:        len(commit.Mutations),
+		MaterializedPaths:       len(files),
+		MaterializationStrategy: MaterializationStrategyLiveSnapshotRebuild,
+		Accounting:              a.system.Meter.Snapshot(),
 	}, nil
 }
 
 var _ replay.SystemAdapter = (*Adapter)(nil)
+
+func applyDefaults(opts Options) Options {
+	defaults := DefaultOptions()
+	if opts.Namespace == "" {
+		opts.Namespace = defaults.Namespace
+	}
+	if opts.ChunkSize == 0 {
+		opts.ChunkSize = defaults.ChunkSize
+	}
+	if opts.ArcTableMode == "" {
+		opts.ArcTableMode = defaults.ArcTableMode
+	}
+	if opts.CommitmentBackend == "" {
+		opts.CommitmentBackend = defaults.CommitmentBackend
+	}
+	return opts
+}
+
+func newArcTable(kv kvstore.KVStore, mode ArcTableMode) (arctable.ArcTable, error) {
+	switch ArcTableMode(strings.ToLower(string(mode))) {
+	case ArcTableModeOverwrite, "simple":
+		return overwrite.NewArcTable(overwrite.WithKVStore(kv))
+	case ArcTableModeVersioned:
+		return versioned.NewArcTable(versioned.WithKVStore(kv))
+	default:
+		return nil, fmt.Errorf("unknown ArcTable mode %q", mode)
+	}
+}
+
+func newCommitmentBackend(backend CommitmentBackend) (commitment.IndexCommitment, error) {
+	switch CommitmentBackend(strings.ToLower(string(backend))) {
+	case CommitmentBackendIPA:
+		return ipa.NewScheme()
+	case CommitmentBackendKZG:
+		return kzg.NewScheme()
+	default:
+		return nil, fmt.Errorf("unknown commitment backend %q", backend)
+	}
+}

--- a/cmd/eval/helper/adapters/maltflat/adapter_test.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter_test.go
@@ -56,6 +56,19 @@ func TestAdapterMaterializesLiveSnapshotWithIndependentStoreAccounting(t *testin
 	if rootHead.NewPersistedBytes != uint64(len(result.Root)) {
 		t.Fatalf("root/head bytes = %d, want emitted root string length %d", rootHead.NewPersistedBytes, len(result.Root))
 	}
+	if result.MaterializationStrategy != maltflat.MaterializationStrategyLiveSnapshotRebuild {
+		t.Fatalf("materialization strategy = %q, want %q", result.MaterializationStrategy, maltflat.MaterializationStrategyLiveSnapshotRebuild)
+	}
+}
+
+func TestDefaultOptionsUsePaperConfiguration(t *testing.T) {
+	opts := maltflat.DefaultOptions()
+	if opts.ArcTableMode != maltflat.ArcTableModeVersioned {
+		t.Fatalf("default ArcTable mode = %q, want %q", opts.ArcTableMode, maltflat.ArcTableModeVersioned)
+	}
+	if opts.CommitmentBackend != maltflat.CommitmentBackendKZG {
+		t.Fatalf("default commitment backend = %q, want %q", opts.CommitmentBackend, maltflat.CommitmentBackendKZG)
+	}
 }
 
 type fakeSnapshot map[string][]byte

--- a/cmd/eval/helper/evalrun/command.go
+++ b/cmd/eval/helper/evalrun/command.go
@@ -47,10 +47,10 @@ func run(cmd *cobra.Command, registry framework.Registry, opts *options) error {
 		return err
 	}
 	if strings.TrimSpace(opts.outputDir) != "" {
-		plan.OutputDir = opts.outputDir
+		plan.OverrideOutputDir(opts.outputDir)
 	}
 	if strings.TrimSpace(opts.runID) != "" {
-		plan.RunID = opts.runID
+		plan.OverrideRunID(opts.runID)
 	}
 	return framework.Run(cmd.Context(), plan, registry, framework.RunOptions{})
 }

--- a/cmd/eval/helper/evalrun/command.go
+++ b/cmd/eval/helper/evalrun/command.go
@@ -1,0 +1,56 @@
+// Package evalrun provides the unified evaluation plan runner command.
+package evalrun
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+	"github.com/spf13/cobra"
+)
+
+const PlanSchemaPath = "cmd/eval/schemas/run-plan.schema.json"
+
+type options struct {
+	planPath  string
+	outputDir string
+	runID     string
+}
+
+// NewCommand creates `malt-eval run`.
+func NewCommand(registry framework.Registry) *cobra.Command {
+	opts := &options{}
+	cmd := &cobra.Command{
+		Use:         "run",
+		Short:       "Run an evaluation plan and write a structured result directory",
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{"malt.plan_schema": PlanSchemaPath},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd, registry, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.planPath, "plan", opts.planPath, "Evaluation plan JSON file")
+	cmd.Flags().StringVar(&opts.outputDir, "out", opts.outputDir, "Override output directory")
+	cmd.Flags().StringVar(&opts.runID, "run-id", opts.runID, "Override run identifier")
+	return cmd
+}
+
+func run(cmd *cobra.Command, registry framework.Registry, opts *options) error {
+	if opts == nil {
+		return fmt.Errorf("options are nil")
+	}
+	if strings.TrimSpace(opts.planPath) == "" {
+		return fmt.Errorf("--plan is required")
+	}
+	plan, err := framework.LoadPlan(opts.planPath)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.outputDir) != "" {
+		plan.OutputDir = opts.outputDir
+	}
+	if strings.TrimSpace(opts.runID) != "" {
+		plan.RunID = opts.runID
+	}
+	return framework.Run(cmd.Context(), plan, registry, framework.RunOptions{})
+}

--- a/cmd/eval/helper/evalrun/command_test.go
+++ b/cmd/eval/helper/evalrun/command_test.go
@@ -1,0 +1,68 @@
+package evalrun
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+)
+
+func TestCommandRunsPlanWithOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	planPath := filepath.Join(tmp, "plan.json")
+	if err := os.WriteFile(planPath, []byte(`{
+		"run_id": "from-plan",
+		"suites": [{"name": "fake_suite", "config": {"value": "ok"}}]
+	}`), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	reg := framework.NewRegistry()
+	if err := reg.Register(fakeSuite{}); err != nil {
+		t.Fatalf("register fake suite: %v", err)
+	}
+	outDir := filepath.Join(tmp, "out")
+	cmd := NewCommand(reg)
+	cmd.SetArgs([]string{"--plan", planPath, "--out", outDir, "--run-id", "from-flags"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	manifestBytes, err := os.ReadFile(filepath.Join(outDir, "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest framework.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if manifest.RunID != "from-flags" {
+		t.Fatalf("manifest run id = %q, want from-flags", manifest.RunID)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "raw", "fake_suite.jsonl")); err != nil {
+		t.Fatalf("raw suite output missing: %v", err)
+	}
+}
+
+func TestCommandRequiresPlan(t *testing.T) {
+	cmd := NewCommand(framework.NewRegistry())
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute should require --plan")
+	}
+}
+
+type fakeSuite struct{}
+
+func (fakeSuite) Name() string { return "fake_suite" }
+
+func (fakeSuite) Run(ctx context.Context, env framework.Env, cfg json.RawMessage) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return env.WriteRecord("fake_suite", map[string]any{"ok": true})
+}

--- a/cmd/eval/helper/evalrun/command_test.go
+++ b/cmd/eval/helper/evalrun/command_test.go
@@ -48,6 +48,38 @@ func TestCommandRunsPlanWithOverrides(t *testing.T) {
 	}
 }
 
+func TestCommandRunIDOverrideUpdatesDefaultOutputDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	planPath := filepath.Join(tmp, "plan.json")
+	if err := os.WriteFile(planPath, []byte(`{
+		"run_id": "from-plan",
+		"suites": [{"name": "fake_suite"}]
+	}`), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	reg := framework.NewRegistry()
+	if err := reg.Register(fakeSuite{}); err != nil {
+		t.Fatalf("register fake suite: %v", err)
+	}
+	cmd := NewCommand(reg)
+	cmd.SetArgs([]string{"--plan", planPath, "--run-id", "from-flags"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	expected := filepath.Join(tmp, "results", "from-flags", "manifest.json")
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("expected manifest at %s: %v", expected, err)
+	}
+	old := filepath.Join(tmp, "results", "from-plan", "manifest.json")
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Fatalf("old output path should not exist, stat err=%v", err)
+	}
+}
+
 func TestCommandRequiresPlan(t *testing.T) {
 	cmd := NewCommand(framework.NewRegistry())
 	cmd.SetArgs(nil)

--- a/cmd/eval/helper/evalschema/command.go
+++ b/cmd/eval/helper/evalschema/command.go
@@ -8,33 +8,44 @@ import (
 	"os"
 	"sort"
 
+	evalschemas "github.com/dewebprotocol/malt/cmd/eval/schemas"
 	"github.com/spf13/cobra"
 )
 
 // Schema identifies one evaluator JSON schema file.
 type Schema struct {
-	Name string `json:"name"`
-	Path string `json:"path"`
+	Name    string `json:"name"`
+	Path    string `json:"path"`
+	Content []byte `json:"-"`
 }
 
 // DefaultSchemas returns schemas known to the evaluator CLI.
 func DefaultSchemas() []Schema {
-	return []Schema{
-		{Name: "cas-model-result", Path: "cmd/eval/schemas/cas-model-result.schema.json"},
-		{Name: "common-record", Path: "cmd/eval/schemas/common-record.schema.json"},
-		{Name: "proof-overhead-result", Path: "cmd/eval/schemas/proof-overhead-result.schema.json"},
-		{Name: "read-query-result", Path: "cmd/eval/schemas/read-query-result.schema.json"},
-		{Name: "readbench-result", Path: "cmd/eval/schemas/readbench-result.schema.json"},
-		{Name: "run-manifest", Path: "cmd/eval/schemas/run-manifest.schema.json"},
-		{Name: "run-plan", Path: "cmd/eval/schemas/run-plan.schema.json"},
-		{Name: "storage-overhead-result", Path: "cmd/eval/schemas/storage-overhead-result.schema.json"},
-		{Name: "write-trace-result", Path: "cmd/eval/schemas/write-trace-result.schema.json"},
+	entries := evalschemas.Entries()
+	schemas := make([]Schema, 0, len(entries))
+	for _, entry := range entries {
+		content, err := evalschemas.Read(entry.Name)
+		if err != nil {
+			panic(err)
+		}
+		schemas = append(schemas, Schema{
+			Name:    entry.Name,
+			Path:    entry.Path,
+			Content: content,
+		})
 	}
+	return schemas
 }
 
 // NewCommand creates `malt-eval schema`.
 func NewCommand() *cobra.Command {
 	return NewCommandWithSchemas(os.Stdout, DefaultSchemas())
+}
+
+// NewCommandWithOutput creates a schema command using the default embedded
+// schema registry and a caller-supplied output writer.
+func NewCommandWithOutput(out io.Writer) *cobra.Command {
+	return NewCommandWithSchemas(out, DefaultSchemas())
 }
 
 // NewCommandWithSchemas creates a schema command for tests or custom registries.
@@ -67,11 +78,15 @@ func run(out io.Writer, schemas []Schema, name string) error {
 		if schema.Name != name {
 			continue
 		}
-		data, err := os.ReadFile(schema.Path)
-		if err != nil {
-			return err
+		data := schema.Content
+		if data == nil {
+			var err error
+			data, err = os.ReadFile(schema.Path)
+			if err != nil {
+				return err
+			}
 		}
-		_, err = out.Write(data)
+		_, err := out.Write(data)
 		return err
 	}
 	return fmt.Errorf("unknown schema %q", name)

--- a/cmd/eval/helper/evalschema/command.go
+++ b/cmd/eval/helper/evalschema/command.go
@@ -1,0 +1,73 @@
+// Package evalschema exposes evaluator JSON schemas through the CLI.
+package evalschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+// Schema identifies one evaluator JSON schema file.
+type Schema struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+// DefaultSchemas returns schemas known to the evaluator CLI.
+func DefaultSchemas() []Schema {
+	return []Schema{
+		{Name: "common-record", Path: "cmd/eval/schemas/common-record.schema.json"},
+		{Name: "readbench-result", Path: "cmd/eval/schemas/readbench-result.schema.json"},
+		{Name: "run-manifest", Path: "cmd/eval/schemas/run-manifest.schema.json"},
+		{Name: "run-plan", Path: "cmd/eval/schemas/run-plan.schema.json"},
+	}
+}
+
+// NewCommand creates `malt-eval schema`.
+func NewCommand() *cobra.Command {
+	return NewCommandWithSchemas(os.Stdout, DefaultSchemas())
+}
+
+// NewCommandWithSchemas creates a schema command for tests or custom registries.
+func NewCommandWithSchemas(out io.Writer, schemas []Schema) *cobra.Command {
+	var name string
+	cmd := &cobra.Command{
+		Use:   "schema",
+		Short: "List or print evaluator JSON schemas",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(out, schemas, name)
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "Print a schema by name instead of listing all schemas")
+	return cmd
+}
+
+func run(out io.Writer, schemas []Schema, name string) error {
+	if out == nil {
+		return fmt.Errorf("output writer is nil")
+	}
+	ordered := append([]Schema(nil), schemas...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Name < ordered[j].Name })
+	if name == "" {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(ordered)
+	}
+	for _, schema := range ordered {
+		if schema.Name != name {
+			continue
+		}
+		data, err := os.ReadFile(schema.Path)
+		if err != nil {
+			return err
+		}
+		_, err = out.Write(data)
+		return err
+	}
+	return fmt.Errorf("unknown schema %q", name)
+}

--- a/cmd/eval/helper/evalschema/command.go
+++ b/cmd/eval/helper/evalschema/command.go
@@ -20,10 +20,15 @@ type Schema struct {
 // DefaultSchemas returns schemas known to the evaluator CLI.
 func DefaultSchemas() []Schema {
 	return []Schema{
+		{Name: "cas-model-result", Path: "cmd/eval/schemas/cas-model-result.schema.json"},
 		{Name: "common-record", Path: "cmd/eval/schemas/common-record.schema.json"},
+		{Name: "proof-overhead-result", Path: "cmd/eval/schemas/proof-overhead-result.schema.json"},
+		{Name: "read-query-result", Path: "cmd/eval/schemas/read-query-result.schema.json"},
 		{Name: "readbench-result", Path: "cmd/eval/schemas/readbench-result.schema.json"},
 		{Name: "run-manifest", Path: "cmd/eval/schemas/run-manifest.schema.json"},
 		{Name: "run-plan", Path: "cmd/eval/schemas/run-plan.schema.json"},
+		{Name: "storage-overhead-result", Path: "cmd/eval/schemas/storage-overhead-result.schema.json"},
+		{Name: "write-trace-result", Path: "cmd/eval/schemas/write-trace-result.schema.json"},
 	}
 }
 

--- a/cmd/eval/helper/evalschema/command_test.go
+++ b/cmd/eval/helper/evalschema/command_test.go
@@ -56,3 +56,18 @@ func TestCommandRejectsUnknownSchema(t *testing.T) {
 		t.Fatal("Execute should reject unknown schema")
 	}
 }
+
+func TestDefaultCommandPrintsNamedSchemaOutsideRepoRoot(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	var out bytes.Buffer
+	cmd := NewCommandWithOutput(&out)
+	cmd.SetArgs([]string{"--name", "run-plan"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "MALT evaluation run plan") {
+		t.Fatalf("schema output did not contain run-plan schema: %s", got)
+	}
+}

--- a/cmd/eval/helper/evalschema/command_test.go
+++ b/cmd/eval/helper/evalschema/command_test.go
@@ -1,0 +1,58 @@
+package evalschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommandListsSchemasAsJSON(t *testing.T) {
+	var out bytes.Buffer
+	cmd := NewCommandWithSchemas(&out, []Schema{
+		{Name: "run-plan", Path: "cmd/eval/schemas/run-plan.schema.json"},
+		{Name: "common-record", Path: "cmd/eval/schemas/common-record.schema.json"},
+	})
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var listed []Schema
+	if err := json.Unmarshal(out.Bytes(), &listed); err != nil {
+		t.Fatalf("unmarshal schema list: %v", err)
+	}
+	if len(listed) != 2 || listed[0].Name != "common-record" || listed[1].Name != "run-plan" {
+		t.Fatalf("listed schemas = %#v", listed)
+	}
+}
+
+func TestCommandPrintsNamedSchema(t *testing.T) {
+	tmp := t.TempDir()
+	schemaPath := filepath.Join(tmp, "schema.json")
+	if err := os.WriteFile(schemaPath, []byte(`{"title":"test"}`), 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+	var out bytes.Buffer
+	cmd := NewCommandWithSchemas(&out, []Schema{{Name: "test", Path: schemaPath}})
+	cmd.SetArgs([]string{"--name", "test"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != `{"title":"test"}` {
+		t.Fatalf("schema output = %q", got)
+	}
+}
+
+func TestCommandRejectsUnknownSchema(t *testing.T) {
+	cmd := NewCommandWithSchemas(&bytes.Buffer{}, []Schema{{Name: "known", Path: "known.json"}})
+	cmd.SetArgs([]string{"--name", "missing"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute should reject unknown schema")
+	}
+}

--- a/cmd/eval/helper/evalsuites/registry.go
+++ b/cmd/eval/helper/evalsuites/registry.go
@@ -1,0 +1,9 @@
+// Package evalsuites assembles the suite registry used by malt-eval run.
+package evalsuites
+
+import "github.com/dewebprotocol/malt/internal/eval/framework"
+
+// NewRegistry returns the production suite registry.
+func NewRegistry() framework.Registry {
+	return framework.NewRegistry()
+}

--- a/cmd/eval/helper/evalsuites/registry.go
+++ b/cmd/eval/helper/evalsuites/registry.go
@@ -1,9 +1,28 @@
 // Package evalsuites assembles the suite registry used by malt-eval run.
 package evalsuites
 
-import "github.com/dewebprotocol/malt/internal/eval/framework"
+import (
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+	"github.com/dewebprotocol/malt/internal/eval/suites/casmodel"
+	"github.com/dewebprotocol/malt/internal/eval/suites/proofoverhead"
+	"github.com/dewebprotocol/malt/internal/eval/suites/readquery"
+	"github.com/dewebprotocol/malt/internal/eval/suites/storageoverhead"
+	"github.com/dewebprotocol/malt/internal/eval/suites/writetrace"
+)
 
 // NewRegistry returns the production suite registry.
 func NewRegistry() framework.Registry {
-	return framework.NewRegistry()
+	registry := framework.NewRegistry()
+	mustRegister(registry, writetrace.Suite{})
+	mustRegister(registry, readquery.Suite{})
+	mustRegister(registry, casmodel.Suite{})
+	mustRegister(registry, proofoverhead.Suite{})
+	mustRegister(registry, storageoverhead.Suite{})
+	return registry
+}
+
+func mustRegister(registry framework.Registry, suite framework.Suite) {
+	if err := registry.Register(suite); err != nil {
+		panic(err)
+	}
 }

--- a/cmd/eval/helper/evalsuites/registry_test.go
+++ b/cmd/eval/helper/evalsuites/registry_test.go
@@ -1,0 +1,18 @@
+package evalsuites
+
+import "testing"
+
+func TestNewRegistryRegistersProductionSuites(t *testing.T) {
+	registry := NewRegistry()
+	for _, name := range []string{
+		"write_trace",
+		"read_query",
+		"cas_model",
+		"proof_overhead",
+		"storage_overhead",
+	} {
+		if suite, ok := registry.Lookup(name); !ok || suite.Name() != name {
+			t.Fatalf("suite %q not registered: suite=%v ok=%v", name, suite, ok)
+		}
+	}
+}

--- a/cmd/eval/helper/evalsummary/command.go
+++ b/cmd/eval/helper/evalsummary/command.go
@@ -1,0 +1,47 @@
+// Package evalsummary provides the evaluation summary command.
+package evalsummary
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/dewebprotocol/malt/internal/eval/summary"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	inputDir string
+	outDir   string
+}
+
+// NewCommand creates `malt-eval summarize`.
+func NewCommand() *cobra.Command {
+	opts := &options{}
+	cmd := &cobra.Command{
+		Use:   "summarize",
+		Short: "Summarize framework raw evaluation envelopes into figure CSVs",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.inputDir, "input", opts.inputDir, "Evaluation run directory containing raw JSONL envelopes")
+	cmd.Flags().StringVar(&opts.outDir, "out", opts.outDir, "Summary output directory (default: <input>/summary)")
+	return cmd
+}
+
+func run(opts *options) error {
+	if opts == nil {
+		return fmt.Errorf("options are nil")
+	}
+	inputDir := strings.TrimSpace(opts.inputDir)
+	if inputDir == "" {
+		return fmt.Errorf("--input is required")
+	}
+	outDir := strings.TrimSpace(opts.outDir)
+	if outDir == "" {
+		outDir = filepath.Join(inputDir, "summary")
+	}
+	return summary.Summarize(inputDir, outDir)
+}

--- a/cmd/eval/helper/evalsummary/command_test.go
+++ b/cmd/eval/helper/evalsummary/command_test.go
@@ -1,0 +1,74 @@
+package evalsummary
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCommandRequiresInput(t *testing.T) {
+	cmd := NewCommand()
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute should require --input")
+	}
+}
+
+func TestCommandWritesKnownSuiteFilenames(t *testing.T) {
+	tmp := t.TempDir()
+	runDir := filepath.Join(tmp, "run")
+	rawDir := filepath.Join(runDir, "raw")
+	outDir := filepath.Join(tmp, "summary")
+	if err := os.MkdirAll(rawDir, 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+
+	wantFiles := map[string]string{
+		"write_trace":      "figure_write_trace.csv",
+		"read_query":       "figure_read_query.csv",
+		"cas_model":        "figure_cas_model.csv",
+		"proof_overhead":   "figure_proof.csv",
+		"storage_overhead": "figure_storage.csv",
+	}
+	for suite := range wantFiles {
+		writeRawEnvelope(t, rawDir, suite, `{"system":"maltflat","value":1}`)
+	}
+
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"--input", runDir, "--out", outDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	for _, name := range wantFiles {
+		if _, err := os.Stat(filepath.Join(outDir, name)); err != nil {
+			t.Fatalf("expected %s: %v", name, err)
+		}
+	}
+}
+
+func writeRawEnvelope(t *testing.T, rawDir, suite, record string) {
+	t.Helper()
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(record)); err != nil {
+		t.Fatalf("compact record: %v", err)
+	}
+	line := fmt.Sprintf(
+		`{"schema_version":"malt.eval.v1","run_id":"run-1","suite":%q,"emitted_at":"2026-05-16T00:00:00Z","record":%s}`+"\n",
+		suite,
+		compact.String(),
+	)
+	path := filepath.Join(rawDir, suite+".jsonl")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open raw envelope: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line); err != nil {
+		t.Fatalf("write raw envelope: %v", err)
+	}
+}

--- a/cmd/eval/helper/replay/runner.go
+++ b/cmd/eval/helper/replay/runner.go
@@ -30,6 +30,24 @@ func RunCommit(ctx context.Context, commit CommitMutation, systems []SystemAdapt
 	if enc == nil {
 		return fmt.Errorf("json encoder is nil")
 	}
+	return RunCommitRecords(ctx, commit, systems, func(record ResultRecord) error {
+		if err := enc.Encode(record); err != nil {
+			return fmt.Errorf("encode %s commit %s: %w", record.System, record.Commit, err)
+		}
+		return nil
+	})
+}
+
+// RunCommitRecords applies one commit to every system and emits structured
+// records through emit. Callers that need framework-specific envelopes can
+// write records directly without JSON encode/decode round trips.
+func RunCommitRecords(ctx context.Context, commit CommitMutation, systems []SystemAdapter, emit func(ResultRecord) error) error {
+	if emit == nil {
+		return fmt.Errorf("record emitter is nil")
+	}
+	if len(systems) == 0 {
+		return fmt.Errorf("at least one system is required")
+	}
 	for _, system := range systems {
 		if system == nil {
 			return fmt.Errorf("system adapter is nil")
@@ -50,8 +68,8 @@ func RunCommit(ctx context.Context, commit CommitMutation, systems []SystemAdapt
 			Result:      result,
 			Accounting:  result.Accounting,
 		}
-		if err := enc.Encode(record); err != nil {
-			return fmt.Errorf("encode %s commit %s: %w", system.Name(), commit.Commit, err)
+		if err := emit(record); err != nil {
+			return fmt.Errorf("emit %s commit %s: %w", system.Name(), commit.Commit, err)
 		}
 	}
 	return nil

--- a/cmd/eval/helper/replay/runner_test.go
+++ b/cmd/eval/helper/replay/runner_test.go
@@ -22,10 +22,11 @@ func (a *fakeAdapter) Name() string {
 func (a *fakeAdapter) Apply(ctx context.Context, commit replay.CommitMutation) (replay.ApplyResult, error) {
 	a.roots = append(a.roots, commit.Commit)
 	return replay.ApplyResult{
-		Root:              a.name + "-" + commit.Commit,
-		AppliedMutations:  len(commit.Mutations),
-		Accounting:        evalstore.NewMeter().Snapshot(),
-		MaterializedPaths: len(commit.LiveFiles),
+		Root:                    a.name + "-" + commit.Commit,
+		AppliedMutations:        len(commit.Mutations),
+		Accounting:              evalstore.NewMeter().Snapshot(),
+		MaterializedPaths:       len(commit.LiveFiles),
+		MaterializationStrategy: "fake-live-snapshot",
 	}, nil
 }
 
@@ -82,5 +83,50 @@ func TestRunJSONLEmitsOneRecordPerSystemPerCommit(t *testing.T) {
 	}
 	if records[2].Commit != "c2" || records[2].LiveStats.LivePayloadBytes != 7 {
 		t.Fatalf("second commit record = commit %q live bytes %d, want c2/7", records[2].Commit, records[2].LiveStats.LivePayloadBytes)
+	}
+}
+
+func TestRunCommitRecordsEmitsStructuredRecords(t *testing.T) {
+	ctx := context.Background()
+	commit := replay.CommitMutation{
+		Repo:   "example",
+		Commit: "c1",
+		Index:  0,
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationAdd, Path: "README.md", Size: 5},
+		},
+		LiveStats: replay.LiveStats{FileCount: 1, LivePayloadBytes: 5},
+		LiveFiles: []replay.LiveFile{{Path: "README.md", Size: 5}},
+	}
+
+	var records []replay.ResultRecord
+	err := replay.RunCommitRecords(ctx, commit, []replay.SystemAdapter{
+		&fakeAdapter{name: "maltflat"},
+	}, func(record replay.ResultRecord) error {
+		records = append(records, record)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunCommitRecords: %v", err)
+	}
+
+	if len(records) != 1 {
+		t.Fatalf("record count = %d, want 1", len(records))
+	}
+	record := records[0]
+	if record.Repo != "example" || record.System != "maltflat" || record.Commit != "c1" || record.Index != 0 {
+		t.Fatalf("record identity = %+v, want repo/system/commit/index preserved", record)
+	}
+	if len(record.MutationSet) != 1 || record.MutationSet[0].Path != "README.md" {
+		t.Fatalf("mutations = %+v, want README.md add preserved", record.MutationSet)
+	}
+	if record.LiveStats.LivePayloadBytes != 5 {
+		t.Fatalf("live stats = %+v, want payload bytes preserved", record.LiveStats)
+	}
+	if record.Result.MaterializationStrategy != "fake-live-snapshot" {
+		t.Fatalf("materialization strategy = %q, want fake-live-snapshot", record.Result.MaterializationStrategy)
+	}
+	if record.Accounting.Total.NewObjectCount != record.Result.Accounting.Total.NewObjectCount {
+		t.Fatalf("top-level accounting = %+v, want result accounting %+v", record.Accounting, record.Result.Accounting)
 	}
 }

--- a/cmd/eval/helper/replay/types.go
+++ b/cmd/eval/helper/replay/types.go
@@ -71,10 +71,11 @@ type CommitMutation struct {
 
 // ApplyResult is returned by one evaluated system after applying a commit.
 type ApplyResult struct {
-	Root              string             `json:"root,omitempty"`
-	AppliedMutations  int                `json:"applied_mutations"`
-	MaterializedPaths int                `json:"materialized_paths"`
-	Accounting        evalstore.Snapshot `json:"accounting"`
+	Root                    string             `json:"root,omitempty"`
+	AppliedMutations        int                `json:"applied_mutations"`
+	MaterializedPaths       int                `json:"materialized_paths"`
+	MaterializationStrategy string             `json:"materialization_strategy,omitempty"`
+	Accounting              evalstore.Snapshot `json:"accounting"`
 }
 
 // ResultRecord is one JSONL measurement point for one system at one commit.

--- a/cmd/eval/schemas/cas-model-result.schema.json
+++ b/cmd/eval/schemas/cas-model-result.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/cas-model-result.schema.json",
+  "title": "CAS model result",
+  "description": "One JSONL record emitted by the cas_model evaluation suite.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "operation",
+    "dependency_shape",
+    "size",
+    "iteration",
+    "elapsed_ns",
+    "configured_latency_ms",
+    "configured_jitter_ms",
+    "cas"
+  ],
+  "properties": {
+    "operation": {
+      "type": "string",
+      "enum": ["put", "get", "has"]
+    },
+    "dependency_shape": {
+      "type": "string",
+      "enum": ["chain", "batch"]
+    },
+    "size": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "elapsed_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "configured_latency_ms": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "configured_jitter_ms": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cas": {
+      "$ref": "#/$defs/cas_stats"
+    }
+  },
+  "$defs": {
+    "counter": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cas_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["put_count", "get_count", "has_count", "bytes_put", "bytes_get"],
+      "properties": {
+        "put_count": { "$ref": "#/$defs/counter" },
+        "get_count": { "$ref": "#/$defs/counter" },
+        "has_count": { "$ref": "#/$defs/counter" },
+        "bytes_put": { "$ref": "#/$defs/counter" },
+        "bytes_get": { "$ref": "#/$defs/counter" }
+      }
+    }
+  }
+}

--- a/cmd/eval/schemas/common-record.schema.json
+++ b/cmd/eval/schemas/common-record.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dewebprotocol.dev/malt/eval/common-record.schema.json",
+  "title": "MALT evaluation common raw record envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "run_id", "suite", "emitted_at", "record"],
+  "properties": {
+    "schema_version": {
+      "const": "malt-eval/v1"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "suite": {
+      "type": "string"
+    },
+    "emitted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "record": {
+      "type": "object"
+    }
+  }
+}

--- a/cmd/eval/schemas/proof-overhead-result.schema.json
+++ b/cmd/eval/schemas/proof-overhead-result.schema.json
@@ -8,6 +8,7 @@
   "required": [
     "structure",
     "commitment",
+    "arctable_mode",
     "size",
     "iteration",
     "method",
@@ -21,6 +22,21 @@
     "commitment": {
       "type": "string",
       "description": "Requested commitment backend. Measured records currently use ipa or kzg; unsupported records may name a backend the suite could not measure."
+    },
+    "arctable_mode": {
+      "type": "string",
+      "description": "ArcTable mode used by measured semantic structures.",
+      "enum": ["versioned"]
+    },
+    "map_backend": {
+      "type": "string",
+      "description": "Map semantic backend for map records.",
+      "enum": ["radix"]
+    },
+    "list_backend": {
+      "type": "string",
+      "description": "List semantic backend for list records.",
+      "enum": ["tree"]
     },
     "size": {
       "type": "integer",

--- a/cmd/eval/schemas/proof-overhead-result.schema.json
+++ b/cmd/eval/schemas/proof-overhead-result.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/proof-overhead-result.schema.json",
+  "title": "Proof overhead result",
+  "description": "One JSONL record emitted by the proof_overhead evaluation suite.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "structure",
+    "commitment",
+    "size",
+    "iteration",
+    "method",
+    "proof_bytes",
+    "evidence_count"
+  ],
+  "properties": {
+    "structure": {
+      "type": "string"
+    },
+    "commitment": {
+      "type": "string",
+      "description": "Requested commitment backend. Measured records currently use ipa or kzg; unsupported records may name a backend the suite could not measure."
+    },
+    "size": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "method": {
+      "type": "string",
+      "enum": ["measured", "unsupported"]
+    },
+    "commit_elapsed_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "prove_elapsed_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "verify_elapsed_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "proof_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "evidence_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "verified": {
+      "type": "boolean"
+    },
+    "error": {
+      "type": "string"
+    }
+  }
+}

--- a/cmd/eval/schemas/read-query-result.schema.json
+++ b/cmd/eval/schemas/read-query-result.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/read-query-result.schema.json",
+  "title": "Read query suite result",
+  "description": "One read_query suite record for a single measured read operation before the common framework envelope is applied.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "system",
+    "operation_kind",
+    "iteration",
+    "fixture",
+    "path",
+    "elapsed_ns",
+    "prooflist_step_count",
+    "evidence_item_count",
+    "cas",
+    "arctable",
+    "proof"
+  ],
+  "properties": {
+    "system": {
+      "type": "string",
+      "enum": ["maltflat", "merkledag", "hamt"],
+      "description": "Evaluated read implementation."
+    },
+    "operation_kind": {
+      "type": "string",
+      "enum": ["resolve_path", "content_range"]
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "fixture": {
+      "type": "string",
+      "minLength": 1
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "range_header": {
+      "type": "string",
+      "description": "HTTP Range header used for content_range records."
+    },
+    "elapsed_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "content_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "prooflist_step_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "evidence_item_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Comparable evidence count: ProofList steps for MALT, CAS block fetches for IPLD UnixFS baselines."
+    },
+    "target": {
+      "type": "string",
+      "description": "Resolved target CID for resolve_path records."
+    },
+    "cas": {
+      "$ref": "#/$defs/cas_stats"
+    },
+    "arctable": {
+      "$ref": "#/$defs/arctable_stats"
+    },
+    "proof": {
+      "$ref": "#/$defs/proof_stats"
+    }
+  },
+  "$defs": {
+    "counter": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cas_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["put_count", "get_count", "has_count", "bytes_put", "bytes_get"],
+      "properties": {
+        "put_count": { "$ref": "#/$defs/counter" },
+        "get_count": { "$ref": "#/$defs/counter" },
+        "has_count": { "$ref": "#/$defs/counter" },
+        "bytes_put": { "$ref": "#/$defs/counter" },
+        "bytes_get": { "$ref": "#/$defs/counter" }
+      }
+    },
+    "arctable_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "get_count",
+        "batch_get_count",
+        "batch_get_path_count",
+        "update_count",
+        "update_arc_count",
+        "snapshot_count",
+        "snapshot_arc_count",
+        "iterate_count"
+      ],
+      "properties": {
+        "get_count": { "$ref": "#/$defs/counter" },
+        "batch_get_count": { "$ref": "#/$defs/counter" },
+        "batch_get_path_count": { "$ref": "#/$defs/counter" },
+        "update_count": { "$ref": "#/$defs/counter" },
+        "update_arc_count": { "$ref": "#/$defs/counter" },
+        "snapshot_count": { "$ref": "#/$defs/counter" },
+        "snapshot_arc_count": { "$ref": "#/$defs/counter" },
+        "iterate_count": { "$ref": "#/$defs/counter" }
+      }
+    },
+    "proof_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "proof_list_count",
+        "step_count",
+        "evidence_bytes",
+        "proof_bytes",
+        "total_bytes"
+      ],
+      "properties": {
+        "proof_list_count": { "$ref": "#/$defs/counter" },
+        "step_count": { "$ref": "#/$defs/counter" },
+        "evidence_bytes": { "$ref": "#/$defs/counter" },
+        "proof_bytes": { "$ref": "#/$defs/counter" },
+        "total_bytes": { "$ref": "#/$defs/counter" }
+      }
+    }
+  }
+}

--- a/cmd/eval/schemas/run-manifest.schema.json
+++ b/cmd/eval/schemas/run-manifest.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dewebprotocol.dev/malt/eval/run-manifest.schema.json",
+  "title": "MALT evaluation run manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "run_id", "started_at", "finished_at", "machine", "suites"],
+  "properties": {
+    "schema_version": {
+      "const": "malt-eval/v1"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "finished_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "machine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["goos", "goarch", "go_version"],
+      "properties": {
+        "hostname": {"type": "string"},
+        "goos": {"type": "string"},
+        "goarch": {"type": "string"},
+        "go_version": {"type": "string"}
+      }
+    },
+    "suites": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/cmd/eval/schemas/run-plan.schema.json
+++ b/cmd/eval/schemas/run-plan.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dewebprotocol.dev/malt/eval/run-plan.schema.json",
+  "title": "MALT evaluation run plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["suites"],
+  "properties": {
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "output_dir": {
+      "type": "string",
+      "minLength": 1
+    },
+    "suites": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "config": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/eval/schemas/run-plan.schema.json
+++ b/cmd/eval/schemas/run-plan.schema.json
@@ -8,7 +8,9 @@
   "properties": {
     "run_id": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "^(?!\\.\\.?$)[^/\\\\]+$",
+      "description": "Run identifier used for result metadata and the default results/<run_id> output path. It must not be a dot segment or contain path separators."
     },
     "output_dir": {
       "type": "string",

--- a/cmd/eval/schemas/schemas.go
+++ b/cmd/eval/schemas/schemas.go
@@ -1,0 +1,47 @@
+// Package schemas embeds the evaluator JSON schemas for installed binaries.
+package schemas
+
+import (
+	"embed"
+	"fmt"
+	"path/filepath"
+)
+
+//go:embed *.json
+var files embed.FS
+
+// Entry identifies one embedded evaluator JSON schema.
+type Entry struct {
+	Name string
+	Path string
+}
+
+// Entries returns schemas known to the evaluator CLI in display form.
+func Entries() []Entry {
+	return []Entry{
+		{Name: "cas-model-result", Path: "cmd/eval/schemas/cas-model-result.schema.json"},
+		{Name: "common-record", Path: "cmd/eval/schemas/common-record.schema.json"},
+		{Name: "proof-overhead-result", Path: "cmd/eval/schemas/proof-overhead-result.schema.json"},
+		{Name: "read-query-result", Path: "cmd/eval/schemas/read-query-result.schema.json"},
+		{Name: "readbench-result", Path: "cmd/eval/schemas/readbench-result.schema.json"},
+		{Name: "run-manifest", Path: "cmd/eval/schemas/run-manifest.schema.json"},
+		{Name: "run-plan", Path: "cmd/eval/schemas/run-plan.schema.json"},
+		{Name: "storage-overhead-result", Path: "cmd/eval/schemas/storage-overhead-result.schema.json"},
+		{Name: "write-trace-result", Path: "cmd/eval/schemas/write-trace-result.schema.json"},
+	}
+}
+
+// Read returns one embedded schema by display name.
+func Read(name string) ([]byte, error) {
+	for _, entry := range Entries() {
+		if entry.Name != name {
+			continue
+		}
+		data, err := files.ReadFile(filepath.Base(entry.Path))
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
+	}
+	return nil, fmt.Errorf("unknown schema %q", name)
+}

--- a/cmd/eval/schemas/storage-overhead-result.schema.json
+++ b/cmd/eval/schemas/storage-overhead-result.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/storage-overhead-result.schema.json",
+  "title": "Storage overhead result",
+  "description": "One JSONL record emitted by the storage_overhead evaluation suite.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "structure",
+    "size",
+    "payload_bytes",
+    "method",
+    "accounting",
+    "persisted_bytes",
+    "logical_payload_bytes",
+    "logical_proof_bytes"
+  ],
+  "properties": {
+    "structure": {
+      "type": "string"
+    },
+    "size": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "payload_bytes": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "method": {
+      "type": "string",
+      "enum": ["measured", "unsupported"]
+    },
+    "accounting": {
+      "$ref": "#/$defs/accounting_snapshot"
+    },
+    "persisted_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "logical_payload_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "logical_proof_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "error": {
+      "type": "string"
+    }
+  },
+  "$defs": {
+    "counter_value": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "counter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "attempted_put_count",
+        "attempted_put_bytes",
+        "new_object_count",
+        "new_persisted_bytes"
+      ],
+      "properties": {
+        "attempted_put_count": { "$ref": "#/$defs/counter_value" },
+        "attempted_put_bytes": { "$ref": "#/$defs/counter_value" },
+        "new_object_count": { "$ref": "#/$defs/counter_value" },
+        "new_persisted_bytes": { "$ref": "#/$defs/counter_value" },
+        "changed_record_count": { "$ref": "#/$defs/counter_value" }
+      }
+    },
+    "accounting_snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "categories"],
+      "properties": {
+        "total": {
+          "$ref": "#/$defs/counter"
+        },
+        "categories": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/counter"
+          },
+          "propertyNames": {
+            "enum": ["cas_payload", "cas_metadata", "arctable", "commitment", "root_head"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/eval/schemas/storage-overhead-result.schema.json
+++ b/cmd/eval/schemas/storage-overhead-result.schema.json
@@ -7,6 +7,9 @@
   "additionalProperties": false,
   "required": [
     "structure",
+    "system",
+    "commitment_backend",
+    "arctable_mode",
     "size",
     "payload_bytes",
     "method",
@@ -18,6 +21,28 @@
   "properties": {
     "structure": {
       "type": "string"
+    },
+    "system": {
+      "type": "string",
+      "enum": ["maltflat"]
+    },
+    "commitment_backend": {
+      "type": "string",
+      "enum": ["kzg"]
+    },
+    "arctable_mode": {
+      "type": "string",
+      "enum": ["versioned"]
+    },
+    "map_backend": {
+      "type": "string",
+      "description": "Map semantic backend for map records.",
+      "enum": ["radix"]
+    },
+    "list_backend": {
+      "type": "string",
+      "description": "List semantic backend for list records.",
+      "enum": ["tree"]
     },
     "size": {
       "type": "integer",

--- a/cmd/eval/schemas/write-trace-result.schema.json
+++ b/cmd/eval/schemas/write-trace-result.schema.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/write-trace-result.schema.json",
+  "title": "Write trace result",
+  "description": "One raw write_trace record emitted for one evaluated system at one Git commit.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "repo",
+    "system",
+    "commit",
+    "index",
+    "live_stats",
+    "mutations",
+    "result",
+    "accounting"
+  ],
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1
+    },
+    "system": {
+      "type": "string",
+      "enum": ["maltflat", "merkledag", "hamt"]
+    },
+    "commit": {
+      "type": "string",
+      "minLength": 1
+    },
+    "parent": {
+      "type": "string"
+    },
+    "index": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "live_stats": {
+      "$ref": "#/$defs/live_stats"
+    },
+    "mutations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/file_mutation"
+      }
+    },
+    "skipped": {
+      "$ref": "#/$defs/skip_stats"
+    },
+    "result": {
+      "$ref": "#/$defs/apply_result"
+    },
+    "accounting": {
+      "$ref": "#/$defs/accounting_snapshot"
+    }
+  },
+  "$defs": {
+    "counter": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "live_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "file_count",
+        "directory_count",
+        "path_count",
+        "live_payload_bytes",
+        "max_path_depth",
+        "average_path_depth"
+      ],
+      "properties": {
+        "file_count": { "$ref": "#/$defs/counter" },
+        "directory_count": { "$ref": "#/$defs/counter" },
+        "path_count": { "$ref": "#/$defs/counter" },
+        "live_payload_bytes": { "$ref": "#/$defs/counter" },
+        "max_path_depth": { "$ref": "#/$defs/counter" },
+        "average_path_depth": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "file_mutation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "path"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["add", "modify", "delete", "rename"]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "old_path": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "size": {
+          "$ref": "#/$defs/counter"
+        },
+        "hash": {
+          "type": "string"
+        }
+      }
+    },
+    "skip_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "symlink_count": { "$ref": "#/$defs/counter" },
+        "other_count": { "$ref": "#/$defs/counter" }
+      }
+    },
+    "apply_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "applied_mutations",
+        "materialized_paths",
+        "accounting"
+      ],
+      "properties": {
+        "root": {
+          "type": "string"
+        },
+        "applied_mutations": { "$ref": "#/$defs/counter" },
+        "materialized_paths": { "$ref": "#/$defs/counter" },
+        "materialization_strategy": {
+          "type": "string",
+          "enum": ["live_snapshot_rebuild"]
+        },
+        "accounting": {
+          "$ref": "#/$defs/accounting_snapshot"
+        }
+      }
+    },
+    "accounting_snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "categories"],
+      "properties": {
+        "total": {
+          "$ref": "#/$defs/accounting_counter"
+        },
+        "categories": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/accounting_counter"
+          }
+        }
+      }
+    },
+    "accounting_counter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "attempted_put_count",
+        "attempted_put_bytes",
+        "new_object_count",
+        "new_persisted_bytes"
+      ],
+      "properties": {
+        "attempted_put_count": { "$ref": "#/$defs/counter" },
+        "attempted_put_bytes": { "$ref": "#/$defs/counter" },
+        "new_object_count": { "$ref": "#/$defs/counter" },
+        "new_persisted_bytes": { "$ref": "#/$defs/counter" },
+        "changed_record_count": { "$ref": "#/$defs/counter" }
+      }
+    }
+  }
+}

--- a/internal/eval/framework/env.go
+++ b/internal/eval/framework/env.go
@@ -1,0 +1,58 @@
+package framework
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Env gives suites access to their run metadata and output directories.
+type Env struct {
+	RunID     string
+	OutputDir string
+	clock     func() time.Time
+}
+
+// RawPath returns the JSONL path for a suite's raw result stream.
+func (e Env) RawPath(suite string) string {
+	return filepath.Join(e.OutputDir, "raw", suite+".jsonl")
+}
+
+// WriteRecord appends one raw result record using the common envelope.
+func (e Env) WriteRecord(suite string, record any) error {
+	if suite == "" {
+		return fmt.Errorf("suite is empty")
+	}
+	if e.clock == nil {
+		e.clock = time.Now
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal record: %w", err)
+	}
+	envelope := RecordEnvelope{
+		SchemaVersion: SchemaVersion,
+		RunID:         e.RunID,
+		Suite:         suite,
+		EmittedAt:     e.clock().UTC().Format(time.RFC3339Nano),
+		Record:        payload,
+	}
+	f, err := os.OpenFile(e.RawPath(suite), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	return enc.Encode(envelope)
+}
+
+// RecordEnvelope wraps suite-specific records with run metadata.
+type RecordEnvelope struct {
+	SchemaVersion string          `json:"schema_version"`
+	RunID         string          `json:"run_id"`
+	Suite         string          `json:"suite"`
+	EmittedAt     string          `json:"emitted_at"`
+	Record        json.RawMessage `json:"record"`
+}

--- a/internal/eval/framework/manifest.go
+++ b/internal/eval/framework/manifest.go
@@ -1,0 +1,39 @@
+package framework
+
+import (
+	"os"
+	"runtime"
+)
+
+// Manifest records enough metadata to make an evaluation run auditable.
+type Manifest struct {
+	SchemaVersion string          `json:"schema_version"`
+	RunID         string          `json:"run_id"`
+	StartedAt     string          `json:"started_at"`
+	FinishedAt    string          `json:"finished_at"`
+	Machine       MachineMetadata `json:"machine"`
+	Suites        []SuiteManifest `json:"suites"`
+}
+
+// MachineMetadata captures local runtime metadata.
+type MachineMetadata struct {
+	Hostname  string `json:"hostname,omitempty"`
+	GOOS      string `json:"goos"`
+	GOARCH    string `json:"goarch"`
+	GoVersion string `json:"go_version"`
+}
+
+// SuiteManifest records a suite that actually ran.
+type SuiteManifest struct {
+	Name string `json:"name"`
+}
+
+func collectMachineMetadata() MachineMetadata {
+	host, _ := os.Hostname()
+	return MachineMetadata{
+		Hostname:  host,
+		GOOS:      runtime.GOOS,
+		GOARCH:    runtime.GOARCH,
+		GoVersion: runtime.Version(),
+	}
+}

--- a/internal/eval/framework/plan.go
+++ b/internal/eval/framework/plan.go
@@ -1,0 +1,78 @@
+package framework
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const SchemaVersion = "malt-eval/v1"
+
+// Plan is the top-level evaluation run plan consumed by `malt-eval run`.
+type Plan struct {
+	RunID     string      `json:"run_id"`
+	OutputDir string      `json:"output_dir,omitempty"`
+	Suites    []SuitePlan `json:"suites"`
+}
+
+// SuitePlan configures one registered evaluation suite.
+type SuitePlan struct {
+	Name    string          `json:"name"`
+	Enabled *bool           `json:"enabled,omitempty"`
+	Config  json.RawMessage `json:"config,omitempty"`
+}
+
+// EnabledOrDefault returns true unless the plan explicitly disables the suite.
+func (p SuitePlan) EnabledOrDefault() bool {
+	return p.Enabled == nil || *p.Enabled
+}
+
+// LoadPlan reads and normalizes an evaluation run plan from disk.
+func LoadPlan(path string) (Plan, error) {
+	if strings.TrimSpace(path) == "" {
+		return Plan{}, fmt.Errorf("plan path is empty")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Plan{}, err
+	}
+	var plan Plan
+	if err := json.Unmarshal(data, &plan); err != nil {
+		return Plan{}, fmt.Errorf("parse plan: %w", err)
+	}
+	if err := plan.Normalize(); err != nil {
+		return Plan{}, err
+	}
+	return plan, nil
+}
+
+// Normalize fills defaults and validates suite names.
+func (p *Plan) Normalize() error {
+	if p == nil {
+		return fmt.Errorf("plan is nil")
+	}
+	if strings.TrimSpace(p.RunID) == "" {
+		p.RunID = "run-" + time.Now().UTC().Format("20060102T150405Z")
+	} else {
+		p.RunID = strings.TrimSpace(p.RunID)
+	}
+	if strings.TrimSpace(p.OutputDir) == "" {
+		p.OutputDir = filepath.Join("results", p.RunID)
+	} else {
+		p.OutputDir = filepath.Clean(p.OutputDir)
+	}
+	if len(p.Suites) == 0 {
+		return fmt.Errorf("at least one suite is required")
+	}
+	for i := range p.Suites {
+		name := strings.TrimSpace(p.Suites[i].Name)
+		if name == "" {
+			return fmt.Errorf("suite %d name is empty", i)
+		}
+		p.Suites[i].Name = name
+	}
+	return nil
+}

--- a/internal/eval/framework/plan.go
+++ b/internal/eval/framework/plan.go
@@ -13,9 +13,10 @@ const SchemaVersion = "malt-eval/v1"
 
 // Plan is the top-level evaluation run plan consumed by `malt-eval run`.
 type Plan struct {
-	RunID     string      `json:"run_id"`
-	OutputDir string      `json:"output_dir,omitempty"`
-	Suites    []SuitePlan `json:"suites"`
+	RunID             string      `json:"run_id"`
+	OutputDir         string      `json:"output_dir,omitempty"`
+	Suites            []SuitePlan `json:"suites"`
+	outputDirExplicit bool
 }
 
 // SuitePlan configures one registered evaluation suite.
@@ -43,6 +44,7 @@ func LoadPlan(path string) (Plan, error) {
 	if err := json.Unmarshal(data, &plan); err != nil {
 		return Plan{}, fmt.Errorf("parse plan: %w", err)
 	}
+	plan.outputDirExplicit = jsonHasKey(data, "output_dir")
 	if err := plan.Normalize(); err != nil {
 		return Plan{}, err
 	}
@@ -75,4 +77,42 @@ func (p *Plan) Normalize() error {
 		p.Suites[i].Name = name
 	}
 	return nil
+}
+
+// OverrideRunID applies a CLI run-id override. If the plan did not explicitly
+// configure output_dir, the output directory is recomputed from the final run id
+// during the next Normalize call.
+func (p *Plan) OverrideRunID(runID string) {
+	if p == nil {
+		return
+	}
+	if strings.TrimSpace(runID) == "" {
+		return
+	}
+	p.RunID = strings.TrimSpace(runID)
+	if !p.outputDirExplicit {
+		p.OutputDir = ""
+	}
+}
+
+// OverrideOutputDir applies a CLI output-dir override and marks the directory
+// as explicit so later run-id overrides do not rewrite it.
+func (p *Plan) OverrideOutputDir(outputDir string) {
+	if p == nil {
+		return
+	}
+	if strings.TrimSpace(outputDir) == "" {
+		return
+	}
+	p.OutputDir = strings.TrimSpace(outputDir)
+	p.outputDirExplicit = true
+}
+
+func jsonHasKey(data []byte, key string) bool {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil {
+		return false
+	}
+	_, ok := object[key]
+	return ok
 }

--- a/internal/eval/framework/plan.go
+++ b/internal/eval/framework/plan.go
@@ -60,6 +60,9 @@ func (p *Plan) Normalize() error {
 		p.RunID = "run-" + time.Now().UTC().Format("20060102T150405Z")
 	} else {
 		p.RunID = strings.TrimSpace(p.RunID)
+		if err := validateRunID(p.RunID); err != nil {
+			return err
+		}
 	}
 	if strings.TrimSpace(p.OutputDir) == "" {
 		p.OutputDir = filepath.Join("results", p.RunID)
@@ -75,6 +78,16 @@ func (p *Plan) Normalize() error {
 			return fmt.Errorf("suite %d name is empty", i)
 		}
 		p.Suites[i].Name = name
+	}
+	return nil
+}
+
+func validateRunID(runID string) error {
+	if runID == "." || runID == ".." {
+		return fmt.Errorf("run_id %q must not be a dot path segment", runID)
+	}
+	if strings.ContainsAny(runID, `/\`) {
+		return fmt.Errorf("run_id %q must not contain path separators", runID)
 	}
 	return nil
 }

--- a/internal/eval/framework/plan.go
+++ b/internal/eval/framework/plan.go
@@ -1,8 +1,10 @@
 package framework
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,7 +43,16 @@ func LoadPlan(path string) (Plan, error) {
 		return Plan{}, err
 	}
 	var plan Plan
-	if err := json.Unmarshal(data, &plan); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&plan); err != nil {
+		return Plan{}, fmt.Errorf("parse plan: %w", err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return Plan{}, fmt.Errorf("parse plan: unexpected trailing JSON")
+		}
 		return Plan{}, fmt.Errorf("parse plan: %w", err)
 	}
 	plan.outputDirExplicit = jsonHasKey(data, "output_dir")

--- a/internal/eval/framework/plan_test.go
+++ b/internal/eval/framework/plan_test.go
@@ -1,0 +1,85 @@
+package framework
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadPlanDefaultsAndPreservesSuiteConfig(t *testing.T) {
+	tmp := t.TempDir()
+	planPath := filepath.Join(tmp, "plan.json")
+	raw := `{
+		"run_id": "paper-eval",
+		"suites": [
+			{
+				"name": "write_trace",
+				"config": {
+					"systems": ["maltflat", "merkledag"],
+					"commit_limit": 25
+				}
+			},
+			{
+				"name": "proof_overhead",
+				"enabled": false,
+				"config": {"iterations": 3}
+			}
+		]
+	}`
+	if err := os.WriteFile(planPath, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	plan, err := LoadPlan(planPath)
+	if err != nil {
+		t.Fatalf("LoadPlan: %v", err)
+	}
+
+	if plan.RunID != "paper-eval" {
+		t.Fatalf("run id = %q, want paper-eval", plan.RunID)
+	}
+	if plan.OutputDir != filepath.Join("results", "paper-eval") {
+		t.Fatalf("output dir = %q", plan.OutputDir)
+	}
+	if len(plan.Suites) != 2 {
+		t.Fatalf("suites len = %d, want 2", len(plan.Suites))
+	}
+	if !plan.Suites[0].EnabledOrDefault() {
+		t.Fatal("suite without enabled flag should default to enabled")
+	}
+	if plan.Suites[1].EnabledOrDefault() {
+		t.Fatal("suite with enabled=false should be disabled")
+	}
+
+	var cfg struct {
+		Systems     []string `json:"systems"`
+		CommitLimit int      `json:"commit_limit"`
+	}
+	if err := json.Unmarshal(plan.Suites[0].Config, &cfg); err != nil {
+		t.Fatalf("unmarshal suite config: %v", err)
+	}
+	if cfg.CommitLimit != 25 || len(cfg.Systems) != 2 || cfg.Systems[0] != "maltflat" {
+		t.Fatalf("suite config = %#v", cfg)
+	}
+}
+
+func TestRegistryRejectsDuplicateAndMissingSuites(t *testing.T) {
+	reg := NewRegistry()
+	suite := fakeSuite{name: "write_trace"}
+	if err := reg.Register(suite); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := reg.Register(suite); err == nil {
+		t.Fatal("duplicate register should fail")
+	}
+	if got, ok := reg.Lookup("write_trace"); !ok || got.Name() != "write_trace" {
+		t.Fatalf("lookup write_trace = %v/%v", got, ok)
+	}
+	if _, ok := reg.Lookup("missing"); ok {
+		t.Fatal("missing suite should not be found")
+	}
+	if names := reg.Names(); len(names) != 1 || names[0] != "write_trace" {
+		t.Fatalf("registry names = %#v", names)
+	}
+}

--- a/internal/eval/framework/plan_test.go
+++ b/internal/eval/framework/plan_test.go
@@ -64,6 +64,44 @@ func TestLoadPlanDefaultsAndPreservesSuiteConfig(t *testing.T) {
 	}
 }
 
+func TestLoadPlanRejectsUnknownTopLevelFields(t *testing.T) {
+	tmp := t.TempDir()
+	planPath := filepath.Join(tmp, "plan.json")
+	raw := `{
+		"run_id": "paper-eval",
+		"output_dr": "results/wrong",
+		"suites": [{"name": "write_trace"}]
+	}`
+	if err := os.WriteFile(planPath, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	if _, err := LoadPlan(planPath); err == nil {
+		t.Fatal("LoadPlan should reject unknown top-level fields")
+	}
+}
+
+func TestLoadPlanRejectsUnknownSuiteFields(t *testing.T) {
+	tmp := t.TempDir()
+	planPath := filepath.Join(tmp, "plan.json")
+	raw := `{
+		"run_id": "paper-eval",
+		"suites": [
+			{
+				"name": "write_trace",
+				"enabledd": false
+			}
+		]
+	}`
+	if err := os.WriteFile(planPath, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	if _, err := LoadPlan(planPath); err == nil {
+		t.Fatal("LoadPlan should reject unknown suite fields")
+	}
+}
+
 func TestPlanRejectsRunIDPathSegments(t *testing.T) {
 	for _, runID := range []string{".", "..", "../outside", "nested/run", `nested\run`} {
 		plan := Plan{

--- a/internal/eval/framework/plan_test.go
+++ b/internal/eval/framework/plan_test.go
@@ -64,6 +64,18 @@ func TestLoadPlanDefaultsAndPreservesSuiteConfig(t *testing.T) {
 	}
 }
 
+func TestPlanRejectsRunIDPathSegments(t *testing.T) {
+	for _, runID := range []string{".", "..", "../outside", "nested/run", `nested\run`} {
+		plan := Plan{
+			RunID:  runID,
+			Suites: []SuitePlan{{Name: "write_trace"}},
+		}
+		if err := plan.Normalize(); err == nil {
+			t.Fatalf("Normalize should reject run_id %q", runID)
+		}
+	}
+}
+
 func TestRegistryRejectsDuplicateAndMissingSuites(t *testing.T) {
 	reg := NewRegistry()
 	suite := fakeSuite{name: "write_trace"}

--- a/internal/eval/framework/registry.go
+++ b/internal/eval/framework/registry.go
@@ -1,0 +1,56 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Suite is one independently runnable evaluation workload.
+type Suite interface {
+	Name() string
+	Run(context.Context, Env, json.RawMessage) error
+}
+
+// Registry maps suite names to implementations.
+type Registry struct {
+	suites map[string]Suite
+}
+
+// NewRegistry creates an empty suite registry.
+func NewRegistry() Registry {
+	return Registry{suites: make(map[string]Suite)}
+}
+
+// Register adds a suite implementation.
+func (r Registry) Register(suite Suite) error {
+	if suite == nil {
+		return fmt.Errorf("suite is nil")
+	}
+	name := suite.Name()
+	if name == "" {
+		return fmt.Errorf("suite name is empty")
+	}
+	if _, exists := r.suites[name]; exists {
+		return fmt.Errorf("suite %q already registered", name)
+	}
+	r.suites[name] = suite
+	return nil
+}
+
+// Lookup returns a registered suite by name.
+func (r Registry) Lookup(name string) (Suite, bool) {
+	suite, ok := r.suites[name]
+	return suite, ok
+}
+
+// Names returns registered suite names in stable order.
+func (r Registry) Names() []string {
+	names := make([]string, 0, len(r.suites))
+	for name := range r.suites {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/eval/framework/runner.go
+++ b/internal/eval/framework/runner.go
@@ -1,0 +1,69 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// RunOptions controls framework execution behavior.
+type RunOptions struct {
+	Clock func() time.Time
+}
+
+// Run executes all enabled suites in plan order.
+func Run(ctx context.Context, plan Plan, registry Registry, opts RunOptions) error {
+	if err := plan.Normalize(); err != nil {
+		return err
+	}
+	clock := opts.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	for _, dir := range []string{"raw", "summary", "logs"} {
+		if err := os.MkdirAll(filepath.Join(plan.OutputDir, dir), 0o755); err != nil {
+			return err
+		}
+	}
+
+	startedAt := clock().UTC().Format(time.RFC3339Nano)
+	env := Env{
+		RunID:     plan.RunID,
+		OutputDir: plan.OutputDir,
+		clock:     clock,
+	}
+	manifest := Manifest{
+		SchemaVersion: SchemaVersion,
+		RunID:         plan.RunID,
+		StartedAt:     startedAt,
+		Machine:       collectMachineMetadata(),
+	}
+
+	for _, suitePlan := range plan.Suites {
+		if !suitePlan.EnabledOrDefault() {
+			continue
+		}
+		suite, ok := registry.Lookup(suitePlan.Name)
+		if !ok {
+			return fmt.Errorf("suite %q is not registered; available suites: %v", suitePlan.Name, registry.Names())
+		}
+		if err := suite.Run(ctx, env, suitePlan.Config); err != nil {
+			return fmt.Errorf("run suite %s: %w", suitePlan.Name, err)
+		}
+		manifest.Suites = append(manifest.Suites, SuiteManifest{Name: suitePlan.Name})
+	}
+	manifest.FinishedAt = clock().UTC().Format(time.RFC3339Nano)
+	return writeManifest(plan.OutputDir, manifest)
+}
+
+func writeManifest(outputDir string, manifest Manifest) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(filepath.Join(outputDir, "manifest.json"), data, 0o644)
+}

--- a/internal/eval/framework/runner.go
+++ b/internal/eval/framework/runner.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/dewebprotocol/malt/internal/eval/summary"
 )
 
 // RunOptions controls framework execution behavior.
@@ -54,6 +56,9 @@ func Run(ctx context.Context, plan Plan, registry Registry, opts RunOptions) err
 			return fmt.Errorf("run suite %s: %w", suitePlan.Name, err)
 		}
 		manifest.Suites = append(manifest.Suites, SuiteManifest{Name: suitePlan.Name})
+	}
+	if err := summary.Summarize(plan.OutputDir, filepath.Join(plan.OutputDir, "summary")); err != nil {
+		return fmt.Errorf("summarize run: %w", err)
 	}
 	manifest.FinishedAt = clock().UTC().Format(time.RFC3339Nano)
 	return writeManifest(plan.OutputDir, manifest)

--- a/internal/eval/framework/runner.go
+++ b/internal/eval/framework/runner.go
@@ -63,6 +63,10 @@ func Run(ctx context.Context, plan Plan, registry Registry, opts RunOptions) err
 }
 
 func prepareOutputLayout(outputDir string) error {
+	manifestPath := filepath.Join(outputDir, "manifest.json")
+	if err := os.Remove(manifestPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
 	for _, dir := range []string{"raw", "summary", "logs"} {
 		path := filepath.Join(outputDir, dir)
 		if err := os.RemoveAll(path); err != nil {

--- a/internal/eval/framework/runner.go
+++ b/internal/eval/framework/runner.go
@@ -25,10 +25,8 @@ func Run(ctx context.Context, plan Plan, registry Registry, opts RunOptions) err
 	if clock == nil {
 		clock = time.Now
 	}
-	for _, dir := range []string{"raw", "summary", "logs"} {
-		if err := os.MkdirAll(filepath.Join(plan.OutputDir, dir), 0o755); err != nil {
-			return err
-		}
+	if err := prepareOutputLayout(plan.OutputDir); err != nil {
+		return err
 	}
 
 	startedAt := clock().UTC().Format(time.RFC3339Nano)
@@ -62,6 +60,19 @@ func Run(ctx context.Context, plan Plan, registry Registry, opts RunOptions) err
 	}
 	manifest.FinishedAt = clock().UTC().Format(time.RFC3339Nano)
 	return writeManifest(plan.OutputDir, manifest)
+}
+
+func prepareOutputLayout(outputDir string) error {
+	for _, dir := range []string{"raw", "summary", "logs"} {
+		path := filepath.Join(outputDir, dir)
+		if err := os.RemoveAll(path); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func writeManifest(outputDir string, manifest Manifest) error {

--- a/internal/eval/framework/runner.go
+++ b/internal/eval/framework/runner.go
@@ -21,6 +21,9 @@ func Run(ctx context.Context, plan Plan, registry Registry, opts RunOptions) err
 	if err := plan.Normalize(); err != nil {
 		return err
 	}
+	if err := preflightSuites(plan, registry); err != nil {
+		return err
+	}
 	clock := opts.Clock
 	if clock == nil {
 		clock = time.Now
@@ -60,6 +63,18 @@ func Run(ctx context.Context, plan Plan, registry Registry, opts RunOptions) err
 	}
 	manifest.FinishedAt = clock().UTC().Format(time.RFC3339Nano)
 	return writeManifest(plan.OutputDir, manifest)
+}
+
+func preflightSuites(plan Plan, registry Registry) error {
+	for _, suitePlan := range plan.Suites {
+		if !suitePlan.EnabledOrDefault() {
+			continue
+		}
+		if _, ok := registry.Lookup(suitePlan.Name); !ok {
+			return fmt.Errorf("suite %q is not registered; available suites: %v", suitePlan.Name, registry.Names())
+		}
+	}
+	return nil
 }
 
 func prepareOutputLayout(outputDir string) error {

--- a/internal/eval/framework/runner_test.go
+++ b/internal/eval/framework/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -132,6 +133,41 @@ func TestRunnerRefreshesOutputDirectoriesBeforeRun(t *testing.T) {
 	}
 }
 
+func TestRunnerRemovesStaleManifestBeforeFailedRerun(t *testing.T) {
+	tmp := t.TempDir()
+	successRegistry := NewRegistry()
+	if err := successRegistry.Register(fakeSuite{name: "write_trace"}); err != nil {
+		t.Fatalf("Register success suite: %v", err)
+	}
+	plan := Plan{
+		RunID:     "failed-rerun",
+		OutputDir: filepath.Join(tmp, "failed-rerun"),
+		Suites: []SuitePlan{{
+			Name:   "write_trace",
+			Config: json.RawMessage(`{"limit": 1}`),
+		}},
+	}
+
+	if err := Run(context.Background(), plan, successRegistry, RunOptions{}); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	manifestPath := filepath.Join(plan.OutputDir, "manifest.json")
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Fatalf("initial manifest missing: %v", err)
+	}
+
+	failingRegistry := NewRegistry()
+	if err := failingRegistry.Register(failingSuite{name: "write_trace"}); err != nil {
+		t.Fatalf("Register failing suite: %v", err)
+	}
+	if err := Run(context.Background(), plan, failingRegistry, RunOptions{}); err == nil {
+		t.Fatal("second Run should fail")
+	}
+	if _, err := os.Stat(manifestPath); !os.IsNotExist(err) {
+		t.Fatalf("stale manifest should be removed before failed rerun, stat err=%v", err)
+	}
+}
+
 func TestRunnerFailsForUnknownEnabledSuite(t *testing.T) {
 	plan := Plan{
 		RunID:     "run-unknown",
@@ -164,6 +200,16 @@ func (s fakeSuite) Run(ctx context.Context, env Env, cfg json.RawMessage) error 
 	return env.WriteRecord(s.name, map[string]any{
 		"limit": parsed.Limit,
 	})
+}
+
+type failingSuite struct {
+	name string
+}
+
+func (s failingSuite) Name() string { return s.name }
+
+func (s failingSuite) Run(context.Context, Env, json.RawMessage) error {
+	return errors.New("suite failed")
 }
 
 func boolPtr(v bool) *bool {

--- a/internal/eval/framework/runner_test.go
+++ b/internal/eval/framework/runner_test.go
@@ -79,6 +79,59 @@ func TestRunnerCreatesEvaluationOutputLayout(t *testing.T) {
 	}
 }
 
+func TestRunnerRefreshesOutputDirectoriesBeforeRun(t *testing.T) {
+	tmp := t.TempDir()
+	reg := NewRegistry()
+	if err := reg.Register(fakeSuite{name: "write_trace"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	plan := Plan{
+		RunID:     "rerun",
+		OutputDir: filepath.Join(tmp, "rerun"),
+		Suites: []SuitePlan{{
+			Name:   "write_trace",
+			Config: json.RawMessage(`{"limit": 1}`),
+		}},
+	}
+
+	if err := Run(context.Background(), plan, reg, RunOptions{}); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(plan.OutputDir, "summary", "stale.csv"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatalf("write stale summary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(plan.OutputDir, "logs", "stale.log"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatalf("write stale log: %v", err)
+	}
+
+	plan.Suites[0].Config = json.RawMessage(`{"limit": 2}`)
+	if err := Run(context.Background(), plan, reg, RunOptions{}); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	rawBytes, err := os.ReadFile(filepath.Join(plan.OutputDir, "raw", "write_trace.jsonl"))
+	if err != nil {
+		t.Fatalf("read raw output: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(rawBytes)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("raw line count after rerun = %d, want 1\n%s", len(lines), rawBytes)
+	}
+	var envelope RecordEnvelope
+	if err := json.Unmarshal([]byte(lines[0]), &envelope); err != nil {
+		t.Fatalf("unmarshal rerun envelope: %v", err)
+	}
+	if strings.Contains(string(envelope.Record), `"limit":1`) || !strings.Contains(string(envelope.Record), `"limit":2`) {
+		t.Fatalf("rerun record = %s, want only latest limit", envelope.Record)
+	}
+	if _, err := os.Stat(filepath.Join(plan.OutputDir, "summary", "stale.csv")); !os.IsNotExist(err) {
+		t.Fatalf("stale summary file still present or stat failed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(plan.OutputDir, "logs", "stale.log")); !os.IsNotExist(err) {
+		t.Fatalf("stale log file still present or stat failed unexpectedly: %v", err)
+	}
+}
+
 func TestRunnerFailsForUnknownEnabledSuite(t *testing.T) {
 	plan := Plan{
 		RunID:     "run-unknown",

--- a/internal/eval/framework/runner_test.go
+++ b/internal/eval/framework/runner_test.go
@@ -1,0 +1,109 @@
+package framework
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRunnerCreatesEvaluationOutputLayout(t *testing.T) {
+	tmp := t.TempDir()
+	reg := NewRegistry()
+	if err := reg.Register(fakeSuite{name: "write_trace"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	plan := Plan{
+		RunID:     "run-001",
+		OutputDir: filepath.Join(tmp, "run-001"),
+		Suites: []SuitePlan{
+			{Name: "write_trace", Config: json.RawMessage(`{"limit": 2}`)},
+			{Name: "proof_overhead", Enabled: boolPtr(false)},
+		},
+	}
+	clock := func() time.Time { return time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC) }
+
+	if err := Run(context.Background(), plan, reg, RunOptions{Clock: clock}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, dir := range []string{"raw", "summary", "logs"} {
+		if info, err := os.Stat(filepath.Join(plan.OutputDir, dir)); err != nil || !info.IsDir() {
+			t.Fatalf("expected %s directory, info=%v err=%v", dir, info, err)
+		}
+	}
+
+	rawPath := filepath.Join(plan.OutputDir, "raw", "write_trace.jsonl")
+	f, err := os.Open(rawPath)
+	if err != nil {
+		t.Fatalf("open raw output: %v", err)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() {
+		t.Fatalf("expected one raw line, err=%v", scanner.Err())
+	}
+	var record RecordEnvelope
+	if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
+		t.Fatalf("unmarshal raw record: %v", err)
+	}
+	if record.RunID != "run-001" || record.Suite != "write_trace" || record.SchemaVersion != SchemaVersion {
+		t.Fatalf("record envelope = %#v", record)
+	}
+
+	manifestBytes, err := os.ReadFile(filepath.Join(plan.OutputDir, "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if manifest.RunID != "run-001" || len(manifest.Suites) != 1 || manifest.Suites[0].Name != "write_trace" {
+		t.Fatalf("manifest = %#v", manifest)
+	}
+	if manifest.StartedAt != clock().Format(time.RFC3339Nano) || manifest.FinishedAt != clock().Format(time.RFC3339Nano) {
+		t.Fatalf("manifest times = %s/%s", manifest.StartedAt, manifest.FinishedAt)
+	}
+}
+
+func TestRunnerFailsForUnknownEnabledSuite(t *testing.T) {
+	plan := Plan{
+		RunID:     "run-unknown",
+		OutputDir: filepath.Join(t.TempDir(), "run-unknown"),
+		Suites:    []SuitePlan{{Name: "missing"}},
+	}
+	if err := Run(context.Background(), plan, NewRegistry(), RunOptions{}); err == nil {
+		t.Fatal("Run should fail for unknown enabled suite")
+	}
+}
+
+type fakeSuite struct {
+	name string
+}
+
+func (s fakeSuite) Name() string { return s.name }
+
+func (s fakeSuite) Run(ctx context.Context, env Env, cfg json.RawMessage) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	var parsed struct {
+		Limit int `json:"limit"`
+	}
+	if len(cfg) > 0 {
+		if err := json.Unmarshal(cfg, &parsed); err != nil {
+			return err
+		}
+	}
+	return env.WriteRecord(s.name, map[string]any{
+		"limit": parsed.Limit,
+	})
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/internal/eval/framework/runner_test.go
+++ b/internal/eval/framework/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -67,6 +68,14 @@ func TestRunnerCreatesEvaluationOutputLayout(t *testing.T) {
 	}
 	if manifest.StartedAt != clock().Format(time.RFC3339Nano) || manifest.FinishedAt != clock().Format(time.RFC3339Nano) {
 		t.Fatalf("manifest times = %s/%s", manifest.StartedAt, manifest.FinishedAt)
+	}
+
+	summaryBytes, err := os.ReadFile(filepath.Join(plan.OutputDir, "summary", "figure_write_trace.csv"))
+	if err != nil {
+		t.Fatalf("read summary csv: %v", err)
+	}
+	if got := string(summaryBytes); !strings.Contains(got, "limit") || !strings.Contains(got, "run-001") {
+		t.Fatalf("summary csv did not include flattened fake record: %s", got)
 	}
 }
 

--- a/internal/eval/framework/runner_test.go
+++ b/internal/eval/framework/runner_test.go
@@ -168,6 +168,45 @@ func TestRunnerRemovesStaleManifestBeforeFailedRerun(t *testing.T) {
 	}
 }
 
+func TestRunnerPreflightsSuitesBeforeRefreshingOutput(t *testing.T) {
+	tmp := t.TempDir()
+	outputDir := filepath.Join(tmp, "preflight")
+	for _, dir := range []string{"raw", "summary", "logs"} {
+		if err := os.MkdirAll(filepath.Join(outputDir, dir), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	sentinels := map[string]string{
+		filepath.Join(outputDir, "manifest.json"):            "previous manifest\n",
+		filepath.Join(outputDir, "raw", "write_trace.jsonl"): "previous raw\n",
+		filepath.Join(outputDir, "summary", "stale.csv"):     "previous summary\n",
+		filepath.Join(outputDir, "logs", "previous-run.log"): "previous logs\n",
+	}
+	for path, content := range sentinels {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write sentinel %s: %v", path, err)
+		}
+	}
+	plan := Plan{
+		RunID:     "preflight",
+		OutputDir: outputDir,
+		Suites:    []SuitePlan{{Name: "missing"}},
+	}
+
+	if err := Run(context.Background(), plan, NewRegistry(), RunOptions{}); err == nil {
+		t.Fatal("Run should fail for unknown enabled suite")
+	}
+	for path, want := range sentinels {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read sentinel %s after failed preflight: %v", path, err)
+		}
+		if string(got) != want {
+			t.Fatalf("sentinel %s = %q, want %q", path, got, want)
+		}
+	}
+}
+
 func TestRunnerFailsForUnknownEnabledSuite(t *testing.T) {
 	plan := Plan{
 		RunID:     "run-unknown",

--- a/internal/eval/suites/casmodel/suite.go
+++ b/internal/eval/suites/casmodel/suite.go
@@ -11,6 +11,7 @@ import (
 	casmock "github.com/dewebprotocol/malt/core/cas/mock"
 	"github.com/dewebprotocol/malt/core/metrics"
 	"github.com/dewebprotocol/malt/internal/eval/framework"
+	"github.com/dewebprotocol/malt/internal/eval/suites/configjson"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -88,8 +89,8 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 		Iterations:   1,
 	}
 	if len(raw) != 0 {
-		if err := json.Unmarshal(raw, &cfg); err != nil {
-			return Config{}, fmt.Errorf("parse cas_model config: %w", err)
+		if err := configjson.Decode(raw, suiteName, &cfg); err != nil {
+			return Config{}, err
 		}
 	}
 	if cfg.ChainLengths == nil {

--- a/internal/eval/suites/casmodel/suite.go
+++ b/internal/eval/suites/casmodel/suite.go
@@ -1,0 +1,234 @@
+// Package casmodel measures the local CAS mock under fixed latency models.
+package casmodel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/dewebprotocol/malt/core/cas"
+	casmock "github.com/dewebprotocol/malt/core/cas/mock"
+	"github.com/dewebprotocol/malt/core/metrics"
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+	cid "github.com/ipfs/go-cid"
+)
+
+const suiteName = "cas_model"
+
+// Suite implements the CAS cost model evaluation.
+type Suite struct{}
+
+// Config controls CAS latency and dependency-shape dimensions.
+type Config struct {
+	GetLatencyMS int   `json:"get_latency_ms"`
+	PutLatencyMS int   `json:"put_latency_ms"`
+	HasLatencyMS int   `json:"has_latency_ms"`
+	JitterMS     int   `json:"jitter_ms"`
+	ChainLengths []int `json:"chain_lengths"`
+	BatchSizes   []int `json:"batch_sizes"`
+	Iterations   int   `json:"iterations"`
+}
+
+// Result is one measured CAS operation record.
+type Result struct {
+	Operation           string           `json:"operation"`
+	DependencyShape     string           `json:"dependency_shape"`
+	Size                int              `json:"size"`
+	Iteration           int              `json:"iteration"`
+	ElapsedNS           int64            `json:"elapsed_ns"`
+	ConfiguredLatencyMS int              `json:"configured_latency_ms"`
+	ConfiguredJitterMS  int              `json:"configured_jitter_ms"`
+	CAS                 metrics.CASStats `json:"cas"`
+}
+
+// Name returns the stable suite name.
+func (Suite) Name() string {
+	return suiteName
+}
+
+// Run executes the configured CAS model matrix and writes raw records.
+func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) error {
+	cfg, err := parseConfig(raw)
+	if err != nil {
+		return err
+	}
+
+	for iteration := 0; iteration < cfg.Iterations; iteration++ {
+		for _, size := range cfg.ChainLengths {
+			for _, op := range []string{"put", "get", "has"} {
+				record, err := measure(ctx, cfg, op, "chain", size, iteration)
+				if err != nil {
+					return err
+				}
+				if err := env.WriteRecord(suiteName, record); err != nil {
+					return err
+				}
+			}
+		}
+		for _, size := range cfg.BatchSizes {
+			for _, op := range []string{"put", "get", "has"} {
+				record, err := measure(ctx, cfg, op, "batch", size, iteration)
+				if err != nil {
+					return err
+				}
+				if err := env.WriteRecord(suiteName, record); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func parseConfig(raw json.RawMessage) (Config, error) {
+	cfg := Config{
+		ChainLengths: []int{1},
+		BatchSizes:   []int{1},
+		Iterations:   1,
+	}
+	if len(raw) != 0 {
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return Config{}, fmt.Errorf("parse cas_model config: %w", err)
+		}
+	}
+	if cfg.ChainLengths == nil {
+		cfg.ChainLengths = []int{1}
+	}
+	if cfg.BatchSizes == nil {
+		cfg.BatchSizes = []int{1}
+	}
+	if cfg.Iterations == 0 {
+		cfg.Iterations = 1
+	}
+	if cfg.GetLatencyMS < 0 || cfg.PutLatencyMS < 0 || cfg.HasLatencyMS < 0 || cfg.JitterMS < 0 {
+		return Config{}, fmt.Errorf("latency and jitter values must be non-negative")
+	}
+	if cfg.Iterations < 0 {
+		return Config{}, fmt.Errorf("iterations must be non-negative")
+	}
+	for _, size := range append(append([]int(nil), cfg.ChainLengths...), cfg.BatchSizes...) {
+		if size <= 0 {
+			return Config{}, fmt.Errorf("dependency sizes must be positive")
+		}
+	}
+	return cfg, nil
+}
+
+func measure(ctx context.Context, cfg Config, operation, shape string, size, iteration int) (Result, error) {
+	store := casmock.NewCAS(
+		casmock.WithGetLatency(ms(cfg.GetLatencyMS)),
+		casmock.WithPutLatency(ms(cfg.PutLatencyMS)),
+		casmock.WithHasLatency(ms(cfg.HasLatencyMS)),
+		casmock.WithJitter(ms(cfg.JitterMS)),
+	)
+
+	payloads := payloadsFor(operation, shape, size, iteration)
+	cids, err := seedForRead(ctx, store, operation, payloads)
+	if err != nil {
+		return Result{}, err
+	}
+	store.ResetStats()
+
+	start := time.Now()
+	switch operation {
+	case "put":
+		if shape == "batch" {
+			blocks := make([]cas.Block, len(payloads))
+			for i, payload := range payloads {
+				blocks[i] = cas.Block{Data: payload}
+			}
+			if _, err := store.PutBatch(ctx, blocks); err != nil {
+				return Result{}, fmt.Errorf("put batch: %w", err)
+			}
+			break
+		}
+		for _, payload := range payloads {
+			if err := ctx.Err(); err != nil {
+				return Result{}, err
+			}
+			if _, err := store.Put(ctx, payload); err != nil {
+				return Result{}, fmt.Errorf("put chain: %w", err)
+			}
+		}
+	case "get":
+		for _, block := range cids {
+			if err := ctx.Err(); err != nil {
+				return Result{}, err
+			}
+			if _, err := store.Get(ctx, block); err != nil {
+				return Result{}, fmt.Errorf("get %s: %w", shape, err)
+			}
+		}
+	case "has":
+		if shape == "batch" {
+			if _, err := store.HasBatch(ctx, cids); err != nil {
+				return Result{}, fmt.Errorf("has batch: %w", err)
+			}
+			break
+		}
+		for _, block := range cids {
+			if err := ctx.Err(); err != nil {
+				return Result{}, err
+			}
+			if _, err := store.Has(ctx, block); err != nil {
+				return Result{}, fmt.Errorf("has chain: %w", err)
+			}
+		}
+	default:
+		return Result{}, fmt.Errorf("unsupported operation %q", operation)
+	}
+	elapsed := time.Since(start).Nanoseconds()
+
+	return Result{
+		Operation:           operation,
+		DependencyShape:     shape,
+		Size:                size,
+		Iteration:           iteration,
+		ElapsedNS:           elapsed,
+		ConfiguredLatencyMS: configuredLatency(cfg, operation),
+		ConfiguredJitterMS:  cfg.JitterMS,
+		CAS:                 store.SnapshotStats(),
+	}, nil
+}
+
+func seedForRead(ctx context.Context, store *casmock.CAS, operation string, payloads [][]byte) ([]cid.Cid, error) {
+	if operation == "put" {
+		return nil, nil
+	}
+	cids := make([]cid.Cid, len(payloads))
+	for i, payload := range payloads {
+		blockCID, err := cas.CIDForBlock(cas.Block{Data: payload})
+		if err != nil {
+			return nil, err
+		}
+		store.AddBlock(blockCID, payload)
+		cids[i] = blockCID
+	}
+	return cids, ctx.Err()
+}
+
+func payloadsFor(operation, shape string, size, iteration int) [][]byte {
+	payloads := make([][]byte, size)
+	for i := range payloads {
+		payloads[i] = []byte(fmt.Sprintf("cas-model:%s:%s:%d:%d", operation, shape, iteration, i))
+	}
+	return payloads
+}
+
+func configuredLatency(cfg Config, operation string) int {
+	switch operation {
+	case "get":
+		return cfg.GetLatencyMS
+	case "put":
+		return cfg.PutLatencyMS
+	case "has":
+		return cfg.HasLatencyMS
+	default:
+		return 0
+	}
+}
+
+func ms(value int) time.Duration {
+	return time.Duration(value) * time.Millisecond
+}

--- a/internal/eval/suites/casmodel/suite_test.go
+++ b/internal/eval/suites/casmodel/suite_test.go
@@ -74,6 +74,12 @@ func TestSuiteEmitsDeterministicCASModelRecords(t *testing.T) {
 	}
 }
 
+func TestParseConfigRejectsUnknownFields(t *testing.T) {
+	if _, err := parseConfig(json.RawMessage(`{"iterationz": 1}`)); err == nil {
+		t.Fatal("parseConfig should reject unknown fields")
+	}
+}
+
 func readCASModelRecords(t *testing.T, path string) []Result {
 	t.Helper()
 	f, err := os.Open(path)

--- a/internal/eval/suites/casmodel/suite_test.go
+++ b/internal/eval/suites/casmodel/suite_test.go
@@ -1,0 +1,105 @@
+package casmodel
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+)
+
+func TestSuiteEmitsDeterministicCASModelRecords(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "raw"), 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+
+	cfg := json.RawMessage(`{
+		"get_latency_ms": 0,
+		"put_latency_ms": 0,
+		"has_latency_ms": 0,
+		"chain_lengths": [2],
+		"batch_sizes": [3],
+		"iterations": 1
+	}`)
+	suite := Suite{}
+	if suite.Name() != "cas_model" {
+		t.Fatalf("Name() = %q, want cas_model", suite.Name())
+	}
+
+	if err := suite.Run(context.Background(), framework.Env{
+		RunID:     "run-cas",
+		OutputDir: tmp,
+	}, cfg); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	records := readCASModelRecords(t, filepath.Join(tmp, "raw", "cas_model.jsonl"))
+	if len(records) != 6 {
+		t.Fatalf("record count = %d, want 6", len(records))
+	}
+
+	var putChain, hasBatch bool
+	for _, record := range records {
+		if record.ConfiguredJitterMS != 0 {
+			t.Fatalf("configured_jitter_ms = %d, want default 0", record.ConfiguredJitterMS)
+		}
+		if record.ElapsedNS < 0 {
+			t.Fatalf("elapsed_ns = %d, want non-negative", record.ElapsedNS)
+		}
+		if record.Operation == "put" && record.DependencyShape == "chain" {
+			putChain = true
+			if record.Size != 2 || record.Iteration != 0 {
+				t.Fatalf("put chain size/iteration = %d/%d, want 2/0", record.Size, record.Iteration)
+			}
+			if record.CAS.PutCount != 2 || record.CAS.BytesPut == 0 {
+				t.Fatalf("put chain CAS stats = %+v, want two puts with bytes", record.CAS)
+			}
+		}
+		if record.Operation == "has" && record.DependencyShape == "batch" {
+			hasBatch = true
+			if record.Size != 3 {
+				t.Fatalf("has batch size = %d, want 3", record.Size)
+			}
+			if record.CAS.HasCount != 3 {
+				t.Fatalf("has batch CAS stats = %+v, want three has calls", record.CAS)
+			}
+		}
+	}
+	if !putChain || !hasBatch {
+		t.Fatalf("missing put chain=%v or has batch=%v records", putChain, hasBatch)
+	}
+}
+
+func readCASModelRecords(t *testing.T, path string) []Result {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open records: %v", err)
+	}
+	defer f.Close()
+
+	var out []Result
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var envelope framework.RecordEnvelope
+		if err := json.Unmarshal(scanner.Bytes(), &envelope); err != nil {
+			t.Fatalf("unmarshal envelope: %v", err)
+		}
+		if envelope.Suite != "cas_model" {
+			t.Fatalf("suite = %q, want cas_model", envelope.Suite)
+		}
+		var record Result
+		if err := json.Unmarshal(envelope.Record, &record); err != nil {
+			t.Fatalf("unmarshal record: %v", err)
+		}
+		out = append(out, record)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan records: %v", err)
+	}
+	return out
+}

--- a/internal/eval/suites/configjson/configjson.go
+++ b/internal/eval/suites/configjson/configjson.go
@@ -1,0 +1,30 @@
+// Package configjson decodes evaluation suite config JSON consistently.
+package configjson
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Decode unmarshals one suite config object while rejecting unknown fields.
+func Decode(raw json.RawMessage, suite string, out any) error {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(out); err != nil {
+		return fmt.Errorf("parse %s config: %w", suite, err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("parse %s config: unexpected trailing JSON", suite)
+		}
+		return fmt.Errorf("parse %s config: %w", suite, err)
+	}
+	return nil
+}

--- a/internal/eval/suites/proofoverhead/suite.go
+++ b/internal/eval/suites/proofoverhead/suite.go
@@ -8,7 +8,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dewebprotocol/malt/core/arctable/overwrite"
+	"github.com/dewebprotocol/malt/core/arctable"
+	"github.com/dewebprotocol/malt/core/arctable/versioned"
 	"github.com/dewebprotocol/malt/core/cas"
 	"github.com/dewebprotocol/malt/core/commitment"
 	"github.com/dewebprotocol/malt/core/commitment/ipa"
@@ -18,13 +19,19 @@ import (
 	"github.com/dewebprotocol/malt/core/structure/list"
 	listtree "github.com/dewebprotocol/malt/core/structure/list/tree"
 	"github.com/dewebprotocol/malt/core/structure/mapping"
-	"github.com/dewebprotocol/malt/core/structure/mapping/indexed"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/internal/eval/framework"
 	cid "github.com/ipfs/go-cid"
 )
 
 const suiteName = "proof_overhead"
+
+const (
+	arcTableModeVersioned = "versioned"
+	mapBackendRadix       = "radix"
+	listBackendTree       = "tree"
+)
 
 // Suite implements the proof overhead evaluation.
 type Suite struct{}
@@ -41,6 +48,9 @@ type Config struct {
 type Result struct {
 	Structure       string `json:"structure"`
 	Commitment      string `json:"commitment"`
+	ArcTableMode    string `json:"arctable_mode,omitempty"`
+	MapBackend      string `json:"map_backend,omitempty"`
+	ListBackend     string `json:"list_backend,omitempty"`
 	Size            int    `json:"size"`
 	Iteration       int    `json:"iteration"`
 	Method          string `json:"method"`
@@ -150,11 +160,13 @@ func parseCommitments(raw json.RawMessage) ([]string, error) {
 
 func measure(ctx context.Context, structureName, commitmentName string, size, iteration int) (Result, error) {
 	base := Result{
-		Structure:  structureName,
-		Commitment: commitmentName,
-		Size:       size,
-		Iteration:  iteration,
+		Structure:    structureName,
+		Commitment:   commitmentName,
+		ArcTableMode: arcTableModeVersioned,
+		Size:         size,
+		Iteration:    iteration,
 	}
+	labelStructureBackend(&base)
 	scheme, err := newScheme(commitmentName)
 	if err != nil {
 		base.Method = "unsupported"
@@ -187,7 +199,7 @@ func measureMap(ctx context.Context, scheme commitment.IndexCommitment, commitme
 		return Result{}, err
 	}
 	defer table.Close()
-	semantics, err := indexed.NewMap(scheme, table)
+	semantics, err := mappingradix.NewMap(scheme, table)
 	if err != nil {
 		return Result{}, err
 	}
@@ -267,9 +279,10 @@ func measureList(ctx context.Context, scheme commitment.IndexCommitment, commitm
 }
 
 func measuredResult(structureName, commitmentName string, size, iteration int, commitElapsed, proveElapsed, verifyElapsed int64, proof structure.Proof, verified bool) Result {
-	return Result{
+	result := Result{
 		Structure:       structureName,
 		Commitment:      commitmentName,
+		ArcTableMode:    arcTableModeVersioned,
 		Size:            size,
 		Iteration:       iteration,
 		Method:          "measured",
@@ -279,6 +292,17 @@ func measuredResult(structureName, commitmentName string, size, iteration int, c
 		ProofBytes:      len(proof),
 		EvidenceCount:   evidenceCount(structureName, proof),
 		Verified:        &verified,
+	}
+	labelStructureBackend(&result)
+	return result
+}
+
+func labelStructureBackend(result *Result) {
+	switch result.Structure {
+	case "map":
+		result.MapBackend = mapBackendRadix
+	case "list":
+		result.ListBackend = listBackendTree
 	}
 }
 
@@ -293,8 +317,8 @@ func newScheme(name string) (commitment.IndexCommitment, error) {
 	}
 }
 
-func newArcTable() (*overwrite.ArcTable, error) {
-	return overwrite.NewArcTable(overwrite.WithKVStore(memory.New()))
+func newArcTable() (arctable.ArcTable, error) {
+	return versioned.NewArcTable(versioned.WithKVStore(memory.New()))
 }
 
 func deterministicCIDs(prefix string, size int) ([]cid.Cid, error) {

--- a/internal/eval/suites/proofoverhead/suite.go
+++ b/internal/eval/suites/proofoverhead/suite.go
@@ -22,6 +22,7 @@ import (
 	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/internal/eval/framework"
+	"github.com/dewebprotocol/malt/internal/eval/suites/configjson"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -107,8 +108,8 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 			Iterations int             `json:"iterations"`
 			Commitment json.RawMessage `json:"commitment"`
 		}
-		if err := json.Unmarshal(raw, &parsed); err != nil {
-			return Config{}, fmt.Errorf("parse proof_overhead config: %w", err)
+		if err := configjson.Decode(raw, suiteName, &parsed); err != nil {
+			return Config{}, err
 		}
 		cfg.Structures = parsed.Structures
 		cfg.Sizes = parsed.Sizes

--- a/internal/eval/suites/proofoverhead/suite.go
+++ b/internal/eval/suites/proofoverhead/suite.go
@@ -1,0 +1,346 @@
+// Package proofoverhead measures local commit/prove/verify costs for semantic structures.
+package proofoverhead
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/dewebprotocol/malt/core/arctable/overwrite"
+	"github.com/dewebprotocol/malt/core/cas"
+	"github.com/dewebprotocol/malt/core/commitment"
+	"github.com/dewebprotocol/malt/core/commitment/ipa"
+	"github.com/dewebprotocol/malt/core/commitment/kzg"
+	"github.com/dewebprotocol/malt/core/kvstore/memory"
+	"github.com/dewebprotocol/malt/core/structure"
+	"github.com/dewebprotocol/malt/core/structure/list"
+	listtree "github.com/dewebprotocol/malt/core/structure/list/tree"
+	"github.com/dewebprotocol/malt/core/structure/mapping"
+	"github.com/dewebprotocol/malt/core/structure/mapping/indexed"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+	cid "github.com/ipfs/go-cid"
+)
+
+const suiteName = "proof_overhead"
+
+// Suite implements the proof overhead evaluation.
+type Suite struct{}
+
+// Config controls proof overhead dimensions.
+type Config struct {
+	Structures  []string `json:"structures"`
+	Sizes       []int    `json:"sizes"`
+	Iterations  int      `json:"iterations"`
+	Commitments []string `json:"commitment"`
+}
+
+// Result is one proof overhead record.
+type Result struct {
+	Structure       string `json:"structure"`
+	Commitment      string `json:"commitment"`
+	Size            int    `json:"size"`
+	Iteration       int    `json:"iteration"`
+	Method          string `json:"method"`
+	CommitElapsedNS int64  `json:"commit_elapsed_ns,omitempty"`
+	ProveElapsedNS  int64  `json:"prove_elapsed_ns,omitempty"`
+	VerifyElapsedNS int64  `json:"verify_elapsed_ns,omitempty"`
+	ProofBytes      int    `json:"proof_bytes"`
+	EvidenceCount   int    `json:"evidence_count"`
+	Verified        *bool  `json:"verified,omitempty"`
+	Error           string `json:"error,omitempty"`
+}
+
+// Name returns the stable suite name.
+func (Suite) Name() string {
+	return suiteName
+}
+
+// Run executes the configured proof overhead matrix.
+func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) error {
+	cfg, err := parseConfig(raw)
+	if err != nil {
+		return err
+	}
+
+	for iteration := 0; iteration < cfg.Iterations; iteration++ {
+		for _, structureName := range cfg.Structures {
+			for _, size := range cfg.Sizes {
+				for _, commitmentName := range cfg.Commitments {
+					record, err := measure(ctx, structureName, commitmentName, size, iteration)
+					if err != nil {
+						return err
+					}
+					if err := env.WriteRecord(suiteName, record); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func parseConfig(raw json.RawMessage) (Config, error) {
+	cfg := Config{
+		Structures:  []string{"map", "list"},
+		Sizes:       []int{1},
+		Iterations:  1,
+		Commitments: []string{"ipa"},
+	}
+	if len(raw) != 0 {
+		var parsed struct {
+			Structures []string        `json:"structures"`
+			Sizes      []int           `json:"sizes"`
+			Iterations int             `json:"iterations"`
+			Commitment json.RawMessage `json:"commitment"`
+		}
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return Config{}, fmt.Errorf("parse proof_overhead config: %w", err)
+		}
+		cfg.Structures = parsed.Structures
+		cfg.Sizes = parsed.Sizes
+		cfg.Iterations = parsed.Iterations
+		if len(bytes.TrimSpace(parsed.Commitment)) != 0 && !bytes.Equal(bytes.TrimSpace(parsed.Commitment), []byte("null")) {
+			commitments, err := parseCommitments(parsed.Commitment)
+			if err != nil {
+				return Config{}, err
+			}
+			cfg.Commitments = commitments
+		} else {
+			cfg.Commitments = nil
+		}
+	}
+	if cfg.Structures == nil {
+		cfg.Structures = []string{"map", "list"}
+	}
+	if cfg.Sizes == nil {
+		cfg.Sizes = []int{1}
+	}
+	if cfg.Iterations == 0 {
+		cfg.Iterations = 1
+	}
+	if cfg.Commitments == nil {
+		cfg.Commitments = []string{"ipa"}
+	}
+	if cfg.Iterations < 0 {
+		return Config{}, fmt.Errorf("iterations must be non-negative")
+	}
+	for _, size := range cfg.Sizes {
+		if size <= 0 {
+			return Config{}, fmt.Errorf("sizes must be positive")
+		}
+	}
+	return cfg, nil
+}
+
+func parseCommitments(raw json.RawMessage) ([]string, error) {
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return []string{single}, nil
+	}
+	var many []string
+	if err := json.Unmarshal(raw, &many); err != nil {
+		return nil, fmt.Errorf("parse proof_overhead commitment: %w", err)
+	}
+	return many, nil
+}
+
+func measure(ctx context.Context, structureName, commitmentName string, size, iteration int) (Result, error) {
+	base := Result{
+		Structure:  structureName,
+		Commitment: commitmentName,
+		Size:       size,
+		Iteration:  iteration,
+	}
+	scheme, err := newScheme(commitmentName)
+	if err != nil {
+		base.Method = "unsupported"
+		base.Error = err.Error()
+		return base, nil
+	}
+
+	var measured Result
+	switch structureName {
+	case "map":
+		measured, err = measureMap(ctx, scheme, commitmentName, size, iteration)
+	case "list":
+		measured, err = measureList(ctx, scheme, commitmentName, size, iteration)
+	default:
+		base.Method = "unsupported"
+		base.Error = fmt.Sprintf("unsupported structure %q", structureName)
+		return base, nil
+	}
+	if err != nil {
+		base.Method = "unsupported"
+		base.Error = err.Error()
+		return base, nil
+	}
+	return measured, nil
+}
+
+func measureMap(ctx context.Context, scheme commitment.IndexCommitment, commitmentName string, size, iteration int) (Result, error) {
+	table, err := newArcTable()
+	if err != nil {
+		return Result{}, err
+	}
+	defer table.Close()
+	semantics, err := indexed.NewMap(scheme, table)
+	if err != nil {
+		return Result{}, err
+	}
+
+	values, err := deterministicCIDs("proof-map", size)
+	if err != nil {
+		return Result{}, err
+	}
+	entries := make(map[arcset.Path]cid.Cid, size)
+	for i, value := range values {
+		entries[mapPath(i)] = value
+	}
+	view := mapping.NewViewFromPaths(entries)
+	key := mapPath(size / 2)
+
+	start := time.Now()
+	root, err := semantics.Commit(ctx, namespace(iteration), view)
+	commitElapsed := time.Since(start).Nanoseconds()
+	if err != nil {
+		return Result{}, err
+	}
+
+	start = time.Now()
+	binding, proof, err := semantics.Prove(ctx, namespace(iteration), root, key)
+	proveElapsed := time.Since(start).Nanoseconds()
+	if err != nil {
+		return Result{}, err
+	}
+
+	start = time.Now()
+	ok, err := semantics.Verify(root, key, binding, proof)
+	verifyElapsed := time.Since(start).Nanoseconds()
+	if err != nil {
+		return Result{}, err
+	}
+	return measuredResult("map", commitmentName, size, iteration, commitElapsed, proveElapsed, verifyElapsed, proof, ok), nil
+}
+
+func measureList(ctx context.Context, scheme commitment.IndexCommitment, commitmentName string, size, iteration int) (Result, error) {
+	table, err := newArcTable()
+	if err != nil {
+		return Result{}, err
+	}
+	defer table.Close()
+	semantics, err := listtree.NewList(scheme, table)
+	if err != nil {
+		return Result{}, err
+	}
+
+	values, err := deterministicCIDs("proof-list", size)
+	if err != nil {
+		return Result{}, err
+	}
+	index := uint64(size / 2)
+
+	start := time.Now()
+	root, err := semantics.Commit(ctx, namespace(iteration), list.NewViewFromSlice(values))
+	commitElapsed := time.Since(start).Nanoseconds()
+	if err != nil {
+		return Result{}, err
+	}
+
+	start = time.Now()
+	query, proof, err := semantics.Prove(ctx, namespace(iteration), root, index)
+	proveElapsed := time.Since(start).Nanoseconds()
+	if err != nil {
+		return Result{}, err
+	}
+
+	start = time.Now()
+	ok, err := semantics.Verify(root, index, query, proof)
+	verifyElapsed := time.Since(start).Nanoseconds()
+	if err != nil {
+		return Result{}, err
+	}
+	return measuredResult("list", commitmentName, size, iteration, commitElapsed, proveElapsed, verifyElapsed, proof, ok), nil
+}
+
+func measuredResult(structureName, commitmentName string, size, iteration int, commitElapsed, proveElapsed, verifyElapsed int64, proof structure.Proof, verified bool) Result {
+	return Result{
+		Structure:       structureName,
+		Commitment:      commitmentName,
+		Size:            size,
+		Iteration:       iteration,
+		Method:          "measured",
+		CommitElapsedNS: commitElapsed,
+		ProveElapsedNS:  proveElapsed,
+		VerifyElapsedNS: verifyElapsed,
+		ProofBytes:      len(proof),
+		EvidenceCount:   evidenceCount(structureName, proof),
+		Verified:        &verified,
+	}
+}
+
+func newScheme(name string) (commitment.IndexCommitment, error) {
+	switch name {
+	case "ipa":
+		return ipa.NewScheme()
+	case "kzg":
+		return kzg.NewScheme()
+	default:
+		return nil, fmt.Errorf("unsupported commitment %q", name)
+	}
+}
+
+func newArcTable() (*overwrite.ArcTable, error) {
+	return overwrite.NewArcTable(overwrite.WithKVStore(memory.New()))
+}
+
+func deterministicCIDs(prefix string, size int) ([]cid.Cid, error) {
+	values := make([]cid.Cid, size)
+	for i := range values {
+		value, err := cas.CIDForBlock(cas.Block{Data: []byte(fmt.Sprintf("%s:%06d", prefix, i))})
+		if err != nil {
+			return nil, err
+		}
+		values[i] = value
+	}
+	return values, nil
+}
+
+func mapPath(index int) arcset.Path {
+	return arcset.CanonicalizePath(fmt.Sprintf("item/%06d", index))
+}
+
+func namespace(iteration int) string {
+	return fmt.Sprintf("proof-overhead-%d", iteration)
+}
+
+func evidenceCount(structureName string, proof []byte) int {
+	if len(proof) == 0 {
+		return 0
+	}
+	if structureName != "list" {
+		return 1
+	}
+	var envelope struct {
+		LengthProof []byte `json:"length_proof"`
+		Steps       []struct {
+			Proof []byte `json:"proof"`
+		} `json:"steps"`
+	}
+	if err := json.Unmarshal(proof, &envelope); err != nil {
+		return 1
+	}
+	count := 0
+	if len(envelope.LengthProof) > 0 {
+		count++
+	}
+	for _, step := range envelope.Steps {
+		if len(step.Proof) > 0 {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/eval/suites/proofoverhead/suite_test.go
+++ b/internal/eval/suites/proofoverhead/suite_test.go
@@ -1,0 +1,152 @@
+package proofoverhead
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+)
+
+func TestSuiteMeasuresMapAndListProofOverhead(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "raw"), 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+
+	cfg := json.RawMessage(`{
+		"structures": ["map", "list"],
+		"sizes": [2],
+		"iterations": 1,
+		"commitment": ["ipa"]
+	}`)
+	suite := Suite{}
+	if suite.Name() != "proof_overhead" {
+		t.Fatalf("Name() = %q, want proof_overhead", suite.Name())
+	}
+
+	if err := suite.Run(context.Background(), framework.Env{
+		RunID:     "run-proof",
+		OutputDir: tmp,
+	}, cfg); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	records := readProofRecords(t, filepath.Join(tmp, "raw", "proof_overhead.jsonl"))
+	if len(records) != 2 {
+		t.Fatalf("record count = %d, want 2", len(records))
+	}
+	for _, record := range records {
+		if record.Method != "measured" {
+			t.Fatalf("method = %q, want measured for %+v", record.Method, record)
+		}
+		if record.Commitment != "ipa" || record.Size != 2 || record.Iteration != 0 {
+			t.Fatalf("record dimensions = %+v, want ipa size 2 iteration 0", record)
+		}
+		if record.CommitElapsedNS < 0 || record.ProveElapsedNS < 0 || record.VerifyElapsedNS < 0 {
+			t.Fatalf("elapsed fields must be non-negative: %+v", record)
+		}
+		if record.ProofBytes == 0 || record.EvidenceCount == 0 {
+			t.Fatalf("proof accounting = proof_bytes %d evidence_count %d, want non-zero", record.ProofBytes, record.EvidenceCount)
+		}
+		if record.Verified == nil || !*record.Verified {
+			t.Fatalf("verified = %v, want true", record.Verified)
+		}
+	}
+}
+
+func TestSuiteReportsUnsupportedProofMethodWithoutFabricatingMetrics(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "raw"), 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+
+	cfg := json.RawMessage(`{
+		"structures": ["map"],
+		"sizes": [257],
+		"iterations": 1,
+		"commitment": ["ipa"]
+	}`)
+	if err := (Suite{}).Run(context.Background(), framework.Env{
+		RunID:     "run-proof-unsupported",
+		OutputDir: tmp,
+	}, cfg); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	records := readProofRecords(t, filepath.Join(tmp, "raw", "proof_overhead.jsonl"))
+	if len(records) != 1 {
+		t.Fatalf("record count = %d, want 1", len(records))
+	}
+	record := records[0]
+	if record.Method != "unsupported" {
+		t.Fatalf("method = %q, want unsupported", record.Method)
+	}
+	if record.ProofBytes != 0 || record.EvidenceCount != 0 || record.Verified != nil {
+		t.Fatalf("unsupported record fabricated metrics: %+v", record)
+	}
+	if record.Error == "" {
+		t.Fatalf("unsupported record should explain why: %+v", record)
+	}
+}
+
+func TestSuiteAcceptsSingleCommitmentConfigValue(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "raw"), 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+
+	cfg := json.RawMessage(`{
+		"structures": ["map"],
+		"sizes": [1],
+		"iterations": 1,
+		"commitment": "ipa"
+	}`)
+	if err := (Suite{}).Run(context.Background(), framework.Env{
+		RunID:     "run-proof-single-commitment",
+		OutputDir: tmp,
+	}, cfg); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	records := readProofRecords(t, filepath.Join(tmp, "raw", "proof_overhead.jsonl"))
+	if len(records) != 1 {
+		t.Fatalf("record count = %d, want 1", len(records))
+	}
+	if records[0].Commitment != "ipa" || records[0].Method != "measured" {
+		t.Fatalf("record = %+v, want measured ipa record", records[0])
+	}
+}
+
+func readProofRecords(t *testing.T, path string) []Result {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open records: %v", err)
+	}
+	defer f.Close()
+
+	var out []Result
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var envelope framework.RecordEnvelope
+		if err := json.Unmarshal(scanner.Bytes(), &envelope); err != nil {
+			t.Fatalf("unmarshal envelope: %v", err)
+		}
+		if envelope.Suite != "proof_overhead" {
+			t.Fatalf("suite = %q, want proof_overhead", envelope.Suite)
+		}
+		var record Result
+		if err := json.Unmarshal(envelope.Record, &record); err != nil {
+			t.Fatalf("unmarshal record: %v", err)
+		}
+		out = append(out, record)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan records: %v", err)
+	}
+	return out
+}

--- a/internal/eval/suites/proofoverhead/suite_test.go
+++ b/internal/eval/suites/proofoverhead/suite_test.go
@@ -168,6 +168,12 @@ func TestSuiteAcceptsSingleCommitmentConfigValue(t *testing.T) {
 	}
 }
 
+func TestParseConfigRejectsUnknownFields(t *testing.T) {
+	if _, err := parseConfig(json.RawMessage(`{"sizse": [1]}`)); err == nil {
+		t.Fatal("parseConfig should reject unknown fields")
+	}
+}
+
 func readProofRecords(t *testing.T, path string) []Result {
 	t.Helper()
 	f, err := os.Open(path)

--- a/internal/eval/suites/proofoverhead/suite_test.go
+++ b/internal/eval/suites/proofoverhead/suite_test.go
@@ -46,6 +46,21 @@ func TestSuiteMeasuresMapAndListProofOverhead(t *testing.T) {
 		if record.Commitment != "ipa" || record.Size != 2 || record.Iteration != 0 {
 			t.Fatalf("record dimensions = %+v, want ipa size 2 iteration 0", record)
 		}
+		switch record.Structure {
+		case "map":
+			if record.MapBackend != "radix" {
+				t.Fatalf("map backend = %q, want radix", record.MapBackend)
+			}
+		case "list":
+			if record.ListBackend != "tree" {
+				t.Fatalf("list backend = %q, want tree", record.ListBackend)
+			}
+		default:
+			t.Fatalf("unexpected structure = %q", record.Structure)
+		}
+		if record.ArcTableMode != "versioned" {
+			t.Fatalf("arctable mode = %q, want versioned", record.ArcTableMode)
+		}
 		if record.CommitElapsedNS < 0 || record.ProveElapsedNS < 0 || record.VerifyElapsedNS < 0 {
 			t.Fatalf("elapsed fields must be non-negative: %+v", record)
 		}
@@ -58,7 +73,7 @@ func TestSuiteMeasuresMapAndListProofOverhead(t *testing.T) {
 	}
 }
 
-func TestSuiteReportsUnsupportedProofMethodWithoutFabricatingMetrics(t *testing.T) {
+func TestSuiteUsesRuntimeRadixMapForLargeMapProofs(t *testing.T) {
 	tmp := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmp, "raw"), 0o755); err != nil {
 		t.Fatalf("mkdir raw: %v", err)
@@ -69,6 +84,38 @@ func TestSuiteReportsUnsupportedProofMethodWithoutFabricatingMetrics(t *testing.
 		"sizes": [257],
 		"iterations": 1,
 		"commitment": ["ipa"]
+	}`)
+	if err := (Suite{}).Run(context.Background(), framework.Env{
+		RunID:     "run-proof-radix-map",
+		OutputDir: tmp,
+	}, cfg); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	records := readProofRecords(t, filepath.Join(tmp, "raw", "proof_overhead.jsonl"))
+	if len(records) != 1 {
+		t.Fatalf("record count = %d, want 1", len(records))
+	}
+	record := records[0]
+	if record.Method != "measured" {
+		t.Fatalf("method = %q, want measured for runtime radix map: %+v", record.Method, record)
+	}
+	if record.MapBackend != "radix" || record.ArcTableMode != "versioned" {
+		t.Fatalf("runtime backend labels = %+v, want radix/versioned", record)
+	}
+}
+
+func TestSuiteReportsUnsupportedProofMethodWithoutFabricatingMetrics(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "raw"), 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+
+	cfg := json.RawMessage(`{
+		"structures": ["map"],
+		"sizes": [1],
+		"iterations": 1,
+		"commitment": ["unknown"]
 	}`)
 	if err := (Suite{}).Run(context.Background(), framework.Env{
 		RunID:     "run-proof-unsupported",

--- a/internal/eval/suites/readquery/doc.go
+++ b/internal/eval/suites/readquery/doc.go
@@ -1,0 +1,2 @@
+// Package readquery adapts the read benchmark runner to the evaluation framework.
+package readquery

--- a/internal/eval/suites/readquery/schema.go
+++ b/internal/eval/suites/readquery/schema.go
@@ -1,0 +1,5 @@
+package readquery
+
+// ResultSchemaPath is the repository-relative JSON Schema for one read_query
+// suite record before the common framework envelope is applied.
+const ResultSchemaPath = "cmd/eval/schemas/read-query-result.schema.json"

--- a/internal/eval/suites/readquery/suite.go
+++ b/internal/eval/suites/readquery/suite.go
@@ -1,0 +1,207 @@
+package readquery
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/dewebprotocol/malt/config"
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+	"github.com/dewebprotocol/malt/internal/eval/readbench"
+)
+
+// Name is the fixed evaluation framework suite name.
+const Name = "read_query"
+
+// Suite adapts readbench.Runner to the unified evaluation framework.
+type Suite struct{}
+
+// Config is the normalized read_query suite configuration.
+type Config struct {
+	Systems    []readbench.SystemName `json:"systems"`
+	Fixture    string                 `json:"fixture"`
+	Depth      int                    `json:"depth"`
+	SmallBytes int                    `json:"small_bytes"`
+	LargeBytes int                    `json:"large_bytes"`
+	Range      string                 `json:"range"`
+	Iterations int                    `json:"iterations"`
+	APIBaseURL string                 `json:"api_base_url"`
+	Arcs       map[string]string      `json:"arcs"`
+}
+
+type rawConfig struct {
+	Systems    json.RawMessage   `json:"systems"`
+	Fixture    string            `json:"fixture"`
+	Depth      *int              `json:"depth"`
+	SmallBytes *int              `json:"small_bytes"`
+	LargeBytes *int              `json:"large_bytes"`
+	Range      string            `json:"range"`
+	Iterations *int              `json:"iterations"`
+	APIBaseURL string            `json:"api_base_url"`
+	Arcs       map[string]string `json:"arcs"`
+}
+
+// Name returns the fixed suite name expected by framework plans.
+func (Suite) Name() string {
+	return Name
+}
+
+// Run executes the read query suite and writes framework-enveloped records.
+func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cfg, err := parseConfig(raw)
+	if err != nil {
+		return err
+	}
+	if err := validateMALTFlatArcs(cfg); err != nil {
+		return err
+	}
+	apiBaseURL, err := resolveAPIBaseURL(cfg)
+	if err != nil {
+		return err
+	}
+
+	var out bytes.Buffer
+	runner := readbench.NewRunner(apiBaseURL)
+	if err := runner.RunJSONL(ctx, readbench.RunConfig{
+		Systems: cfg.Systems,
+		Fixture: readbench.FixtureConfig{
+			FixtureName:    cfg.Fixture,
+			DirectoryDepth: cfg.Depth,
+			SmallFileBytes: cfg.SmallBytes,
+			LargeFileBytes: cfg.LargeBytes,
+			Arcs:           cfg.Arcs,
+		},
+		RangeHeader: cfg.Range,
+		Iterations:  cfg.Iterations,
+	}, &out); err != nil {
+		return err
+	}
+	return writeEnvelopedResults(env, out.Bytes())
+}
+
+func parseConfig(raw json.RawMessage) (Config, error) {
+	cfg := Config{
+		Systems:    readbench.DefaultSystems(),
+		Depth:      readbench.DefaultDirectoryDepth,
+		SmallBytes: readbench.DefaultSmallFileBytes,
+		LargeBytes: readbench.DefaultLargeFileBytes,
+		Range:      readbench.DefaultRangeHeader,
+		Iterations: readbench.DefaultIterations,
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return cfg, nil
+	}
+
+	var parsed rawConfig
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&parsed); err != nil {
+		return Config{}, fmt.Errorf("decode read_query config: %w", err)
+	}
+
+	systems, err := parseSystems(parsed.Systems)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Systems = systems
+	cfg.Fixture = parsed.Fixture
+	if parsed.Depth != nil {
+		cfg.Depth = *parsed.Depth
+	}
+	if parsed.SmallBytes != nil {
+		cfg.SmallBytes = *parsed.SmallBytes
+	}
+	if parsed.LargeBytes != nil {
+		cfg.LargeBytes = *parsed.LargeBytes
+	}
+	if strings.TrimSpace(parsed.Range) != "" {
+		cfg.Range = parsed.Range
+	}
+	if parsed.Iterations != nil {
+		cfg.Iterations = *parsed.Iterations
+	}
+	cfg.APIBaseURL = parsed.APIBaseURL
+	cfg.Arcs = parsed.Arcs
+	return cfg, nil
+}
+
+func parseSystems(raw json.RawMessage) ([]readbench.SystemName, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return readbench.DefaultSystems(), nil
+	}
+
+	var csv string
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		if err := json.Unmarshal(trimmed, &csv); err != nil {
+			return nil, fmt.Errorf("decode systems: %w", err)
+		}
+		return readbench.ParseSystemsCSV(csv)
+	}
+
+	var names []string
+	if err := json.Unmarshal(trimmed, &names); err != nil {
+		return nil, fmt.Errorf("decode systems: expected string or string array: %w", err)
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no systems selected")
+	}
+	return readbench.ParseSystemsCSV(strings.Join(names, ","))
+}
+
+func validateMALTFlatArcs(cfg Config) error {
+	if !systemsInclude(cfg.Systems, readbench.SystemMALTFlat) {
+		return nil
+	}
+	if strings.TrimSpace(cfg.Arcs["@payload"]) == "" {
+		return fmt.Errorf(`read_query requires arcs["@payload"] when maltflat is selected`)
+	}
+	return nil
+}
+
+func resolveAPIBaseURL(cfg Config) (string, error) {
+	if !systemsInclude(cfg.Systems, readbench.SystemMALTFlat) {
+		return cfg.APIBaseURL, nil
+	}
+	if strings.TrimSpace(cfg.APIBaseURL) != "" {
+		return cfg.APIBaseURL, nil
+	}
+	cfgFile, err := config.Load()
+	if err != nil {
+		return "", fmt.Errorf("load default config for read_query API base URL: %w", err)
+	}
+	return cfgFile.APIBaseURL(), nil
+}
+
+func systemsInclude(systems []readbench.SystemName, target readbench.SystemName) bool {
+	for _, system := range systems {
+		if system == target {
+			return true
+		}
+	}
+	return false
+}
+
+func writeEnvelopedResults(env framework.Env, data []byte) error {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		var result readbench.Result
+		if err := json.Unmarshal(scanner.Bytes(), &result); err != nil {
+			return fmt.Errorf("decode readbench JSONL result: %w", err)
+		}
+		if err := env.WriteRecord(Name, result); err != nil {
+			return fmt.Errorf("write read_query record: %w", err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan readbench JSONL results: %w", err)
+	}
+	return nil
+}

--- a/internal/eval/suites/readquery/suite_test.go
+++ b/internal/eval/suites/readquery/suite_test.go
@@ -1,0 +1,370 @@
+package readquery
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+	"github.com/dewebprotocol/malt/internal/eval/readbench"
+)
+
+func TestSuiteNameIsReadQuery(t *testing.T) {
+	if got := (Suite{}).Name(); got != Name {
+		t.Fatalf("Suite.Name() = %q, want %q", got, Name)
+	}
+	if Name != "read_query" {
+		t.Fatalf("Name = %q, want read_query", Name)
+	}
+}
+
+func TestParseConfigDefaultsMatchReadBenchAndEvalRead(t *testing.T) {
+	cfg, err := parseConfig(nil)
+	if err != nil {
+		t.Fatalf("parseConfig() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(cfg.Systems, readbench.DefaultSystems()) {
+		t.Fatalf("systems = %q, want %q", cfg.Systems, readbench.DefaultSystems())
+	}
+	if cfg.Fixture != "" {
+		t.Fatalf("fixture = %q, want empty for generated readbench fixture", cfg.Fixture)
+	}
+	if cfg.Depth != readbench.DefaultDirectoryDepth {
+		t.Fatalf("depth = %d, want %d", cfg.Depth, readbench.DefaultDirectoryDepth)
+	}
+	if cfg.SmallBytes != readbench.DefaultSmallFileBytes {
+		t.Fatalf("small bytes = %d, want %d", cfg.SmallBytes, readbench.DefaultSmallFileBytes)
+	}
+	if cfg.LargeBytes != readbench.DefaultLargeFileBytes {
+		t.Fatalf("large bytes = %d, want %d", cfg.LargeBytes, readbench.DefaultLargeFileBytes)
+	}
+	if cfg.Range != readbench.DefaultRangeHeader {
+		t.Fatalf("range = %q, want %q", cfg.Range, readbench.DefaultRangeHeader)
+	}
+	if cfg.Iterations != readbench.DefaultIterations {
+		t.Fatalf("iterations = %d, want %d", cfg.Iterations, readbench.DefaultIterations)
+	}
+	if cfg.APIBaseURL != "" {
+		t.Fatalf("api base url = %q, want empty until maltflat execution needs config default", cfg.APIBaseURL)
+	}
+	if len(cfg.Arcs) != 0 {
+		t.Fatalf("arcs = %#v, want empty", cfg.Arcs)
+	}
+}
+
+func TestParseConfigSupportsReadQueryFields(t *testing.T) {
+	cfg, err := parseConfig(json.RawMessage(`{
+		"systems": ["merkledag", "hamt"],
+		"fixture": "custom-read-fixture",
+		"depth": 0,
+		"small_bytes": 128,
+		"large_bytes": 262145,
+		"range": "bytes=5-9",
+		"iterations": 0,
+		"api_base_url": "http://127.0.0.1:4317/",
+		"arcs": {
+			"@payload": "bafyPayload",
+			"seed": "bafySeed"
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("parseConfig() error = %v", err)
+	}
+
+	wantSystems := []readbench.SystemName{readbench.SystemMerkleDAG, readbench.SystemHAMT}
+	if !reflect.DeepEqual(cfg.Systems, wantSystems) {
+		t.Fatalf("systems = %q, want %q", cfg.Systems, wantSystems)
+	}
+	if cfg.Fixture != "custom-read-fixture" {
+		t.Fatalf("fixture = %q", cfg.Fixture)
+	}
+	if cfg.Depth != 0 {
+		t.Fatalf("depth = %d, want explicit zero", cfg.Depth)
+	}
+	if cfg.SmallBytes != 128 || cfg.LargeBytes != 262145 {
+		t.Fatalf("bytes = small %d large %d", cfg.SmallBytes, cfg.LargeBytes)
+	}
+	if cfg.Range != "bytes=5-9" || cfg.Iterations != 0 {
+		t.Fatalf("range/iterations = %q/%d", cfg.Range, cfg.Iterations)
+	}
+	if cfg.APIBaseURL != "http://127.0.0.1:4317/" {
+		t.Fatalf("api base url = %q", cfg.APIBaseURL)
+	}
+	if cfg.Arcs["@payload"] != "bafyPayload" || cfg.Arcs["seed"] != "bafySeed" {
+		t.Fatalf("arcs = %#v", cfg.Arcs)
+	}
+}
+
+func TestRunAllowsBaselineOnlyWithoutDaemonArcs(t *testing.T) {
+	env := newSuiteTestEnv(t, "run-baseline")
+	err := (Suite{}).Run(context.Background(), env, json.RawMessage(`{
+		"systems": ["merkledag"],
+		"fixture": "baseline-only",
+		"api_base_url": "http://127.0.0.1:1"
+	}`))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	envelopes := readRawEnvelopes(t, env.RawPath(Name))
+	if len(envelopes) != 2 {
+		t.Fatalf("envelope count = %d, want 2", len(envelopes))
+	}
+	for _, envelope := range envelopes {
+		result := decodeEnvelopeResult(t, envelope)
+		if result.System != readbench.SystemMerkleDAG {
+			t.Fatalf("system = %q, want merkledag", result.System)
+		}
+		if result.FixtureName != "baseline-only" {
+			t.Fatalf("fixture = %q, want baseline-only", result.FixtureName)
+		}
+	}
+}
+
+func TestRunRejectsMALTFlatWithoutPayloadArc(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+	}{
+		{
+			name: "missing arcs",
+			raw:  json.RawMessage(`{"systems":["maltflat"],"fixture":"missing-arcs"}`),
+		},
+		{
+			name: "missing payload",
+			raw:  json.RawMessage(`{"systems":["maltflat"],"fixture":"missing-payload","arcs":{"seed":"bafySeed"}}`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newSuiteTestEnv(t, "run-maltflat-missing-arcs")
+			err := (Suite{}).Run(context.Background(), env, tt.raw)
+			if err == nil {
+				t.Fatal("Run() should reject maltflat config without arcs[@payload]")
+			}
+			if !bytes.Contains([]byte(err.Error()), []byte(`read_query requires arcs["@payload"] when maltflat is selected`)) {
+				t.Fatalf("error = %q", err)
+			}
+		})
+	}
+}
+
+func TestFrameworkRunWritesEnvelopedReadQueryRecords(t *testing.T) {
+	tmp := t.TempDir()
+	reg := framework.NewRegistry()
+	if err := reg.Register(Suite{}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	plan := framework.Plan{
+		RunID:     "run-read-query",
+		OutputDir: filepath.Join(tmp, "out"),
+		Suites: []framework.SuitePlan{{
+			Name: Name,
+			Config: json.RawMessage(`{
+				"systems": ["hamt"],
+				"fixture": "read-query-envelope",
+				"range": "bytes=3-6"
+			}`),
+		}},
+	}
+
+	if err := framework.Run(context.Background(), plan, reg, framework.RunOptions{}); err != nil {
+		t.Fatalf("framework.Run() error = %v", err)
+	}
+
+	envelopes := readRawEnvelopes(t, filepath.Join(plan.OutputDir, "raw", "read_query.jsonl"))
+	if len(envelopes) != 2 {
+		t.Fatalf("envelope count = %d, want 2", len(envelopes))
+	}
+
+	for _, envelope := range envelopes {
+		if envelope.SchemaVersion != framework.SchemaVersion {
+			t.Fatalf("schema version = %q, want %q", envelope.SchemaVersion, framework.SchemaVersion)
+		}
+		if envelope.RunID != "run-read-query" {
+			t.Fatalf("run id = %q, want run-read-query", envelope.RunID)
+		}
+		if envelope.Suite != Name {
+			t.Fatalf("suite = %q, want %q", envelope.Suite, Name)
+		}
+		result := decodeEnvelopeResult(t, envelope)
+		if result.System != readbench.SystemHAMT {
+			t.Fatalf("record system = %q, want hamt", result.System)
+		}
+		if result.ElapsedNS <= 0 {
+			t.Fatalf("elapsed_ns = %d, want > 0", result.ElapsedNS)
+		}
+		if result.CAS.GetCount == 0 || result.CAS.BytesGet == 0 {
+			t.Fatalf("CAS metrics not preserved in envelope record: %+v", result.CAS)
+		}
+	}
+	rangeResult := decodeEnvelopeResult(t, envelopes[1])
+	if rangeResult.OperationKind != readbench.OperationContentRange {
+		t.Fatalf("second operation = %q, want content_range", rangeResult.OperationKind)
+	}
+	if rangeResult.RangeHeader != "bytes=3-6" {
+		t.Fatalf("range header = %q, want bytes=3-6", rangeResult.RangeHeader)
+	}
+	if rangeResult.ContentBytes == nil || *rangeResult.ContentBytes != 4 {
+		t.Fatalf("content bytes = %v, want 4", rangeResult.ContentBytes)
+	}
+}
+
+func TestResultSchemaIsCheckedInForReadBenchResult(t *testing.T) {
+	schema := readResultSchema(t)
+	if schema.Schema == "" || schema.ID == "" {
+		t.Fatalf("schema must declare $schema and $id: %+v", schema)
+	}
+	if schema.Type != "object" {
+		t.Fatalf("schema type = %q, want object", schema.Type)
+	}
+	if schema.AdditionalProperties {
+		t.Fatal("read query result schema should reject unknown top-level fields")
+	}
+
+	wantFields, wantRequired := readbenchResultJSONFields(t)
+	for fieldName := range wantFields {
+		if _, ok := schema.Properties[fieldName]; !ok {
+			t.Fatalf("schema missing Result field %q", fieldName)
+		}
+	}
+	for fieldName := range schema.Properties {
+		if _, ok := wantFields[fieldName]; !ok {
+			t.Fatalf("schema has unknown top-level field %q", fieldName)
+		}
+	}
+	for fieldName := range wantRequired {
+		if !containsString(schema.Required, fieldName) {
+			t.Fatalf("schema required list missing %q", fieldName)
+		}
+	}
+}
+
+func newSuiteTestEnv(t *testing.T, runID string) framework.Env {
+	t.Helper()
+
+	outputDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(outputDir, "raw"), 0o755); err != nil {
+		t.Fatalf("create raw dir: %v", err)
+	}
+	return framework.Env{
+		RunID:     runID,
+		OutputDir: outputDir,
+	}
+}
+
+func readRawEnvelopes(t *testing.T, path string) []framework.RecordEnvelope {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open raw output: %v", err)
+	}
+	defer f.Close()
+
+	var out []framework.RecordEnvelope
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var envelope framework.RecordEnvelope
+		if err := json.Unmarshal(scanner.Bytes(), &envelope); err != nil {
+			t.Fatalf("decode envelope %q: %v", scanner.Text(), err)
+		}
+		out = append(out, envelope)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan raw output: %v", err)
+	}
+	return out
+}
+
+func decodeEnvelopeResult(t *testing.T, envelope framework.RecordEnvelope) readbench.Result {
+	t.Helper()
+
+	var result readbench.Result
+	if err := json.Unmarshal(envelope.Record, &result); err != nil {
+		t.Fatalf("decode readbench result: %v", err)
+	}
+	return result
+}
+
+type jsonSchema struct {
+	Schema               string                  `json:"$schema"`
+	ID                   string                  `json:"$id"`
+	Title                string                  `json:"title"`
+	Type                 string                  `json:"type"`
+	AdditionalProperties bool                    `json:"additionalProperties"`
+	Required             []string                `json:"required"`
+	Properties           map[string]schemaObject `json:"properties"`
+}
+
+type schemaObject struct {
+	Type string `json:"type"`
+	Ref  string `json:"$ref"`
+}
+
+func readResultSchema(t *testing.T) jsonSchema {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "cmd", "eval", "schemas", "read-query-result.schema.json"))
+	if err != nil {
+		t.Fatalf("read schema %s: %v", ResultSchemaPath, err)
+	}
+	var schema jsonSchema
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("parse schema %s: %v", ResultSchemaPath, err)
+	}
+	return schema
+}
+
+func readbenchResultJSONFields(t *testing.T) (map[string]struct{}, map[string]struct{}) {
+	t.Helper()
+
+	fields := make(map[string]struct{})
+	required := make(map[string]struct{})
+	resultType := reflect.TypeOf(readbench.Result{})
+	for i := 0; i < resultType.NumField(); i++ {
+		field := resultType.Field(i)
+		name, omitempty := jsonFieldName(field)
+		if name == "" || name == "-" {
+			continue
+		}
+		fields[name] = struct{}{}
+		if !omitempty {
+			required[name] = struct{}{}
+		}
+	}
+	return fields, required
+}
+
+func jsonFieldName(field reflect.StructField) (string, bool) {
+	tag := field.Tag.Get("json")
+	if tag == "" {
+		return field.Name, false
+	}
+	parts := bytes.Split([]byte(tag), []byte(","))
+	name := string(parts[0])
+	if name == "" {
+		name = field.Name
+	}
+	for _, opt := range parts[1:] {
+		if string(opt) == "omitempty" {
+			return name, true
+		}
+	}
+	return name, false
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/eval/suites/storageoverhead/suite.go
+++ b/internal/eval/suites/storageoverhead/suite.go
@@ -17,6 +17,7 @@ import (
 	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/internal/eval/framework"
+	"github.com/dewebprotocol/malt/internal/eval/suites/configjson"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -91,8 +92,8 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 		PayloadBytes: 64,
 	}
 	if len(raw) != 0 {
-		if err := json.Unmarshal(raw, &cfg); err != nil {
-			return Config{}, fmt.Errorf("parse storage_overhead config: %w", err)
+		if err := configjson.Decode(raw, suiteName, &cfg); err != nil {
+			return Config{}, err
 		}
 	}
 	if cfg.Structures == nil {

--- a/internal/eval/suites/storageoverhead/suite.go
+++ b/internal/eval/suites/storageoverhead/suite.go
@@ -8,19 +8,27 @@ import (
 	"fmt"
 
 	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
-	"github.com/dewebprotocol/malt/core/arctable/overwrite"
-	"github.com/dewebprotocol/malt/core/commitment/ipa"
+	"github.com/dewebprotocol/malt/core/arctable/versioned"
+	"github.com/dewebprotocol/malt/core/commitment/kzg"
 	"github.com/dewebprotocol/malt/core/structure"
 	"github.com/dewebprotocol/malt/core/structure/list"
 	listtree "github.com/dewebprotocol/malt/core/structure/list/tree"
 	"github.com/dewebprotocol/malt/core/structure/mapping"
-	"github.com/dewebprotocol/malt/core/structure/mapping/indexed"
+	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/internal/eval/framework"
 	cid "github.com/ipfs/go-cid"
 )
 
 const suiteName = "storage_overhead"
+
+const (
+	systemMALTFlat        = "maltflat"
+	commitmentBackendKZG  = "kzg"
+	arcTableModeVersioned = "versioned"
+	mapBackendRadix       = "radix"
+	listBackendTree       = "tree"
+)
 
 // Suite implements the storage overhead evaluation.
 type Suite struct{}
@@ -35,6 +43,11 @@ type Config struct {
 // Result is one storage overhead record.
 type Result struct {
 	Structure           string             `json:"structure"`
+	System              string             `json:"system"`
+	CommitmentBackend   string             `json:"commitment_backend"`
+	ArcTableMode        string             `json:"arctable_mode"`
+	MapBackend          string             `json:"map_backend,omitempty"`
+	ListBackend         string             `json:"list_backend,omitempty"`
 	Size                int                `json:"size"`
 	PayloadBytes        int                `json:"payload_bytes"`
 	Method              string             `json:"method"`
@@ -101,10 +114,14 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 
 func measure(ctx context.Context, structureName string, size, payloadBytes int) (Result, error) {
 	base := Result{
-		Structure:    structureName,
-		Size:         size,
-		PayloadBytes: payloadBytes,
+		Structure:         structureName,
+		System:            systemMALTFlat,
+		CommitmentBackend: commitmentBackendKZG,
+		ArcTableMode:      arcTableModeVersioned,
+		Size:              size,
+		PayloadBytes:      payloadBytes,
 	}
+	labelStructureBackend(&base)
 	switch structureName {
 	case "map", "list":
 	default:
@@ -143,6 +160,11 @@ func measure(ctx context.Context, structureName string, size, payloadBytes int) 
 	accounting := normalizeSnapshot(system.Meter.Snapshot())
 	return Result{
 		Structure:           structureName,
+		System:              systemMALTFlat,
+		CommitmentBackend:   commitmentBackendKZG,
+		ArcTableMode:        arcTableModeVersioned,
+		MapBackend:          structureMapBackend(structureName),
+		ListBackend:         structureListBackend(structureName),
 		Size:                size,
 		PayloadBytes:        payloadBytes,
 		Method:              "measured",
@@ -166,11 +188,11 @@ func writePayloads(ctx context.Context, system *evalstore.System, size, payloadB
 }
 
 func commitAndProve(ctx context.Context, system *evalstore.System, structureName string, values []cid.Cid) (structure.Proof, cid.Cid, error) {
-	scheme, err := ipa.NewScheme()
+	scheme, err := kzg.NewScheme()
 	if err != nil {
 		return nil, cid.Undef, err
 	}
-	table, err := overwrite.NewArcTable(overwrite.WithKVStore(system.StateKV))
+	table, err := versioned.NewArcTable(versioned.WithKVStore(system.StateKV))
 	if err != nil {
 		return nil, cid.Undef, err
 	}
@@ -179,7 +201,7 @@ func commitAndProve(ctx context.Context, system *evalstore.System, structureName
 	namespace := "storage-overhead"
 	switch structureName {
 	case "map":
-		semantics, err := indexed.NewMap(scheme, table)
+		semantics, err := mappingradix.NewMap(scheme, table)
 		if err != nil {
 			return nil, cid.Undef, err
 		}
@@ -229,6 +251,25 @@ func commitAndProve(ctx context.Context, system *evalstore.System, structureName
 	default:
 		return nil, cid.Undef, fmt.Errorf("unsupported structure %q", structureName)
 	}
+}
+
+func labelStructureBackend(result *Result) {
+	result.MapBackend = structureMapBackend(result.Structure)
+	result.ListBackend = structureListBackend(result.Structure)
+}
+
+func structureMapBackend(structureName string) string {
+	if structureName == "map" {
+		return mapBackendRadix
+	}
+	return ""
+}
+
+func structureListBackend(structureName string) string {
+	if structureName == "list" {
+		return listBackendTree
+	}
+	return ""
 }
 
 func normalizeSnapshot(snapshot evalstore.Snapshot) evalstore.Snapshot {

--- a/internal/eval/suites/storageoverhead/suite.go
+++ b/internal/eval/suites/storageoverhead/suite.go
@@ -1,0 +1,263 @@
+// Package storageoverhead measures persisted and logical storage overhead.
+package storageoverhead
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/core/arctable/overwrite"
+	"github.com/dewebprotocol/malt/core/commitment/ipa"
+	"github.com/dewebprotocol/malt/core/structure"
+	"github.com/dewebprotocol/malt/core/structure/list"
+	listtree "github.com/dewebprotocol/malt/core/structure/list/tree"
+	"github.com/dewebprotocol/malt/core/structure/mapping"
+	"github.com/dewebprotocol/malt/core/structure/mapping/indexed"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+	cid "github.com/ipfs/go-cid"
+)
+
+const suiteName = "storage_overhead"
+
+// Suite implements the storage overhead evaluation.
+type Suite struct{}
+
+// Config controls storage-overhead dimensions.
+type Config struct {
+	Structures   []string `json:"structures"`
+	Sizes        []int    `json:"sizes"`
+	PayloadBytes int      `json:"payload_bytes"`
+}
+
+// Result is one storage overhead record.
+type Result struct {
+	Structure           string             `json:"structure"`
+	Size                int                `json:"size"`
+	PayloadBytes        int                `json:"payload_bytes"`
+	Method              string             `json:"method"`
+	Accounting          evalstore.Snapshot `json:"accounting"`
+	PersistedBytes      uint64             `json:"persisted_bytes"`
+	LogicalPayloadBytes uint64             `json:"logical_payload_bytes"`
+	LogicalProofBytes   uint64             `json:"logical_proof_bytes"`
+	Error               string             `json:"error,omitempty"`
+}
+
+// Name returns the stable suite name.
+func (Suite) Name() string {
+	return suiteName
+}
+
+// Run executes the configured storage overhead matrix.
+func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) error {
+	cfg, err := parseConfig(raw)
+	if err != nil {
+		return err
+	}
+
+	for _, structureName := range cfg.Structures {
+		for _, size := range cfg.Sizes {
+			record, err := measure(ctx, structureName, size, cfg.PayloadBytes)
+			if err != nil {
+				return err
+			}
+			if err := env.WriteRecord(suiteName, record); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func parseConfig(raw json.RawMessage) (Config, error) {
+	cfg := Config{
+		Structures:   []string{"map", "list"},
+		Sizes:        []int{1},
+		PayloadBytes: 64,
+	}
+	if len(raw) != 0 {
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return Config{}, fmt.Errorf("parse storage_overhead config: %w", err)
+		}
+	}
+	if cfg.Structures == nil {
+		cfg.Structures = []string{"map", "list"}
+	}
+	if cfg.Sizes == nil {
+		cfg.Sizes = []int{1}
+	}
+	if cfg.PayloadBytes <= 0 {
+		return Config{}, fmt.Errorf("payload_bytes must be positive")
+	}
+	for _, size := range cfg.Sizes {
+		if size <= 0 {
+			return Config{}, fmt.Errorf("sizes must be positive")
+		}
+	}
+	return cfg, nil
+}
+
+func measure(ctx context.Context, structureName string, size, payloadBytes int) (Result, error) {
+	base := Result{
+		Structure:    structureName,
+		Size:         size,
+		PayloadBytes: payloadBytes,
+	}
+	switch structureName {
+	case "map", "list":
+	default:
+		base.Method = "unsupported"
+		base.Accounting = normalizeSnapshot(evalstore.Snapshot{})
+		base.Error = fmt.Sprintf("unsupported structure %q", structureName)
+		return base, nil
+	}
+
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	defer factory.Close()
+	system, err := factory.NewSystem(ctx, structureName)
+	if err != nil {
+		return Result{}, err
+	}
+
+	values, err := writePayloads(ctx, system, size, payloadBytes)
+	if err != nil {
+		return Result{}, err
+	}
+	proof, root, err := commitAndProve(ctx, system, structureName, values)
+	if err != nil {
+		base.Method = "unsupported"
+		base.Accounting = normalizeSnapshot(evalstore.Snapshot{})
+		base.Error = err.Error()
+		return base, nil
+	}
+	system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(root.Bytes()))
+
+	accounting := normalizeSnapshot(system.Meter.Snapshot())
+	return Result{
+		Structure:           structureName,
+		Size:                size,
+		PayloadBytes:        payloadBytes,
+		Method:              "measured",
+		Accounting:          accounting,
+		PersistedBytes:      accounting.Total.NewPersistedBytes,
+		LogicalPayloadBytes: uint64(size * payloadBytes),
+		LogicalProofBytes:   uint64(len(proof)),
+	}, nil
+}
+
+func writePayloads(ctx context.Context, system *evalstore.System, size, payloadBytes int) ([]cid.Cid, error) {
+	values := make([]cid.Cid, size)
+	for i := range values {
+		value, err := system.CAS.Put(ctx, payloadFor(i, payloadBytes))
+		if err != nil {
+			return nil, err
+		}
+		values[i] = value
+	}
+	return values, nil
+}
+
+func commitAndProve(ctx context.Context, system *evalstore.System, structureName string, values []cid.Cid) (structure.Proof, cid.Cid, error) {
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		return nil, cid.Undef, err
+	}
+	table, err := overwrite.NewArcTable(overwrite.WithKVStore(system.StateKV))
+	if err != nil {
+		return nil, cid.Undef, err
+	}
+	defer table.Close()
+
+	namespace := "storage-overhead"
+	switch structureName {
+	case "map":
+		semantics, err := indexed.NewMap(scheme, table)
+		if err != nil {
+			return nil, cid.Undef, err
+		}
+		entries := make(map[arcset.Path]cid.Cid, len(values))
+		for i, value := range values {
+			entries[mapPath(i)] = value
+		}
+		root, err := semantics.Commit(ctx, namespace, mapping.NewViewFromPaths(entries))
+		if err != nil {
+			return nil, cid.Undef, err
+		}
+		key := mapPath(len(values) / 2)
+		binding, proof, err := semantics.Prove(ctx, namespace, root, key)
+		if err != nil {
+			return nil, cid.Undef, err
+		}
+		ok, err := semantics.Verify(root, key, binding, proof)
+		if err != nil {
+			return nil, cid.Undef, err
+		}
+		if !ok {
+			return nil, cid.Undef, fmt.Errorf("map proof did not verify")
+		}
+		return proof, root, nil
+	case "list":
+		semantics, err := listtree.NewList(scheme, table)
+		if err != nil {
+			return nil, cid.Undef, err
+		}
+		root, err := semantics.Commit(ctx, namespace, list.NewViewFromSlice(values))
+		if err != nil {
+			return nil, cid.Undef, err
+		}
+		index := uint64(len(values) / 2)
+		query, proof, err := semantics.Prove(ctx, namespace, root, index)
+		if err != nil {
+			return nil, cid.Undef, err
+		}
+		ok, err := semantics.Verify(root, index, query, proof)
+		if err != nil {
+			return nil, cid.Undef, err
+		}
+		if !ok {
+			return nil, cid.Undef, fmt.Errorf("list proof did not verify")
+		}
+		return proof, root, nil
+	default:
+		return nil, cid.Undef, fmt.Errorf("unsupported structure %q", structureName)
+	}
+}
+
+func normalizeSnapshot(snapshot evalstore.Snapshot) evalstore.Snapshot {
+	if snapshot.Categories == nil {
+		snapshot.Categories = map[evalstore.Category]evalstore.Counter{}
+	}
+	for _, category := range []evalstore.Category{
+		evalstore.CategoryCASPayload,
+		evalstore.CategoryCASMetadata,
+		evalstore.CategoryArcTable,
+		evalstore.CategoryCommitment,
+		evalstore.CategoryRootHead,
+	} {
+		if _, ok := snapshot.Categories[category]; !ok {
+			snapshot.Categories[category] = evalstore.Counter{}
+		}
+	}
+	return snapshot
+}
+
+func payloadFor(index, size int) []byte {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("storage-overhead:%d", index)))
+	out := make([]byte, size)
+	for i := range out {
+		out[i] = sum[i%len(sum)]
+	}
+	return out
+}
+
+func mapPath(index int) arcset.Path {
+	return arcset.CanonicalizePath(fmt.Sprintf("item/%06d", index))
+}

--- a/internal/eval/suites/storageoverhead/suite_test.go
+++ b/internal/eval/suites/storageoverhead/suite_test.go
@@ -46,6 +46,24 @@ func TestSuiteRecordsPersistedAndLogicalStorageOverhead(t *testing.T) {
 		if record.Size != 2 || record.PayloadBytes != 8 {
 			t.Fatalf("record dimensions = %+v, want size 2 payload 8", record)
 		}
+		if record.System != "maltflat" {
+			t.Fatalf("system = %q, want maltflat", record.System)
+		}
+		if record.CommitmentBackend != "kzg" || record.ArcTableMode != "versioned" {
+			t.Fatalf("backend labels = %+v, want kzg/versioned", record)
+		}
+		switch record.Structure {
+		case "map":
+			if record.MapBackend != "radix" {
+				t.Fatalf("map backend = %q, want radix", record.MapBackend)
+			}
+		case "list":
+			if record.ListBackend != "tree" {
+				t.Fatalf("list backend = %q, want tree", record.ListBackend)
+			}
+		default:
+			t.Fatalf("unexpected structure = %q", record.Structure)
+		}
 		if record.LogicalPayloadBytes != 16 {
 			t.Fatalf("logical_payload_bytes = %d, want 16", record.LogicalPayloadBytes)
 		}

--- a/internal/eval/suites/storageoverhead/suite_test.go
+++ b/internal/eval/suites/storageoverhead/suite_test.go
@@ -125,6 +125,12 @@ func TestSuiteReportsUnsupportedStorageStructure(t *testing.T) {
 	}
 }
 
+func TestParseConfigRejectsUnknownFields(t *testing.T) {
+	if _, err := parseConfig(json.RawMessage(`{"payload_bytse": 64}`)); err == nil {
+		t.Fatal("parseConfig should reject unknown fields")
+	}
+}
+
 func readStorageRecords(t *testing.T, path string) []Result {
 	t.Helper()
 	f, err := os.Open(path)

--- a/internal/eval/suites/storageoverhead/suite_test.go
+++ b/internal/eval/suites/storageoverhead/suite_test.go
@@ -1,0 +1,138 @@
+package storageoverhead
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+)
+
+func TestSuiteRecordsPersistedAndLogicalStorageOverhead(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "raw"), 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+
+	cfg := json.RawMessage(`{
+		"structures": ["map", "list"],
+		"sizes": [2],
+		"payload_bytes": 8
+	}`)
+	suite := Suite{}
+	if suite.Name() != "storage_overhead" {
+		t.Fatalf("Name() = %q, want storage_overhead", suite.Name())
+	}
+
+	if err := suite.Run(context.Background(), framework.Env{
+		RunID:     "run-storage",
+		OutputDir: tmp,
+	}, cfg); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	records := readStorageRecords(t, filepath.Join(tmp, "raw", "storage_overhead.jsonl"))
+	if len(records) != 2 {
+		t.Fatalf("record count = %d, want 2", len(records))
+	}
+	for _, record := range records {
+		if record.Method != "measured" {
+			t.Fatalf("method = %q, want measured", record.Method)
+		}
+		if record.Size != 2 || record.PayloadBytes != 8 {
+			t.Fatalf("record dimensions = %+v, want size 2 payload 8", record)
+		}
+		if record.LogicalPayloadBytes != 16 {
+			t.Fatalf("logical_payload_bytes = %d, want 16", record.LogicalPayloadBytes)
+		}
+		if record.LogicalProofBytes == 0 {
+			t.Fatalf("logical_proof_bytes = 0, want measured proof bytes")
+		}
+		if record.PersistedBytes == 0 || record.Accounting.Total.NewPersistedBytes != record.PersistedBytes {
+			t.Fatalf("persisted/accounting mismatch: %+v", record)
+		}
+		if record.Accounting.Categories[evalstore.CategoryCASPayload].NewObjectCount != 2 {
+			t.Fatalf("cas payload category = %+v, want two payload objects", record.Accounting.Categories[evalstore.CategoryCASPayload])
+		}
+		if record.Accounting.Categories[evalstore.CategoryArcTable].NewPersistedBytes == 0 {
+			t.Fatalf("arctable category = %+v, want persisted ArcTable bytes", record.Accounting.Categories[evalstore.CategoryArcTable])
+		}
+		if record.Accounting.Categories[evalstore.CategoryRootHead].NewPersistedBytes == 0 {
+			t.Fatalf("root_head category = %+v, want root publication bytes", record.Accounting.Categories[evalstore.CategoryRootHead])
+		}
+		if _, ok := record.Accounting.Categories[evalstore.CategoryCASMetadata]; !ok {
+			t.Fatalf("accounting categories should explicitly include cas_metadata")
+		}
+	}
+}
+
+func TestSuiteReportsUnsupportedStorageStructure(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "raw"), 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+
+	cfg := json.RawMessage(`{
+		"structures": ["unknown"],
+		"sizes": [1],
+		"payload_bytes": 4
+	}`)
+	if err := (Suite{}).Run(context.Background(), framework.Env{
+		RunID:     "run-storage-unsupported",
+		OutputDir: tmp,
+	}, cfg); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	records := readStorageRecords(t, filepath.Join(tmp, "raw", "storage_overhead.jsonl"))
+	if len(records) != 1 {
+		t.Fatalf("record count = %d, want 1", len(records))
+	}
+	record := records[0]
+	if record.Method != "unsupported" {
+		t.Fatalf("method = %q, want unsupported", record.Method)
+	}
+	if record.PersistedBytes != 0 || record.LogicalPayloadBytes != 0 || record.LogicalProofBytes != 0 {
+		t.Fatalf("unsupported record fabricated storage metrics: %+v", record)
+	}
+	if _, ok := record.Accounting.Categories[evalstore.CategoryCASPayload]; !ok {
+		t.Fatalf("unsupported record should include zero accounting categories: %+v", record.Accounting.Categories)
+	}
+	if record.Error == "" {
+		t.Fatalf("unsupported record should explain why: %+v", record)
+	}
+}
+
+func readStorageRecords(t *testing.T, path string) []Result {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open records: %v", err)
+	}
+	defer f.Close()
+
+	var out []Result
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var envelope framework.RecordEnvelope
+		if err := json.Unmarshal(scanner.Bytes(), &envelope); err != nil {
+			t.Fatalf("unmarshal envelope: %v", err)
+		}
+		if envelope.Suite != "storage_overhead" {
+			t.Fatalf("suite = %q, want storage_overhead", envelope.Suite)
+		}
+		var record Result
+		if err := json.Unmarshal(envelope.Record, &record); err != nil {
+			t.Fatalf("unmarshal record: %v", err)
+		}
+		out = append(out, record)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan records: %v", err)
+	}
+	return out
+}

--- a/internal/eval/suites/writetrace/config.go
+++ b/internal/eval/suites/writetrace/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/internal/eval/suites/configjson"
 )
 
 const SuiteName = "write_trace"
@@ -47,8 +48,8 @@ func ParseConfig(raw json.RawMessage) (Config, error) {
 	if len(strings.TrimSpace(string(raw))) == 0 {
 		return cfg, nil
 	}
-	if err := json.Unmarshal(raw, &cfg); err != nil {
-		return Config{}, fmt.Errorf("parse write_trace config: %w", err)
+	if err := configjson.Decode(raw, SuiteName, &cfg); err != nil {
+		return Config{}, err
 	}
 	cfg.Systems = normalizeSystems(cfg.Systems)
 	return cfg, nil

--- a/internal/eval/suites/writetrace/config.go
+++ b/internal/eval/suites/writetrace/config.go
@@ -1,0 +1,108 @@
+// Package writetrace runs Git write-trace replay as an eval framework suite.
+package writetrace
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+)
+
+const SuiteName = "write_trace"
+
+// Config controls the write_trace evaluation suite.
+type Config struct {
+	RepoURL      string     `json:"repo_url,omitempty"`
+	RepoPath     string     `json:"repo_path,omitempty"`
+	RepoRef      string     `json:"repo_ref,omitempty"`
+	CommitLimit  int        `json:"commit_limit,omitempty"`
+	CacheDir     string     `json:"cache_dir,omitempty"`
+	StoreDir     string     `json:"store_dir,omitempty"`
+	StoreMode    string     `json:"store_mode,omitempty"`
+	StoreBackend string     `json:"store_backend,omitempty"`
+	Systems      SystemList `json:"systems,omitempty"`
+	FirstParent  bool       `json:"first_parent"`
+}
+
+// SystemList accepts either a JSON array or a comma-separated JSON string.
+type SystemList []string
+
+// DefaultConfig returns the same replay defaults used by malt-eval write.
+func DefaultConfig() Config {
+	return Config{
+		RepoRef:      "HEAD",
+		CacheDir:     ".eval-cache/repos",
+		StoreDir:     ".eval-cache/write-stores",
+		StoreMode:    string(evalstore.StoreModeIsolated),
+		StoreBackend: string(evalstore.StoreBackendMemory),
+		Systems:      SystemList{"maltflat", "merkledag", "hamt"},
+		FirstParent:  true,
+	}
+}
+
+// ParseConfig decodes a framework suite config over write-command defaults.
+func ParseConfig(raw json.RawMessage) (Config, error) {
+	cfg := DefaultConfig()
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return cfg, nil
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse write_trace config: %w", err)
+	}
+	cfg.Systems = normalizeSystems(cfg.Systems)
+	return cfg, nil
+}
+
+// SystemsCSV returns the comma-separated system selection expected by evalwrite.
+func (c Config) SystemsCSV() string {
+	return strings.Join(normalizeSystems(c.Systems), ",")
+}
+
+func (c Config) validate() error {
+	if strings.TrimSpace(c.RepoURL) == "" && strings.TrimSpace(c.RepoPath) == "" {
+		return fmt.Errorf("one of repo_url or repo_path is required")
+	}
+	if c.CommitLimit < 0 {
+		return fmt.Errorf("commit_limit must be non-negative")
+	}
+	return nil
+}
+
+func (s *SystemList) UnmarshalJSON(data []byte) error {
+	text := strings.TrimSpace(string(data))
+	if text == "null" {
+		*s = nil
+		return nil
+	}
+	if strings.HasPrefix(text, "[") {
+		var values []string
+		if err := json.Unmarshal(data, &values); err != nil {
+			return err
+		}
+		*s = normalizeSystems(values)
+		return nil
+	}
+	var csv string
+	if err := json.Unmarshal(data, &csv); err != nil {
+		return err
+	}
+	*s = parseSystemsCSV(csv)
+	return nil
+}
+
+func parseSystemsCSV(csv string) SystemList {
+	return normalizeSystems(strings.Split(csv, ","))
+}
+
+func normalizeSystems(values []string) SystemList {
+	out := make(SystemList, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/eval/suites/writetrace/suite.go
+++ b/internal/eval/suites/writetrace/suite.go
@@ -1,0 +1,64 @@
+package writetrace
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/evalwrite"
+	gittrace "github.com/dewebprotocol/malt/cmd/eval/helper/git"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+)
+
+// Suite replays Git commit traces and writes framework raw records.
+type Suite struct{}
+
+func (Suite) Name() string {
+	return SuiteName
+}
+
+func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) (err error) {
+	cfg, err := ParseConfig(raw)
+	if err != nil {
+		return err
+	}
+	if err := cfg.validate(); err != nil {
+		return err
+	}
+
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreMode(cfg.StoreMode),
+		Backend: evalstore.StoreBackend(cfg.StoreBackend),
+		RootDir: cfg.StoreDir,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := factory.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	systems, err := evalwrite.BuildSystems(ctx, factory, cfg.SystemsCSV())
+	if err != nil {
+		return err
+	}
+
+	source := gittrace.Source{
+		RepoURL:     cfg.RepoURL,
+		RepoPath:    cfg.RepoPath,
+		CacheDir:    cfg.CacheDir,
+		Ref:         cfg.RepoRef,
+		Limit:       cfg.CommitLimit,
+		FirstParent: cfg.FirstParent,
+	}
+	return source.Walk(ctx, func(commit replay.CommitMutation) error {
+		return replay.RunCommitRecords(ctx, commit, systems, func(record replay.ResultRecord) error {
+			return env.WriteRecord(SuiteName, record)
+		})
+	})
+}
+
+var _ framework.Suite = Suite{}

--- a/internal/eval/suites/writetrace/suite_test.go
+++ b/internal/eval/suites/writetrace/suite_test.go
@@ -65,6 +65,12 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	}
 }
 
+func TestParseConfigRejectsUnknownFields(t *testing.T) {
+	if _, err := writetrace.ParseConfig(json.RawMessage(`{"commit_limti": 7}`)); err == nil {
+		t.Fatal("ParseConfig should reject unknown fields")
+	}
+}
+
 func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git binary not available")

--- a/internal/eval/suites/writetrace/suite_test.go
+++ b/internal/eval/suites/writetrace/suite_test.go
@@ -1,0 +1,208 @@
+package writetrace_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/adapters/maltflat"
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+	"github.com/dewebprotocol/malt/internal/eval/suites/writetrace"
+)
+
+func TestSuiteName(t *testing.T) {
+	if got := (writetrace.Suite{}).Name(); got != "write_trace" {
+		t.Fatalf("suite name = %q, want write_trace", got)
+	}
+}
+
+func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
+	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
+		"repo_url": "https://example.test/repo.git",
+		"repo_path": "/tmp/repo",
+		"repo_ref": "main",
+		"commit_limit": 7,
+		"cache_dir": "/tmp/cache",
+		"store_dir": "/tmp/stores",
+		"store_mode": "shared",
+		"store_backend": "fs",
+		"systems": ["maltflat", "hamt"],
+		"first_parent": false
+	}`))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if cfg.RepoURL != "https://example.test/repo.git" || cfg.RepoPath != "/tmp/repo" || cfg.RepoRef != "main" {
+		t.Fatalf("repo config = %+v, want JSON values", cfg)
+	}
+	if cfg.CommitLimit != 7 || cfg.CacheDir != "/tmp/cache" || cfg.StoreDir != "/tmp/stores" {
+		t.Fatalf("storage/limit config = %+v, want JSON values", cfg)
+	}
+	if cfg.StoreMode != "shared" || cfg.StoreBackend != "fs" || cfg.FirstParent {
+		t.Fatalf("mode config = %+v, want JSON values", cfg)
+	}
+	if got := cfg.SystemsCSV(); got != "maltflat,hamt" {
+		t.Fatalf("systems CSV = %q, want maltflat,hamt", got)
+	}
+
+	defaults, err := writetrace.ParseConfig(nil)
+	if err != nil {
+		t.Fatalf("ParseConfig defaults: %v", err)
+	}
+	if defaults.RepoRef != "HEAD" || defaults.CacheDir != ".eval-cache/repos" || defaults.StoreDir != ".eval-cache/write-stores" {
+		t.Fatalf("defaults = %+v, want write command paths/ref", defaults)
+	}
+	if defaults.StoreMode != "isolated" || defaults.StoreBackend != "memory" || !defaults.FirstParent {
+		t.Fatalf("defaults = %+v, want isolated memory first-parent", defaults)
+	}
+	if got := defaults.SystemsCSV(); got != "maltflat,merkledag,hamt" {
+		t.Fatalf("default systems = %q, want maltflat,merkledag,hamt", got)
+	}
+}
+
+func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	repo := initWriteTraceRepo(t)
+	outDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(outDir, "raw"), 0755); err != nil {
+		t.Fatalf("mkdir raw dir: %v", err)
+	}
+
+	cfg := json.RawMessage(`{
+		"repo_path": ` + strconvQuote(repo) + `,
+		"commit_limit": 3,
+		"store_backend": "memory",
+		"systems": ["maltflat"]
+	}`)
+	err := (writetrace.Suite{}).Run(ctx, framework.Env{
+		RunID:     "run-write-trace-test",
+		OutputDir: outDir,
+	}, cfg)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	envelopes := readWriteTraceEnvelopes(t, filepath.Join(outDir, "raw", "write_trace.jsonl"))
+	if len(envelopes) != 3 {
+		t.Fatalf("envelope count = %d, want 3", len(envelopes))
+	}
+	var records []replay.ResultRecord
+	for i, envelope := range envelopes {
+		if envelope.RunID != "run-write-trace-test" || envelope.Suite != "write_trace" {
+			t.Fatalf("envelope %d = %+v, want run id and suite preserved", i, envelope)
+		}
+		var record replay.ResultRecord
+		if err := json.Unmarshal(envelope.Record, &record); err != nil {
+			t.Fatalf("unmarshal record %d: %v", i, err)
+		}
+		records = append(records, record)
+	}
+
+	if records[0].Repo != filepath.Base(repo) || records[0].System != "maltflat" || records[0].Index != 0 {
+		t.Fatalf("first record identity = %+v, want repo/maltflat/index 0", records[0])
+	}
+	if records[1].MutationSet[0].Kind != replay.MutationRename || records[1].MutationSet[0].OldPath != "README.md" || records[1].MutationSet[0].Path != "docs/README.md" {
+		t.Fatalf("rename mutation = %+v, want README.md -> docs/README.md", records[1].MutationSet)
+	}
+	if records[2].MutationSet[0].Kind != replay.MutationDelete || records[2].Result.MaterializedPaths != 0 {
+		t.Fatalf("delete record = %+v, want delete with zero materialized paths", records[2])
+	}
+	for i, record := range records {
+		if record.Commit == "" {
+			t.Fatalf("record %d commit is empty", i)
+		}
+		if record.Result.MaterializationStrategy != maltflat.MaterializationStrategyLiveSnapshotRebuild {
+			t.Fatalf("record %d materialization strategy = %q, want %q", i, record.Result.MaterializationStrategy, maltflat.MaterializationStrategyLiveSnapshotRebuild)
+		}
+		if record.Result.Accounting.Categories == nil || record.Accounting.Categories == nil {
+			t.Fatalf("record %d accounting missing: %+v", i, record)
+		}
+	}
+}
+
+func initWriteTraceRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-b", "main")
+	runGit(t, repo, "config", "user.email", "bench@example.test")
+	runGit(t, repo, "config", "user.name", "Bench Test")
+
+	writeFile(t, repo, "README.md", "hello\n")
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "initial")
+
+	if err := os.MkdirAll(filepath.Join(repo, "docs"), 0755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.Rename(filepath.Join(repo, "README.md"), filepath.Join(repo, "docs", "README.md")); err != nil {
+		t.Fatalf("rename README.md: %v", err)
+	}
+	runGit(t, repo, "add", "-A")
+	runGit(t, repo, "commit", "-m", "rename readme")
+
+	if err := os.Remove(filepath.Join(repo, "docs", "README.md")); err != nil {
+		t.Fatalf("delete docs/README.md: %v", err)
+	}
+	runGit(t, repo, "add", "-A")
+	runGit(t, repo, "commit", "-m", "delete readme")
+	return repo
+}
+
+func readWriteTraceEnvelopes(t *testing.T, path string) []framework.RecordEnvelope {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var envelopes []framework.RecordEnvelope
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var envelope framework.RecordEnvelope
+		if err := json.Unmarshal(scanner.Bytes(), &envelope); err != nil {
+			t.Fatalf("unmarshal envelope: %v", err)
+		}
+		envelopes = append(envelopes, envelope)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan envelopes: %v", err)
+	}
+	return envelopes
+}
+
+func writeFile(t *testing.T, repo, rel, content string) {
+	t.Helper()
+	path := filepath.Join(repo, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func runGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func strconvQuote(s string) string {
+	data, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}

--- a/internal/eval/summary/summary.go
+++ b/internal/eval/summary/summary.go
@@ -135,6 +135,9 @@ func readRawFile(path, fileSuite string, tables map[string]*suiteTable) error {
 		if suite == "" {
 			return fmt.Errorf("decode %s:%d: suite is empty", path, lineNumber)
 		}
+		if err := validateSuiteName(suite); err != nil {
+			return fmt.Errorf("decode %s:%d: %w", path, lineNumber, err)
+		}
 		table := tables[suite]
 		if table == nil {
 			table = &suiteTable{recordKeys: map[string]struct{}{}}
@@ -218,7 +221,10 @@ func flattenValue(key string, value any, row map[string]string, recordKeys map[s
 }
 
 func writeSuiteCSV(outDir, suite string, table *suiteTable) error {
-	path := filepath.Join(outDir, figureCSVName(suite))
+	path, err := figureCSVPath(outDir, suite)
+	if err != nil {
+		return err
+	}
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", path, err)
@@ -260,9 +266,45 @@ func writeSuiteCSV(outDir, suite string, table *suiteTable) error {
 	return nil
 }
 
+func figureCSVPath(outDir, suite string) (string, error) {
+	if err := validateSuiteName(suite); err != nil {
+		return "", err
+	}
+	name := figureCSVName(suite)
+	if filepath.Base(name) != name {
+		return "", fmt.Errorf("unsafe figure csv name %q", name)
+	}
+	path := filepath.Join(outDir, name)
+	rel, err := filepath.Rel(outDir, path)
+	if err != nil {
+		return "", fmt.Errorf("resolve summary csv path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("summary csv path escapes output directory: %s", path)
+	}
+	return path, nil
+}
+
 func figureCSVName(suite string) string {
 	if name, ok := figureNames[suite]; ok {
 		return name
 	}
 	return "figure_" + suite + ".csv"
+}
+
+func validateSuiteName(suite string) error {
+	if suite == "" {
+		return fmt.Errorf("suite is empty")
+	}
+	for _, r := range suite {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return fmt.Errorf("unsafe suite name %q", suite)
+		}
+	}
+	return nil
 }

--- a/internal/eval/summary/summary.go
+++ b/internal/eval/summary/summary.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"github.com/dewebprotocol/malt/internal/eval/framework"
 )
 
 var metadataColumns = []string{"schema_version", "run_id", "suite", "emitted_at"}
@@ -28,6 +26,14 @@ var figureNames = map[string]string{
 type suiteTable struct {
 	rows       []map[string]string
 	recordKeys map[string]struct{}
+}
+
+type recordEnvelope struct {
+	SchemaVersion string          `json:"schema_version"`
+	RunID         string          `json:"run_id"`
+	Suite         string          `json:"suite"`
+	EmittedAt     string          `json:"emitted_at"`
+	Record        json.RawMessage `json:"record"`
 }
 
 // Summarize reads framework raw envelopes from inputDir/raw and writes figure
@@ -120,20 +126,20 @@ func readRawFile(path, fileSuite string, tables map[string]*suiteTable) error {
 	return nil
 }
 
-func decodeEnvelope(data []byte) (framework.RecordEnvelope, error) {
-	var envelope framework.RecordEnvelope
+func decodeEnvelope(data []byte) (recordEnvelope, error) {
+	var envelope recordEnvelope
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
 	if err := dec.Decode(&envelope); err != nil {
-		return framework.RecordEnvelope{}, err
+		return recordEnvelope{}, err
 	}
 	if dec.More() {
-		return framework.RecordEnvelope{}, fmt.Errorf("unexpected trailing JSON")
+		return recordEnvelope{}, fmt.Errorf("unexpected trailing JSON")
 	}
 	return envelope, nil
 }
 
-func envelopeRow(envelope framework.RecordEnvelope, recordKeys map[string]struct{}) (map[string]string, error) {
+func envelopeRow(envelope recordEnvelope, recordKeys map[string]struct{}) (map[string]string, error) {
 	row := map[string]string{
 		"schema_version": envelope.SchemaVersion,
 		"run_id":         envelope.RunID,

--- a/internal/eval/summary/summary.go
+++ b/internal/eval/summary/summary.go
@@ -1,0 +1,235 @@
+// Package summary converts framework raw result envelopes into figure CSVs.
+package summary
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dewebprotocol/malt/internal/eval/framework"
+)
+
+var metadataColumns = []string{"schema_version", "run_id", "suite", "emitted_at"}
+
+var figureNames = map[string]string{
+	"write_trace":      "figure_write_trace.csv",
+	"read_query":       "figure_read_query.csv",
+	"cas_model":        "figure_cas_model.csv",
+	"proof_overhead":   "figure_proof.csv",
+	"storage_overhead": "figure_storage.csv",
+}
+
+type suiteTable struct {
+	rows       []map[string]string
+	recordKeys map[string]struct{}
+}
+
+// Summarize reads framework raw envelopes from inputDir/raw and writes figure
+// CSVs into outDir.
+func Summarize(inputDir, outDir string) error {
+	if strings.TrimSpace(inputDir) == "" {
+		return fmt.Errorf("input directory is required")
+	}
+	if strings.TrimSpace(outDir) == "" {
+		outDir = filepath.Join(inputDir, "summary")
+	}
+
+	rawDir := filepath.Join(inputDir, "raw")
+	entries, err := os.ReadDir(rawDir)
+	if err != nil {
+		return fmt.Errorf("read raw directory: %w", err)
+	}
+
+	tables := make(map[string]*suiteTable)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".jsonl" {
+			continue
+		}
+		path := filepath.Join(rawDir, entry.Name())
+		fileSuite := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+		if err := readRawFile(path, fileSuite, tables); err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create summary directory: %w", err)
+	}
+
+	suites := make([]string, 0, len(tables))
+	for suite := range tables {
+		suites = append(suites, suite)
+	}
+	sort.Strings(suites)
+	for _, suite := range suites {
+		if err := writeSuiteCSV(outDir, suite, tables[suite]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readRawFile(path, fileSuite string, tables map[string]*suiteTable) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open raw file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		envelope, err := decodeEnvelope([]byte(line))
+		if err != nil {
+			return fmt.Errorf("decode %s:%d: %w", path, lineNumber, err)
+		}
+		suite := strings.TrimSpace(envelope.Suite)
+		if suite == "" {
+			suite = fileSuite
+		}
+		if suite == "" {
+			return fmt.Errorf("decode %s:%d: suite is empty", path, lineNumber)
+		}
+		table := tables[suite]
+		if table == nil {
+			table = &suiteTable{recordKeys: map[string]struct{}{}}
+			tables[suite] = table
+		}
+		row, err := envelopeRow(envelope, table.recordKeys)
+		if err != nil {
+			return fmt.Errorf("decode record %s:%d: %w", path, lineNumber, err)
+		}
+		row["suite"] = suite
+		table.rows = append(table.rows, row)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan raw file %s: %w", path, err)
+	}
+	return nil
+}
+
+func decodeEnvelope(data []byte) (framework.RecordEnvelope, error) {
+	var envelope framework.RecordEnvelope
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&envelope); err != nil {
+		return framework.RecordEnvelope{}, err
+	}
+	if dec.More() {
+		return framework.RecordEnvelope{}, fmt.Errorf("unexpected trailing JSON")
+	}
+	return envelope, nil
+}
+
+func envelopeRow(envelope framework.RecordEnvelope, recordKeys map[string]struct{}) (map[string]string, error) {
+	row := map[string]string{
+		"schema_version": envelope.SchemaVersion,
+		"run_id":         envelope.RunID,
+		"suite":          envelope.Suite,
+		"emitted_at":     envelope.EmittedAt,
+	}
+	if len(bytes.TrimSpace(envelope.Record)) == 0 {
+		return row, nil
+	}
+
+	var record map[string]any
+	dec := json.NewDecoder(bytes.NewReader(envelope.Record))
+	dec.UseNumber()
+	if err := dec.Decode(&record); err != nil {
+		return nil, err
+	}
+	for key, value := range record {
+		flattenValue(key, value, row, recordKeys)
+	}
+	return row, nil
+}
+
+func flattenValue(key string, value any, row map[string]string, recordKeys map[string]struct{}) {
+	if key == "" {
+		return
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		for childKey, childValue := range typed {
+			flattenValue(key+"."+childKey, childValue, row, recordKeys)
+		}
+	case string:
+		row[key] = typed
+		recordKeys[key] = struct{}{}
+	case json.Number:
+		row[key] = typed.String()
+		recordKeys[key] = struct{}{}
+	case bool:
+		if typed {
+			row[key] = "true"
+		} else {
+			row[key] = "false"
+		}
+		recordKeys[key] = struct{}{}
+	case nil:
+		row[key] = ""
+		recordKeys[key] = struct{}{}
+	}
+}
+
+func writeSuiteCSV(outDir, suite string, table *suiteTable) error {
+	path := filepath.Join(outDir, figureCSVName(suite))
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
+	}
+	defer f.Close()
+
+	header := append([]string{}, metadataColumns...)
+	recordColumns := make([]string, 0, len(table.recordKeys))
+	metadata := make(map[string]struct{}, len(metadataColumns))
+	for _, column := range metadataColumns {
+		metadata[column] = struct{}{}
+	}
+	for column := range table.recordKeys {
+		if _, ok := metadata[column]; ok {
+			continue
+		}
+		recordColumns = append(recordColumns, column)
+	}
+	sort.Strings(recordColumns)
+	header = append(header, recordColumns...)
+
+	writer := csv.NewWriter(f)
+	if err := writer.Write(header); err != nil {
+		return fmt.Errorf("write %s header: %w", path, err)
+	}
+	for _, row := range table.rows {
+		values := make([]string, len(header))
+		for i, column := range header {
+			values[i] = row[column]
+		}
+		if err := writer.Write(values); err != nil {
+			return fmt.Errorf("write %s row: %w", path, err)
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return fmt.Errorf("flush %s: %w", path, err)
+	}
+	return nil
+}
+
+func figureCSVName(suite string) string {
+	if name, ok := figureNames[suite]; ok {
+		return name
+	}
+	return "figure_" + suite + ".csv"
+}

--- a/internal/eval/summary/summary.go
+++ b/internal/eval/summary/summary.go
@@ -67,6 +67,9 @@ func Summarize(inputDir, outDir string) error {
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return fmt.Errorf("create summary directory: %w", err)
 	}
+	if err := removeGeneratedFigures(outDir); err != nil {
+		return err
+	}
 
 	suites := make([]string, 0, len(tables))
 	for suite := range tables {
@@ -76,6 +79,30 @@ func Summarize(inputDir, outDir string) error {
 	for _, suite := range suites {
 		if err := writeSuiteCSV(outDir, suite, tables[suite]); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func removeGeneratedFigures(outDir string) error {
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read summary directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "figure_") || !strings.HasSuffix(name, ".csv") {
+			continue
+		}
+		path := filepath.Join(outDir, name)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove stale summary csv %s: %w", path, err)
 		}
 	}
 	return nil

--- a/internal/eval/summary/summary_test.go
+++ b/internal/eval/summary/summary_test.go
@@ -1,0 +1,130 @@
+package summary
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestSummarizeFlattensNestedScalarFields(t *testing.T) {
+	tmp := t.TempDir()
+	runDir := filepath.Join(tmp, "run")
+	rawDir := filepath.Join(runDir, "raw")
+	outDir := filepath.Join(tmp, "summary")
+	if err := os.MkdirAll(rawDir, 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+	writeEnvelope(t, rawDir, "write_trace", `{
+		"system": "maltflat",
+		"iteration": 7,
+		"accounting": {"total": {"new_persisted_bytes": 1234}},
+		"ignored": {"samples": [1, 2, 3]}
+	}`)
+
+	if err := Summarize(runDir, outDir); err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+
+	rows := readCSV(t, filepath.Join(outDir, "figure_write_trace.csv"))
+	wantHeader := []string{
+		"schema_version",
+		"run_id",
+		"suite",
+		"emitted_at",
+		"accounting.total.new_persisted_bytes",
+		"iteration",
+		"system",
+	}
+	if !reflect.DeepEqual(rows[0], wantHeader) {
+		t.Fatalf("header = %#v, want %#v", rows[0], wantHeader)
+	}
+	wantRow := []string{
+		"malt.eval.v1",
+		"run-1",
+		"write_trace",
+		"2026-05-16T00:00:00Z",
+		"1234",
+		"7",
+		"maltflat",
+	}
+	if !reflect.DeepEqual(rows[1], wantRow) {
+		t.Fatalf("row = %#v, want %#v", rows[1], wantRow)
+	}
+}
+
+func TestSummarizeUsesDeterministicHeader(t *testing.T) {
+	tmp := t.TempDir()
+	runDir := filepath.Join(tmp, "run")
+	rawDir := filepath.Join(runDir, "raw")
+	outDir := filepath.Join(tmp, "summary")
+	if err := os.MkdirAll(rawDir, 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+	writeEnvelope(t, rawDir, "read_query", `{"z":1,"a":2,"nested":{"b":3}}`)
+	writeEnvelope(t, rawDir, "read_query", `{"m":4,"nested":{"a":5}}`)
+
+	if err := Summarize(runDir, outDir); err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+
+	rows := readCSV(t, filepath.Join(outDir, "figure_read_query.csv"))
+	wantHeader := []string{
+		"schema_version",
+		"run_id",
+		"suite",
+		"emitted_at",
+		"a",
+		"m",
+		"nested.a",
+		"nested.b",
+		"z",
+	}
+	if !reflect.DeepEqual(rows[0], wantHeader) {
+		t.Fatalf("header = %#v, want %#v", rows[0], wantHeader)
+	}
+	wantFirstRow := []string{"malt.eval.v1", "run-1", "read_query", "2026-05-16T00:00:00Z", "2", "", "", "3", "1"}
+	if !reflect.DeepEqual(rows[1], wantFirstRow) {
+		t.Fatalf("first row = %#v, want %#v", rows[1], wantFirstRow)
+	}
+}
+
+func writeEnvelope(t *testing.T, rawDir, suite, record string) {
+	t.Helper()
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(record)); err != nil {
+		t.Fatalf("compact record: %v", err)
+	}
+	line := fmt.Sprintf(
+		`{"schema_version":"malt.eval.v1","run_id":"run-1","suite":%q,"emitted_at":"2026-05-16T00:00:00Z","record":%s}`+"\n",
+		suite,
+		compact.String(),
+	)
+	path := filepath.Join(rawDir, suite+".jsonl")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open raw envelope: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line); err != nil {
+		t.Fatalf("write raw envelope: %v", err)
+	}
+}
+
+func readCSV(t *testing.T, path string) [][]string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open csv: %v", err)
+	}
+	defer f.Close()
+	rows, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	return rows
+}

--- a/internal/eval/summary/summary_test.go
+++ b/internal/eval/summary/summary_test.go
@@ -136,6 +136,27 @@ func TestSummarizeRefreshesGeneratedFigureCSVs(t *testing.T) {
 	}
 }
 
+func TestSummarizeRejectsUnsafeEnvelopeSuiteName(t *testing.T) {
+	tmp := t.TempDir()
+	runDir := filepath.Join(tmp, "run")
+	rawDir := filepath.Join(runDir, "raw")
+	outDir := filepath.Join(runDir, "summary")
+	if err := os.MkdirAll(rawDir, 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+	line := `{"schema_version":"malt.eval.v1","run_id":"run-1","suite":"x/../../escaped","emitted_at":"2026-05-16T00:00:00Z","record":{"value":1}}` + "\n"
+	if err := os.WriteFile(filepath.Join(rawDir, "safe.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatalf("write malicious raw envelope: %v", err)
+	}
+
+	if err := Summarize(runDir, outDir); err == nil {
+		t.Fatal("Summarize should reject unsafe suite names from raw envelopes")
+	}
+	if _, err := os.Stat(filepath.Join(runDir, "escaped.csv")); !os.IsNotExist(err) {
+		t.Fatalf("escaped summary file exists or stat failed unexpectedly: %v", err)
+	}
+}
+
 func writeEnvelope(t *testing.T, rawDir, suite, record string) {
 	t.Helper()
 	var compact bytes.Buffer

--- a/internal/eval/summary/summary_test.go
+++ b/internal/eval/summary/summary_test.go
@@ -93,6 +93,49 @@ func TestSummarizeUsesDeterministicHeader(t *testing.T) {
 	}
 }
 
+func TestSummarizeRefreshesGeneratedFigureCSVs(t *testing.T) {
+	tmp := t.TempDir()
+	runDir := filepath.Join(tmp, "run")
+	rawDir := filepath.Join(runDir, "raw")
+	outDir := filepath.Join(runDir, "summary")
+	if err := os.MkdirAll(rawDir, 0o755); err != nil {
+		t.Fatalf("mkdir raw: %v", err)
+	}
+	writeEnvelope(t, rawDir, "write_trace", `{"iteration":1}`)
+	if err := Summarize(runDir, outDir); err != nil {
+		t.Fatalf("first Summarize: %v", err)
+	}
+	stalePath := filepath.Join(outDir, "figure_write_trace.csv")
+	if _, err := os.Stat(stalePath); err != nil {
+		t.Fatalf("initial figure missing: %v", err)
+	}
+	notesPath := filepath.Join(outDir, "notes.txt")
+	if err := os.WriteFile(notesPath, []byte("keep\n"), 0o644); err != nil {
+		t.Fatalf("write notes: %v", err)
+	}
+	if err := os.Remove(filepath.Join(rawDir, "write_trace.jsonl")); err != nil {
+		t.Fatalf("remove write trace raw: %v", err)
+	}
+	writeEnvelope(t, rawDir, "read_query", `{"query":"/a"}`)
+
+	if err := Summarize(runDir, outDir); err != nil {
+		t.Fatalf("second Summarize: %v", err)
+	}
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale write trace figure still present or stat failed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "figure_read_query.csv")); err != nil {
+		t.Fatalf("current read query figure missing: %v", err)
+	}
+	notes, err := os.ReadFile(notesPath)
+	if err != nil {
+		t.Fatalf("read notes: %v", err)
+	}
+	if string(notes) != "keep\n" {
+		t.Fatalf("notes = %q, want keep", notes)
+	}
+}
+
 func writeEnvelope(t *testing.T, rawDir, suite, record string) {
 	t.Helper()
 	var compact bytes.Buffer


### PR DESCRIPTION
## Summary
- Add `malt-eval run --plan`, common run manifests, raw JSONL envelopes, schema discovery, and summary CSV generation.
- Add final evaluation suites for write traces, read/query benchmarks, CAS cost model, proof overhead, and storage overhead.
- Preserve existing `read`, `write`, and `metrics` commands while exposing `schema` and `summarize` helpers.

## Notes
- The MALT-flat write trace adapter now defaults to versioned ArcTable + KZG for paper-aligned runs.
- Write trace output explicitly records `materialization_strategy: live_snapshot_rebuild`; incremental UnixFS delete/rename replay remains a separate implementation task.

## Test Plan
- `git diff --check`
- `env GOCACHE=/tmp/go-build-cache go test -count=1 ./...`
- `env GOCACHE=/tmp/go-build-cache go build -buildvcs=false -o /tmp/malt-eval-schema-check ./cmd/eval/malt-eval`
- From `/tmp`: `/tmp/malt-eval-schema-check schema --name run-plan`
- `env GOCACHE=/tmp/go-build-cache go run ./cmd/eval/malt-eval run --plan /tmp/malt-eval-autosummary-plan.json`
- Verified `/tmp/malt-eval-autosummary-smoke/{manifest.json,raw/cas_model.jsonl,summary/figure_cas_model.csv}`