### PR TITLE
Support repository URL lists in write trace evaluation

### DIFF
--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -305,10 +305,10 @@ func repoName(path, repoURL string) string {
 }
 
 // CanonicalRepoIDFromURL derives the evaluation repository identity from a Git
-// URL. The identity is semantic result metadata, so it uses owner/repo rather
-// than the local cache path or branch/ref name.
+// URL. The identity is semantic result metadata, so it uses host plus the full
+// namespace path rather than the local cache path or branch/ref name.
 func CanonicalRepoIDFromURL(repoURL string) (string, error) {
-	path := repoIdentityPath(repoURL)
+	host, path := repoIdentityParts(repoURL)
 	path = strings.TrimRight(strings.TrimSpace(path), `/\`)
 	if strings.HasSuffix(strings.ToLower(path), ".git") {
 		path = path[:len(path)-len(".git")]
@@ -318,13 +318,15 @@ func CanonicalRepoIDFromURL(repoURL string) (string, error) {
 	if path == "" {
 		return "", fmt.Errorf("repo URL %q does not contain a repository path", repoURL)
 	}
-	parts := strings.Split(path, "/")
-	filtered := parts[:0]
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part != "" {
-			filtered = append(filtered, part)
-		}
+	filtered := nonEmptyPathParts(path)
+	if len(filtered) == 0 {
+		return "", fmt.Errorf("repo URL %q does not contain a repository path", repoURL)
+	}
+	if host = strings.ToLower(strings.TrimSpace(host)); host != "" {
+		return host + "/" + strings.ToLower(strings.Join(filtered, "/")), nil
+	}
+	if hostIndex := firstHostPathSegment(filtered); hostIndex >= 0 && hostIndex < len(filtered)-1 {
+		return strings.ToLower(strings.Join(filtered[hostIndex:], "/")), nil
 	}
 	switch {
 	case len(filtered) >= 2:
@@ -336,18 +338,39 @@ func CanonicalRepoIDFromURL(repoURL string) (string, error) {
 	}
 }
 
-func repoIdentityPath(repoURL string) string {
+func nonEmptyPathParts(path string) []string {
+	parts := strings.Split(path, "/")
+	filtered := parts[:0]
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			filtered = append(filtered, part)
+		}
+	}
+	return filtered
+}
+
+func firstHostPathSegment(parts []string) int {
+	for i, part := range parts {
+		if strings.Contains(part, ".") {
+			return i
+		}
+	}
+	return -1
+}
+
+func repoIdentityParts(repoURL string) (string, string) {
 	trimmed := strings.TrimSpace(repoURL)
 	if !strings.Contains(trimmed, "://") && strings.Contains(trimmed, "@") {
 		afterUser := strings.SplitN(trimmed, "@", 2)[1]
-		if _, path, ok := strings.Cut(afterUser, ":"); ok {
-			return path
+		if host, path, ok := strings.Cut(afterUser, ":"); ok {
+			return host, path
 		}
 	}
 	if parsed, err := url.Parse(trimmed); err == nil && parsed.Scheme != "" {
-		return parsed.Path
+		return parsed.Host, parsed.Path
 	}
-	return trimmed
+	return "", trimmed
 }
 
 const (

--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -304,6 +304,52 @@ func repoName(path, repoURL string) string {
 	return filepath.Base(path)
 }
 
+// CanonicalRepoIDFromURL derives the evaluation repository identity from a Git
+// URL. The identity is semantic result metadata, so it uses owner/repo rather
+// than the local cache path or branch/ref name.
+func CanonicalRepoIDFromURL(repoURL string) (string, error) {
+	path := repoIdentityPath(repoURL)
+	path = strings.TrimRight(strings.TrimSpace(path), `/\`)
+	if strings.HasSuffix(strings.ToLower(path), ".git") {
+		path = path[:len(path)-len(".git")]
+	}
+	path = strings.ReplaceAll(path, "\\", "/")
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return "", fmt.Errorf("repo URL %q does not contain a repository path", repoURL)
+	}
+	parts := strings.Split(path, "/")
+	filtered := parts[:0]
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			filtered = append(filtered, part)
+		}
+	}
+	switch {
+	case len(filtered) >= 2:
+		return strings.ToLower(filtered[len(filtered)-2] + "/" + filtered[len(filtered)-1]), nil
+	case len(filtered) == 1:
+		return strings.ToLower(filtered[0]), nil
+	default:
+		return "", fmt.Errorf("repo URL %q does not contain a repository path", repoURL)
+	}
+}
+
+func repoIdentityPath(repoURL string) string {
+	trimmed := strings.TrimSpace(repoURL)
+	if !strings.Contains(trimmed, "://") && strings.Contains(trimmed, "@") {
+		afterUser := strings.SplitN(trimmed, "@", 2)[1]
+		if _, path, ok := strings.Cut(afterUser, ":"); ok {
+			return path
+		}
+	}
+	if parsed, err := url.Parse(trimmed); err == nil && parsed.Scheme != "" {
+		return parsed.Path
+	}
+	return trimmed
+}
+
 const (
 	cacheNameHashLen = 12
 	maxCacheNameLen  = 80

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -173,9 +173,10 @@ func TestCacheNameForURLIncludesFullRepositoryIdentity(t *testing.T) {
 
 func TestCanonicalRepoIDFromURLUsesOwnerAndRepo(t *testing.T) {
 	cases := map[string]string{
-		"https://github.com/ipfs/kubo.git":        "ipfs/kubo",
-		"git@github.com:ethereum/go-ethereum.git": "ethereum/go-ethereum",
-		"file:///tmp/eval/repos/fork/kubo.git":    "fork/kubo",
+		"https://github.com/ipfs/kubo.git":                "github.com/ipfs/kubo",
+		"git@github.com:ethereum/go-ethereum.git":         "github.com/ethereum/go-ethereum",
+		"file:///tmp/eval/repos/github.com/fork/kubo.git": "github.com/fork/kubo",
+		"https://gitlab.com/group/subgroup/project.git":   "gitlab.com/group/subgroup/project",
 	}
 	for raw, want := range cases {
 		got, err := gittrace.CanonicalRepoIDFromURL(raw)

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -171,6 +171,23 @@ func TestCacheNameForURLIncludesFullRepositoryIdentity(t *testing.T) {
 	}
 }
 
+func TestCanonicalRepoIDFromURLUsesOwnerAndRepo(t *testing.T) {
+	cases := map[string]string{
+		"https://github.com/ipfs/kubo.git":        "ipfs/kubo",
+		"git@github.com:ethereum/go-ethereum.git": "ethereum/go-ethereum",
+		"file:///tmp/eval/repos/fork/kubo.git":    "fork/kubo",
+	}
+	for raw, want := range cases {
+		got, err := gittrace.CanonicalRepoIDFromURL(raw)
+		if err != nil {
+			t.Fatalf("CanonicalRepoIDFromURL(%q): %v", raw, err)
+		}
+		if got != want {
+			t.Fatalf("CanonicalRepoIDFromURL(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
 func TestCacheNameForURLIsBoundedForLongLocalPaths(t *testing.T) {
 	name := gittrace.CacheNameForURL("C:\\" + strings.Repeat("long-path-segment\\", 20) + "project.git")
 	if len(name) > 80 {

--- a/internal/eval/framework/plan_test.go
+++ b/internal/eval/framework/plan_test.go
@@ -17,7 +17,7 @@ func TestLoadPlanDefaultsAndPreservesSuiteConfig(t *testing.T) {
 				"name": "write_trace",
 				"config": {
 					"systems": ["maltflat", "merkledag"],
-					"commit_limit": 25
+					"max_commits_per_repo": 25
 				}
 			},
 			{
@@ -53,13 +53,13 @@ func TestLoadPlanDefaultsAndPreservesSuiteConfig(t *testing.T) {
 	}
 
 	var cfg struct {
-		Systems     []string `json:"systems"`
-		CommitLimit int      `json:"commit_limit"`
+		Systems           []string `json:"systems"`
+		MaxCommitsPerRepo int      `json:"max_commits_per_repo"`
 	}
 	if err := json.Unmarshal(plan.Suites[0].Config, &cfg); err != nil {
 		t.Fatalf("unmarshal suite config: %v", err)
 	}
-	if cfg.CommitLimit != 25 || len(cfg.Systems) != 2 || cfg.Systems[0] != "maltflat" {
+	if cfg.MaxCommitsPerRepo != 25 || len(cfg.Systems) != 2 || cfg.Systems[0] != "maltflat" {
 		t.Fatalf("suite config = %#v", cfg)
 	}
 }

--- a/internal/eval/suites/writetrace/config.go
+++ b/internal/eval/suites/writetrace/config.go
@@ -155,31 +155,30 @@ func (r RepositoryConfig) validate(index int) error {
 
 // StoreName returns a stable filesystem-safe name for this repository.
 func (r RepositoryConfig) StoreName(index int) string {
+	label := "repo"
 	if name := sanitizeName(r.Name); name != "" {
-		return name
-	}
-	if strings.TrimSpace(r.RepoPath) != "" {
+		label = name
+	} else if strings.TrimSpace(r.RepoPath) != "" {
 		if name := sanitizeName(filepath.Base(r.RepoPath)); name != "" {
-			return name
+			label = name
 		}
-	}
-	if strings.TrimSpace(r.RepoURL) != "" {
+	} else if strings.TrimSpace(r.RepoURL) != "" {
 		trimmed := strings.TrimSuffix(r.RepoURL, ".git")
 		parts := strings.FieldsFunc(trimmed, func(r rune) bool {
 			return r == '/' || r == '\\' || r == ':'
 		})
 		if len(parts) > 0 {
 			if name := sanitizeName(parts[len(parts)-1]); name != "" {
-				return name
+				label = name
 			}
 		}
 	}
-	return fmt.Sprintf("repo-%d", index)
+	return fmt.Sprintf("%03d-%s", index, label)
 }
 
 func (r *RepositoryConfig) UnmarshalJSON(data []byte) error {
 	var parsed repositoryConfigJSON
-	if err := json.Unmarshal(data, &parsed); err != nil {
+	if err := configjson.Decode(data, "write_trace repository", &parsed); err != nil {
 		return err
 	}
 	r.Name = strings.TrimSpace(parsed.Name)

--- a/internal/eval/suites/writetrace/config.go
+++ b/internal/eval/suites/writetrace/config.go
@@ -4,9 +4,9 @@ package writetrace
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strings"
 
+	gittrace "github.com/dewebprotocol/malt/cmd/eval/helper/git"
 	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
 	"github.com/dewebprotocol/malt/internal/eval/suites/configjson"
 )
@@ -15,41 +15,21 @@ const SuiteName = "write_trace"
 
 // Config controls the write_trace evaluation suite.
 type Config struct {
-	RepoURL      string             `json:"repo_url,omitempty"`
-	RepoPath     string             `json:"repo_path,omitempty"`
-	RepoRef      string             `json:"repo_ref,omitempty"`
-	CommitLimit  int                `json:"commit_limit,omitempty"`
-	CacheDir     string             `json:"cache_dir,omitempty"`
-	StoreDir     string             `json:"store_dir,omitempty"`
-	StoreMode    string             `json:"store_mode,omitempty"`
-	StoreBackend string             `json:"store_backend,omitempty"`
-	Systems      SystemList         `json:"systems,omitempty"`
-	FirstParent  bool               `json:"first_parent"`
-	Repositories []RepositoryConfig `json:"repositories,omitempty"`
+	RepoURLs          []string   `json:"repo_urls,omitempty"`
+	MaxCommitsPerRepo int        `json:"max_commits_per_repo,omitempty"`
+	CacheDir          string     `json:"cache_dir,omitempty"`
+	StoreDir          string     `json:"store_dir,omitempty"`
+	StoreMode         string     `json:"store_mode,omitempty"`
+	StoreBackend      string     `json:"store_backend,omitempty"`
+	Systems           SystemList `json:"systems,omitempty"`
+	FirstParent       bool       `json:"first_parent"`
 }
 
-// RepositoryConfig describes one Git repository replay target after defaults
-// have been applied.
-type RepositoryConfig struct {
-	Name           string `json:"name,omitempty"`
-	RepoURL        string `json:"repo_url,omitempty"`
-	RepoPath       string `json:"repo_path,omitempty"`
-	RepoRef        string `json:"repo_ref,omitempty"`
-	CommitLimit    int    `json:"commit_limit,omitempty"`
-	commitLimitSet bool
-	CacheDir       string `json:"cache_dir,omitempty"`
-	FirstParent    bool   `json:"first_parent"`
-	firstParentSet bool
-}
-
-type repositoryConfigJSON struct {
-	Name        string `json:"name,omitempty"`
-	RepoURL     string `json:"repo_url,omitempty"`
-	RepoPath    string `json:"repo_path,omitempty"`
-	RepoRef     string `json:"repo_ref,omitempty"`
-	CommitLimit *int   `json:"commit_limit,omitempty"`
-	CacheDir    string `json:"cache_dir,omitempty"`
-	FirstParent *bool  `json:"first_parent,omitempty"`
+// RepositoryTarget is one repository-level replay target resolved from a repo
+// URL list. RepoID is result metadata; StoreName is only a local run key.
+type RepositoryTarget struct {
+	RepoURL string
+	RepoID  string
 }
 
 // SystemList accepts either a JSON array or a comma-separated JSON string.
@@ -58,7 +38,6 @@ type SystemList []string
 // DefaultConfig returns the same replay defaults used by malt-eval write.
 func DefaultConfig() Config {
 	return Config{
-		RepoRef:      "HEAD",
 		CacheDir:     ".eval-cache/repos",
 		StoreDir:     ".eval-cache/write-stores",
 		StoreMode:    string(evalstore.StoreModeIsolated),
@@ -87,114 +66,45 @@ func (c Config) SystemsCSV() string {
 }
 
 func (c Config) validate() error {
-	_, err := c.RepositoriesOrSingle()
+	_, err := c.RepositoryTargets()
 	return err
 }
 
-// RepositoriesOrSingle returns normalized repositories. It preserves the
-// original single-repository fields for compatibility and applies suite-level
-// defaults to repositories[] entries.
-func (c Config) RepositoriesOrSingle() ([]RepositoryConfig, error) {
-	if c.CommitLimit < 0 {
-		return nil, fmt.Errorf("commit_limit must be non-negative")
+// RepositoryTargets returns normalized repository targets from repo_urls.
+func (c Config) RepositoryTargets() ([]RepositoryTarget, error) {
+	if c.MaxCommitsPerRepo < 0 {
+		return nil, fmt.Errorf("max_commits_per_repo must be non-negative")
 	}
-	if len(c.Repositories) > 0 {
-		if strings.TrimSpace(c.RepoURL) != "" || strings.TrimSpace(c.RepoPath) != "" {
-			return nil, fmt.Errorf("repositories cannot be combined with repo_url or repo_path")
+	if len(c.RepoURLs) == 0 {
+		return nil, fmt.Errorf("repo_urls must contain at least one repository URL")
+	}
+	repos := make([]RepositoryTarget, 0, len(c.RepoURLs))
+	seen := make(map[string]int, len(c.RepoURLs))
+	for i, raw := range c.RepoURLs {
+		repoURL := strings.TrimSpace(raw)
+		if repoURL == "" {
+			return nil, fmt.Errorf("repo_urls[%d] must not be empty", i)
 		}
-		repos := make([]RepositoryConfig, 0, len(c.Repositories))
-		for i, repo := range c.Repositories {
-			repo = c.applyRepositoryDefaults(repo)
-			if err := repo.validate(i); err != nil {
-				return nil, err
-			}
-			repos = append(repos, repo)
+		repoID, err := gittrace.CanonicalRepoIDFromURL(repoURL)
+		if err != nil {
+			return nil, fmt.Errorf("repo_urls[%d]: %w", i, err)
 		}
-		return repos, nil
+		if previous, ok := seen[repoID]; ok {
+			return nil, fmt.Errorf("repo_urls[%d] duplicates repository %q from repo_urls[%d]", i, repoID, previous)
+		}
+		seen[repoID] = i
+		repos = append(repos, RepositoryTarget{RepoURL: repoURL, RepoID: repoID})
 	}
-	repo := RepositoryConfig{
-		RepoURL:     c.RepoURL,
-		RepoPath:    c.RepoPath,
-		RepoRef:     c.RepoRef,
-		CommitLimit: c.CommitLimit,
-		CacheDir:    c.CacheDir,
-		FirstParent: c.FirstParent,
-	}
-	repo = c.applyRepositoryDefaults(repo)
-	if err := repo.validate(0); err != nil {
-		return nil, err
-	}
-	return []RepositoryConfig{repo}, nil
+	return repos, nil
 }
 
-func (c Config) applyRepositoryDefaults(repo RepositoryConfig) RepositoryConfig {
-	if strings.TrimSpace(repo.RepoRef) == "" {
-		repo.RepoRef = c.RepoRef
-	}
-	if !repo.commitLimitSet && c.CommitLimit != 0 {
-		repo.CommitLimit = c.CommitLimit
-	}
-	if strings.TrimSpace(repo.CacheDir) == "" {
-		repo.CacheDir = c.CacheDir
-	}
-	if !repo.firstParentSet {
-		repo.FirstParent = c.FirstParent
-	}
-	return repo
-}
-
-func (r RepositoryConfig) validate(index int) error {
-	if strings.TrimSpace(r.RepoURL) == "" && strings.TrimSpace(r.RepoPath) == "" {
-		return fmt.Errorf("repository %d: one of repo_url or repo_path is required", index)
-	}
-	if r.CommitLimit < 0 {
-		return fmt.Errorf("repository %d: commit_limit must be non-negative", index)
-	}
-	return nil
-}
-
-// StoreName returns a stable filesystem-safe name for this repository.
-func (r RepositoryConfig) StoreName(index int) string {
-	label := "repo"
-	if name := sanitizeName(r.Name); name != "" {
-		label = name
-	} else if strings.TrimSpace(r.RepoPath) != "" {
-		if name := sanitizeName(filepath.Base(r.RepoPath)); name != "" {
-			label = name
-		}
-	} else if strings.TrimSpace(r.RepoURL) != "" {
-		trimmed := strings.TrimSuffix(r.RepoURL, ".git")
-		parts := strings.FieldsFunc(trimmed, func(r rune) bool {
-			return r == '/' || r == '\\' || r == ':'
-		})
-		if len(parts) > 0 {
-			if name := sanitizeName(parts[len(parts)-1]); name != "" {
-				label = name
-			}
-		}
+// StoreName returns a stable filesystem-safe name for this repository target.
+func (r RepositoryTarget) StoreName(index int) string {
+	label := sanitizeName(r.RepoID)
+	if label == "" {
+		label = "repo"
 	}
 	return fmt.Sprintf("%03d-%s", index, label)
-}
-
-func (r *RepositoryConfig) UnmarshalJSON(data []byte) error {
-	var parsed repositoryConfigJSON
-	if err := configjson.Decode(data, "write_trace repository", &parsed); err != nil {
-		return err
-	}
-	r.Name = strings.TrimSpace(parsed.Name)
-	r.RepoURL = strings.TrimSpace(parsed.RepoURL)
-	r.RepoPath = strings.TrimSpace(parsed.RepoPath)
-	r.RepoRef = strings.TrimSpace(parsed.RepoRef)
-	r.CacheDir = strings.TrimSpace(parsed.CacheDir)
-	if parsed.CommitLimit != nil {
-		r.CommitLimit = *parsed.CommitLimit
-		r.commitLimitSet = true
-	}
-	if parsed.FirstParent != nil {
-		r.FirstParent = *parsed.FirstParent
-		r.firstParentSet = true
-	}
-	return nil
 }
 
 func (s *SystemList) UnmarshalJSON(data []byte) error {

--- a/internal/eval/suites/writetrace/config.go
+++ b/internal/eval/suites/writetrace/config.go
@@ -4,6 +4,7 @@ package writetrace
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
@@ -13,16 +14,41 @@ const SuiteName = "write_trace"
 
 // Config controls the write_trace evaluation suite.
 type Config struct {
-	RepoURL      string     `json:"repo_url,omitempty"`
-	RepoPath     string     `json:"repo_path,omitempty"`
-	RepoRef      string     `json:"repo_ref,omitempty"`
-	CommitLimit  int        `json:"commit_limit,omitempty"`
-	CacheDir     string     `json:"cache_dir,omitempty"`
-	StoreDir     string     `json:"store_dir,omitempty"`
-	StoreMode    string     `json:"store_mode,omitempty"`
-	StoreBackend string     `json:"store_backend,omitempty"`
-	Systems      SystemList `json:"systems,omitempty"`
-	FirstParent  bool       `json:"first_parent"`
+	RepoURL      string             `json:"repo_url,omitempty"`
+	RepoPath     string             `json:"repo_path,omitempty"`
+	RepoRef      string             `json:"repo_ref,omitempty"`
+	CommitLimit  int                `json:"commit_limit,omitempty"`
+	CacheDir     string             `json:"cache_dir,omitempty"`
+	StoreDir     string             `json:"store_dir,omitempty"`
+	StoreMode    string             `json:"store_mode,omitempty"`
+	StoreBackend string             `json:"store_backend,omitempty"`
+	Systems      SystemList         `json:"systems,omitempty"`
+	FirstParent  bool               `json:"first_parent"`
+	Repositories []RepositoryConfig `json:"repositories,omitempty"`
+}
+
+// RepositoryConfig describes one Git repository replay target after defaults
+// have been applied.
+type RepositoryConfig struct {
+	Name           string `json:"name,omitempty"`
+	RepoURL        string `json:"repo_url,omitempty"`
+	RepoPath       string `json:"repo_path,omitempty"`
+	RepoRef        string `json:"repo_ref,omitempty"`
+	CommitLimit    int    `json:"commit_limit,omitempty"`
+	commitLimitSet bool
+	CacheDir       string `json:"cache_dir,omitempty"`
+	FirstParent    bool   `json:"first_parent"`
+	firstParentSet bool
+}
+
+type repositoryConfigJSON struct {
+	Name        string `json:"name,omitempty"`
+	RepoURL     string `json:"repo_url,omitempty"`
+	RepoPath    string `json:"repo_path,omitempty"`
+	RepoRef     string `json:"repo_ref,omitempty"`
+	CommitLimit *int   `json:"commit_limit,omitempty"`
+	CacheDir    string `json:"cache_dir,omitempty"`
+	FirstParent *bool  `json:"first_parent,omitempty"`
 }
 
 // SystemList accepts either a JSON array or a comma-separated JSON string.
@@ -60,11 +86,113 @@ func (c Config) SystemsCSV() string {
 }
 
 func (c Config) validate() error {
-	if strings.TrimSpace(c.RepoURL) == "" && strings.TrimSpace(c.RepoPath) == "" {
-		return fmt.Errorf("one of repo_url or repo_path is required")
-	}
+	_, err := c.RepositoriesOrSingle()
+	return err
+}
+
+// RepositoriesOrSingle returns normalized repositories. It preserves the
+// original single-repository fields for compatibility and applies suite-level
+// defaults to repositories[] entries.
+func (c Config) RepositoriesOrSingle() ([]RepositoryConfig, error) {
 	if c.CommitLimit < 0 {
-		return fmt.Errorf("commit_limit must be non-negative")
+		return nil, fmt.Errorf("commit_limit must be non-negative")
+	}
+	if len(c.Repositories) > 0 {
+		if strings.TrimSpace(c.RepoURL) != "" || strings.TrimSpace(c.RepoPath) != "" {
+			return nil, fmt.Errorf("repositories cannot be combined with repo_url or repo_path")
+		}
+		repos := make([]RepositoryConfig, 0, len(c.Repositories))
+		for i, repo := range c.Repositories {
+			repo = c.applyRepositoryDefaults(repo)
+			if err := repo.validate(i); err != nil {
+				return nil, err
+			}
+			repos = append(repos, repo)
+		}
+		return repos, nil
+	}
+	repo := RepositoryConfig{
+		RepoURL:     c.RepoURL,
+		RepoPath:    c.RepoPath,
+		RepoRef:     c.RepoRef,
+		CommitLimit: c.CommitLimit,
+		CacheDir:    c.CacheDir,
+		FirstParent: c.FirstParent,
+	}
+	repo = c.applyRepositoryDefaults(repo)
+	if err := repo.validate(0); err != nil {
+		return nil, err
+	}
+	return []RepositoryConfig{repo}, nil
+}
+
+func (c Config) applyRepositoryDefaults(repo RepositoryConfig) RepositoryConfig {
+	if strings.TrimSpace(repo.RepoRef) == "" {
+		repo.RepoRef = c.RepoRef
+	}
+	if !repo.commitLimitSet && c.CommitLimit != 0 {
+		repo.CommitLimit = c.CommitLimit
+	}
+	if strings.TrimSpace(repo.CacheDir) == "" {
+		repo.CacheDir = c.CacheDir
+	}
+	if !repo.firstParentSet {
+		repo.FirstParent = c.FirstParent
+	}
+	return repo
+}
+
+func (r RepositoryConfig) validate(index int) error {
+	if strings.TrimSpace(r.RepoURL) == "" && strings.TrimSpace(r.RepoPath) == "" {
+		return fmt.Errorf("repository %d: one of repo_url or repo_path is required", index)
+	}
+	if r.CommitLimit < 0 {
+		return fmt.Errorf("repository %d: commit_limit must be non-negative", index)
+	}
+	return nil
+}
+
+// StoreName returns a stable filesystem-safe name for this repository.
+func (r RepositoryConfig) StoreName(index int) string {
+	if name := sanitizeName(r.Name); name != "" {
+		return name
+	}
+	if strings.TrimSpace(r.RepoPath) != "" {
+		if name := sanitizeName(filepath.Base(r.RepoPath)); name != "" {
+			return name
+		}
+	}
+	if strings.TrimSpace(r.RepoURL) != "" {
+		trimmed := strings.TrimSuffix(r.RepoURL, ".git")
+		parts := strings.FieldsFunc(trimmed, func(r rune) bool {
+			return r == '/' || r == '\\' || r == ':'
+		})
+		if len(parts) > 0 {
+			if name := sanitizeName(parts[len(parts)-1]); name != "" {
+				return name
+			}
+		}
+	}
+	return fmt.Sprintf("repo-%d", index)
+}
+
+func (r *RepositoryConfig) UnmarshalJSON(data []byte) error {
+	var parsed repositoryConfigJSON
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+	r.Name = strings.TrimSpace(parsed.Name)
+	r.RepoURL = strings.TrimSpace(parsed.RepoURL)
+	r.RepoPath = strings.TrimSpace(parsed.RepoPath)
+	r.RepoRef = strings.TrimSpace(parsed.RepoRef)
+	r.CacheDir = strings.TrimSpace(parsed.CacheDir)
+	if parsed.CommitLimit != nil {
+		r.CommitLimit = *parsed.CommitLimit
+		r.commitLimitSet = true
+	}
+	if parsed.FirstParent != nil {
+		r.FirstParent = *parsed.FirstParent
+		r.firstParentSet = true
 	}
 	return nil
 }
@@ -105,4 +233,27 @@ func normalizeSystems(values []string) SystemList {
 		out = append(out, value)
 	}
 	return out
+}
+
+func sanitizeName(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range raw {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(b.String(), "-_.")
 }

--- a/internal/eval/suites/writetrace/suite.go
+++ b/internal/eval/suites/writetrace/suite.go
@@ -3,6 +3,7 @@ package writetrace
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 
 	"github.com/dewebprotocol/malt/cmd/eval/helper/evalwrite"
 	gittrace "github.com/dewebprotocol/malt/cmd/eval/helper/git"
@@ -26,11 +27,24 @@ func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) (e
 	if err := cfg.validate(); err != nil {
 		return err
 	}
+	repositories, err := cfg.RepositoriesOrSingle()
+	if err != nil {
+		return err
+	}
 
+	for i, repo := range repositories {
+		if err := runRepository(ctx, env, cfg, repo, i, len(repositories)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runRepository(ctx context.Context, env framework.Env, cfg Config, repo RepositoryConfig, index, repoCount int) (err error) {
 	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
 		Mode:    evalstore.StoreMode(cfg.StoreMode),
 		Backend: evalstore.StoreBackend(cfg.StoreBackend),
-		RootDir: cfg.StoreDir,
+		RootDir: storeDirForRepository(cfg.StoreDir, repo, index, repoCount),
 	})
 	if err != nil {
 		return err
@@ -47,14 +61,17 @@ func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) (e
 	}
 
 	source := gittrace.Source{
-		RepoURL:     cfg.RepoURL,
-		RepoPath:    cfg.RepoPath,
-		CacheDir:    cfg.CacheDir,
-		Ref:         cfg.RepoRef,
-		Limit:       cfg.CommitLimit,
-		FirstParent: cfg.FirstParent,
+		RepoURL:     repo.RepoURL,
+		RepoPath:    repo.RepoPath,
+		CacheDir:    repo.CacheDir,
+		Ref:         repo.RepoRef,
+		Limit:       repo.CommitLimit,
+		FirstParent: repo.FirstParent,
 	}
 	return source.Walk(ctx, func(commit replay.CommitMutation) error {
+		if repo.Name != "" {
+			commit.Repo = repo.Name
+		}
 		return replay.RunCommitRecords(ctx, commit, systems, func(record replay.ResultRecord) error {
 			return env.WriteRecord(SuiteName, record)
 		})
@@ -62,3 +79,10 @@ func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) (e
 }
 
 var _ framework.Suite = Suite{}
+
+func storeDirForRepository(base string, repo RepositoryConfig, index, repoCount int) string {
+	if base == "" || repoCount <= 1 {
+		return base
+	}
+	return filepath.Join(base, repo.StoreName(index))
+}

--- a/internal/eval/suites/writetrace/suite.go
+++ b/internal/eval/suites/writetrace/suite.go
@@ -27,7 +27,7 @@ func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) (e
 	if err := cfg.validate(); err != nil {
 		return err
 	}
-	repositories, err := cfg.RepositoriesOrSingle()
+	repositories, err := cfg.RepositoryTargets()
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) (e
 	return nil
 }
 
-func runRepository(ctx context.Context, env framework.Env, cfg Config, repo RepositoryConfig, index, repoCount int) (err error) {
+func runRepository(ctx context.Context, env framework.Env, cfg Config, repo RepositoryTarget, index, repoCount int) (err error) {
 	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
 		Mode:    evalstore.StoreMode(cfg.StoreMode),
 		Backend: evalstore.StoreBackend(cfg.StoreBackend),
@@ -62,16 +62,13 @@ func runRepository(ctx context.Context, env framework.Env, cfg Config, repo Repo
 
 	source := gittrace.Source{
 		RepoURL:     repo.RepoURL,
-		RepoPath:    repo.RepoPath,
-		CacheDir:    repo.CacheDir,
-		Ref:         repo.RepoRef,
-		Limit:       repo.CommitLimit,
-		FirstParent: repo.FirstParent,
+		CacheDir:    cfg.CacheDir,
+		Ref:         "HEAD",
+		Limit:       cfg.MaxCommitsPerRepo,
+		FirstParent: cfg.FirstParent,
 	}
 	return source.Walk(ctx, func(commit replay.CommitMutation) error {
-		if repo.Name != "" {
-			commit.Repo = repo.Name
-		}
+		commit.Repo = repo.RepoID
 		return replay.RunCommitRecords(ctx, commit, systems, func(record replay.ResultRecord) error {
 			return env.WriteRecord(SuiteName, record)
 		})
@@ -80,7 +77,7 @@ func runRepository(ctx context.Context, env framework.Env, cfg Config, repo Repo
 
 var _ framework.Suite = Suite{}
 
-func storeDirForRepository(base string, repo RepositoryConfig, index, repoCount int) string {
+func storeDirForRepository(base string, repo RepositoryTarget, index, repoCount int) string {
 	if base == "" || repoCount <= 1 {
 		return base
 	}

--- a/internal/eval/suites/writetrace/suite_test.go
+++ b/internal/eval/suites/writetrace/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,10 +24,8 @@ func TestSuiteName(t *testing.T) {
 
 func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
-		"repo_url": "https://example.test/repo.git",
-		"repo_path": "/tmp/repo",
-		"repo_ref": "main",
-		"commit_limit": 7,
+		"repo_urls": ["https://github.com/ipfs/kubo.git"],
+		"max_commits_per_repo": 7,
 		"cache_dir": "/tmp/cache",
 		"store_dir": "/tmp/stores",
 		"store_mode": "shared",
@@ -37,10 +36,10 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseConfig: %v", err)
 	}
-	if cfg.RepoURL != "https://example.test/repo.git" || cfg.RepoPath != "/tmp/repo" || cfg.RepoRef != "main" {
+	if len(cfg.RepoURLs) != 1 || cfg.RepoURLs[0] != "https://github.com/ipfs/kubo.git" {
 		t.Fatalf("repo config = %+v, want JSON values", cfg)
 	}
-	if cfg.CommitLimit != 7 || cfg.CacheDir != "/tmp/cache" || cfg.StoreDir != "/tmp/stores" {
+	if cfg.MaxCommitsPerRepo != 7 || cfg.CacheDir != "/tmp/cache" || cfg.StoreDir != "/tmp/stores" {
 		t.Fatalf("storage/limit config = %+v, want JSON values", cfg)
 	}
 	if cfg.StoreMode != "shared" || cfg.StoreBackend != "fs" || cfg.FirstParent {
@@ -54,7 +53,7 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseConfig defaults: %v", err)
 	}
-	if defaults.RepoRef != "HEAD" || defaults.CacheDir != ".eval-cache/repos" || defaults.StoreDir != ".eval-cache/write-stores" {
+	if defaults.CacheDir != ".eval-cache/repos" || defaults.StoreDir != ".eval-cache/write-stores" {
 		t.Fatalf("defaults = %+v, want write command paths/ref", defaults)
 	}
 	if defaults.StoreMode != "isolated" || defaults.StoreBackend != "memory" || !defaults.FirstParent {
@@ -65,96 +64,72 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	}
 }
 
-func TestParseConfigSupportsRepositoryListWithInheritedDefaults(t *testing.T) {
+func TestParseConfigBuildsRepositoryTargetsFromURLList(t *testing.T) {
 	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
-		"repo_ref": "main",
-		"commit_limit": 10,
+		"max_commits_per_repo": 10,
 		"cache_dir": "/tmp/shared-cache",
 		"first_parent": true,
-		"repositories": [
-			{
-				"name": "alpha",
-				"repo_url": "https://example.test/alpha.git"
-			},
-			{
-				"name": "beta",
-				"repo_path": "/tmp/beta",
-				"repo_ref": "release",
-				"commit_limit": 0,
-				"cache_dir": "/tmp/beta-cache",
-				"first_parent": false
-			}
+		"repo_urls": [
+			"https://github.com/ipfs/kubo.git",
+			"git@github.com:ethereum/go-ethereum.git"
 		]
 	}`))
 	if err != nil {
 		t.Fatalf("ParseConfig: %v", err)
 	}
 
