### PR TITLE
feat: add measured range proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ freshness, and multi-writer arbitration are application or deployment policy,
 not the gateway correctness interface. In the HTTP deployment, successful
 default blob and directory `GET /{root}/{path}` reads carry `ProofList`
 metadata in response headers; large-file range reads return selected bytes plus
-path/`@payload` proof and the corresponding composed list-index `ProofList`
-evidence. Explicit `@size`/`@chunksize` metadata proof and response-body range
-binding are still ProofList-schema TODOs.
+path/`@payload` proof and a measured-list range `ProofList` step that composes
+fixed chunk metadata proof with the required index proofs. Response-body range
+binding is still a ProofList-schema TODO.
 
 Current core semantics are:
 
@@ -128,9 +128,10 @@ Vary: X-Malt-Proof
 
 The proof header is generated for file bytes, directory JSON responses, and
 byte-range reads. For list-backed file ranges, the current `ProofList` includes
-path/`@payload` proof plus the touched list-index steps; explicit file metadata
-proof is still being formalized. Clients that only need content bytes can opt
-out of default proof generation with either
+path/`@payload` proof plus a measured-list range step carrying authenticated
+fixed chunk metadata, the covered segment CID list, and the composed index
+proofs. Clients that only need content bytes can opt out of default proof
+generation with either
 `?proof=false` or request header
 `X-Malt-Proof: omit`; the `Vary` response header advertises the header-based
 variance to shared HTTP caches.
@@ -230,8 +231,8 @@ Native operations:
 
 - read an index and return keys plus proof
 - verify an index query under a root