-	repos, err := cfg.RepositoriesOrSingle()
+	repos, err := cfg.RepositoryTargets()
 	if err != nil {
-		t.Fatalf("RepositoriesOrSingle: %v", err)
+		t.Fatalf("RepositoryTargets: %v", err)
 	}
 	if len(repos) != 2 {
 		t.Fatalf("repo count = %d, want 2", len(repos))
 	}
-	if repos[0].Name != "alpha" || repos[0].RepoURL != "https://example.test/alpha.git" {
-		t.Fatalf("repo 0 identity = %+v", repos[0])
+	if repos[0].RepoID != "ipfs/kubo" || repos[0].RepoURL != "https://github.com/ipfs/kubo.git" {
+		t.Fatalf("repo 0 target = %+v", repos[0])
 	}
-	if repos[0].RepoRef != "main" || repos[0].CommitLimit != 10 || repos[0].CacheDir != "/tmp/shared-cache" || !repos[0].FirstParent {
-		t.Fatalf("repo 0 inherited defaults = %+v", repos[0])
+	if repos[1].RepoID != "ethereum/go-ethereum" || repos[1].RepoURL != "git@github.com:ethereum/go-ethereum.git" {
+		t.Fatalf("repo 1 target = %+v", repos[1])
 	}
-	if repos[1].Name != "beta" || repos[1].RepoPath != "/tmp/beta" {
-		t.Fatalf("repo 1 identity = %+v", repos[1])
-	}
-	if repos[1].RepoRef != "release" || repos[1].CommitLimit != 0 || repos[1].CacheDir != "/tmp/beta-cache" || repos[1].FirstParent {
-		t.Fatalf("repo 1 overrides = %+v", repos[1])
+	if cfg.MaxCommitsPerRepo != 10 || cfg.CacheDir != "/tmp/shared-cache" || !cfg.FirstParent {
+		t.Fatalf("suite defaults = %+v", cfg)
 	}
 }
 
-func TestRepositoryStoreNameIncludesIndexForIsolation(t *testing.T) {
-	first := writetrace.RepositoryConfig{Name: "alpha"}.StoreName(0)
-	second := writetrace.RepositoryConfig{Name: "alpha"}.StoreName(1)
-	if first != "000-alpha" || second != "001-alpha" {
-		t.Fatalf("store names = %q/%q, want indexed names", first, second)
-	}
-	if first == second {
-		t.Fatal("store names should not collide for repositories with the same sanitized label")
-	}
-}
-
-func TestParseConfigKeepsSingleRepositoryCompatibility(t *testing.T) {
+func TestRepositoryStoreNameUsesIndexedCanonicalRepoID(t *testing.T) {
 	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
-		"repo_path": "/tmp/single",
-		"repo_ref": "HEAD",
-		"commit_limit": 3
-	}`))
-	if err != nil {
-		t.Fatalf("ParseConfig: %v", err)
-	}
-	repos, err := cfg.RepositoriesOrSingle()
-	if err != nil {
-		t.Fatalf("RepositoriesOrSingle: %v", err)
-	}
-	if len(repos) != 1 {
-		t.Fatalf("repo count = %d, want 1", len(repos))
-	}
-	if repos[0].RepoPath != "/tmp/single" || repos[0].RepoRef != "HEAD" || repos[0].CommitLimit != 3 {
-		t.Fatalf("single repo = %+v", repos[0])
-	}
-}
-
-func TestParseConfigRejectsRepositoryListMixedWithSingleRepoFields(t *testing.T) {
-	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
-		"repo_path": "/tmp/single",
-		"repositories": [
-			{"repo_path": "/tmp/other"}
+		"repo_urls": [
+			"https://github.com/ipfs/kubo.git",
+			"https://github.com/fork/kubo.git"
 		]
 	}`))
 	if err != nil {
 		t.Fatalf("ParseConfig: %v", err)
 	}
-	if _, err := cfg.RepositoriesOrSingle(); err == nil {
-		t.Fatal("RepositoriesOrSingle should reject repositories mixed with repo_path")
+	repos, err := cfg.RepositoryTargets()
+	if err != nil {
+		t.Fatalf("RepositoryTargets: %v", err)
+	}
+	if got := repos[0].StoreName(0); got != "000-ipfs-kubo" {
+		t.Fatalf("repo 0 store name = %q", got)
+	}
+	if got := repos[1].StoreName(1); got != "001-fork-kubo" {
+		t.Fatalf("repo 1 store name = %q", got)
+	}
+}
+
+func TestParseConfigRejectsDuplicateCanonicalRepoIDs(t *testing.T) {
+	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
+		"repo_urls": [
+			"https://github.com/ipfs/kubo.git",
+			"git@github.com:ipfs/kubo.git"
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if _, err := cfg.RepositoryTargets(); err == nil {
+		t.Fatal("RepositoryTargets should reject duplicate canonical repo IDs")
 	}
 }
 
@@ -164,16 +139,16 @@ func TestParseConfigRejectsUnknownFields(t *testing.T) {
 	}
 }
 
-func TestParseConfigRejectsUnknownRepositoryFields(t *testing.T) {
-	if _, err := writetrace.ParseConfig(json.RawMessage(`{
-		"repositories": [
-			{
-				"repo_path": "/tmp/repo",
-				"repo_reff": "main"
-			}
-		]
-	}`)); err == nil {
-		t.Fatal("ParseConfig should reject unknown repositories[] fields")
+func TestParseConfigRejectsLegacyRepositoryFields(t *testing.T) {
+	for _, raw := range []string{
+		`{"repo_url": "https://github.com/ipfs/kubo.git"}`,
+		`{"repo_ref": "main"}`,
+		`{"commit_limit": 7}`,
+		`{"repositories": [{"repo_url": "https://github.com/ipfs/kubo.git"}]}`,
+	} {
+		if _, err := writetrace.ParseConfig(json.RawMessage(raw)); err == nil {
+			t.Fatalf("ParseConfig should reject legacy field in %s", raw)
+		}
 	}
 }
 
@@ -182,15 +157,17 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 		t.Skip("git binary not available")
 	}
 	ctx := context.Background()
-	repo := initWriteTraceRepo(t)
+	repo := initWriteTraceRepo(t, "ipfs", "kubo.git")
 	outDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(outDir, "raw"), 0755); err != nil {
 		t.Fatalf("mkdir raw dir: %v", err)
 	}
+	cacheDir := t.TempDir()
 
 	cfg := json.RawMessage(`{
-		"repo_path": ` + strconvQuote(repo) + `,
-		"commit_limit": 3,
+		"repo_urls": [` + strconvQuote(fileURL(repo)) + `],
+		"max_commits_per_repo": 3,
+		"cache_dir": ` + strconvQuote(cacheDir) + `,
 		"store_backend": "memory",
 		"systems": ["maltflat"]
 	}`)
@@ -218,8 +195,8 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 		records = append(records, record)
 	}
 
-	if records[0].Repo != filepath.Base(repo) || records[0].System != "maltflat" || records[0].Index != 0 {
-		t.Fatalf("first record identity = %+v, want repo/maltflat/index 0", records[0])
+	if records[0].Repo != "ipfs/kubo" || records[0].System != "maltflat" || records[0].Index != 0 {
+		t.Fatalf("first record identity = %+v, want canonical repo/maltflat/index 0", records[0])
 	}
 	if records[1].MutationSet[0].Kind != replay.MutationRename || records[1].MutationSet[0].OldPath != "README.md" || records[1].MutationSet[0].Path != "docs/README.md" {
 		t.Fatalf("rename mutation = %+v, want README.md -> docs/README.md", records[1].MutationSet)
@@ -240,24 +217,27 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 	}
 }
 
-func TestSuiteRunReplaysRepositoryListWithAliases(t *testing.T) {
+func TestSuiteRunReplaysRepoURLListWithCanonicalRepoLabels(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git binary not available")
 	}
 	ctx := context.Background()
-	repoA := initWriteTraceRepo(t)
-	repoB := initWriteTraceRepo(t)
+	repoA := initWriteTraceRepo(t, "ipfs", "kubo.git")
+	repoB := initWriteTraceRepo(t, "fork", "kubo.git")
 	outDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(outDir, "raw"), 0755); err != nil {
 		t.Fatalf("mkdir raw dir: %v", err)
 	}