-- represent file range reads today as path/`@payload` proof plus composed index
-  proofs; explicit metadata proof is a schema TODO
+- optionally prove a byte range for measured fixed-width lists by returning
+  authenticated metadata plus the minimum covered segment CID list
 - append a key
 - replace an existing key
 - truncate the sequence

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -628,24 +628,33 @@ func TestClientListBackedContentReadReturnsListIndexProof(t *testing.T) {
 	if err := proof.ValidateShape(prooflist.RequireSteps()); err != nil {
 		t.Fatalf("prooflist shape: %v", err)
 	}
-	var indexes []uint64
+	var ranges []prooflist.Step
 	for _, step := range proof.Steps {
-		if step.Kind != prooflist.KindListIndex {
-			continue
+		if step.Kind == prooflist.KindListRange {
+			ranges = append(ranges, step)
 		}
-		if step.Index == nil {
-			t.Fatalf("list-index step missing index: %+v", step)
-		}
-		if step.Length == nil || *step.Length != 2 {
-			t.Fatalf("list-index length = %v, want 2", step.Length)
-		}
-		if step.EvidenceBackend != "list" {
-			t.Fatalf("list-index evidence backend = %q, want list", step.EvidenceBackend)
-		}
-		indexes = append(indexes, *step.Index)
 	}
-	if len(indexes) != 2 || indexes[0] != 0 || indexes[1] != 1 {
-		t.Fatalf("list-index steps = %v, want [0 1]", indexes)
+	if len(ranges) != 1 {
+		t.Fatalf("list-range steps = %d, want 1", len(ranges))
+	}
+	rangeStep := ranges[0]
+	if rangeStep.Start == nil || *rangeStep.Start != 0 {
+		t.Fatalf("list-range start = %v, want 0", rangeStep.Start)
+	}
+	if rangeStep.End == nil || *rangeStep.End != uint64(len(fileBody)) {
+		t.Fatalf("list-range end = %v, want %d", rangeStep.End, len(fileBody))
+	}
+	if rangeStep.ChildCount == nil || *rangeStep.ChildCount != 2 {
+		t.Fatalf("list-range child count = %v, want 2", rangeStep.ChildCount)
+	}
+	if rangeStep.ChunkSize == nil || *rangeStep.ChunkSize != 262144 {
+		t.Fatalf("list-range chunk size = %v, want 262144", rangeStep.ChunkSize)
+	}
+	if rangeStep.EvidenceBackend != "measured_list" {
+		t.Fatalf("list-range evidence backend = %q, want measured_list", rangeStep.EvidenceBackend)
+	}
+	if len(rangeStep.Segments) != 2 {
+		t.Fatalf("list-range segments = %d, want 2", len(rangeStep.Segments))
 	}
 
 	verifyResp, err := client.Verify(ctx, &httpapi.VerifyRequest{ProofList: *proof})

--- a/core/gateway/gateway.go
+++ b/core/gateway/gateway.go
@@ -30,6 +30,10 @@ var (
 
 	// ErrNilArcSet is returned when a put has no canonical arcset.
 	ErrNilArcSet = errors.New("nil arcset")
+
+	// ErrExpectedRootMismatch is returned when a replayed put does not reproduce
+	// the root declared by the mutation plan.
+	ErrExpectedRootMismatch = errors.New("expected root mismatch")
 )
 
 // SemanticMutation is the gateway write boundary emitted by application layouts.
@@ -40,9 +44,23 @@ type SemanticMutation struct {
 
 // ArcSetPut replaces one touched semantic object's full canonical arcset.
 type ArcSetPut struct {
-	Object cid.Cid
-	Kind   arcset.Kind
-	ArcSet *arcset.CanonicalArcSet
+	Object       cid.Cid
+	ExpectedRoot cid.Cid
+	Kind         arcset.Kind
+	ArcSet       *arcset.CanonicalArcSet
+	Commit       CommitDescriptor
+}
+
+// CommitDescriptor records how a logical canonical arcset should be committed
+// into a concrete semantic root. The zero value is the default map/list commit.
+type CommitDescriptor struct {
+	FixedList *FixedListCommit
+}
+
+// FixedListCommit describes the measured fixed-width list commit profile.
+type FixedListCommit struct {
+	TotalSize uint64
+	ChunkSize uint64
 }
 
 // WriteReceipt records the library-level outcome of applying a semantic mutation.
@@ -78,6 +96,12 @@ func ValidateSemanticMutation(mut SemanticMutation) error {
 		}
 		if !objectKindMatches(put.Object, put.Kind) {
 			return fmt.Errorf("put %d: %w", i, ErrObjectKindMismatch)
+		}
+		if !objectKindMatches(put.ExpectedRoot, put.Kind) {
+			return fmt.Errorf("put %d expected root: %w", i, ErrObjectKindMismatch)
+		}
+		if put.Commit.FixedList != nil && put.Kind != arcset.KindList {
+			return fmt.Errorf("put %d fixed list commit on %q: %w", i, put.Kind, ErrObjectKindMismatch)
 		}
 	}
 	return nil
@@ -129,6 +153,9 @@ func (e Executor) commitPut(ctx context.Context, namespace string, put ArcSetPut
 		if err != nil {
 			return cid.Undef, 0, err
 		}
+		if err := checkExpectedRoot(put.ExpectedRoot, root); err != nil {
+			return cid.Undef, 0, err
+		}
 		if e.ArcTable != nil {
 			snapshot, err := canonicalMapSnapshot(put.ArcSet)
 			if err != nil {
@@ -143,18 +170,34 @@ func (e Executor) commitPut(ctx context.Context, namespace string, put ArcSetPut
 		if e.Lists == nil {
 			return cid.Undef, 0, errors.New("list semantics is nil")
 		}
-		view, err := canonicalListView(put.ArcSet)
+		values, err := canonicalListValues(put.ArcSet)
 		if err != nil {
 			return cid.Undef, 0, err
 		}
-		root, err := e.Lists.Commit(ctx, namespace, view)
+		root, err := e.commitList(ctx, namespace, values, put.Commit)
 		if err != nil {
+			return cid.Undef, 0, err
+		}
+		if err := checkExpectedRoot(put.ExpectedRoot, root); err != nil {
 			return cid.Undef, 0, err
 		}
 		return root, put.ArcSet.Len(), nil
 	default:
 		return cid.Undef, 0, fmt.Errorf("%w: %q", arcset.ErrInvalidKind, put.Kind)
 	}
+}
+
+func (e Executor) commitList(ctx context.Context, namespace string, values []cid.Cid, descriptor CommitDescriptor) (cid.Cid, error) {
+	if descriptor.FixedList == nil {
+		return e.Lists.Commit(ctx, namespace, list.NewViewFromSlice(values))
+	}
+	measured, ok := e.Lists.(interface {
+		CommitFixed(context.Context, string, []cid.Cid, uint64, uint64) (cid.Cid, error)
+	})
+	if !ok {
+		return cid.Undef, errors.New("list semantics does not support fixed list commits")
+	}
+	return measured.CommitFixed(ctx, namespace, values, descriptor.FixedList.ChunkSize, descriptor.FixedList.TotalSize)
 }
 
 func canonicalMapView(set *arcset.CanonicalArcSet) (mapping.View, error) {
@@ -181,7 +224,7 @@ func canonicalMapSnapshot(set *arcset.CanonicalArcSet) (arcset.ArcSet, error) {
 	return arcset.NewArcSetFromPaths(entries)
 }
 
-func canonicalListView(set *arcset.CanonicalArcSet) (list.View, error) {
+func canonicalListValues(set *arcset.CanonicalArcSet) ([]cid.Cid, error) {
 	entries := set.Entries()
 	values := make([]cid.Cid, len(entries))
 	for i, entry := range entries {
@@ -195,7 +238,14 @@ func canonicalListView(set *arcset.CanonicalArcSet) (list.View, error) {
 		}
 		values[i] = entry.Target.CID()
 	}
-	return list.NewViewFromSlice(values), nil
+	return values, nil
+}
+
+func checkExpectedRoot(expectedRoot, actualRoot cid.Cid) error {
+	if !expectedRoot.Defined() || expectedRoot.Equals(actualRoot) {
+		return nil
+	}
+	return fmt.Errorf("%w: got %s want %s", ErrExpectedRootMismatch, actualRoot, expectedRoot)
 }
 
 func objectKindMatches(object cid.Cid, kind arcset.Kind) bool {

--- a/core/gateway/gateway_test.go
+++ b/core/gateway/gateway_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dewebprotocol/malt/core/commitment/kzg"
 	"github.com/dewebprotocol/malt/core/gateway"
 	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
+	"github.com/dewebprotocol/malt/core/structure/list"
 	listtree "github.com/dewebprotocol/malt/core/structure/list/tree"
 	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	"github.com/dewebprotocol/malt/core/types/arcset"
@@ -214,6 +215,84 @@ func TestExecutorAppliesListReplacementAndReturnsStableReceipt(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("expected list proof to verify")
+	}
+}
+
+func TestExecutorReplaysFixedMeasuredListToExpectedRoot(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("kzg.NewScheme failed: %v", err)
+	}
+	chunks := []cid.Cid{testCID("chunk-0"), testCID("chunk-1")}
+	chunkSize := uint64(4)
+	totalSize := uint64(7)
+
+	sourceArcs, err := overwrite.NewArcTable(overwrite.WithKVStore(kvmemory.New()))
+	if err != nil {
+		t.Fatalf("source overwrite.NewArcTable failed: %v", err)
+	}
+	sourceLists, err := listtree.NewList(scheme, sourceArcs)
+	if err != nil {
+		t.Fatalf("source tree.NewList failed: %v", err)
+	}
+	expectedRoot, err := sourceLists.CommitFixed(ctx, "source", chunks, chunkSize, totalSize)
+	if err != nil {
+		t.Fatalf("CommitFixed failed: %v", err)
+	}
+
+	replayArcs, err := overwrite.NewArcTable(overwrite.WithKVStore(kvmemory.New()))
+	if err != nil {
+		t.Fatalf("replay overwrite.NewArcTable failed: %v", err)
+	}
+	replayMaps, err := mappingradix.NewMap(scheme, replayArcs)
+	if err != nil {
+		t.Fatalf("replay radix.NewMap failed: %v", err)
+	}
+	replayLists, err := listtree.NewList(scheme, replayArcs)
+	if err != nil {
+		t.Fatalf("replay tree.NewList failed: %v", err)
+	}
+	exec := gateway.Executor{
+		Namespace: "measured-replay",
+		Maps:      replayMaps,
+		Lists:     replayLists,
+		ArcTable:  replayArcs,
+	}
+
+	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
+		BaseRoot: testCID("base"),
+		Puts: []gateway.ArcSetPut{{
+			ExpectedRoot: expectedRoot,
+			Kind:         arcset.KindList,
+			ArcSet:       mustCanonicalList(t, chunks),
+			Commit: gateway.CommitDescriptor{
+				FixedList: &gateway.FixedListCommit{
+					TotalSize: totalSize,
+					ChunkSize: chunkSize,
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if !receipt.NewRoot.Equals(expectedRoot) {
+		t.Fatalf("replayed root = %s, want expected measured root %s", receipt.NewRoot, expectedRoot)
+	}
+
+	measured := exec.Lists.(list.MeasuredSemantics)
+	end := totalSize
+	result, proof, err := measured.ProveRange(ctx, exec.Namespace, expectedRoot, 0, &end)
+	if err != nil {
+		t.Fatalf("ProveRange on replayed root failed: %v", err)
+	}
+	ok, err := measured.VerifyRange(expectedRoot, 0, &end, result, proof)
+	if err != nil {
+		t.Fatalf("VerifyRange on replayed root failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("VerifyRange on replayed root returned false")
 	}
 }
 

--- a/core/layout/malt/unixfs/layout.go
+++ b/core/layout/malt/unixfs/layout.go
@@ -433,6 +433,11 @@ func (l *Layout) commitPayload(ctx context.Context, data []byte) (cid.Cid, error
 	for i, result := range results {
 		chunks[i] = result.CID
 	}
+	if measured, ok := l.lists.(interface {
+		CommitFixed(context.Context, string, []cid.Cid, uint64, uint64) (cid.Cid, error)
+	}); ok {
+		return measured.CommitFixed(ctx, l.namespace, chunks, uint64(l.chunkSize), uint64(len(data)))
+	}
 	return l.lists.Commit(ctx, l.namespace, list.NewViewFromSlice(chunks))
 }
 

--- a/core/layout/malt/unixfs/mutation.go
+++ b/core/layout/malt/unixfs/mutation.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/dewebprotocol/malt/core/codec"
+	"github.com/dewebprotocol/malt/core/structure/list"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	cid "github.com/ipfs/go-cid"
 )
@@ -21,9 +22,18 @@ type MutationPlan struct {
 
 // MutationPut binds one materialized semantic root to its canonical arc set.
 type MutationPut struct {
-	Object cid.Cid
-	Kind   arcset.Kind
-	ArcSet *arcset.CanonicalArcSet
+	Object       cid.Cid
+	ExpectedRoot cid.Cid
+	Kind         arcset.Kind
+	ArcSet       *arcset.CanonicalArcSet
+	FixedList    *FixedListCommit
+}
+
+// FixedListCommit carries the measured fixed-width list commit profile needed
+// to replay a list root exactly from logical list entries.
+type FixedListCommit struct {
+	TotalSize uint64
+	ChunkSize uint64
 }
 
 // MutationPlanForPath exposes canonical map/list arcsets for the UnixFS node
@@ -52,9 +62,10 @@ func (l *Layout) MutationPlanForPath(ctx context.Context, root cid.Cid, path str
 		BaseRoot: root,
 		Puts: []MutationPut{
 			{
-				Object: nodeRoot,
-				Kind:   arcset.KindMap,
-				ArcSet: nodeArcSet,
+				Object:       nodeRoot,
+				ExpectedRoot: nodeRoot,
+				Kind:         arcset.KindMap,
+				ArcSet:       nodeArcSet,
 			},
 		},
 	}
@@ -82,10 +93,16 @@ func (l *Layout) MutationPlanForPath(ctx context.Context, root cid.Cid, path str
 	if err != nil {
 		return nil, err
 	}
+	fixedList, err := l.fixedListCommitForPayload(ctx, payload, info)
+	if err != nil {
+		return nil, err
+	}
 	plan.Puts = append(plan.Puts, MutationPut{
-		Object: payload,
-		Kind:   arcset.KindList,
-		ArcSet: listArcSet,
+		Object:       payload,
+		ExpectedRoot: payload,
+		Kind:         arcset.KindList,
+		ArcSet:       listArcSet,
+		FixedList:    fixedList,
 	})
 	return plan, nil
 }
@@ -155,10 +172,16 @@ func (l *Layout) appendRootMutationPuts(ctx context.Context, plan *MutationPlan,
 			if err != nil {
 				return err
 			}
+			fixedList, err := l.fixedListCommitForPayload(ctx, payload, info)
+			if err != nil {
+				return err
+			}
 			plan.Puts = append(plan.Puts, MutationPut{
-				Object: payload,
-				Kind:   arcset.KindList,
-				ArcSet: listArcSet,
+				Object:       payload,
+				ExpectedRoot: payload,
+				Kind:         arcset.KindList,
+				ArcSet:       listArcSet,
+				FixedList:    fixedList,
 			})
 		}
 	default:
@@ -170,9 +193,10 @@ func (l *Layout) appendRootMutationPuts(ctx context.Context, plan *MutationPlan,
 		return err
 	}
 	plan.Puts = append(plan.Puts, MutationPut{
-		Object: nodeRoot,
-		Kind:   arcset.KindMap,
-		ArcSet: nodeArcSet,
+		Object:       nodeRoot,
+		ExpectedRoot: nodeRoot,
+		Kind:         arcset.KindMap,
+		ArcSet:       nodeArcSet,
 	})
 	return nil
 }
@@ -288,6 +312,31 @@ func (l *Layout) canonicalListArcSet(ctx context.Context, root cid.Cid, length u
 		})
 	}
 	return arcset.NewCanonicalArcSet(arcset.KindList, entries)
+}
+
+func (l *Layout) fixedListCommitForPayload(ctx context.Context, payload cid.Cid, info *fileInfo) (*FixedListCommit, error) {
+	measured, ok := l.lists.(list.MeasuredSemantics)
+	if !ok {
+		return nil, nil
+	}
+	end := uint64(0)
+	result, _, err := measured.ProveRange(ctx, l.namespace, payload, 0, &end)
+	if err != nil {
+		return nil, nil
+	}
+	if result.Metadata.ChildCount != chunkCount(info.size, info.chunkSize) {
+		return nil, fmt.Errorf("fixed list child count = %d, want %d", result.Metadata.ChildCount, chunkCount(info.size, info.chunkSize))
+	}
+	if result.Metadata.TotalSize != info.size {
+		return nil, fmt.Errorf("fixed list total size = %d, want %d", result.Metadata.TotalSize, info.size)
+	}
+	if result.Metadata.ChunkSize != info.chunkSize {
+		return nil, fmt.Errorf("fixed list chunk size = %d, want %d", result.Metadata.ChunkSize, info.chunkSize)
+	}
+	return &FixedListCommit{
+		TotalSize: result.Metadata.TotalSize,
+		ChunkSize: result.Metadata.ChunkSize,
+	}, nil
 }
 
 func mapEntry(key string, target arcset.TargetRef) (arcset.ArcEntry, error) {

--- a/core/layout/malt/unixfs/mutation_test.go
+++ b/core/layout/malt/unixfs/mutation_test.go
@@ -67,6 +67,15 @@ func TestLargeFileMutationPlanIncludesFileMapAndOrderedList(t *testing.T) {
 	if plan.Puts[1].Kind != arcset.KindList {
 		t.Fatalf("put 1 kind = %q, want list", plan.Puts[1].Kind)
 	}
+	if !plan.Puts[1].ExpectedRoot.Equals(plan.Puts[1].Object) {
+		t.Fatalf("list put expected root = %s, want object %s", plan.Puts[1].ExpectedRoot, plan.Puts[1].Object)
+	}
+	if plan.Puts[1].FixedList == nil {
+		t.Fatal("large file list put missing fixed-list commit metadata")
+	}
+	if plan.Puts[1].FixedList.TotalSize != 12 || plan.Puts[1].FixedList.ChunkSize != 4 {
+		t.Fatalf("fixed list metadata = %+v, want total=12 chunk=4", plan.Puts[1].FixedList)
+	}
 
 	got := entryCoordinates(plan.Puts[1].ArcSet)
 	want := []string{"0", "1", "2"}

--- a/core/layout/malt/unixfs/prooflist.go
+++ b/core/layout/malt/unixfs/prooflist.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dewebprotocol/malt/core/codec"
 	"github.com/dewebprotocol/malt/core/structure"
+	"github.com/dewebprotocol/malt/core/structure/list"
 	"github.com/dewebprotocol/malt/core/types/prooflist"
 	cid "github.com/ipfs/go-cid"
 )
@@ -80,6 +81,44 @@ func AppendListIndexSteps(pl *prooflist.ProofList, queriedPath string, steps []L
 			Proof:           cloneProofBytes(layoutStep.Proof),
 		})
 	}
+	return nil
+}
+
+// AppendListRangeStep appends one measured-list range evidence step. The proof
+// payload is produced by the list semantic and internally composes metadata and
+// index proofs for the minimum segment set.
+func AppendListRangeStep(pl *prooflist.ProofList, queriedPath string, root cid.Cid, start, end uint64, result list.RangeResult, proof structure.Proof) error {
+	if pl == nil {
+		return fmt.Errorf("prooflist is nil")
+	}
+	if !root.Defined() {
+		return fmt.Errorf("list range root is undefined")
+	}
+	childCount := result.Metadata.ChildCount
+	totalSize := result.Metadata.TotalSize
+	chunkSize := result.Metadata.ChunkSize
+	segments := append([]cid.Cid(nil), result.Segments...)
+	for i, segment := range segments {
+		if !segment.Defined() {
+			return fmt.Errorf("list range segment %d is undefined", i)
+		}
+	}
+	pl.Steps = append(pl.Steps, prooflist.Step{
+		Kind:            prooflist.KindListRange,
+		From:            root,
+		Query:           queriedPath,
+		Coordinate:      fmt.Sprintf("%d:%d", start, end),
+		Start:           &start,
+		End:             &end,
+		ChildCount:      &childCount,
+		TotalSize:       &totalSize,
+		ChunkSize:       &chunkSize,
+		Target:          root,
+		Segments:        segments,
+		EvidenceKind:    "structure",
+		EvidenceBackend: "measured_list",
+		Proof:           cloneProofBytes(proof),
+	})
 	return nil
 }
 

--- a/core/layout/malt/unixfs/prooflist_test.go
+++ b/core/layout/malt/unixfs/prooflist_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/dewebprotocol/malt/core/layout/malt/unixfs"
+	"github.com/dewebprotocol/malt/core/structure/list"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	"github.com/dewebprotocol/malt/core/types/prooflist"
 	cid "github.com/ipfs/go-cid"
@@ -118,6 +119,64 @@ func TestAppendListIndexStepsClassifiesKnownListQueries(t *testing.T) {
 	}
 	if !bytes.Equal(pl.Steps[1].Proof, []byte("index 1 proof")) {
 		t.Fatalf("list index proof bytes were not preserved")
+	}
+}
+
+func TestAppendListRangeStepClassifiesMeasuredListQuery(t *testing.T) {
+	listRoot := testCID(t, "list")
+	chunk0 := testCID(t, "chunk-0")
+	chunk1 := testCID(t, "chunk-1")
+	start := uint64(2)
+	end := uint64(6)
+
+	pl, err := unixfs.ProofListFromSteps(listRoot, "blob.bin", nil)
+	if err != nil {
+		t.Fatalf("ProofListFromSteps failed: %v", err)
+	}
+	err = unixfs.AppendListRangeStep(pl, "blob.bin", listRoot, start, end, list.RangeResult{
+		Metadata: list.RangeMetadata{
+			ChildCount: 2,
+			TotalSize:  8,
+			ChunkSize:  4,
+		},
+		Segments: []cid.Cid{chunk0, chunk1},
+	}, []byte("range proof"))
+	if err != nil {
+		t.Fatalf("AppendListRangeStep failed: %v", err)
+	}
+	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("ValidateShape failed: %v", err)
+	}
+	if len(pl.Steps) != 1 {
+		t.Fatalf("steps len = %d, want 1", len(pl.Steps))
+	}
+	step := pl.Steps[0]
+	if step.Kind != prooflist.KindListRange {
+		t.Fatalf("step kind = %q, want %q", step.Kind, prooflist.KindListRange)
+	}
+	if step.Start == nil || *step.Start != start {
+		t.Fatalf("step start = %v, want %d", step.Start, start)
+	}
+	if step.End == nil || *step.End != end {
+		t.Fatalf("step end = %v, want %d", step.End, end)
+	}
+	if step.ChildCount == nil || *step.ChildCount != 2 {
+		t.Fatalf("step child count = %v, want 2", step.ChildCount)
+	}
+	if step.TotalSize == nil || *step.TotalSize != 8 {
+		t.Fatalf("step total size = %v, want 8", step.TotalSize)
+	}
+	if step.ChunkSize == nil || *step.ChunkSize != 4 {
+		t.Fatalf("step chunk size = %v, want 4", step.ChunkSize)
+	}
+	if len(step.Segments) != 2 || !step.Segments[0].Equals(chunk0) || !step.Segments[1].Equals(chunk1) {
+		t.Fatalf("step segments = %v, want [%s %s]", step.Segments, chunk0, chunk1)
+	}
+	if step.EvidenceKind != "structure" || step.EvidenceBackend != "measured_list" {
+		t.Fatalf("step evidence labels = %q/%q, want structure/measured_list", step.EvidenceKind, step.EvidenceBackend)
+	}
+	if !bytes.Equal(step.Proof, []byte("range proof")) {
+		t.Fatalf("list range proof bytes were not preserved")
 	}
 }
 

--- a/core/structure/list/list.go
+++ b/core/structure/list/list.go
@@ -30,6 +30,23 @@ type Query struct {
 	Length uint64
 }
 
+// RangeMetadata is authenticated measurement metadata for a byte-addressable
+// list. ChunkSize is the fixed segment width used to map byte ranges to list
+// indexes.
+type RangeMetadata struct {
+	ChildCount uint64
+	TotalSize  uint64
+	ChunkSize  uint64
+}
+
+// RangeResult is the verifiable result of a byte-range query over a measured
+// list. Segments contains the minimal list targets needed to satisfy the
+// requested range.
+type RangeResult struct {
+	Metadata RangeMetadata
+	Segments []cid.Cid
+}
+
 // Semantics defines the public stable-indexed list semantics.
 //
 // Commit is the bootstrap path from a materialized list view. All other
@@ -54,4 +71,15 @@ type Semantics interface {
 
 	// Truncate shrinks the committed length while preserving the remaining prefix.
 	Truncate(ctx context.Context, namespace string, root cid.Cid, newLen uint64) (cid.Cid, error)
+}
+
+// MeasuredSemantics is an optional list extension for byte-addressable list
+// layouts. The range proof is composed from authenticated metadata and the
+// index proofs for the minimum segment set covering [start, end). A nil end
+// means the authenticated total size.
+type MeasuredSemantics interface {
+	Semantics
+
+	ProveRange(ctx context.Context, namespace string, root cid.Cid, start uint64, end *uint64) (RangeResult, structure.Proof, error)
+	VerifyRange(root cid.Cid, start uint64, end *uint64, expected RangeResult, proof structure.Proof) (bool, error)
 }

--- a/core/structure/list/tree/internal/layout.go
+++ b/core/structure/list/tree/internal/layout.go
@@ -36,6 +36,10 @@ const (
 	// NodeWidth is the fixed slot width for all committed non-root nodes.
 	NodeWidth = DefaultFanout
 
+	// LegacyNodeWidth is the v1 non-root width. Legacy children do not reserve
+	// slot 0 for metadata; all slots are content slots.
+	LegacyNodeWidth = BranchingFactor
+
 	lengthMarkerPrefix = "malt:list:length:v1:"
 	fixedMetaPrefix    = "malt:list:fixed-meta:v1:"
 	nodeMetaPrefix     = "malt:list:node-meta:v2:"
@@ -82,14 +86,30 @@ func EmptyNodeSlots() []cid.Cid {
 	return make([]cid.Cid, NodeWidth)
 }
 
-// ContentSlots returns the data-bearing portion of a slot vector. Slot 0 is
-// metadata for every v2 list node. The isRoot parameter is retained for callers
-// that still pass the node role while the physical layout is now uniform.
-func ContentSlots(slots []cid.Cid, _ bool) []cid.Cid {
+// ContentSlots returns the data-bearing portion of a slot vector.
+func ContentSlots(slots []cid.Cid, isRoot bool) []cid.Cid {
 	if len(slots) == 0 {
 		return nil
 	}
+	if !isRoot && len(slots) == LegacyNodeWidth {
+		return slots
+	}
 	return slots[1:]
+}
+
+// ContentSlotIndex maps a logical child digit to its physical committed slot.
+func ContentSlotIndex(slots []cid.Cid, isRoot bool, digit int) (uint64, error) {
+	if digit < 0 {
+		return 0, fmt.Errorf("content digit %d is negative", digit)
+	}
+	content := ContentSlots(slots, isRoot)
+	if digit >= len(content) {
+		return 0, fmt.Errorf("content digit %d exceeds content width %d", digit, len(content))
+	}
+	if !isRoot && len(slots) == LegacyNodeWidth {
+		return uint64(digit), nil
+	}
+	return uint64(digit) + 1, nil
 }
 
 // NodeSlotPath returns the canonical ArcTable key for a materialized list node slot.

--- a/core/structure/list/tree/internal/layout.go
+++ b/core/structure/list/tree/internal/layout.go
@@ -22,21 +22,23 @@ const (
 
 	// BranchingFactor is the number of content slots per committed list node.
 	//
-	// Slot 0 in the root node is reserved for the authenticated length marker,
-	// so the root exposes (DefaultFanout-1) content slots.
+	// Slot 0 in every list node is reserved for authenticated node metadata, so
+	// all nodes expose (DefaultFanout-1) content slots.
 	//
-	// For simplicity, v1 uses the same branching factor for all non-root nodes.
+	// For simplicity, v2 uses the same branching factor for root and non-root
+	// nodes.
 	BranchingFactor = DefaultFanout - 1
 
 	// RootWidth is the fixed slot width for the committed root node.
-	// Slot 0 is the authenticated length marker.
+	// Slot 0 is the authenticated node metadata marker.
 	RootWidth = DefaultFanout
 
 	// NodeWidth is the fixed slot width for all committed non-root nodes.
-	NodeWidth = BranchingFactor
+	NodeWidth = DefaultFanout
 
 	lengthMarkerPrefix = "malt:list:length:v1:"
 	fixedMetaPrefix    = "malt:list:fixed-meta:v1:"
+	nodeMetaPrefix     = "malt:list:node-meta:v2:"
 )
 
 // FixedMetadata is the authenticated root metadata for fixed-width measured
@@ -47,8 +49,19 @@ type FixedMetadata struct {
 	ChunkSize  uint64
 }
 
+// NodeMetadata is the authenticated metadata stored in slot 0 of every v2 list
+// tree node. ChunkSize == 0 identifies a plain list node; ChunkSize > 0
+// identifies a fixed-width measured node whose TotalSize is the byte span
+// covered by that subtree.
+type NodeMetadata struct {
+	Height     uint64
+	ChildCount uint64
+	TotalSize  uint64
+	ChunkSize  uint64
+}
+
 // ValidateCommitment checks whether the supplied index commitment can support
-// the v1 list layout.
+// the v2 list layout.
 func ValidateCommitment(scheme commitment.IndexCommitment) error {
 	if scheme == nil {
 		return fmt.Errorf("index commitment is nil")
@@ -69,12 +82,14 @@ func EmptyNodeSlots() []cid.Cid {
 	return make([]cid.Cid, NodeWidth)
 }
 
-// ContentSlots returns the data-bearing portion of a slot vector.
-func ContentSlots(slots []cid.Cid, isRoot bool) []cid.Cid {
-	if isRoot {
-		return slots[1:]
+// ContentSlots returns the data-bearing portion of a slot vector. Slot 0 is
+// metadata for every v2 list node. The isRoot parameter is retained for callers
+// that still pass the node role while the physical layout is now uniform.
+func ContentSlots(slots []cid.Cid, _ bool) []cid.Cid {
+	if len(slots) == 0 {
+		return nil
 	}
-	return slots
+	return slots[1:]
 }
 
 // NodeSlotPath returns the canonical ArcTable key for a materialized list node slot.
@@ -258,9 +273,25 @@ func DecodeFixedMetadata(marker cid.Cid) (FixedMetadata, error) {
 		return FixedMetadata{}, fmt.Errorf("fixed metadata marker is not identity-encoded")
 	}
 	if len(decoded.Digest) != len(fixedMetaPrefix)+24 {
+		nodeMeta, nodeErr := DecodeNodeMetadata(marker)
+		if nodeErr == nil && nodeMeta.ChunkSize > 0 {
+			return FixedMetadata{
+				ChildCount: nodeMeta.ChildCount,
+				TotalSize:  nodeMeta.TotalSize,
+				ChunkSize:  nodeMeta.ChunkSize,
+			}, nil
+		}
 		return FixedMetadata{}, fmt.Errorf("fixed metadata marker payload has unexpected size %d", len(decoded.Digest))
 	}
 	if string(decoded.Digest[:len(fixedMetaPrefix)]) != fixedMetaPrefix {
+		nodeMeta, nodeErr := DecodeNodeMetadata(marker)
+		if nodeErr == nil && nodeMeta.ChunkSize > 0 {
+			return FixedMetadata{
+				ChildCount: nodeMeta.ChildCount,
+				TotalSize:  nodeMeta.TotalSize,
+				ChunkSize:  nodeMeta.ChunkSize,
+			}, nil
+		}
 		return FixedMetadata{}, fmt.Errorf("fixed metadata marker prefix mismatch")
 	}
 	return FixedMetadata{
@@ -268,6 +299,63 @@ func DecodeFixedMetadata(marker cid.Cid) (FixedMetadata, error) {
 		TotalSize:  binary.BigEndian.Uint64(decoded.Digest[len(fixedMetaPrefix)+8:]),
 		ChunkSize:  binary.BigEndian.Uint64(decoded.Digest[len(fixedMetaPrefix)+16:]),
 	}, nil
+}
+
+// EncodeNodeMetadata encodes authenticated v2 list node metadata as a
+// self-describing identity CID.
+func EncodeNodeMetadata(meta NodeMetadata) (cid.Cid, error) {
+	if meta.ChunkSize == 0 && meta.TotalSize != 0 {
+		return cid.Undef, fmt.Errorf("plain node metadata cannot carry total size %d", meta.TotalSize)
+	}
+	if meta.ChunkSize > 0 && meta.ChildCount == 0 && meta.TotalSize != 0 {
+		return cid.Undef, fmt.Errorf("measured empty node cannot carry total size %d", meta.TotalSize)
+	}
+	payload := make([]byte, len(nodeMetaPrefix)+32)
+	copy(payload, []byte(nodeMetaPrefix))
+	binary.BigEndian.PutUint64(payload[len(nodeMetaPrefix):], meta.Height)
+	binary.BigEndian.PutUint64(payload[len(nodeMetaPrefix)+8:], meta.ChildCount)
+	binary.BigEndian.PutUint64(payload[len(nodeMetaPrefix)+16:], meta.TotalSize)
+	binary.BigEndian.PutUint64(payload[len(nodeMetaPrefix)+24:], meta.ChunkSize)
+
+	sum, err := mh.Sum(payload, mh.IDENTITY, len(payload))
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, sum), nil
+}
+
+// DecodeNodeMetadata parses authenticated v2 list node metadata.
+func DecodeNodeMetadata(marker cid.Cid) (NodeMetadata, error) {
+	if !marker.Defined() {
+		return NodeMetadata{}, fmt.Errorf("node metadata marker is undefined")
+	}
+
+	decoded, err := mh.Decode(marker.Hash())
+	if err != nil {
+		return NodeMetadata{}, err
+	}
+	if decoded.Code != mh.IDENTITY {
+		return NodeMetadata{}, fmt.Errorf("node metadata marker is not identity-encoded")
+	}
+	if len(decoded.Digest) != len(nodeMetaPrefix)+32 {
+		return NodeMetadata{}, fmt.Errorf("node metadata marker payload has unexpected size %d", len(decoded.Digest))
+	}
+	if string(decoded.Digest[:len(nodeMetaPrefix)]) != nodeMetaPrefix {
+		return NodeMetadata{}, fmt.Errorf("node metadata marker prefix mismatch")
+	}
+	meta := NodeMetadata{
+		Height:     binary.BigEndian.Uint64(decoded.Digest[len(nodeMetaPrefix):]),
+		ChildCount: binary.BigEndian.Uint64(decoded.Digest[len(nodeMetaPrefix)+8:]),
+		TotalSize:  binary.BigEndian.Uint64(decoded.Digest[len(nodeMetaPrefix)+16:]),
+		ChunkSize:  binary.BigEndian.Uint64(decoded.Digest[len(nodeMetaPrefix)+24:]),
+	}
+	if meta.ChunkSize == 0 && meta.TotalSize != 0 {
+		return NodeMetadata{}, fmt.Errorf("plain node metadata carries total size %d", meta.TotalSize)
+	}
+	if meta.ChunkSize > 0 && meta.ChildCount == 0 && meta.TotalSize != 0 {
+		return NodeMetadata{}, fmt.Errorf("measured empty node carries total size %d", meta.TotalSize)
+	}
+	return meta, nil
 }
 
 // DecodeRootLength parses the child count authenticated in a root metadata
@@ -281,6 +369,10 @@ func DecodeRootLength(marker cid.Cid) (uint64, error) {
 	meta, metaErr := DecodeFixedMetadata(marker)
 	if metaErr == nil {
 		return meta.ChildCount, nil
+	}
+	nodeMeta, nodeMetaErr := DecodeNodeMetadata(marker)
+	if nodeMetaErr == nil {
+		return nodeMeta.ChildCount, nil
 	}
 	return 0, err
 }

--- a/core/structure/list/tree/internal/layout.go
+++ b/core/structure/list/tree/internal/layout.go
@@ -36,7 +36,16 @@ const (
 	NodeWidth = BranchingFactor
 
 	lengthMarkerPrefix = "malt:list:length:v1:"
+	fixedMetaPrefix    = "malt:list:fixed-meta:v1:"
 )
+
+// FixedMetadata is the authenticated root metadata for fixed-width measured
+// lists.
+type FixedMetadata struct {
+	ChildCount uint64
+	TotalSize  uint64
+	ChunkSize  uint64
+}
 
 // ValidateCommitment checks whether the supplied index commitment can support
 // the v1 list layout.
@@ -216,6 +225,64 @@ func DecodeLengthMarker(marker cid.Cid) (uint64, error) {
 		return 0, fmt.Errorf("length marker prefix mismatch")
 	}
 	return binary.BigEndian.Uint64(decoded.Digest[len(lengthMarkerPrefix):]), nil
+}
+
+// EncodeFixedMetadata encodes fixed-width measured list metadata as a
+// self-describing identity CID.
+func EncodeFixedMetadata(meta FixedMetadata) (cid.Cid, error) {
+	payload := make([]byte, len(fixedMetaPrefix)+24)
+	copy(payload, []byte(fixedMetaPrefix))
+	binary.BigEndian.PutUint64(payload[len(fixedMetaPrefix):], meta.ChildCount)
+	binary.BigEndian.PutUint64(payload[len(fixedMetaPrefix)+8:], meta.TotalSize)
+	binary.BigEndian.PutUint64(payload[len(fixedMetaPrefix)+16:], meta.ChunkSize)
+
+	sum, err := mh.Sum(payload, mh.IDENTITY, len(payload))
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, sum), nil
+}
+
+// DecodeFixedMetadata parses fixed-width measured list metadata from an
+// identity CID.
+func DecodeFixedMetadata(marker cid.Cid) (FixedMetadata, error) {
+	if !marker.Defined() {
+		return FixedMetadata{}, fmt.Errorf("fixed metadata marker is undefined")
+	}
+
+	decoded, err := mh.Decode(marker.Hash())
+	if err != nil {
+		return FixedMetadata{}, err
+	}
+	if decoded.Code != mh.IDENTITY {
+		return FixedMetadata{}, fmt.Errorf("fixed metadata marker is not identity-encoded")
+	}
+	if len(decoded.Digest) != len(fixedMetaPrefix)+24 {
+		return FixedMetadata{}, fmt.Errorf("fixed metadata marker payload has unexpected size %d", len(decoded.Digest))
+	}
+	if string(decoded.Digest[:len(fixedMetaPrefix)]) != fixedMetaPrefix {
+		return FixedMetadata{}, fmt.Errorf("fixed metadata marker prefix mismatch")
+	}
+	return FixedMetadata{
+		ChildCount: binary.BigEndian.Uint64(decoded.Digest[len(fixedMetaPrefix):]),
+		TotalSize:  binary.BigEndian.Uint64(decoded.Digest[len(fixedMetaPrefix)+8:]),
+		ChunkSize:  binary.BigEndian.Uint64(decoded.Digest[len(fixedMetaPrefix)+16:]),
+	}, nil
+}
+
+// DecodeRootLength parses the child count authenticated in a root metadata
+// marker. Plain lists encode only length; fixed measured lists encode length as
+// ChildCount inside their metadata marker.
+func DecodeRootLength(marker cid.Cid) (uint64, error) {
+	length, err := DecodeLengthMarker(marker)
+	if err == nil {
+		return length, nil
+	}
+	meta, metaErr := DecodeFixedMetadata(marker)
+	if metaErr == nil {
+		return meta.ChildCount, nil
+	}
+	return 0, err
 }
 
 // RequiredHeight returns the minimal non-root height required for length values.

--- a/core/structure/list/tree/tree.go
+++ b/core/structure/list/tree/tree.go
@@ -683,7 +683,7 @@ func (s *TreeList) appendInto(ctx context.Context, namespace string, root cid.Ci
 	}
 
 	if height == 0 {
-		nextSlots := cloneSlots(slots)
+		nextSlots := cloneSlotsForMetadataMutation(slots)
 		content := layout.ContentSlots(nextSlots, false)
 		if index >= uint64(len(content)) {
 			return cid.Undef, fmt.Errorf("index %d out of leaf range", index)
@@ -707,7 +707,7 @@ func (s *TreeList) appendInto(ctx context.Context, namespace string, root cid.Ci
 	digit := int(index / childSpan)
 	localIndex := index % childSpan
 
-	nextSlots := cloneSlots(slots)
+	nextSlots := cloneSlotsForMetadataMutation(slots)
 	marker, err := plainNodeMetadata(height, index+1)
 	if err != nil {
 		return cid.Undef, err
@@ -1043,6 +1043,15 @@ func cloneBytes(data []byte) []byte {
 
 func cloneSlots(slots []cid.Cid) []cid.Cid {
 	return append([]cid.Cid(nil), slots...)
+}
+
+func cloneSlotsForMetadataMutation(slots []cid.Cid) []cid.Cid {
+	if len(slots) != layout.LegacyNodeWidth {
+		return cloneSlots(slots)
+	}
+	nextSlots := layout.EmptyNodeSlots()
+	copy(layout.ContentSlots(nextSlots, false), slots)
+	return nextSlots
 }
 
 var _ list.Semantics = (*TreeList)(nil)

--- a/core/structure/list/tree/tree.go
+++ b/core/structure/list/tree/tree.go
@@ -197,11 +197,11 @@ func (s *TreeList) Verify(root cid.Cid, index uint64, expected list.Query, proof
 			return false, err
 		}
 
-		slot, err := contentSlotForVerify(step, level == 0, digit)
+		slots, err := contentSlotsForVerify(step, level == 0, digit)
 		if err != nil {
 			return false, err
 		}
-		ok, err := layout.VerifySlot(s.scheme, currentRoot, slot, target, step.Proof)
+		ok, err := s.verifyAnyContentSlot(currentRoot, slots, target, step.Proof)
 		if err != nil || !ok {
 			return ok, err
 		}
@@ -908,22 +908,45 @@ func parseStepTarget(step proofStep) (commitment.Cell, error) {
 	return commitment.NewCell(step.Target), nil
 }
 
-func contentSlotForVerify(step proofStep, isRoot bool, digit int) (uint64, error) {
+func (s *TreeList) verifyAnyContentSlot(root cid.Cid, slots []uint64, target commitment.Cell, proof []byte) (bool, error) {
+	var verifyErr error
+	for _, slot := range slots {
+		// Backends may mutate proof buffers while decoding; keep retries isolated.
+		proofCopy := append([]byte(nil), proof...)
+		ok, err := layout.VerifySlot(s.scheme, root, slot, target, proofCopy)
+		if err != nil {
+			verifyErr = err
+			continue
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	if verifyErr != nil {
+		return false, verifyErr
+	}
+	return false, nil
+}
+
+func contentSlotsForVerify(step proofStep, isRoot bool, digit int) ([]uint64, error) {
 	v2Slot := uint64(digit) + 1
 	if step.Slot == nil {
-		return v2Slot, nil
+		if isRoot {
+			return []uint64{v2Slot}, nil
+		}
+		return []uint64{v2Slot, uint64(digit)}, nil
 	}
 	slot := *step.Slot
 	if isRoot {
 		if slot != v2Slot {
-			return 0, fmt.Errorf("root content digit %d proved slot %d, want %d", digit, slot, v2Slot)
+			return nil, fmt.Errorf("root content digit %d proved slot %d, want %d", digit, slot, v2Slot)
 		}
-		return slot, nil
+		return []uint64{slot}, nil
 	}
 	if slot != uint64(digit) && slot != v2Slot {
-		return 0, fmt.Errorf("content digit %d proved unsupported slot %d", digit, slot)
+		return nil, fmt.Errorf("content digit %d proved unsupported slot %d", digit, slot)
 	}
-	return slot, nil
+	return []uint64{slot}, nil
 }
 
 func needsExplicitLengthTarget(marker cid.Cid, length uint64) bool {

--- a/core/structure/list/tree/tree.go
+++ b/core/structure/list/tree/tree.go
@@ -61,11 +61,7 @@ func (s *TreeList) Commit(ctx context.Context, namespace string, view list.View)
 	if err != nil {
 		return cid.Undef, err
 	}
-	lengthMarker, err := layout.EncodeLengthMarker(uint64(len(values)))
-	if err != nil {
-		return cid.Undef, err
-	}
-	return s.buildRootFromValues(ctx, namespace, values, lengthMarker)
+	return s.buildPlainFromValues(ctx, namespace, values, layout.RequiredHeight(uint64(len(values))))
 }
 
 // CommitFixed commits fixed-width measured list chunks. The resulting root
@@ -83,16 +79,8 @@ func (s *TreeList) CommitFixed(ctx context.Context, namespace string, chunks []c
 			return cid.Undef, fmt.Errorf("chunk at index %d is undefined", i)
 		}
 	}
-	metaMarker, err := layout.EncodeFixedMetadata(layout.FixedMetadata{
-		ChildCount: uint64(len(chunks)),
-		TotalSize:  totalSize,
-		ChunkSize:  chunkSize,
-	})
-	if err != nil {
-		return cid.Undef, err
-	}
 	values := append([]cid.Cid(nil), chunks...)
-	return s.buildRootFromValues(ctx, namespace, values, metaMarker)
+	return s.buildMeasuredFromValues(ctx, namespace, values, layout.RequiredHeight(uint64(len(values))), 0, chunkSize, totalSize)
 }
 
 func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, index uint64) (list.Query, structure.Proof, error) {
@@ -127,10 +115,7 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 	currentRoot := root
 	currentSlots := rootSlots
 	for level, digit := range digits {
-		slot := uint64(digit)
-		if level == 0 {
-			slot++
-		}
+		slot := uint64(digit) + 1
 
 		target, proof, err := layout.ProveSlot(s.scheme, currentRoot, currentSlots, slot)
 		if err != nil {
@@ -208,10 +193,7 @@ func (s *TreeList) Verify(root cid.Cid, index uint64, expected list.Query, proof
 			return false, err
 		}
 
-		slot := uint64(digit)
-		if level == 0 {
-			slot++
-		}
+		slot := uint64(digit) + 1
 		ok, err := layout.VerifySlot(s.scheme, currentRoot, slot, target, step.Proof)
 		if err != nil || !ok {
 			return ok, err
@@ -300,11 +282,7 @@ func (s *TreeList) VerifyRange(root cid.Cid, start uint64, end *uint64, expected
 	if err := validateFixedMetadata(meta); err != nil {
 		return false, err
 	}
-	metaMarker, err := layout.EncodeFixedMetadata(meta)
-	if err != nil {
-		return false, err
-	}
-	ok, err := layout.VerifySlot(s.scheme, root, 0, commitment.CellFromCID(metaMarker), envelope.MetadataProof)
+	ok, err := s.verifyFixedMetadataSlot(root, meta, envelope.MetadataProof)
 	if err != nil || !ok {
 		return ok, err
 	}
@@ -365,6 +343,9 @@ func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, k
 	if err != nil {
 		return cid.Undef, 0, err
 	}
+	if _, err := fixedRangeMetadata(rootSlots[0]); err == nil {
+		return cid.Undef, 0, fmt.Errorf("append is not supported for fixed measured list roots")
+	}
 
 	newIndex := length
 	newLength := length + 1
@@ -378,11 +359,11 @@ func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, k
 		}
 
 		nextRootSlots := layout.EmptyRootSlots()
-		lengthMarker, err := layout.EncodeLengthMarker(newLength)
+		rootMarker, err := plainNodeMetadata(newHeight, newLength)
 		if err != nil {
 			return cid.Undef, 0, err
 		}
-		nextRootSlots[0] = lengthMarker
+		nextRootSlots[0] = rootMarker
 		content := layout.ContentSlots(nextRootSlots, true)
 		content[0] = grownRoot
 
@@ -403,11 +384,11 @@ func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, k
 	}
 
 	nextRootSlots := cloneSlots(rootSlots)
-	lengthMarker, err := layout.EncodeLengthMarker(newLength)
+	rootMarker, err := plainNodeMetadata(newHeight, newLength)
 	if err != nil {
 		return cid.Undef, 0, err
 	}
-	nextRootSlots[0] = lengthMarker
+	nextRootSlots[0] = rootMarker
 	content := layout.ContentSlots(nextRootSlots, true)
 
 	if oldHeight == 0 {
@@ -440,9 +421,12 @@ func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, k
 }
 
 func (s *TreeList) Truncate(ctx context.Context, namespace string, root cid.Cid, newLen uint64) (cid.Cid, error) {
-	_, oldLen, err := s.loadRoot(ctx, namespace, root)
+	rootSlots, oldLen, err := s.loadRoot(ctx, namespace, root)
 	if err != nil {
 		return cid.Undef, err
+	}
+	if _, err := fixedRangeMetadata(rootSlots[0]); err == nil && newLen != oldLen {
+		return cid.Undef, fmt.Errorf("truncate is not supported for fixed measured list roots")
 	}
 	if newLen > oldLen {
 		return cid.Undef, fmt.Errorf("new length %d exceeds current length %d", newLen, oldLen)
@@ -459,13 +443,19 @@ func (s *TreeList) Truncate(ctx context.Context, namespace string, root cid.Cid,
 	return s.rebuildPrefix(ctx, namespace, root, true, oldHeight, true, newHeight, newLen)
 }
 
-func (s *TreeList) buildRootFromValues(ctx context.Context, namespace string, values []cid.Cid, rootMarker cid.Cid) (cid.Cid, error) {
-	if !rootMarker.Defined() {
-		return cid.Undef, fmt.Errorf("root marker is undefined")
+func (s *TreeList) buildPlainFromValues(ctx context.Context, namespace string, values []cid.Cid, height int) (cid.Cid, error) {
+	if height < 0 {
+		return cid.Undef, fmt.Errorf("height must be non-negative")
 	}
-	height := layout.RequiredHeight(uint64(len(values)))
+	marker, err := layout.EncodeNodeMetadata(layout.NodeMetadata{
+		Height:     uint64(height),
+		ChildCount: uint64(len(values)),
+	})
+	if err != nil {
+		return cid.Undef, err
+	}
 	slots := layout.EmptyRootSlots()
-	slots[0] = rootMarker
+	slots[0] = marker
 	content := layout.ContentSlots(slots, true)
 	if height == 0 {
 		copy(content, values)
@@ -481,7 +471,7 @@ func (s *TreeList) buildRootFromValues(ctx context.Context, namespace string, va
 		if end > len(values) {
 			end = len(values)
 		}
-		childRoot, err := s.buildFromValues(ctx, namespace, values[start:end], height-1, false)
+		childRoot, err := s.buildPlainFromValues(ctx, namespace, values[start:end], height-1)
 		if err != nil {
 			return cid.Undef, err
 		}
@@ -492,20 +482,26 @@ func (s *TreeList) buildRootFromValues(ctx context.Context, namespace string, va
 	return s.commitSlots(ctx, namespace, slots)
 }
 
-func (s *TreeList) buildFromValues(ctx context.Context, namespace string, values []cid.Cid, height int, isRoot bool) (cid.Cid, error) {
-	var slots []cid.Cid
-	if isRoot {
-		slots = layout.EmptyRootSlots()
-		lengthMarker, err := layout.EncodeLengthMarker(uint64(len(values)))
-		if err != nil {
-			return cid.Undef, err
-		}
-		slots[0] = lengthMarker
-	} else {
-		slots = layout.EmptyNodeSlots()
+func (s *TreeList) buildMeasuredFromValues(ctx context.Context, namespace string, values []cid.Cid, height int, startIndex, chunkSize, totalSize uint64) (cid.Cid, error) {
+	if height < 0 {
+		return cid.Undef, fmt.Errorf("height must be non-negative")
 	}
-
-	content := layout.ContentSlots(slots, isRoot)
+	nodeSize, err := measuredNodeSize(startIndex, uint64(len(values)), chunkSize, totalSize)
+	if err != nil {
+		return cid.Undef, err
+	}
+	marker, err := layout.EncodeNodeMetadata(layout.NodeMetadata{
+		Height:     uint64(height),
+		ChildCount: uint64(len(values)),
+		TotalSize:  nodeSize,
+		ChunkSize:  chunkSize,
+	})
+	if err != nil {
+		return cid.Undef, err
+	}
+	slots := layout.EmptyRootSlots()
+	slots[0] = marker
+	content := layout.ContentSlots(slots, true)
 	if height == 0 {
 		copy(content, values)
 		return s.commitSlots(ctx, namespace, slots)
@@ -520,7 +516,7 @@ func (s *TreeList) buildFromValues(ctx context.Context, namespace string, values
 		if end > len(values) {
 			end = len(values)
 		}
-		childRoot, err := s.buildFromValues(ctx, namespace, values[start:end], height-1, false)
+		childRoot, err := s.buildMeasuredFromValues(ctx, namespace, values[start:end], height-1, startIndex+uint64(start), chunkSize, totalSize)
 		if err != nil {
 			return cid.Undef, err
 		}
@@ -571,14 +567,14 @@ func (s *TreeList) rebuildPrefix(
 	var nextSlots []cid.Cid
 	if targetRoot {
 		nextSlots = layout.EmptyRootSlots()
-		lengthMarker, err := layout.EncodeLengthMarker(keepLen)
-		if err != nil {
-			return cid.Undef, err
-		}
-		nextSlots[0] = lengthMarker
 	} else {
 		nextSlots = layout.EmptyNodeSlots()
 	}
+	marker, err := plainNodeMetadata(targetHeight, keepLen)
+	if err != nil {
+		return cid.Undef, err
+	}
+	nextSlots[0] = marker
 	nextContent := layout.ContentSlots(nextSlots, targetRoot)
 
 	if targetHeight == 0 {
@@ -680,14 +676,20 @@ func (s *TreeList) appendInto(ctx context.Context, namespace string, root cid.Ci
 	}
 
 	if height == 0 {
-		if index >= uint64(len(slots)) {
+		nextSlots := cloneSlots(slots)
+		content := layout.ContentSlots(nextSlots, false)
+		if index >= uint64(len(content)) {
 			return cid.Undef, fmt.Errorf("index %d out of leaf range", index)
 		}
-		if slots[index].Defined() {
+		if content[index].Defined() {
 			return cid.Undef, fmt.Errorf("append slot %d is already occupied", index)
 		}
-		nextSlots := cloneSlots(slots)
-		nextSlots[index] = key
+		marker, err := plainNodeMetadata(height, index+1)
+		if err != nil {
+			return cid.Undef, err
+		}
+		nextSlots[0] = marker
+		content[index] = key
 		return s.commitSlots(ctx, namespace, nextSlots)
 	}
 
@@ -699,10 +701,16 @@ func (s *TreeList) appendInto(ctx context.Context, namespace string, root cid.Ci
 	localIndex := index % childSpan
 
 	nextSlots := cloneSlots(slots)
-	if nextSlots[digit].Defined() {
-		nextSlots[digit], err = s.appendInto(ctx, namespace, nextSlots[digit], height-1, localIndex, key)
+	marker, err := plainNodeMetadata(height, index+1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	nextSlots[0] = marker
+	nextContent := layout.ContentSlots(nextSlots, false)
+	if nextContent[digit].Defined() {
+		nextContent[digit], err = s.appendInto(ctx, namespace, nextContent[digit], height-1, localIndex, key)
 	} else {
-		nextSlots[digit], err = s.buildSparseSubtree(ctx, namespace, height-1, localIndex, key)
+		nextContent[digit], err = s.buildSparseSubtree(ctx, namespace, height-1, localIndex, key)
 	}
 	if err != nil {
 		return cid.Undef, err
@@ -713,10 +721,16 @@ func (s *TreeList) appendInto(ctx context.Context, namespace string, root cid.Ci
 func (s *TreeList) buildSparseSubtree(ctx context.Context, namespace string, height int, index uint64, key cid.Cid) (cid.Cid, error) {
 	if height == 0 {
 		slots := layout.EmptyNodeSlots()
-		if index >= uint64(len(slots)) {
+		marker, err := plainNodeMetadata(height, index+1)
+		if err != nil {
+			return cid.Undef, err
+		}
+		slots[0] = marker
+		content := layout.ContentSlots(slots, false)
+		if index >= uint64(len(content)) {
 			return cid.Undef, fmt.Errorf("index %d out of leaf range", index)
 		}
-		slots[index] = key
+		content[index] = key
 		return s.commitSlots(ctx, namespace, slots)
 	}
 
@@ -728,7 +742,13 @@ func (s *TreeList) buildSparseSubtree(ctx context.Context, namespace string, hei
 	localIndex := index % childSpan
 
 	slots := layout.EmptyNodeSlots()
-	slots[digit], err = s.buildSparseSubtree(ctx, namespace, height-1, localIndex, key)
+	marker, err := plainNodeMetadata(height, index+1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	slots[0] = marker
+	content := layout.ContentSlots(slots, false)
+	content[digit], err = s.buildSparseSubtree(ctx, namespace, height-1, localIndex, key)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -737,7 +757,7 @@ func (s *TreeList) buildSparseSubtree(ctx context.Context, namespace string, hei
 
 func (s *TreeList) commitEmptyRoot(ctx context.Context, namespace string) (cid.Cid, error) {
 	slots := layout.EmptyRootSlots()
-	lengthMarker, err := layout.EncodeLengthMarker(0)
+	lengthMarker, err := plainNodeMetadata(0, 0)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -792,6 +812,28 @@ func (s *TreeList) commitSlots(ctx context.Context, namespace string, slots []ci
 		return cid.Undef, err
 	}
 	return listRoot, nil
+}
+
+func (s *TreeList) verifyFixedMetadataSlot(root cid.Cid, meta layout.FixedMetadata, proof []byte) (bool, error) {
+	nodeMarker, err := layout.EncodeNodeMetadata(layout.NodeMetadata{
+		Height:     uint64(layout.RequiredHeight(meta.ChildCount)),
+		ChildCount: meta.ChildCount,
+		TotalSize:  meta.TotalSize,
+		ChunkSize:  meta.ChunkSize,
+	})
+	if err != nil {
+		return false, err
+	}
+	ok, err := layout.VerifySlot(s.scheme, root, 0, commitment.CellFromCID(nodeMarker), proof)
+	if err != nil || ok {
+		return ok, err
+	}
+
+	legacyMarker, err := layout.EncodeFixedMetadata(meta)
+	if err != nil {
+		return false, err
+	}
+	return layout.VerifySlot(s.scheme, root, 0, commitment.CellFromCID(legacyMarker), proof)
 }
 
 func encodeProof(query list.Query, envelope proofEnvelope) (list.Query, structure.Proof, error) {
@@ -893,6 +935,44 @@ func validateFixedMetadata(meta layout.FixedMetadata) error {
 		return fmt.Errorf("child count %d does not match total size %d and chunk size %d", meta.ChildCount, meta.TotalSize, meta.ChunkSize)
 	}
 	return nil
+}
+
+func plainNodeMetadata(height int, childCount uint64) (cid.Cid, error) {
+	if height < 0 {
+		return cid.Undef, fmt.Errorf("height must be non-negative")
+	}
+	return layout.EncodeNodeMetadata(layout.NodeMetadata{
+		Height:     uint64(height),
+		ChildCount: childCount,
+	})
+}
+
+func measuredNodeSize(startIndex, childCount, chunkSize, totalSize uint64) (uint64, error) {
+	if chunkSize == 0 {
+		return 0, fmt.Errorf("chunk size is zero")
+	}
+	if childCount == 0 {
+		return 0, nil
+	}
+	if startIndex > ^uint64(0)/chunkSize {
+		return 0, fmt.Errorf("measured node start index %d overflows chunk size %d", startIndex, chunkSize)
+	}
+	endIndex := startIndex + childCount
+	if endIndex < startIndex {
+		return 0, fmt.Errorf("measured node child count overflows")
+	}
+	if endIndex > ^uint64(0)/chunkSize {
+		return 0, fmt.Errorf("measured node end index %d overflows chunk size %d", endIndex, chunkSize)
+	}
+	startByte := startIndex * chunkSize
+	if startByte >= totalSize {
+		return 0, nil
+	}
+	endByte := endIndex * chunkSize
+	if endByte > totalSize {
+		endByte = totalSize
+	}
+	return endByte - startByte, nil
 }
 
 func normalizeRange(start uint64, end *uint64, totalSize uint64) (endExclusive uint64, empty bool, err error) {

--- a/core/structure/list/tree/tree.go
+++ b/core/structure/list/tree/tree.go
@@ -29,8 +29,9 @@ type proofEnvelope struct {
 }
 
 type proofStep struct {
-	Target []byte `json:"target"`
-	Proof  []byte `json:"proof"`
+	Target []byte  `json:"target"`
+	Proof  []byte  `json:"proof"`
+	Slot   *uint64 `json:"slot,omitempty"`
 }
 
 type rangeProofEnvelope struct {
@@ -115,13 +116,16 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 	currentRoot := root
 	currentSlots := rootSlots
 	for level, digit := range digits {
-		slot := uint64(digit) + 1
+		slot, err := layout.ContentSlotIndex(currentSlots, level == 0, digit)
+		if err != nil {
+			return list.Query{}, nil, err
+		}
 
 		target, proof, err := layout.ProveSlot(s.scheme, currentRoot, currentSlots, slot)
 		if err != nil {
 			return list.Query{}, nil, err
 		}
-		envelope.Steps = append(envelope.Steps, newProofStep(target, proof))
+		envelope.Steps = append(envelope.Steps, newProofStep(target, proof, slot))
 
 		if level == len(digits)-1 {
 			query.Key, err = target.AsCID()
@@ -193,7 +197,10 @@ func (s *TreeList) Verify(root cid.Cid, index uint64, expected list.Query, proof
 			return false, err
 		}
 
-		slot := uint64(digit) + 1
+		slot, err := contentSlotForVerify(step, level == 0, digit)
+		if err != nil {
+			return false, err
+		}
 		ok, err := layout.VerifySlot(s.scheme, currentRoot, slot, target, step.Proof)
 		if err != nil || !ok {
 			return ok, err
@@ -786,10 +793,21 @@ func (s *TreeList) loadNode(ctx context.Context, namespace string, root cid.Cid,
 	if err != nil {
 		return nil, err
 	}
-	if err := layout.ValidateSlots(s.scheme, root, slots); err != nil {
-		return nil, err
+	validateErr := layout.ValidateSlots(s.scheme, root, slots)
+	if validateErr == nil {
+		return slots, nil
 	}
-	return slots, nil
+	if !isRoot && width != layout.LegacyNodeWidth {
+		legacySlots, err := layout.LoadSlots(ctx, s.arctable, namespace, root, layout.LegacyNodeWidth)
+		if err != nil {
+			return nil, validateErr
+		}
+		if err := layout.ValidateSlots(s.scheme, root, legacySlots); err == nil {
+			return legacySlots, nil
+		}
+		return nil, validateErr
+	}
+	return nil, validateErr
 }
 
 func (s *TreeList) commitSlots(ctx context.Context, namespace string, slots []cid.Cid) (cid.Cid, error) {
@@ -871,13 +889,15 @@ func valuesFromView(view list.View) ([]cid.Cid, error) {
 	return values, nil
 }
 
-func newProofStep(target commitment.Cell, proof []byte) proofStep {
+func newProofStep(target commitment.Cell, proof []byte, slot uint64) proofStep {
+	provedSlot := slot
 	if !target.Defined() {
-		return proofStep{Proof: proof}
+		return proofStep{Proof: proof, Slot: &provedSlot}
 	}
 	return proofStep{
 		Target: target.Bytes(),
 		Proof:  proof,
+		Slot:   &provedSlot,
 	}
 }
 
@@ -886,6 +906,24 @@ func parseStepTarget(step proofStep) (commitment.Cell, error) {
 		return nil, nil
 	}
 	return commitment.NewCell(step.Target), nil
+}
+
+func contentSlotForVerify(step proofStep, isRoot bool, digit int) (uint64, error) {
+	v2Slot := uint64(digit) + 1
+	if step.Slot == nil {
+		return v2Slot, nil
+	}
+	slot := *step.Slot
+	if isRoot {
+		if slot != v2Slot {
+			return 0, fmt.Errorf("root content digit %d proved slot %d, want %d", digit, slot, v2Slot)
+		}
+		return slot, nil
+	}
+	if slot != uint64(digit) && slot != v2Slot {
+		return 0, fmt.Errorf("content digit %d proved unsupported slot %d", digit, slot)
+	}
+	return slot, nil
 }
 
 func needsExplicitLengthTarget(marker cid.Cid, length uint64) bool {

--- a/core/structure/list/tree/tree.go
+++ b/core/structure/list/tree/tree.go
@@ -23,13 +23,24 @@ type TreeList struct {
 }
 
 type proofEnvelope struct {
-	LengthProof []byte      `json:"length_proof"`
-	Steps       []proofStep `json:"steps,omitempty"`
+	LengthProof  []byte      `json:"length_proof"`
+	LengthTarget []byte      `json:"length_target,omitempty"`
+	Steps        []proofStep `json:"steps,omitempty"`
 }
 
 type proofStep struct {
 	Target []byte `json:"target"`
 	Proof  []byte `json:"proof"`
+}
+
+type rangeProofEnvelope struct {
+	MetadataProof []byte            `json:"metadata_proof"`
+	IndexProofs   []rangeIndexProof `json:"index_proofs,omitempty"`
+}
+
+type rangeIndexProof struct {
+	Index uint64 `json:"index"`
+	Proof []byte `json:"proof"`
 }
 
 func NewList(scheme commitment.IndexCommitment, arctable arctable.ArcTable) (*TreeList, error) {
@@ -50,7 +61,38 @@ func (s *TreeList) Commit(ctx context.Context, namespace string, view list.View)
 	if err != nil {
 		return cid.Undef, err
 	}
-	return s.buildFromValues(ctx, namespace, values, layout.RequiredHeight(uint64(len(values))), true)
+	lengthMarker, err := layout.EncodeLengthMarker(uint64(len(values)))
+	if err != nil {
+		return cid.Undef, err
+	}
+	return s.buildRootFromValues(ctx, namespace, values, lengthMarker)
+}
+
+// CommitFixed commits fixed-width measured list chunks. The resulting root
+// remains compatible with base index proofs while also supporting byte-range
+// proofs over authenticated fixed chunk metadata.
+func (s *TreeList) CommitFixed(ctx context.Context, namespace string, chunks []cid.Cid, chunkSize, totalSize uint64) (cid.Cid, error) {
+	if chunkSize == 0 {
+		return cid.Undef, fmt.Errorf("chunk size must be positive")
+	}
+	if uint64(len(chunks)) != chunkCount(totalSize, chunkSize) {
+		return cid.Undef, fmt.Errorf("chunk count %d does not match total size %d and chunk size %d", len(chunks), totalSize, chunkSize)
+	}
+	for i, chunk := range chunks {
+		if !chunk.Defined() {
+			return cid.Undef, fmt.Errorf("chunk at index %d is undefined", i)
+		}
+	}
+	metaMarker, err := layout.EncodeFixedMetadata(layout.FixedMetadata{
+		ChildCount: uint64(len(chunks)),
+		TotalSize:  totalSize,
+		ChunkSize:  chunkSize,
+	})
+	if err != nil {
+		return cid.Undef, err
+	}
+	values := append([]cid.Cid(nil), chunks...)
+	return s.buildRootFromValues(ctx, namespace, values, metaMarker)
 }
 
 func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, index uint64) (list.Query, structure.Proof, error) {
@@ -60,11 +102,16 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 	}
 
 	query := list.Query{Length: length}
-	_, lengthProof, err := layout.ProveSlot(s.scheme, root, rootSlots, 0)
+	lengthTarget, lengthProof, err := layout.ProveSlot(s.scheme, root, rootSlots, 0)
 	if err != nil {
 		return list.Query{}, nil, err
 	}
 	envelope := proofEnvelope{LengthProof: lengthProof}
+	if target, err := lengthTarget.AsCID(); err != nil {
+		return list.Query{}, nil, err
+	} else if needsExplicitLengthTarget(target, length) {
+		envelope.LengthTarget = lengthTarget.Bytes()
+	}
 
 	if index >= length {
 		query.Key = cid.Undef
@@ -124,11 +171,11 @@ func (s *TreeList) Verify(root cid.Cid, index uint64, expected list.Query, proof
 		return false, fmt.Errorf("missing length proof")
 	}
 
-	lengthMarker, err := layout.EncodeLengthMarker(expected.Length)
+	lengthTarget, err := lengthTargetForVerify(expected.Length, envelope.LengthTarget)
 	if err != nil {
 		return false, err
 	}
-	ok, err := layout.VerifySlot(s.scheme, root, 0, commitment.CellFromCID(lengthMarker), envelope.LengthProof)
+	ok, err := layout.VerifySlot(s.scheme, root, 0, lengthTarget, envelope.LengthProof)
 	if err != nil || !ok {
 		return ok, err
 	}
@@ -180,6 +227,117 @@ func (s *TreeList) Verify(root cid.Cid, index uint64, expected list.Query, proof
 	}
 
 	return false, nil
+}
+
+func (s *TreeList) ProveRange(ctx context.Context, namespace string, root cid.Cid, start uint64, end *uint64) (list.RangeResult, structure.Proof, error) {
+	rootSlots, _, err := s.loadRoot(ctx, namespace, root)
+	if err != nil {
+		return list.RangeResult{}, nil, err
+	}
+	meta, err := fixedRangeMetadata(rootSlots[0])
+	if err != nil {
+		return list.RangeResult{}, nil, err
+	}
+	if err := validateFixedMetadata(meta); err != nil {
+		return list.RangeResult{}, nil, err
+	}
+
+	_, metadataProof, err := layout.ProveSlot(s.scheme, root, rootSlots, 0)
+	if err != nil {
+		return list.RangeResult{}, nil, err
+	}
+	result := list.RangeResult{
+		Metadata: list.RangeMetadata{
+			ChildCount: meta.ChildCount,
+			TotalSize:  meta.TotalSize,
+			ChunkSize:  meta.ChunkSize,
+		},
+	}
+	envelope := rangeProofEnvelope{MetadataProof: metadataProof}
+
+	endExclusive, empty, err := normalizeRange(start, end, meta.TotalSize)
+	if err != nil {
+		return list.RangeResult{}, nil, err
+	}
+	if empty {
+		return encodeRangeProof(result, envelope)
+	}
+
+	first := start / meta.ChunkSize
+	last := (endExclusive - 1) / meta.ChunkSize
+	result.Segments = make([]cid.Cid, 0, last-first+1)
+	envelope.IndexProofs = make([]rangeIndexProof, 0, last-first+1)
+	for index := first; index <= last; index++ {
+		query, proof, err := s.Prove(ctx, namespace, root, index)
+		if err != nil {
+			return list.RangeResult{}, nil, err
+		}
+		if !query.Key.Defined() {
+			return list.RangeResult{}, nil, fmt.Errorf("missing segment at index %d", index)
+		}
+		result.Segments = append(result.Segments, query.Key)
+		envelope.IndexProofs = append(envelope.IndexProofs, rangeIndexProof{
+			Index: index,
+			Proof: cloneBytes(proof),
+		})
+	}
+	return encodeRangeProof(result, envelope)
+}
+
+func (s *TreeList) VerifyRange(root cid.Cid, start uint64, end *uint64, expected list.RangeResult, proof structure.Proof) (bool, error) {
+	var envelope rangeProofEnvelope
+	if err := json.Unmarshal(proof, &envelope); err != nil {
+		return false, err
+	}
+	if len(envelope.MetadataProof) == 0 {
+		return false, fmt.Errorf("missing metadata proof")
+	}
+	meta := layout.FixedMetadata{
+		ChildCount: expected.Metadata.ChildCount,
+		TotalSize:  expected.Metadata.TotalSize,
+		ChunkSize:  expected.Metadata.ChunkSize,
+	}
+	if err := validateFixedMetadata(meta); err != nil {
+		return false, err
+	}
+	metaMarker, err := layout.EncodeFixedMetadata(meta)
+	if err != nil {
+		return false, err
+	}
+	ok, err := layout.VerifySlot(s.scheme, root, 0, commitment.CellFromCID(metaMarker), envelope.MetadataProof)
+	if err != nil || !ok {
+		return ok, err
+	}
+
+	endExclusive, empty, err := normalizeRange(start, end, meta.TotalSize)
+	if err != nil {
+		return false, err
+	}
+	if empty {
+		return len(expected.Segments) == 0 && len(envelope.IndexProofs) == 0, nil
+	}
+
+	first := start / meta.ChunkSize
+	last := (endExclusive - 1) / meta.ChunkSize
+	wantCount := int(last - first + 1)
+	if len(expected.Segments) != wantCount || len(envelope.IndexProofs) != wantCount {
+		return false, nil
+	}
+	for i := 0; i < wantCount; i++ {
+		index := first + uint64(i)
+		indexProof := envelope.IndexProofs[i]
+		if indexProof.Index != index {
+			return false, nil
+		}
+		ok, err := s.Verify(root, index, list.Query{
+			Key:    expected.Segments[i],
+			Length: meta.ChildCount,
+		}, structure.Proof(indexProof.Proof))
+		if err != nil || !ok {
+			return ok, err
+		}
+	}
+	return true, nil
 }
 
 func (s *TreeList) Replace(ctx context.Context, namespace string, root cid.Cid, index uint64, oldKey, newKey cid.Cid) (cid.Cid, error) {
@@ -299,6 +457,39 @@ func (s *TreeList) Truncate(ctx context.Context, namespace string, root cid.Cid,
 	oldHeight := layout.RequiredHeight(oldLen)
 	newHeight := layout.RequiredHeight(newLen)
 	return s.rebuildPrefix(ctx, namespace, root, true, oldHeight, true, newHeight, newLen)
+}
+
+func (s *TreeList) buildRootFromValues(ctx context.Context, namespace string, values []cid.Cid, rootMarker cid.Cid) (cid.Cid, error) {
+	if !rootMarker.Defined() {
+		return cid.Undef, fmt.Errorf("root marker is undefined")
+	}
+	height := layout.RequiredHeight(uint64(len(values)))
+	slots := layout.EmptyRootSlots()
+	slots[0] = rootMarker
+	content := layout.ContentSlots(slots, true)
+	if height == 0 {
+		copy(content, values)
+		return s.commitSlots(ctx, namespace, slots)
+	}
+
+	childSpan, err := layout.SubtreeCapacity(height - 1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	for childIdx, start := 0, 0; start < len(values); childIdx++ {
+		end := start + int(childSpan)
+		if end > len(values) {
+			end = len(values)
+		}
+		childRoot, err := s.buildFromValues(ctx, namespace, values[start:end], height-1, false)
+		if err != nil {
+			return cid.Undef, err
+		}
+		content[childIdx] = childRoot
+		start = end
+	}
+
+	return s.commitSlots(ctx, namespace, slots)
 }
 
 func (s *TreeList) buildFromValues(ctx context.Context, namespace string, values []cid.Cid, height int, isRoot bool) (cid.Cid, error) {
@@ -559,7 +750,7 @@ func (s *TreeList) loadRoot(ctx context.Context, namespace string, root cid.Cid)
 	if err != nil {
 		return nil, 0, err
 	}
-	length, err := layout.DecodeLengthMarker(slots[0])
+	length, err := layout.DecodeRootLength(slots[0])
 	if err != nil {
 		return nil, 0, err
 	}
@@ -611,6 +802,14 @@ func encodeProof(query list.Query, envelope proofEnvelope) (list.Query, structur
 	return query, structure.Proof(proofBytes), nil
 }
 
+func encodeRangeProof(result list.RangeResult, envelope rangeProofEnvelope) (list.RangeResult, structure.Proof, error) {
+	proofBytes, err := json.Marshal(envelope)
+	if err != nil {
+		return list.RangeResult{}, nil, err
+	}
+	return result, structure.Proof(proofBytes), nil
+}
+
 func valuesFromView(view list.View) ([]cid.Cid, error) {
 	if view == nil {
 		return nil, fmt.Errorf("list view is nil")
@@ -647,8 +846,86 @@ func parseStepTarget(step proofStep) (commitment.Cell, error) {
 	return commitment.NewCell(step.Target), nil
 }
 
+func needsExplicitLengthTarget(marker cid.Cid, length uint64) bool {
+	legacy, err := layout.EncodeLengthMarker(length)
+	if err != nil {
+		return true
+	}
+	return !marker.Equals(legacy)
+}
+
+func lengthTargetForVerify(expectedLength uint64, explicit []byte) (commitment.Cell, error) {
+	if len(explicit) == 0 {
+		lengthMarker, err := layout.EncodeLengthMarker(expectedLength)
+		if err != nil {
+			return nil, err
+		}
+		return commitment.CellFromCID(lengthMarker), nil
+	}
+	cell := commitment.NewCell(explicit)
+	marker, err := cell.AsCID()
+	if err != nil {
+		return nil, err
+	}
+	length, err := layout.DecodeRootLength(marker)
+	if err != nil {
+		return nil, err
+	}
+	if length != expectedLength {
+		return nil, fmt.Errorf("length target commits child count %d, expected %d", length, expectedLength)
+	}
+	return cell, nil
+}
+
+func fixedRangeMetadata(marker cid.Cid) (layout.FixedMetadata, error) {
+	meta, err := layout.DecodeFixedMetadata(marker)
+	if err != nil {
+		return layout.FixedMetadata{}, fmt.Errorf("root does not carry fixed range metadata: %w", err)
+	}
+	return meta, nil
+}
+
+func validateFixedMetadata(meta layout.FixedMetadata) error {
+	if meta.ChunkSize == 0 {
+		return fmt.Errorf("chunk size is zero")
+	}
+	if meta.ChildCount != chunkCount(meta.TotalSize, meta.ChunkSize) {
+		return fmt.Errorf("child count %d does not match total size %d and chunk size %d", meta.ChildCount, meta.TotalSize, meta.ChunkSize)
+	}
+	return nil
+}
+
+func normalizeRange(start uint64, end *uint64, totalSize uint64) (endExclusive uint64, empty bool, err error) {
+	endExclusive = totalSize
+	if end != nil {
+		endExclusive = *end
+		if endExclusive > totalSize {
+			endExclusive = totalSize
+		}
+	}
+	if start > endExclusive {
+		return 0, false, fmt.Errorf("range start %d exceeds end %d", start, endExclusive)
+	}
+	if start >= totalSize || endExclusive == start {
+		return endExclusive, true, nil
+	}
+	return endExclusive, false, nil
+}
+
+func chunkCount(totalSize, chunkSize uint64) uint64 {
+	if totalSize == 0 {
+		return 0
+	}
+	return ((totalSize - 1) / chunkSize) + 1
+}
+
+func cloneBytes(data []byte) []byte {
+	return append([]byte(nil), data...)
+}
+
 func cloneSlots(slots []cid.Cid) []cid.Cid {
 	return append([]cid.Cid(nil), slots...)
 }
 
 var _ list.Semantics = (*TreeList)(nil)
+var _ list.MeasuredSemantics = (*TreeList)(nil)

--- a/core/structure/list/tree/tree_test.go
+++ b/core/structure/list/tree/tree_test.go
@@ -147,6 +147,107 @@ func TestTreeListSemanticProofsAndRestart(t *testing.T) {
 	}
 }
 
+func TestTreeListChildNodesCarryAuthenticatedMetadata(t *testing.T) {
+	ctx := context.Background()
+	values := makeValues(300)
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			namespace := "tree-child-meta-" + name
+			scheme := factory(t)
+			semantic, e, err := newListWithArcTable(scheme, kv)
+			if err != nil {
+				t.Fatalf("newListWithArcTable failed: %v", err)
+			}
+
+			root, err := semantic.Commit(ctx, namespace, list.NewViewFromSlice(values))
+			if err != nil {
+				t.Fatalf("Commit failed: %v", err)
+			}
+
+			childRoot, err := e.Get(ctx, namespace, cid.Undef, layout.NodeSlotPath(root, 1))
+			if err != nil {
+				t.Fatalf("fetch first child root: %v", err)
+			}
+			childSlots, err := layout.LoadSlots(ctx, e, namespace, childRoot, layout.NodeWidth)
+			if err != nil {
+				t.Fatalf("load child slots: %v", err)
+			}
+			childLen, err := layout.DecodeRootLength(childSlots[0])
+			if err != nil {
+				t.Fatalf("decode child metadata: %v", err)
+			}
+			if childLen != uint64(layout.BranchingFactor) {
+				t.Fatalf("child length = %d, want %d", childLen, layout.BranchingFactor)
+			}
+			if !childSlots[1].Equals(values[0]) {
+				t.Fatalf("child logical index 0 stored at slot 1 = %s, want %s", childSlots[1], values[0])
+			}
+		})
+	}
+}
+
+func TestTreeListMeasuredChildNodesCarryRangeMetadata(t *testing.T) {
+	ctx := context.Background()
+	chunks := makeValues(300)
+	chunkSize := uint64(4)
+	totalSize := uint64(len(chunks)-1)*chunkSize + 3
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			namespace := "tree-child-range-meta-" + name
+			scheme := factory(t)
+			semantic, e, err := newListWithArcTable(scheme, kv)
+			if err != nil {
+				t.Fatalf("newListWithArcTable failed: %v", err)
+			}
+
+			root, err := semantic.CommitFixed(ctx, namespace, chunks, chunkSize, totalSize)
+			if err != nil {
+				t.Fatalf("CommitFixed failed: %v", err)
+			}
+
+			firstChildRoot, err := e.Get(ctx, namespace, cid.Undef, layout.NodeSlotPath(root, 1))
+			if err != nil {
+				t.Fatalf("fetch first child root: %v", err)
+			}
+			firstChildSlots, err := layout.LoadSlots(ctx, e, namespace, firstChildRoot, layout.NodeWidth)
+			if err != nil {
+				t.Fatalf("load first child slots: %v", err)
+			}
+			firstMeta, err := layout.DecodeFixedMetadata(firstChildSlots[0])
+			if err != nil {
+				t.Fatalf("decode first child fixed metadata: %v", err)
+			}
+			if firstMeta.ChildCount != uint64(layout.BranchingFactor) || firstMeta.TotalSize != uint64(layout.BranchingFactor)*chunkSize || firstMeta.ChunkSize != chunkSize {
+				t.Fatalf("first child metadata = %+v, want count=%d total=%d chunk=%d", firstMeta, layout.BranchingFactor, uint64(layout.BranchingFactor)*chunkSize, chunkSize)
+			}
+
+			secondChildRoot, err := e.Get(ctx, namespace, cid.Undef, layout.NodeSlotPath(root, 2))
+			if err != nil {
+				t.Fatalf("fetch second child root: %v", err)
+			}
+			secondChildSlots, err := layout.LoadSlots(ctx, e, namespace, secondChildRoot, layout.NodeWidth)
+			if err != nil {
+				t.Fatalf("load second child slots: %v", err)
+			}
+			secondMeta, err := layout.DecodeFixedMetadata(secondChildSlots[0])
+			if err != nil {
+				t.Fatalf("decode second child fixed metadata: %v", err)
+			}
+			wantSecondSize := totalSize - uint64(layout.BranchingFactor)*chunkSize
+			if secondMeta.ChildCount != uint64(len(chunks)-layout.BranchingFactor) || secondMeta.TotalSize != wantSecondSize || secondMeta.ChunkSize != chunkSize {
+				t.Fatalf("second child metadata = %+v, want count=%d total=%d chunk=%d", secondMeta, len(chunks)-layout.BranchingFactor, wantSecondSize, chunkSize)
+			}
+			if !secondChildSlots[1].Equals(chunks[layout.BranchingFactor]) {
+				t.Fatalf("second child logical index 0 stored at slot 1 = %s, want %s", secondChildSlots[1], chunks[layout.BranchingFactor])
+			}
+		})
+	}
+}
+
 func TestTreeListFixedRangeProofsUseOptionalEnd(t *testing.T) {
 	ctx := context.Background()
 	chunks := makeValues(5)
@@ -230,6 +331,13 @@ func TestTreeListFixedRangeProofsUseOptionalEnd(t *testing.T) {
 			}
 			if ok {
 				t.Fatal("VerifyRange accepted tampered segment CID")
+			}
+
+			if _, _, err := semantic.Append(ctx, namespace, root, newPayloadCID([]byte("new chunk"))); err == nil {
+				t.Fatal("Append should reject fixed measured list roots")
+			}
+			if _, err := semantic.Truncate(ctx, namespace, root, uint64(len(chunks)-1)); err == nil {
+				t.Fatal("Truncate should reject fixed measured list roots")
 			}
 		})
 	}

--- a/core/structure/list/tree/tree_test.go
+++ b/core/structure/list/tree/tree_test.go
@@ -102,6 +102,71 @@ func assertVerifiedQuery(t *testing.T, semantic *tree.TreeList, namespace string
 	}
 }
 
+func commitLegacyPlainListRoot(t *testing.T, ctx context.Context, scheme commitment.IndexCommitment, e *overwrite.ArcTable, namespace string, values []cid.Cid) cid.Cid {
+	t.Helper()
+	return commitLegacyPlainListNode(t, ctx, scheme, e, namespace, values, layout.RequiredHeight(uint64(len(values))), true)
+}
+
+func commitLegacyPlainListNode(t *testing.T, ctx context.Context, scheme commitment.IndexCommitment, e *overwrite.ArcTable, namespace string, values []cid.Cid, height int, isRoot bool) cid.Cid {
+	t.Helper()
+
+	var slots []cid.Cid
+	if isRoot {
+		slots = layout.EmptyRootSlots()
+		marker, err := layout.EncodeLengthMarker(uint64(len(values)))
+		if err != nil {
+			t.Fatalf("encode legacy length marker: %v", err)
+		}
+		slots[0] = marker
+	} else {
+		slots = make([]cid.Cid, layout.BranchingFactor)
+	}
+	content := slots
+	if isRoot {
+		content = slots[1:]
+	}
+
+	if height == 0 {
+		copy(content, values)
+		return commitLegacySlots(t, ctx, scheme, e, namespace, slots)
+	}
+
+	childSpan, err := layout.SubtreeCapacity(height - 1)
+	if err != nil {
+		t.Fatalf("legacy child span: %v", err)
+	}
+	for childIdx, start := 0, 0; start < len(values); childIdx++ {
+		end := start + int(childSpan)
+		if end > len(values) {
+			end = len(values)
+		}
+		content[childIdx] = commitLegacyPlainListNode(t, ctx, scheme, e, namespace, values[start:end], height-1, false)
+		start = end
+	}
+	return commitLegacySlots(t, ctx, scheme, e, namespace, slots)
+}
+
+func commitLegacySlots(t *testing.T, ctx context.Context, scheme commitment.IndexCommitment, e *overwrite.ArcTable, namespace string, slots []cid.Cid) cid.Cid {
+	t.Helper()
+
+	root, err := layout.CommitSlots(scheme, slots)
+	if err != nil {
+		t.Fatalf("commit legacy slots: %v", err)
+	}
+	commBytes, err := codec.ExtractCommitment(root)
+	if err != nil {
+		t.Fatalf("extract legacy commitment: %v", err)
+	}
+	listRoot, err := codec.NewTypedCID(codec.SemanticKindList, codec.BackendKindOf(root), commBytes)
+	if err != nil {
+		t.Fatalf("wrap legacy list root: %v", err)
+	}
+	if err := layout.StoreSlots(ctx, e, namespace, listRoot, slots); err != nil {
+		t.Fatalf("store legacy slots: %v", err)
+	}
+	return listRoot
+}
+
 func TestTreeListSemanticProofsAndRestart(t *testing.T) {
 	ctx := context.Background()
 	values := makeValues(300)
@@ -139,6 +204,33 @@ func TestTreeListSemanticProofsAndRestart(t *testing.T) {
 			})
 
 			restarted := newList(t, factory, kv)
+			assertVerifiedQuery(t, restarted, namespace, root, 256, list.Query{
+				Key:    values[256],
+				Length: uint64(len(values)),
+			})
+		})
+	}
+}
+
+func TestTreeListProvesLegacyMultiLevelRootsAfterRestart(t *testing.T) {
+	ctx := context.Background()
+	values := makeValues(300)
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			namespace := "tree-legacy-multilevel-" + name
+			scheme := factory(t)
+			_, e, err := newListWithArcTable(scheme, kv)
+			if err != nil {
+				t.Fatalf("newListWithArcTable failed: %v", err)
+			}
+			root := commitLegacyPlainListRoot(t, ctx, scheme, e, namespace, values)
+
+			restarted, err := tree.NewList(scheme, e)
+			if err != nil {
+				t.Fatalf("NewList after restart failed: %v", err)
+			}
 			assertVerifiedQuery(t, restarted, namespace, root, 256, list.Query{
 				Key:    values[256],
 				Length: uint64(len(values)),

--- a/core/structure/list/tree/tree_test.go
+++ b/core/structure/list/tree/tree_test.go
@@ -2,6 +2,7 @@ package tree_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/dewebprotocol/malt/core/arctable/overwrite"
@@ -100,6 +101,27 @@ func assertVerifiedQuery(t *testing.T, semantic *tree.TreeList, namespace string
 	if !ok {
 		t.Fatalf("Verify(%d) returned false", index)
 	}
+}
+
+func stripProofStepSlots(t *testing.T, proof []byte) []byte {
+	t.Helper()
+
+	var envelope struct {
+		LengthProof  []byte                       `json:"length_proof"`
+		LengthTarget []byte                       `json:"length_target,omitempty"`
+		Steps        []map[string]json.RawMessage `json:"steps,omitempty"`
+	}
+	if err := json.Unmarshal(proof, &envelope); err != nil {
+		t.Fatalf("decode proof envelope: %v", err)
+	}
+	for _, step := range envelope.Steps {
+		delete(step, "slot")
+	}
+	stripped, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("encode proof envelope without step slots: %v", err)
+	}
+	return stripped
 }
 
 func commitLegacyPlainListRoot(t *testing.T, ctx context.Context, scheme commitment.IndexCommitment, e *overwrite.ArcTable, namespace string, values []cid.Cid) cid.Cid {
@@ -235,6 +257,82 @@ func TestTreeListProvesLegacyMultiLevelRootsAfterRestart(t *testing.T) {
 				Key:    values[256],
 				Length: uint64(len(values)),
 			})
+		})
+	}
+}
+
+func TestTreeListVerifiesLegacyMultiLevelProofWithoutStepSlots(t *testing.T) {
+	ctx := context.Background()
+	values := makeValues(300)
+	index := uint64(layout.BranchingFactor)
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			namespace := "tree-legacy-proof-without-slots-" + name
+			scheme := factory(t)
+			_, e, err := newListWithArcTable(scheme, kv)
+			if err != nil {
+				t.Fatalf("newListWithArcTable failed: %v", err)
+			}
+			root := commitLegacyPlainListRoot(t, ctx, scheme, e, namespace, values)
+
+			restarted, err := tree.NewList(scheme, e)
+			if err != nil {
+				t.Fatalf("NewList after restart failed: %v", err)
+			}
+			query, proof, err := restarted.Prove(ctx, namespace, root, index)
+			if err != nil {
+				t.Fatalf("Prove(%d) failed: %v", index, err)
+			}
+			ok, err := restarted.Verify(root, index, query, proof)
+			if err != nil {
+				t.Fatalf("Verify(%d) with explicit slots failed: %v", index, err)
+			}
+			if !ok {
+				t.Fatalf("Verify(%d) with explicit slots returned false", index)
+			}
+			legacyProof := stripProofStepSlots(t, proof)
+
+			ok, err = restarted.Verify(root, index, query, legacyProof)
+			if err != nil {
+				t.Fatalf("Verify(%d) failed: %v", index, err)
+			}
+			if !ok {
+				t.Fatalf("Verify(%d) returned false", index)
+			}
+		})
+	}
+}
+
+func TestTreeListVerifiesModernMultiLevelProofWithoutStepSlots(t *testing.T) {
+	ctx := context.Background()
+	values := makeValues(300)
+	index := uint64(layout.BranchingFactor)
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			namespace := "tree-modern-proof-without-slots-" + name
+
+			semantic := newList(t, factory, kv)
+			root, err := semantic.Commit(ctx, namespace, list.NewViewFromSlice(values))
+			if err != nil {
+				t.Fatalf("Commit failed: %v", err)
+			}
+			query, proof, err := semantic.Prove(ctx, namespace, root, index)
+			if err != nil {
+				t.Fatalf("Prove(%d) failed: %v", index, err)
+			}
+			legacyProof := stripProofStepSlots(t, proof)
+
+			ok, err := semantic.Verify(root, index, query, legacyProof)
+			if err != nil {
+				t.Fatalf("Verify(%d) failed: %v", index, err)
+			}
+			if !ok {
+				t.Fatalf("Verify(%d) returned false", index)
+			}
 		})
 	}
 }

--- a/core/structure/list/tree/tree_test.go
+++ b/core/structure/list/tree/tree_test.go
@@ -239,6 +239,50 @@ func TestTreeListProvesLegacyMultiLevelRootsAfterRestart(t *testing.T) {
 	}
 }
 
+func TestTreeListAppendIntoLegacyChildPreservesSlotZero(t *testing.T) {
+	ctx := context.Background()
+	values := makeValues(300)
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			namespace := "tree-legacy-append-" + name
+			scheme := factory(t)
+			_, e, err := newListWithArcTable(scheme, kv)
+			if err != nil {
+				t.Fatalf("newListWithArcTable failed: %v", err)
+			}
+			root := commitLegacyPlainListRoot(t, ctx, scheme, e, namespace, values)
+
+			restarted, err := tree.NewList(scheme, e)
+			if err != nil {
+				t.Fatalf("NewList after restart failed: %v", err)
+			}
+			appended := newPayloadCID([]byte("appended to legacy child"))
+			appendedRoot, appendedIndex, err := restarted.Append(ctx, namespace, root, appended)
+			if err != nil {
+				t.Fatalf("Append into legacy child failed: %v", err)
+			}
+			if appendedIndex != uint64(len(values)) {
+				t.Fatalf("append index = %d, want %d", appendedIndex, len(values))
+			}
+
+			assertVerifiedQuery(t, restarted, namespace, appendedRoot, 0, list.Query{
+				Key:    values[0],
+				Length: uint64(len(values) + 1),
+			})
+			assertVerifiedQuery(t, restarted, namespace, appendedRoot, uint64(layout.BranchingFactor), list.Query{
+				Key:    values[layout.BranchingFactor],
+				Length: uint64(len(values) + 1),
+			})
+			assertVerifiedQuery(t, restarted, namespace, appendedRoot, appendedIndex, list.Query{
+				Key:    appended,
+				Length: uint64(len(values) + 1),
+			})
+		})
+	}
+}
+
 func TestTreeListChildNodesCarryAuthenticatedMetadata(t *testing.T) {
 	ctx := context.Background()
 	values := makeValues(300)

--- a/core/structure/list/tree/tree_test.go
+++ b/core/structure/list/tree/tree_test.go
@@ -147,6 +147,94 @@ func TestTreeListSemanticProofsAndRestart(t *testing.T) {
 	}
 }
 
+func TestTreeListFixedRangeProofsUseOptionalEnd(t *testing.T) {
+	ctx := context.Background()
+	chunks := makeValues(5)
+	chunkSize := uint64(4)
+	totalSize := uint64(18)
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			kv := kvmemory.New()
+			namespace := "tree-fixed-range-" + name
+
+			semantic := newList(t, factory, kv)
+			root, err := semantic.CommitFixed(ctx, namespace, chunks, chunkSize, totalSize)
+			if err != nil {
+				t.Fatalf("CommitFixed failed: %v", err)
+			}
+
+			assertVerifiedQuery(t, semantic, namespace, root, 4, list.Query{
+				Key:    chunks[4],
+				Length: uint64(len(chunks)),
+			})
+
+			end := uint64(10)
+			result, proof, err := semantic.ProveRange(ctx, namespace, root, 3, &end)
+			if err != nil {
+				t.Fatalf("ProveRange bounded failed: %v", err)
+			}
+			if result.Metadata.ChildCount != uint64(len(chunks)) {
+				t.Fatalf("child count = %d, want %d", result.Metadata.ChildCount, len(chunks))
+			}
+			if result.Metadata.TotalSize != totalSize {
+				t.Fatalf("total size = %d, want %d", result.Metadata.TotalSize, totalSize)
+			}
+			if result.Metadata.ChunkSize != chunkSize {
+				t.Fatalf("chunk size = %d, want %d", result.Metadata.ChunkSize, chunkSize)
+			}
+			wantBounded := chunks[:3]
+			if len(result.Segments) != len(wantBounded) {
+				t.Fatalf("bounded segment count = %d, want %d", len(result.Segments), len(wantBounded))
+			}
+			for i, want := range wantBounded {
+				if !result.Segments[i].Equals(want) {
+					t.Fatalf("bounded segment %d = %s, want %s", i, result.Segments[i], want)
+				}
+			}
+			ok, err := semantic.VerifyRange(root, 3, &end, result, proof)
+			if err != nil {
+				t.Fatalf("VerifyRange bounded failed: %v", err)
+			}
+			if !ok {
+				t.Fatal("VerifyRange bounded returned false")
+			}
+
+			toEOF, proof, err := semantic.ProveRange(ctx, namespace, root, 12, nil)
+			if err != nil {
+				t.Fatalf("ProveRange EOF failed: %v", err)
+			}
+			wantEOF := chunks[3:]
+			if len(toEOF.Segments) != len(wantEOF) {
+				t.Fatalf("EOF segment count = %d, want %d", len(toEOF.Segments), len(wantEOF))
+			}
+			for i, want := range wantEOF {
+				if !toEOF.Segments[i].Equals(want) {
+					t.Fatalf("EOF segment %d = %s, want %s", i, toEOF.Segments[i], want)
+				}
+			}
+			ok, err = semantic.VerifyRange(root, 12, nil, toEOF, proof)
+			if err != nil {
+				t.Fatalf("VerifyRange EOF failed: %v", err)
+			}
+			if !ok {
+				t.Fatal("VerifyRange EOF returned false")
+			}
+
+			tampered := result
+			tampered.Segments = append([]cid.Cid(nil), result.Segments...)
+			tampered.Segments[1] = newPayloadCID([]byte("wrong segment"))
+			ok, err = semantic.VerifyRange(root, 3, &end, tampered, proof)
+			if err != nil {
+				t.Fatalf("VerifyRange tampered failed: %v", err)
+			}
+			if ok {
+				t.Fatal("VerifyRange accepted tampered segment CID")
+			}
+		})
+	}
+}
+
 func TestTreeListSemanticUpdates(t *testing.T) {
 	ctx := context.Background()
 	initial := makeValues(255)

--- a/core/types/prooflist/prooflist.go
+++ b/core/types/prooflist/prooflist.go
@@ -14,6 +14,7 @@ const (
 	KindMapStep        StepKind = "map_step"
 	KindPayloadBinding StepKind = "payload_binding"
 	KindListIndex      StepKind = "list_index"
+	KindListRange      StepKind = "list_range"
 	KindBlobBinding    StepKind = "blob_binding"
 	KindImplicitBlock  StepKind = "implicit_block"
 	KindLegacyUnknown  StepKind = "legacy_unknown"
@@ -31,18 +32,24 @@ type ProofList struct {
 
 // Step records one hop from a structure root or block to a target CID.
 type Step struct {
-	Kind            StepKind `json:"kind"`
-	From            cid.Cid  `json:"from"`
-	Query           string   `json:"query,omitempty"`
-	Coordinate      string   `json:"coordinate,omitempty"`
-	Path            string   `json:"path,omitempty"`
-	Index           *uint64  `json:"index,omitempty"`
-	Length          *uint64  `json:"length,omitempty"`
-	Target          cid.Cid  `json:"target"`
-	EvidenceKind    string   `json:"evidence_kind,omitempty"`
-	EvidenceBackend string   `json:"evidence_backend,omitempty"`
-	Evidence        []byte   `json:"evidence,omitempty"`
-	Proof           []byte   `json:"proof,omitempty"`
+	Kind            StepKind  `json:"kind"`
+	From            cid.Cid   `json:"from"`
+	Query           string    `json:"query,omitempty"`
+	Coordinate      string    `json:"coordinate,omitempty"`
+	Path            string    `json:"path,omitempty"`
+	Index           *uint64   `json:"index,omitempty"`
+	Length          *uint64   `json:"length,omitempty"`
+	Start           *uint64   `json:"start,omitempty"`
+	End             *uint64   `json:"end,omitempty"`
+	ChildCount      *uint64   `json:"child_count,omitempty"`
+	TotalSize       *uint64   `json:"total_size,omitempty"`
+	ChunkSize       *uint64   `json:"chunk_size,omitempty"`
+	Target          cid.Cid   `json:"target"`
+	Segments        []cid.Cid `json:"segments,omitempty"`
+	EvidenceKind    string    `json:"evidence_kind,omitempty"`
+	EvidenceBackend string    `json:"evidence_backend,omitempty"`
+	Evidence        []byte    `json:"evidence,omitempty"`
+	Proof           []byte    `json:"proof,omitempty"`
 }
 
 type validateConfig struct {
@@ -92,13 +99,20 @@ func (p ProofList) ValidateShape(opts ...ValidateOption) error {
 			return fmt.Errorf("prooflist step %d from CID %s does not continue from current target %s", i, step.From.String(), current.String())
 		}
 		listIndexEvidence := step.structureListEvidence()
+		listRangeEvidence := step.structureMeasuredListEvidence()
 		if step.Kind == KindListIndex && !listIndexEvidence {
 			return fmt.Errorf("prooflist step %d list_index kind does not match evidence labels %q/%q", i, step.EvidenceKind, step.EvidenceBackend)
+		}
+		if step.Kind == KindListRange && !listRangeEvidence {
+			return fmt.Errorf("prooflist step %d list_range kind does not match evidence labels %q/%q", i, step.EvidenceKind, step.EvidenceBackend)
 		}
 		if listIndexEvidence && step.Kind != KindListIndex {
 			return fmt.Errorf("prooflist step %d structure/list evidence does not match kind %q", i, step.Kind)
 		}
-		if listIndexEvidence {
+		if listRangeEvidence && step.Kind != KindListRange {
+			return fmt.Errorf("prooflist step %d structure/measured_list evidence does not match kind %q", i, step.Kind)
+		}
+		if listIndexEvidence || listRangeEvidence {
 			listIndexPhase = true
 			continue
 		}
@@ -121,7 +135,7 @@ func (p ProofList) LastStepTarget() (cid.Cid, error) {
 // Known reports whether k is part of the current ProofList schema.
 func (k StepKind) Known() bool {
 	switch k {
-	case KindMapStep, KindPayloadBinding, KindListIndex, KindBlobBinding, KindImplicitBlock, KindLegacyUnknown:
+	case KindMapStep, KindPayloadBinding, KindListIndex, KindListRange, KindBlobBinding, KindImplicitBlock, KindLegacyUnknown:
 		return true
 	default:
 		return false
@@ -130,4 +144,8 @@ func (k StepKind) Known() bool {
 
 func (s Step) structureListEvidence() bool {
 	return s.EvidenceKind == "structure" && s.EvidenceBackend == "list"
+}
+
+func (s Step) structureMeasuredListEvidence() bool {
+	return s.EvidenceKind == "structure" && s.EvidenceBackend == "measured_list"
 }

--- a/core/types/prooflist/prooflist_test.go
+++ b/core/types/prooflist/prooflist_test.go
@@ -153,6 +153,10 @@ func TestValidateShapeRejectsUnanchoredSteps(t *testing.T) {
 	index0 := uint64(0)
 	index1 := uint64(1)
 	length := uint64(2)
+	start := uint64(0)
+	end := uint64(8)
+	totalSize := uint64(8)
+	chunkSize := uint64(4)
 	if err := (ProofList{
 		Root: root,
 		Steps: []Step{
@@ -183,6 +187,33 @@ func TestValidateShapeRejectsUnanchoredSteps(t *testing.T) {
 		},
 	}).ValidateShape(RequireSteps()); err != nil {
 		t.Fatalf("expected sibling list-index steps anchored at a prior target to pass: %v", err)
+	}
+
+	if err := (ProofList{
+		Root: root,
+		Steps: []Step{
+			{
+				Kind:   KindMapStep,
+				From:   root,
+				Path:   "large.bin",
+				Target: mid,
+			},
+			{
+				Kind:            KindListRange,
+				From:            mid,
+				Start:           &start,
+				End:             &end,
+				ChildCount:      &length,
+				TotalSize:       &totalSize,
+				ChunkSize:       &chunkSize,
+				Target:          mid,
+				Segments:        []cid.Cid{chunk0, chunk1},
+				EvidenceKind:    "structure",
+				EvidenceBackend: "measured_list",
+			},
+		},
+	}).ValidateShape(RequireSteps()); err != nil {
+		t.Fatalf("expected list-range step anchored at a prior target to pass: %v", err)
 	}
 }
 
@@ -219,6 +250,10 @@ func TestValidateShapeRejectsTraversalAfterListEvidence(t *testing.T) {
 	next := testCID(t, "next")
 	index := uint64(0)
 	length := uint64(1)
+	start := uint64(0)
+	end := uint64(4)
+	totalSize := uint64(4)
+	chunkSize := uint64(4)
 
 	if err := (ProofList{
 		Root: root,
@@ -251,5 +286,42 @@ func TestValidateShapeRejectsTraversalAfterListEvidence(t *testing.T) {
 		},
 	}).ValidateShape(RequireSteps()); err == nil {
 		t.Fatal("expected traversal after structure/list evidence to be rejected")
+	}
+
+	if err := (ProofList{
+		Root: root,
+		Steps: []Step{
+			{
+				Kind:            KindMapStep,
+				From:            root,
+				Path:            "large.bin",
+				Target:          listRoot,
+				EvidenceKind:    "structure",
+				EvidenceBackend: "map",
+			},
+			{
+				Kind:            KindListRange,
+				From:            listRoot,
+				Start:           &start,
+				End:             &end,
+				ChildCount:      &length,
+				TotalSize:       &totalSize,
+				ChunkSize:       &chunkSize,
+				Target:          listRoot,
+				Segments:        []cid.Cid{chunk},
+				EvidenceKind:    "structure",
+				EvidenceBackend: "measured_list",
+			},
+			{
+				Kind:            KindMapStep,
+				From:            chunk,
+				Path:            "forged",
+				Target:          next,
+				EvidenceKind:    "structure",
+				EvidenceBackend: "map",
+			},
+		},
+	}).ValidateShape(RequireSteps()); err == nil {
+		t.Fatal("expected traversal after structure/measured_list evidence to be rejected")
 	}
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -464,6 +464,9 @@ func (s *Server) verifyProofListStep(g *graph.Graph, index int, step prooflist.S
 			}
 			return g.ListSemantic().Verify(step.From, *step.Index, list.Query{Key: step.Target, Length: *step.Length}, structure.Proof(step.Proof))
 		case "measured_list":
+			if !step.Target.Equals(step.From) {
+				return false, nil
+			}
 			if step.Start == nil {
 				return false, fmt.Errorf("prooflist step %d list range start is missing", index)
 			}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -467,9 +467,6 @@ func (s *Server) verifyProofListStep(g *graph.Graph, index int, step prooflist.S
 			if step.Start == nil {
 				return false, fmt.Errorf("prooflist step %d list range start is missing", index)
 			}
-			if step.End == nil {
-				return false, fmt.Errorf("prooflist step %d list range end is missing", index)
-			}
 			if step.ChildCount == nil {
 				return false, fmt.Errorf("prooflist step %d list range child count is missing", index)
 			}
@@ -843,11 +840,19 @@ func semanticMutationFromUnixFSPlan(plan *unixfs.MutationPlan, fallbackRoot cid.
 	for _, put := range plan.Puts {
 		// UnixFS replay rematerializes deterministic roots; do not treat the
 		// already-materialized object as a versioned ArcTable parent.
-		mut.Puts = append(mut.Puts, gateway.ArcSetPut{
-			Object: cid.Undef,
-			Kind:   put.Kind,
-			ArcSet: put.ArcSet,
-		})
+		gatewayPut := gateway.ArcSetPut{
+			Object:       cid.Undef,
+			ExpectedRoot: put.ExpectedRoot,
+			Kind:         put.Kind,
+			ArcSet:       put.ArcSet,
+		}
+		if put.FixedList != nil {
+			gatewayPut.Commit.FixedList = &gateway.FixedListCommit{
+				TotalSize: put.FixedList.TotalSize,
+				ChunkSize: put.FixedList.ChunkSize,
+			}
+		}
+		mut.Puts = append(mut.Puts, gatewayPut)
 	}
 	return mut
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -420,7 +420,7 @@ type proofListVerifiedPath struct {
 
 func (p *proofListVerifiedPath) addStep(step prooflist.Step) error {
 	path := arcset.CanonicalizePath(step.Path).String()
-	if path == "" || step.EvidenceKind == "structure" && step.EvidenceBackend == "list" {
+	if path == "" || step.EvidenceKind == "structure" && (step.EvidenceBackend == "list" || step.EvidenceBackend == "measured_list") {
 		return nil
 	}
 	if p.hasPayloadBinding {
@@ -463,6 +463,34 @@ func (s *Server) verifyProofListStep(g *graph.Graph, index int, step prooflist.S
 				return false, fmt.Errorf("prooflist step %d list length is missing", index)
 			}
 			return g.ListSemantic().Verify(step.From, *step.Index, list.Query{Key: step.Target, Length: *step.Length}, structure.Proof(step.Proof))
+		case "measured_list":
+			if step.Start == nil {
+				return false, fmt.Errorf("prooflist step %d list range start is missing", index)
+			}
+			if step.End == nil {
+				return false, fmt.Errorf("prooflist step %d list range end is missing", index)
+			}
+			if step.ChildCount == nil {
+				return false, fmt.Errorf("prooflist step %d list range child count is missing", index)
+			}
+			if step.TotalSize == nil {
+				return false, fmt.Errorf("prooflist step %d list range total size is missing", index)
+			}
+			if step.ChunkSize == nil {
+				return false, fmt.Errorf("prooflist step %d list range chunk size is missing", index)
+			}
+			measured, ok := g.ListSemantic().(list.MeasuredSemantics)
+			if !ok {
+				return false, fmt.Errorf("prooflist step %d has measured list evidence but graph list semantic does not support measured ranges", index)
+			}
+			return measured.VerifyRange(step.From, *step.Start, step.End, list.RangeResult{
+				Metadata: list.RangeMetadata{
+					ChildCount: *step.ChildCount,
+					TotalSize:  *step.TotalSize,
+					ChunkSize:  *step.ChunkSize,
+				},
+				Segments: append([]cid.Cid(nil), step.Segments...),
+			}, structure.Proof(step.Proof))
 		default:
 			return false, fmt.Errorf("prooflist step %d has unsupported structure evidence backend %q", index, step.EvidenceBackend)
 		}
@@ -599,6 +627,17 @@ func (s *Server) readProofList(ctx context.Context, g *graph.Graph, resolved *pa
 		listRoot, err := decodeCID(resolved.stat.Key)
 		if err != nil {
 			return nil, err
+		}
+		if measured, ok := g.ListSemantic().(list.MeasuredSemantics); ok {
+			rangeStart := uint64(start)
+			rangeEnd := uint64(endExclusive)
+			result, proof, err := measured.ProveRange(ctx, g.Namespace(), listRoot, rangeStart, &rangeEnd)
+			if err == nil {
+				if err := unixfs.AppendListRangeStep(&pl, resolved.queryPath, listRoot, rangeStart, rangeEnd, result, proof); err != nil {
+					return nil, err
+				}
+				return &pl, nil
+			}
 		}
 		steps, err := s.listIndexStepsForRange(ctx, g, listRoot, start, endExclusive)
 		if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1787,7 +1787,7 @@ func TestServerDefaultGETSmallUnixFSFileIncludesPayloadProof(t *testing.T) {
 	}
 }
 
-func TestServerDefaultGETRangeIncludesTouchedListIndexes(t *testing.T) {
+func TestServerDefaultGETRangeIncludesMeasuredListRangeStep(t *testing.T) {
 	node := newTestNode(t)
 
 	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
@@ -1848,23 +1848,36 @@ func TestServerDefaultGETRangeIncludesTouchedListIndexes(t *testing.T) {
 		t.Fatalf("prooflist shape: %v", err)
 	}
 
-	var indexes []uint64
+	var ranges []prooflist.Step
 	for _, step := range proofResp.Steps {
-		if step.Kind == prooflist.KindListIndex {
-			if step.Index == nil {
-				t.Fatalf("list-index step missing index: %+v", step)
-			}
-			if step.Length == nil || *step.Length != 2 {
-				t.Fatalf("list-index step length = %v, want 2", step.Length)
-			}
-			indexes = append(indexes, *step.Index)
-			if step.EvidenceBackend != "list" {
-				t.Fatalf("list-index evidence backend = %q, want list", step.EvidenceBackend)
-			}
+		if step.Kind == prooflist.KindListRange {
+			ranges = append(ranges, step)
 		}
 	}
-	if len(indexes) != 2 || indexes[0] != 0 || indexes[1] != 1 {
-		t.Fatalf("list-index steps = %v, want [0 1]", indexes)
+	if len(ranges) != 1 {
+		t.Fatalf("list-range steps = %d, want 1", len(ranges))
+	}
+	rangeStep := ranges[0]
+	if rangeStep.Start == nil || *rangeStep.Start != 262142 {
+		t.Fatalf("list-range start = %v, want 262142", rangeStep.Start)
+	}
+	if rangeStep.End == nil || *rangeStep.End != 262146 {
+		t.Fatalf("list-range end = %v, want 262146", rangeStep.End)
+	}
+	if rangeStep.ChildCount == nil || *rangeStep.ChildCount != 2 {
+		t.Fatalf("list-range child count = %v, want 2", rangeStep.ChildCount)
+	}
+	if rangeStep.TotalSize == nil || *rangeStep.TotalSize != uint64(len(fileBody)) {
+		t.Fatalf("list-range total size = %v, want %d", rangeStep.TotalSize, len(fileBody))
+	}
+	if rangeStep.ChunkSize == nil || *rangeStep.ChunkSize != fixedListChunkSize {
+		t.Fatalf("list-range chunk size = %v, want %d", rangeStep.ChunkSize, fixedListChunkSize)
+	}
+	if len(rangeStep.Segments) != 2 {
+		t.Fatalf("list-range segments = %d, want 2", len(rangeStep.Segments))
+	}
+	if rangeStep.EvidenceBackend != "measured_list" {
+		t.Fatalf("list-range evidence backend = %q, want measured_list", rangeStep.EvidenceBackend)
 	}
 
 	verifyBody, err := json.Marshal(&httpapi.VerifyRequest{ProofList: proofResp})
@@ -1873,18 +1886,18 @@ func TestServerDefaultGETRangeIncludesTouchedListIndexes(t *testing.T) {
 	}
 	verifyRespHTTP, err := http.Post(ts.URL+"/verify", "application/json", bytes.NewReader(verifyBody))
 	if err != nil {
-		t.Fatalf("verify list-index prooflist request: %v", err)
+		t.Fatalf("verify list-range prooflist request: %v", err)
 	}
 	defer verifyRespHTTP.Body.Close()
 	if verifyRespHTTP.StatusCode != http.StatusOK {
-		t.Fatalf("verify list-index prooflist status = %d, want %d", verifyRespHTTP.StatusCode, http.StatusOK)
+		t.Fatalf("verify list-range prooflist status = %d, want %d", verifyRespHTTP.StatusCode, http.StatusOK)
 	}
 	var verifyResp httpapi.VerifyResponse
 	if err := json.NewDecoder(verifyRespHTTP.Body).Decode(&verifyResp); err != nil {
-		t.Fatalf("decode verify list-index response: %v", err)
+		t.Fatalf("decode verify list-range response: %v", err)
 	}
 	if !verifyResp.Valid {
-		t.Fatal("expected list-index prooflist verification to succeed")
+		t.Fatal("expected list-range prooflist verification to succeed")
 	}
 }
 
@@ -2205,7 +2218,7 @@ func TestServerDefaultGETRangeProofHeader(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	// Range GET should include proof header with list index steps
+	// Range GET should include proof header with measured list range evidence.
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/"+writeResp.NewRoot+"/large.bin", nil)
 	req.Header.Set("Range", "bytes=262142-262145")
 	resp, err = http.DefaultClient.Do(req)
@@ -2252,18 +2265,25 @@ func TestServerDefaultGETRangeProofHeader(t *testing.T) {
 		t.Fatalf("proof list validation: %v", err)
 	}
 
-	// Range GET proof should include list index steps for the touched chunks
-	var indexes []uint64
+	// Range GET proof should include one measured list-range step for the touched chunks.
+	var rangeSteps []prooflist.Step
 	for _, step := range pl.Steps {
-		if step.Kind == prooflist.KindListIndex {
-			if step.Index == nil {
-				t.Fatalf("list-index step missing index: %+v", step)
-			}
-			indexes = append(indexes, *step.Index)
+		if step.Kind == prooflist.KindListRange {
+			rangeSteps = append(rangeSteps, step)
 		}
 	}
-	if len(indexes) != 2 || indexes[0] != 0 || indexes[1] != 1 {
-		t.Fatalf("list-index steps = %v, want [0 1]", indexes)
+	if len(rangeSteps) != 1 {
+		t.Fatalf("list-range steps = %d, want 1", len(rangeSteps))
+	}
+	rangeStep := rangeSteps[0]
+	if rangeStep.Start == nil || *rangeStep.Start != 262142 {
+		t.Fatalf("list-range start = %v, want 262142", rangeStep.Start)
+	}
+	if rangeStep.End == nil || *rangeStep.End != 262146 {
+		t.Fatalf("list-range end = %v, want 262146", rangeStep.End)
+	}
+	if len(rangeStep.Segments) != 2 {
+		t.Fatalf("list-range segments = %d, want 2", len(rangeStep.Segments))
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1900,6 +1900,43 @@ func TestServerDefaultGETRangeIncludesMeasuredListRangeStep(t *testing.T) {
 		t.Fatal("expected list-range prooflist verification to succeed")
 	}
 
+	forgedTarget, err := fakeCID([]byte("forged measured list range target"))
+	if err != nil {
+		t.Fatalf("forge target cid: %v", err)
+	}
+	forgedProof := proofResp
+	forgedProof.Steps = append([]prooflist.Step(nil), proofResp.Steps...)
+	foundRange := false
+	for i := range forgedProof.Steps {
+		if forgedProof.Steps[i].Kind == prooflist.KindListRange {
+			forgedProof.Steps[i].Target = forgedTarget
+			foundRange = true
+			break
+		}
+	}
+	if !foundRange {
+		t.Fatal("prooflist missing list-range step to forge")
+	}
+	verifyBody, err = json.Marshal(&httpapi.VerifyRequest{ProofList: forgedProof})
+	if err != nil {
+		t.Fatalf("marshal forged target verify request: %v", err)
+	}
+	verifyRespHTTP, err = http.Post(ts.URL+"/verify", "application/json", bytes.NewReader(verifyBody))
+	if err != nil {
+		t.Fatalf("verify forged target list-range prooflist request: %v", err)
+	}
+	defer verifyRespHTTP.Body.Close()
+	if verifyRespHTTP.StatusCode == http.StatusOK {
+		if err := json.NewDecoder(verifyRespHTTP.Body).Decode(&verifyResp); err != nil {
+			t.Fatalf("decode forged target verify response: %v", err)
+		}
+		if verifyResp.Valid {
+			t.Fatal("expected forged list-range target prooflist verification to fail")
+		}
+	} else if verifyRespHTTP.StatusCode != http.StatusBadRequest {
+		t.Fatalf("verify forged target prooflist status = %d, want %d or invalid response", verifyRespHTTP.StatusCode, http.StatusBadRequest)
+	}
+
 	openEndedProof := proofResp
 	openEndedProof.Steps = append([]prooflist.Step(nil), proofResp.Steps...)
 	for i := range openEndedProof.Steps {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1899,6 +1899,32 @@ func TestServerDefaultGETRangeIncludesMeasuredListRangeStep(t *testing.T) {
 	if !verifyResp.Valid {
 		t.Fatal("expected list-range prooflist verification to succeed")
 	}
+
+	openEndedProof := proofResp
+	openEndedProof.Steps = append([]prooflist.Step(nil), proofResp.Steps...)
+	for i := range openEndedProof.Steps {
+		if openEndedProof.Steps[i].Kind == prooflist.KindListRange {
+			openEndedProof.Steps[i].End = nil
+		}
+	}
+	verifyBody, err = json.Marshal(&httpapi.VerifyRequest{ProofList: openEndedProof})
+	if err != nil {
+		t.Fatalf("marshal open-ended verify request: %v", err)
+	}
+	verifyRespHTTP, err = http.Post(ts.URL+"/verify", "application/json", bytes.NewReader(verifyBody))
+	if err != nil {
+		t.Fatalf("verify open-ended list-range prooflist request: %v", err)
+	}
+	defer verifyRespHTTP.Body.Close()
+	if verifyRespHTTP.StatusCode != http.StatusOK {
+		t.Fatalf("verify open-ended list-range prooflist status = %d, want %d", verifyRespHTTP.StatusCode, http.StatusOK)
+	}
+	if err := json.NewDecoder(verifyRespHTTP.Body).Decode(&verifyResp); err != nil {
+		t.Fatalf("decode verify open-ended list-range response: %v", err)
+	}
+	if !verifyResp.Valid {
+		t.Fatal("expected open-ended list-range prooflist verification to succeed")
+	}
 }
 
 func TestServerDefaultGETReturnsProofHeader(t *testing.T) {


### PR DESCRIPTION
## Summary
- add measured list range semantics with `uint64` start and optional `*uint64` end
- commit fixed-width list metadata in root slot 0 and compose metadata/index proofs for range reads
- emit `list_range` ProofList steps for list-backed HTTP content reads while keeping legacy list-index fallback

## Verification
- `env GOCACHE=/tmp/go-build-cache go test ./...`