+	cacheDir := t.TempDir()
 
 	cfg := json.RawMessage(`{
 		"store_backend": "memory",
 		"systems": ["maltflat"],
-		"repositories": [
-			{"name": "alpha", "repo_path": ` + strconvQuote(repoA) + `, "commit_limit": 1},
-			{"name": "beta", "repo_path": ` + strconvQuote(repoB) + `, "commit_limit": 1}
+		"max_commits_per_repo": 1,
+		"cache_dir": ` + strconvQuote(cacheDir) + `,
+		"repo_urls": [
+			` + strconvQuote(fileURL(repoA)) + `,
+			` + strconvQuote(fileURL(repoB)) + `
 		]
 	}`)
 	err := (writetrace.Suite{}).Run(ctx, framework.Env{
@@ -280,17 +260,20 @@ func TestSuiteRunReplaysRepositoryListWithAliases(t *testing.T) {
 		}
 		records = append(records, record)
 	}
-	if records[0].Repo != "alpha" || records[0].Index != 0 {
-		t.Fatalf("record 0 = %+v, want alpha index 0", records[0])
+	if records[0].Repo != "ipfs/kubo" || records[0].Index != 0 {
+		t.Fatalf("record 0 = %+v, want ipfs/kubo index 0", records[0])
 	}
-	if records[1].Repo != "beta" || records[1].Index != 0 {
-		t.Fatalf("record 1 = %+v, want beta index 0", records[1])
+	if records[1].Repo != "fork/kubo" || records[1].Index != 0 {
+		t.Fatalf("record 1 = %+v, want fork/kubo index 0", records[1])
 	}
 }
 
-func initWriteTraceRepo(t *testing.T) string {
+func initWriteTraceRepo(t *testing.T, owner, repoName string) string {
 	t.Helper()
-	repo := t.TempDir()
+	repo := filepath.Join(t.TempDir(), owner, repoName)
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
 	runGit(t, repo, "init", "-b", "main")
 	runGit(t, repo, "config", "user.email", "bench@example.test")
 	runGit(t, repo, "config", "user.name", "Bench Test")
@@ -314,6 +297,10 @@ func initWriteTraceRepo(t *testing.T) string {
 	runGit(t, repo, "add", "-A")
 	runGit(t, repo, "commit", "-m", "delete readme")
 	return repo
+}
+
+func fileURL(path string) string {
+	return (&url.URL{Scheme: "file", Path: path}).String()
 }
 
 func readWriteTraceEnvelopes(t *testing.T, path string) []framework.RecordEnvelope {

--- a/internal/eval/suites/writetrace/suite_test.go
+++ b/internal/eval/suites/writetrace/suite_test.go
@@ -111,6 +111,17 @@ func TestParseConfigSupportsRepositoryListWithInheritedDefaults(t *testing.T) {
 	}
 }
 
+func TestRepositoryStoreNameIncludesIndexForIsolation(t *testing.T) {
+	first := writetrace.RepositoryConfig{Name: "alpha"}.StoreName(0)
+	second := writetrace.RepositoryConfig{Name: "alpha"}.StoreName(1)
+	if first != "000-alpha" || second != "001-alpha" {
+		t.Fatalf("store names = %q/%q, want indexed names", first, second)
+	}
+	if first == second {
+		t.Fatal("store names should not collide for repositories with the same sanitized label")
+	}
+}
+
 func TestParseConfigKeepsSingleRepositoryCompatibility(t *testing.T) {
 	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
 		"repo_path": "/tmp/single",
@@ -150,6 +161,19 @@ func TestParseConfigRejectsRepositoryListMixedWithSingleRepoFields(t *testing.T)
 func TestParseConfigRejectsUnknownFields(t *testing.T) {
 	if _, err := writetrace.ParseConfig(json.RawMessage(`{"commit_limti": 7}`)); err == nil {
 		t.Fatal("ParseConfig should reject unknown fields")
+	}
+}
+
+func TestParseConfigRejectsUnknownRepositoryFields(t *testing.T) {
+	if _, err := writetrace.ParseConfig(json.RawMessage(`{
+		"repositories": [
+			{
+				"repo_path": "/tmp/repo",
+				"repo_reff": "main"
+			}
+		]
+	}`)); err == nil {
+		t.Fatal("ParseConfig should reject unknown repositories[] fields")
 	}
 }
 

--- a/internal/eval/suites/writetrace/suite_test.go
+++ b/internal/eval/suites/writetrace/suite_test.go
@@ -65,6 +65,88 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	}
 }
 
+func TestParseConfigSupportsRepositoryListWithInheritedDefaults(t *testing.T) {
+	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
+		"repo_ref": "main",
+		"commit_limit": 10,
+		"cache_dir": "/tmp/shared-cache",
+		"first_parent": true,
+		"repositories": [
+			{
+				"name": "alpha",
+				"repo_url": "https://example.test/alpha.git"
+			},
+			{
+				"name": "beta",
+				"repo_path": "/tmp/beta",
+				"repo_ref": "release",
+				"commit_limit": 0,
+				"cache_dir": "/tmp/beta-cache",
+				"first_parent": false
+			}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+
+	repos, err := cfg.RepositoriesOrSingle()
+	if err != nil {
+		t.Fatalf("RepositoriesOrSingle: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("repo count = %d, want 2", len(repos))
+	}
+	if repos[0].Name != "alpha" || repos[0].RepoURL != "https://example.test/alpha.git" {
+		t.Fatalf("repo 0 identity = %+v", repos[0])
+	}
+	if repos[0].RepoRef != "main" || repos[0].CommitLimit != 10 || repos[0].CacheDir != "/tmp/shared-cache" || !repos[0].FirstParent {
+		t.Fatalf("repo 0 inherited defaults = %+v", repos[0])
+	}
+	if repos[1].Name != "beta" || repos[1].RepoPath != "/tmp/beta" {
+		t.Fatalf("repo 1 identity = %+v", repos[1])
+	}
+	if repos[1].RepoRef != "release" || repos[1].CommitLimit != 0 || repos[1].CacheDir != "/tmp/beta-cache" || repos[1].FirstParent {
+		t.Fatalf("repo 1 overrides = %+v", repos[1])
+	}
+}
+
+func TestParseConfigKeepsSingleRepositoryCompatibility(t *testing.T) {
+	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
+		"repo_path": "/tmp/single",
+		"repo_ref": "HEAD",
+		"commit_limit": 3
+	}`))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	repos, err := cfg.RepositoriesOrSingle()
+	if err != nil {
+		t.Fatalf("RepositoriesOrSingle: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("repo count = %d, want 1", len(repos))
+	}
+	if repos[0].RepoPath != "/tmp/single" || repos[0].RepoRef != "HEAD" || repos[0].CommitLimit != 3 {
+		t.Fatalf("single repo = %+v", repos[0])
+	}
+}
+
+func TestParseConfigRejectsRepositoryListMixedWithSingleRepoFields(t *testing.T) {
+	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
+		"repo_path": "/tmp/single",
+		"repositories": [
+			{"repo_path": "/tmp/other"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if _, err := cfg.RepositoriesOrSingle(); err == nil {
+		t.Fatal("RepositoriesOrSingle should reject repositories mixed with repo_path")
+	}
+}
+
 func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git binary not available")
@@ -125,6 +207,54 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 		if record.Result.Accounting.Categories == nil || record.Accounting.Categories == nil {
 			t.Fatalf("record %d accounting missing: %+v", i, record)
 		}
+	}
+}
+
+func TestSuiteRunReplaysRepositoryListWithAliases(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	repoA := initWriteTraceRepo(t)
+	repoB := initWriteTraceRepo(t)
+	outDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(outDir, "raw"), 0755); err != nil {
+		t.Fatalf("mkdir raw dir: %v", err)
+	}
+
+	cfg := json.RawMessage(`{
+		"store_backend": "memory",
+		"systems": ["maltflat"],
+		"repositories": [
+			{"name": "alpha", "repo_path": ` + strconvQuote(repoA) + `, "commit_limit": 1},
+			{"name": "beta", "repo_path": ` + strconvQuote(repoB) + `, "commit_limit": 1}
+		]
+	}`)
+	err := (writetrace.Suite{}).Run(ctx, framework.Env{
+		RunID:     "run-write-trace-repos-test",
+		OutputDir: outDir,
+	}, cfg)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	envelopes := readWriteTraceEnvelopes(t, filepath.Join(outDir, "raw", "write_trace.jsonl"))
+	if len(envelopes) != 2 {
+		t.Fatalf("envelope count = %d, want 2", len(envelopes))
+	}
+	var records []replay.ResultRecord
+	for i, envelope := range envelopes {
+		var record replay.ResultRecord
+		if err := json.Unmarshal(envelope.Record, &record); err != nil {
+			t.Fatalf("unmarshal record %d: %v", i, err)
+		}
+		records = append(records, record)
+	}
+	if records[0].Repo != "alpha" || records[0].Index != 0 {
+		t.Fatalf("record 0 = %+v, want alpha index 0", records[0])
+	}
+	if records[1].Repo != "beta" || records[1].Index != 0 {
+		t.Fatalf("record 1 = %+v, want beta index 0", records[1])
 	}
 }
 

--- a/internal/eval/suites/writetrace/suite_test.go
+++ b/internal/eval/suites/writetrace/suite_test.go
@@ -85,10 +85,10 @@ func TestParseConfigBuildsRepositoryTargetsFromURLList(t *testing.T) {
 	if len(repos) != 2 {
 		t.Fatalf("repo count = %d, want 2", len(repos))
 	}
-	if repos[0].RepoID != "ipfs/kubo" || repos[0].RepoURL != "https://github.com/ipfs/kubo.git" {
+	if repos[0].RepoID != "github.com/ipfs/kubo" || repos[0].RepoURL != "https://github.com/ipfs/kubo.git" {
 		t.Fatalf("repo 0 target = %+v", repos[0])
 	}
-	if repos[1].RepoID != "ethereum/go-ethereum" || repos[1].RepoURL != "git@github.com:ethereum/go-ethereum.git" {
+	if repos[1].RepoID != "github.com/ethereum/go-ethereum" || repos[1].RepoURL != "git@github.com:ethereum/go-ethereum.git" {
 		t.Fatalf("repo 1 target = %+v", repos[1])
 	}
 	if cfg.MaxCommitsPerRepo != 10 || cfg.CacheDir != "/tmp/shared-cache" || !cfg.FirstParent {
@@ -110,10 +110,10 @@ func TestRepositoryStoreNameUsesIndexedCanonicalRepoID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepositoryTargets: %v", err)
 	}
-	if got := repos[0].StoreName(0); got != "000-ipfs-kubo" {
+	if got := repos[0].StoreName(0); got != "000-github.com-ipfs-kubo" {
 		t.Fatalf("repo 0 store name = %q", got)
 	}
-	if got := repos[1].StoreName(1); got != "001-fork-kubo" {
+	if got := repos[1].StoreName(1); got != "001-github.com-fork-kubo" {
 		t.Fatalf("repo 1 store name = %q", got)
 	}
 }
@@ -157,7 +157,7 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 		t.Skip("git binary not available")
 	}
 	ctx := context.Background()
-	repo := initWriteTraceRepo(t, "ipfs", "kubo.git")
+	repo := initWriteTraceRepo(t, "github.com", "ipfs", "kubo.git")
 	outDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(outDir, "raw"), 0755); err != nil {
 		t.Fatalf("mkdir raw dir: %v", err)
@@ -195,7 +195,7 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 		records = append(records, record)
 	}
 
-	if records[0].Repo != "ipfs/kubo" || records[0].System != "maltflat" || records[0].Index != 0 {
+	if records[0].Repo != "github.com/ipfs/kubo" || records[0].System != "maltflat" || records[0].Index != 0 {
 		t.Fatalf("first record identity = %+v, want canonical repo/maltflat/index 0", records[0])
 	}
 	if records[1].MutationSet[0].Kind != replay.MutationRename || records[1].MutationSet[0].OldPath != "README.md" || records[1].MutationSet[0].Path != "docs/README.md" {
@@ -222,8 +222,8 @@ func TestSuiteRunReplaysRepoURLListWithCanonicalRepoLabels(t *testing.T) {
 		t.Skip("git binary not available")
 	}
 	ctx := context.Background()
-	repoA := initWriteTraceRepo(t, "ipfs", "kubo.git")
-	repoB := initWriteTraceRepo(t, "fork", "kubo.git")
+	repoA := initWriteTraceRepo(t, "github.com", "ipfs", "kubo.git")
+	repoB := initWriteTraceRepo(t, "github.com", "fork", "kubo.git")
 	outDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(outDir, "raw"), 0755); err != nil {
 		t.Fatalf("mkdir raw dir: %v", err)
@@ -260,17 +260,17 @@ func TestSuiteRunReplaysRepoURLListWithCanonicalRepoLabels(t *testing.T) {
 		}
 		records = append(records, record)
 	}
-	if records[0].Repo != "ipfs/kubo" || records[0].Index != 0 {
-		t.Fatalf("record 0 = %+v, want ipfs/kubo index 0", records[0])
+	if records[0].Repo != "github.com/ipfs/kubo" || records[0].Index != 0 {
+		t.Fatalf("record 0 = %+v, want github.com/ipfs/kubo index 0", records[0])
 	}
-	if records[1].Repo != "fork/kubo" || records[1].Index != 0 {
-		t.Fatalf("record 1 = %+v, want fork/kubo index 0", records[1])
+	if records[1].Repo != "github.com/fork/kubo" || records[1].Index != 0 {
+		t.Fatalf("record 1 = %+v, want github.com/fork/kubo index 0", records[1])
 	}
 }
 
-func initWriteTraceRepo(t *testing.T, owner, repoName string) string {
+func initWriteTraceRepo(t *testing.T, pathParts ...string) string {
 	t.Helper()
-	repo := filepath.Join(t.TempDir(), owner, repoName)
+	repo := filepath.Join(append([]string{t.TempDir()}, pathParts...)...)
 	if err := os.MkdirAll(repo, 0755); err != nil {
 		t.Fatalf("mkdir repo: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Bring the write_trace repository URL list support from the evaluation framework branch into main.
- Use strict `repo_urls` plus `max_commits_per_repo` suite config for paper-facing write trace evaluations.
- Emit canonical GitHub repository labels such as `github.com/ipfs/kubo` and keep indexed store keys separate from result semantics.

## Test Plan
- `git diff --check main...codex/one-time/feature/evaluation-framework`
- `env GOCACHE=/tmp/go-build-cache go test -count=1 ./cmd/eval/helper/git ./internal/eval/suites/writetrace ./internal/eval/framework`
- `env GOCACHE=/tmp/go-build-cache go test -count=1 ./...`