### PR TITLE
refactor: use delta mutations

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -422,12 +422,20 @@ func TestClientRootSemanticMutation(t *testing.T) {
 
 	nextName := fakeCIDString("root-next-name")
 	resp, err := client.ApplyRootSemanticMutation(ctx, createResp.Root, &httpapi.SemanticMutationRequest{
-		Puts: []httpapi.SemanticMutationPut{{
+		Deltas: []httpapi.SemanticMutationDelta{{
 			Object: createResp.Root,
 			Kind:   "map",
-			Entries: []httpapi.SemanticMutationEntry{
-				{Path: "@payload", Target: fakeCIDString("root-next-payload")},
-				{Path: "name", Target: nextName},
+			Changes: []httpapi.SemanticMutationChange{
+				{
+					Path:   "@payload",
+					Before: &httpapi.SemanticMutationTarget{Target: fakeCIDString("payload")},
+					After:  &httpapi.SemanticMutationTarget{Target: fakeCIDString("root-next-payload")},
+				},
+				{
+					Path:   "name",
+					Before: &httpapi.SemanticMutationTarget{Target: fakeCIDString("initial-name")},
+					After:  &httpapi.SemanticMutationTarget{Target: nextName},
+				},
 			},
 		}},
 	})
@@ -437,8 +445,8 @@ func TestClientRootSemanticMutation(t *testing.T) {
 	if resp.BaseRoot != createResp.Root || resp.NewRoot == "" || resp.NewRoot == createResp.Root {
 		t.Fatalf("unexpected root semantic mutation response: %+v", resp)
 	}
-	if resp.PutCount != 1 || resp.ArcCount != 2 {
-		t.Fatalf("semantic mutation counts = puts %d arcs %d, want 1/2", resp.PutCount, resp.ArcCount)
+	if resp.DeltaCount != 1 || resp.ArcCount != 2 {
+		t.Fatalf("semantic mutation counts = deltas %d arcs %d, want 1/2", resp.DeltaCount, resp.ArcCount)
 	}
 
 	resolved, err := client.ResolveRoot(ctx, resp.NewRoot, "name")

--- a/cmd/malt/add.go
+++ b/cmd/malt/add.go
@@ -1097,19 +1097,21 @@ func uploadAsList(ctx context.Context, casClient addCASClient, daemon *daemoncli
 	if err != nil {
 		return cid.Undef, err
 	}
-	entries := make([]httpapi.SemanticMutationEntry, len(chunks))
+	changes := make([]httpapi.SemanticMutationChange, len(chunks))
 	for i, chunk := range chunks {
 		index := uint64(i)
-		entries[i] = httpapi.SemanticMutationEntry{
-			Index:      &index,
-			Target:     chunk.String(),
-			TargetKind: "cas",
+		changes[i] = httpapi.SemanticMutationChange{
+			Index: &index,
+			After: &httpapi.SemanticMutationTarget{
+				Target:     chunk.String(),
+				TargetKind: "cas",
+			},
 		}
 	}
 	resp, err := daemon.ApplyRootSemanticMutation(ctx, tempRootResp.Root, &httpapi.SemanticMutationRequest{
-		Puts: []httpapi.SemanticMutationPut{{
+		Deltas: []httpapi.SemanticMutationDelta{{
 			Kind:    "list",
-			Entries: entries,
+			Changes: changes,
 		}},
 	})
 	if err != nil {

--- a/core/gateway/delta_test.go
+++ b/core/gateway/delta_test.go
@@ -1,0 +1,214 @@
+package gateway_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/dewebprotocol/malt/core/gateway"
+	"github.com/dewebprotocol/malt/core/structure/list"
+	"github.com/dewebprotocol/malt/core/structure/mapping"
+	"github.com/dewebprotocol/malt/core/types/arcset"
+	cid "github.com/ipfs/go-cid"
+)
+
+func TestExecutorAppliesMapDelta(t *testing.T) {
+	ctx := context.Background()
+	exec := newExecutor(t)
+	payload := testCID("payload")
+	oldChild := testCID("old-child")
+	newChild := testCID("new-child")
+	baseRoot, err := exec.Maps.Commit(ctx, exec.Namespace, mapping.NewViewFromPaths(map[arcset.Path]cid.Cid{
+		arcset.CanonicalizePath("@payload"): payload,
+		arcset.CanonicalizePath("child"):    oldChild,
+	}))
+	if err != nil {
+		t.Fatalf("Commit base map failed: %v", err)
+	}
+
+	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
+		BaseRoot: baseRoot,
+		Deltas: []gateway.ArcSetDelta{{
+			Object: baseRoot,
+			Kind:   arcset.KindMap,
+			Changes: mustCanonicalDelta(t, arcset.KindMap, []deltaChangeSpec{{
+				Path:   "child",
+				Before: arcset.NewMapTarget(oldChild),
+				After:  arcset.NewMapTarget(newChild),
+			}}),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Apply delta failed: %v", err)
+	}
+	if receipt.DeltaCount != 1 || receipt.ArcCount != 1 {
+		t.Fatalf("receipt counts = deltas %d arcs %d, want 1/1", receipt.DeltaCount, receipt.ArcCount)
+	}
+
+	binding, proof, err := exec.Maps.Prove(ctx, exec.Namespace, receipt.NewRoot, arcset.CanonicalizePath("child"))
+	if err != nil {
+		t.Fatalf("Prove child failed: %v", err)
+	}
+	if !binding.Present || !binding.Value.Equals(newChild) {
+		t.Fatalf("child binding = %+v, want %s", binding, newChild)
+	}
+	ok, err := exec.Maps.Verify(receipt.NewRoot, arcset.CanonicalizePath("child"), binding, proof)
+	if err != nil {
+		t.Fatalf("Verify child failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("child proof did not verify")
+	}
+}
+
+func TestExecutorAppliesListAppendDelta(t *testing.T) {
+	ctx := context.Background()
+	exec := newExecutor(t)
+	first := testCID("first")
+	second := testCID("second")
+	third := testCID("third")
+	baseRoot, err := exec.Lists.Commit(ctx, exec.Namespace, list.NewViewFromSlice([]cid.Cid{first, second}))
+	if err != nil {
+		t.Fatalf("Commit base list failed: %v", err)
+	}
+
+	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
+		BaseRoot: baseRoot,
+		Deltas: []gateway.ArcSetDelta{{
+			Object: baseRoot,
+			Kind:   arcset.KindList,
+			Changes: mustCanonicalDelta(t, arcset.KindList, []deltaChangeSpec{{
+				Index: uint64Ptr(2),
+				After: arcset.NewCASTarget(third),
+			}}),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Apply list append delta failed: %v", err)
+	}
+
+	query, proof, err := exec.Lists.Prove(ctx, exec.Namespace, receipt.NewRoot, 2)
+	if err != nil {
+		t.Fatalf("Prove appended index failed: %v", err)
+	}
+	if query.Length != 3 || !query.Key.Equals(third) {
+		t.Fatalf("query = %+v, want length 3 key %s", query, third)
+	}
+	ok, err := exec.Lists.Verify(receipt.NewRoot, 2, query, proof)
+	if err != nil {
+		t.Fatalf("Verify appended index failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("appended index proof did not verify")
+	}
+}
+
+func TestExecutorAppliesFixedMeasuredListAppendDeltaAcrossGrowth(t *testing.T) {
+	ctx := context.Background()
+	exec := newExecutor(t)
+	chunkSize := uint64(4)
+	chunks := make([]cid.Cid, 256)
+	for i := range chunks {
+		chunks[i] = testCID("fixed-chunk-" + strconv.Itoa(i))
+	}
+	baseRoot, err := exec.Lists.(interface {
+		CommitFixed(context.Context, string, []cid.Cid, uint64, uint64) (cid.Cid, error)
+	}).CommitFixed(ctx, exec.Namespace, chunks[:255], chunkSize, uint64(255)*chunkSize)
+	if err != nil {
+		t.Fatalf("CommitFixed base failed: %v", err)
+	}
+	expectedRoot, err := exec.Lists.(interface {
+		CommitFixed(context.Context, string, []cid.Cid, uint64, uint64) (cid.Cid, error)
+	}).CommitFixed(ctx, exec.Namespace, chunks, chunkSize, uint64(256)*chunkSize)
+	if err != nil {
+		t.Fatalf("CommitFixed expected failed: %v", err)
+	}
+
+	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
+		BaseRoot: baseRoot,
+		Deltas: []gateway.ArcSetDelta{{
+			Object:       baseRoot,
+			ExpectedRoot: expectedRoot,
+			Kind:         arcset.KindList,
+			Changes: mustCanonicalDelta(t, arcset.KindList, []deltaChangeSpec{{
+				Index: uint64Ptr(255),
+				After: arcset.NewCASTarget(chunks[255]),
+			}}),
+			Commit: gateway.CommitDescriptor{
+				FixedList: &gateway.FixedListCommit{
+					TotalSize: uint64(256) * chunkSize,
+					ChunkSize: chunkSize,
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Apply fixed list append delta failed: %v", err)
+	}
+	if !receipt.NewRoot.Equals(expectedRoot) {
+		t.Fatalf("new root = %s, want %s", receipt.NewRoot, expectedRoot)
+	}
+
+	measured := exec.Lists.(list.MeasuredSemantics)
+	result, proof, err := measured.ProveRange(ctx, exec.Namespace, receipt.NewRoot, uint64(255)*chunkSize, nil)
+	if err != nil {
+		t.Fatalf("ProveRange appended chunk failed: %v", err)
+	}
+	if result.Metadata.ChildCount != 256 || result.Metadata.TotalSize != uint64(256)*chunkSize {
+		t.Fatalf("metadata = %+v, want count=256 total=%d", result.Metadata, uint64(256)*chunkSize)
+	}
+	ok, err := measured.VerifyRange(receipt.NewRoot, uint64(255)*chunkSize, nil, result, proof)
+	if err != nil {
+		t.Fatalf("VerifyRange appended chunk failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("appended range proof did not verify")
+	}
+}
+
+type deltaChangeSpec struct {
+	Path   string
+	Index  *uint64
+	Before arcset.TargetRef
+	After  arcset.TargetRef
+}
+
+func mustCanonicalDelta(t *testing.T, kind arcset.Kind, specs []deltaChangeSpec) *arcset.CanonicalArcDelta {
+	t.Helper()
+
+	changes := make([]arcset.ArcChange, 0, len(specs))
+	for _, spec := range specs {
+		var coord arcset.CanonicalCoordinate
+		var err error
+		switch kind {
+		case arcset.KindMap:
+			coord, err = arcset.NewMapCoordinate(spec.Path)
+		case arcset.KindList:
+			coord, err = arcset.NewListCoordinate(int64(*spec.Index))
+		default:
+			t.Fatalf("unsupported kind %q", kind)
+		}
+		if err != nil {
+			t.Fatalf("coordinate: %v", err)
+		}
+		change := arcset.ArcChange{Coordinate: coord}
+		if spec.Before.CID().Defined() {
+			before := spec.Before
+			change.Before = &before
+		}
+		if spec.After.CID().Defined() {
+			after := spec.After
+			change.After = &after
+		}
+		changes = append(changes, change)
+	}
+	delta, err := arcset.NewCanonicalArcDelta(kind, changes)
+	if err != nil {
+		t.Fatalf("NewCanonicalArcDelta failed: %v", err)
+	}
+	return delta
+}
+
+func uint64Ptr(v uint64) *uint64 {
+	return &v
+}

--- a/core/gateway/gateway.go
+++ b/core/gateway/gateway.go
@@ -22,32 +22,32 @@ var (
 	// ErrInvalidBaseRoot is returned when an update mutation has no base root.
 	ErrInvalidBaseRoot = errors.New("invalid base root")
 
-	// ErrEmptyPuts is returned when a semantic mutation carries no arcset replacements.
-	ErrEmptyPuts = errors.New("empty puts")
+	// ErrEmptyDeltas is returned when a semantic mutation carries no arc deltas.
+	ErrEmptyDeltas = errors.New("empty deltas")
 
-	// ErrObjectKindMismatch is returned when a put kind disagrees with its object or arcset kind.
+	// ErrObjectKindMismatch is returned when a delta kind disagrees with its object or changes kind.
 	ErrObjectKindMismatch = errors.New("object kind mismatch")
 
-	// ErrNilArcSet is returned when a put has no canonical arcset.
-	ErrNilArcSet = errors.New("nil arcset")
+	// ErrNilDelta is returned when a mutation has no canonical delta.
+	ErrNilDelta = errors.New("nil delta")
 
-	// ErrExpectedRootMismatch is returned when a replayed put does not reproduce
-	// the root declared by the mutation plan.
+	// ErrExpectedRootMismatch is returned when a replayed delta does not
+	// reproduce the root declared by the mutation plan.
 	ErrExpectedRootMismatch = errors.New("expected root mismatch")
 )
 
 // SemanticMutation is the gateway write boundary emitted by application layouts.
 type SemanticMutation struct {
 	BaseRoot cid.Cid
-	Puts     []ArcSetPut
+	Deltas   []ArcSetDelta
 }
 
-// ArcSetPut replaces one touched semantic object's full canonical arcset.
-type ArcSetPut struct {
+// ArcSetDelta applies coordinate-level changes to one semantic object.
+type ArcSetDelta struct {
 	Object       cid.Cid
 	ExpectedRoot cid.Cid
 	Kind         arcset.Kind
-	ArcSet       *arcset.CanonicalArcSet
+	Changes      *arcset.CanonicalArcDelta
 	Commit       CommitDescriptor
 }
 
@@ -65,10 +65,10 @@ type FixedListCommit struct {
 
 // WriteReceipt records the library-level outcome of applying a semantic mutation.
 type WriteReceipt struct {
-	BaseRoot cid.Cid
-	NewRoot  cid.Cid
-	PutCount int
-	ArcCount int
+	BaseRoot   cid.Cid
+	NewRoot    cid.Cid
+	DeltaCount int
+	ArcCount   int
 }
 
 // Executor submits semantic mutations to the current map/list semantic backends.
@@ -84,30 +84,30 @@ func ValidateSemanticMutation(mut SemanticMutation) error {
 	if !mut.BaseRoot.Defined() {
 		return ErrInvalidBaseRoot
 	}
-	if len(mut.Puts) == 0 {
-		return ErrEmptyPuts
+	if len(mut.Deltas) == 0 {
+		return ErrEmptyDeltas
 	}
-	for i, put := range mut.Puts {
-		if put.ArcSet == nil {
-			return fmt.Errorf("put %d: %w", i, ErrNilArcSet)
+	for i, delta := range mut.Deltas {
+		if delta.Changes == nil {
+			return fmt.Errorf("delta %d: %w", i, ErrNilDelta)
 		}
-		if put.Kind != put.ArcSet.Kind() {
-			return fmt.Errorf("put %d: %w", i, ErrObjectKindMismatch)
+		if delta.Kind != delta.Changes.Kind() {
+			return fmt.Errorf("delta %d: %w", i, ErrObjectKindMismatch)
 		}
-		if !objectKindMatches(put.Object, put.Kind) {
-			return fmt.Errorf("put %d: %w", i, ErrObjectKindMismatch)
+		if !objectKindMatches(delta.Object, delta.Kind) {
+			return fmt.Errorf("delta %d: %w", i, ErrObjectKindMismatch)
 		}
-		if !objectKindMatches(put.ExpectedRoot, put.Kind) {
-			return fmt.Errorf("put %d expected root: %w", i, ErrObjectKindMismatch)
+		if !objectKindMatches(delta.ExpectedRoot, delta.Kind) {
+			return fmt.Errorf("delta %d expected root: %w", i, ErrObjectKindMismatch)
 		}
-		if put.Commit.FixedList != nil && put.Kind != arcset.KindList {
-			return fmt.Errorf("put %d fixed list commit on %q: %w", i, put.Kind, ErrObjectKindMismatch)
+		if delta.Commit.FixedList != nil && delta.Kind != arcset.KindList {
+			return fmt.Errorf("delta %d fixed list commit on %q: %w", i, delta.Kind, ErrObjectKindMismatch)
 		}
 	}
 	return nil
 }
 
-// Apply commits full canonical arcset replacements in order.
+// Apply commits canonical arc deltas in order.
 //
 // The executor treats BaseRoot as the caller's update base for receipt and
 // validation purposes only. It does not publish heads, arbitrate freshness, or
@@ -122,69 +122,237 @@ func (e Executor) Apply(ctx context.Context, mut SemanticMutation) (WriteReceipt
 
 	var newRoot cid.Cid
 	arcCount := 0
-	for i, put := range mut.Puts {
-		root, count, err := e.commitPut(ctx, e.Namespace, put)
+	for i, delta := range mut.Deltas {
+		root, count, err := e.commitDelta(ctx, e.Namespace, delta)
 		if err != nil {
-			return WriteReceipt{}, fmt.Errorf("put %d: %w", i, err)
+			return WriteReceipt{}, fmt.Errorf("delta %d: %w", i, err)
 		}
 		newRoot = root
 		arcCount += count
 	}
 
 	return WriteReceipt{
-		BaseRoot: mut.BaseRoot,
-		NewRoot:  newRoot,
-		PutCount: len(mut.Puts),
-		ArcCount: arcCount,
+		BaseRoot:   mut.BaseRoot,
+		NewRoot:    newRoot,
+		DeltaCount: len(mut.Deltas),
+		ArcCount:   arcCount,
 	}, nil
 }
 
-func (e Executor) commitPut(ctx context.Context, namespace string, put ArcSetPut) (cid.Cid, int, error) {
-	switch put.Kind {
+func (e Executor) commitDelta(ctx context.Context, namespace string, delta ArcSetDelta) (cid.Cid, int, error) {
+	switch delta.Kind {
 	case arcset.KindMap:
 		if e.Maps == nil {
 			return cid.Undef, 0, errors.New("map semantics is nil")
 		}
-		view, err := canonicalMapView(put.ArcSet)
+		root, err := e.commitMapDelta(ctx, namespace, delta)
 		if err != nil {
 			return cid.Undef, 0, err
 		}
-		root, err := e.Maps.Commit(ctx, namespace, view)
-		if err != nil {
+		if err := checkExpectedRoot(delta.ExpectedRoot, root); err != nil {
 			return cid.Undef, 0, err
 		}
-		if err := checkExpectedRoot(put.ExpectedRoot, root); err != nil {
-			return cid.Undef, 0, err
-		}
-		if e.ArcTable != nil {
-			snapshot, err := canonicalMapSnapshot(put.ArcSet)
-			if err != nil {
-				return cid.Undef, 0, err
-			}
-			if err := e.ArcTable.Update(ctx, namespace, root, put.Object, snapshot); err != nil {
-				return cid.Undef, 0, err
-			}
-		}
-		return root, put.ArcSet.Len(), nil
+		return root, delta.Changes.Len(), nil
 	case arcset.KindList:
 		if e.Lists == nil {
 			return cid.Undef, 0, errors.New("list semantics is nil")
 		}
-		values, err := canonicalListValues(put.ArcSet)
+		root, err := e.commitListDelta(ctx, namespace, delta)
 		if err != nil {
 			return cid.Undef, 0, err
 		}
-		root, err := e.commitList(ctx, namespace, values, put.Commit)
-		if err != nil {
+		if err := checkExpectedRoot(delta.ExpectedRoot, root); err != nil {
 			return cid.Undef, 0, err
 		}
-		if err := checkExpectedRoot(put.ExpectedRoot, root); err != nil {
-			return cid.Undef, 0, err
-		}
-		return root, put.ArcSet.Len(), nil
+		return root, delta.Changes.Len(), nil
 	default:
-		return cid.Undef, 0, fmt.Errorf("%w: %q", arcset.ErrInvalidKind, put.Kind)
+		return cid.Undef, 0, fmt.Errorf("%w: %q", arcset.ErrInvalidKind, delta.Kind)
 	}
+}
+
+func (e Executor) commitMapDelta(ctx context.Context, namespace string, delta ArcSetDelta) (cid.Cid, error) {
+	changes := delta.Changes.Changes()
+	if !delta.Object.Defined() {
+		entries := make(map[arcset.Path]cid.Cid, len(changes))
+		hasPayload := false
+		for _, change := range changes {
+			if change.Before != nil {
+				return cid.Undef, fmt.Errorf("create map delta has before value for %s", change.Coordinate.String())
+			}
+			if change.After == nil {
+				return cid.Undef, fmt.Errorf("create map delta deletes %s", change.Coordinate.String())
+			}
+			key := arcset.CanonicalizePath(change.Coordinate.String())
+			if key.String() == "@payload" {
+				hasPayload = true
+			}
+			entries[key] = change.After.CID()
+		}
+		if !hasPayload {
+			return cid.Undef, arcset.ErrMissingPayloadBinding
+		}
+		view := mapping.NewViewFromPaths(entries)
+		root, err := e.Maps.Commit(ctx, namespace, view)
+		if err != nil {
+			return cid.Undef, err
+		}
+		if e.ArcTable != nil {
+			snapshot, err := arcset.NewArcSetFromPaths(entries)
+			if err != nil {
+				return cid.Undef, err
+			}
+			if err := e.ArcTable.Update(ctx, namespace, root, cid.Undef, snapshot); err != nil {
+				return cid.Undef, err
+			}
+		}
+		return root, nil
+	}
+
+	root := delta.Object
+	logical := make(map[arcset.Path]cid.Cid, len(changes))
+	for _, change := range changes {
+		key := arcset.CanonicalizePath(change.Coordinate.String())
+		oldValue := cid.Undef
+		if change.Before != nil {
+			oldValue = change.Before.CID()
+		}
+		newValue := cid.Undef
+		if change.After != nil {
+			newValue = change.After.CID()
+		}
+		if key.String() == "@payload" && !newValue.Defined() {
+			return cid.Undef, arcset.ErrMissingPayloadBinding
+		}
+		nextRoot, err := e.Maps.Update(ctx, namespace, root, key, oldValue, newValue)
+		if err != nil {
+			return cid.Undef, err
+		}
+		root = nextRoot
+		logical[key] = newValue
+	}
+	if e.ArcTable != nil {
+		deltaSet, err := arcset.NewArcSetFromPaths(logical)
+		if err != nil {
+			return cid.Undef, err
+		}
+		if err := e.ArcTable.Update(ctx, namespace, root, delta.Object, deltaSet); err != nil {
+			return cid.Undef, err
+		}
+	}
+	return root, nil
+}
+
+func (e Executor) commitListDelta(ctx context.Context, namespace string, delta ArcSetDelta) (cid.Cid, error) {
+	changes := delta.Changes.Changes()
+	if !delta.Object.Defined() {
+		values, err := listCreateValues(changes)
+		if err != nil {
+			return cid.Undef, err
+		}
+		return e.commitList(ctx, namespace, values, delta.Commit)
+	}
+
+	length, err := e.listLength(ctx, namespace, delta.Object)
+	if err != nil {
+		return cid.Undef, err
+	}
+	root := delta.Object
+	deleteFrom := length
+	deleteSeen := map[uint64]struct{}{}
+
+	for _, change := range changes {
+		index, err := listChangeIndex(change)
+		if err != nil {
+			return cid.Undef, err
+		}
+		if change.Before != nil {
+			query, proof, err := e.Lists.Prove(ctx, namespace, delta.Object, index)
+			if err != nil {
+				return cid.Undef, err
+			}
+			ok, err := e.Lists.Verify(delta.Object, index, query, proof)
+			if err != nil || !ok {
+				return cid.Undef, err
+			}
+			if !query.Key.Equals(change.Before.CID()) {
+				return cid.Undef, fmt.Errorf("old value mismatch at list index %d", index)
+			}
+		}
+		if change.After == nil {
+			if change.Before == nil {
+				return cid.Undef, fmt.Errorf("list delete at %d is missing before value", index)
+			}
+			if index < deleteFrom {
+				deleteFrom = index
+			}
+			deleteSeen[index] = struct{}{}
+		}
+	}
+	if len(deleteSeen) > 0 {
+		if deleteFrom >= length {
+			return cid.Undef, fmt.Errorf("list delete starts beyond length")
+		}
+		for index := deleteFrom; index < length; index++ {
+			if _, ok := deleteSeen[index]; !ok {
+				return cid.Undef, fmt.Errorf("list delta deletes non-suffix index %d", index)
+			}
+		}
+	}
+
+	for _, change := range changes {
+		if change.After == nil {
+			continue
+		}
+		index, err := listChangeIndex(change)
+		if err != nil {
+			return cid.Undef, err
+		}
+		switch {
+		case index < length:
+			if change.Before == nil {
+				return cid.Undef, fmt.Errorf("list replace at %d is missing before value", index)
+			}
+			root, err = e.Lists.Replace(ctx, namespace, root, index, change.Before.CID(), change.After.CID())
+		case index == length:
+			if delta.Commit.FixedList != nil {
+				appender, ok := e.Lists.(interface {
+					AppendFixed(context.Context, string, cid.Cid, cid.Cid, uint64) (cid.Cid, uint64, error)
+				})
+				if !ok {
+					return cid.Undef, errors.New("list semantics does not support fixed list append")
+				}
+				var newIndex uint64
+				totalSize := fixedAppendTotalSize(index+1, delta.Commit.FixedList.ChunkSize, delta.Commit.FixedList.TotalSize)
+				root, newIndex, err = appender.AppendFixed(ctx, namespace, root, change.After.CID(), totalSize)
+				if err == nil && newIndex != index {
+					return cid.Undef, fmt.Errorf("fixed list append index = %d, want %d", newIndex, index)
+				}
+			} else {
+				var newIndex uint64
+				root, newIndex, err = e.Lists.Append(ctx, namespace, root, change.After.CID())
+				if err == nil && newIndex != index {
+					return cid.Undef, fmt.Errorf("list append index = %d, want %d", newIndex, index)
+				}
+			}
+			length++
+		default:
+			return cid.Undef, fmt.Errorf("list delta is sparse at index %d", index)
+		}
+		if err != nil {
+			return cid.Undef, err
+		}
+	}
+	if len(deleteSeen) > 0 {
+		if delta.Commit.FixedList != nil {
+			return cid.Undef, errors.New("fixed list truncate is not supported")
+		}
+		var err error
+		root, err = e.Lists.Truncate(ctx, namespace, root, deleteFrom)
+		if err != nil {
+			return cid.Undef, err
+		}
+	}
+	return root, nil
 }
 
 func (e Executor) commitList(ctx context.Context, namespace string, values []cid.Cid, descriptor CommitDescriptor) (cid.Cid, error) {
@@ -200,45 +368,53 @@ func (e Executor) commitList(ctx context.Context, namespace string, values []cid
 	return measured.CommitFixed(ctx, namespace, values, descriptor.FixedList.ChunkSize, descriptor.FixedList.TotalSize)
 }
 
-func canonicalMapView(set *arcset.CanonicalArcSet) (mapping.View, error) {
-	entries := make(map[arcset.Path]cid.Cid, set.Len())
-	for _, entry := range set.Entries() {
-		path := arcset.CanonicalizePath(entry.Coordinate.String())
-		if path.IsEmpty() || path.String() != entry.Coordinate.String() {
-			return nil, fmt.Errorf("invalid canonical map coordinate %q", entry.Coordinate.String())
-		}
-		entries[path] = entry.Target.CID()
+func (e Executor) listLength(ctx context.Context, namespace string, root cid.Cid) (uint64, error) {
+	query, proof, err := e.Lists.Prove(ctx, namespace, root, 0)
+	if err != nil {
+		return 0, err
 	}
-	return mapping.NewViewFromPaths(entries), nil
+	ok, err := e.Lists.Verify(root, 0, query, proof)
+	if err != nil || !ok {
+		return 0, err
+	}
+	return query.Length, nil
 }
 
-func canonicalMapSnapshot(set *arcset.CanonicalArcSet) (arcset.ArcSet, error) {
-	entries := make(map[arcset.Path]cid.Cid, set.Len())
-	for _, entry := range set.Entries() {
-		path := arcset.CanonicalizePath(entry.Coordinate.String())
-		if path.IsEmpty() || path.String() != entry.Coordinate.String() {
-			return nil, fmt.Errorf("invalid canonical map coordinate %q", entry.Coordinate.String())
+func listCreateValues(changes []arcset.ArcChange) ([]cid.Cid, error) {
+	values := make([]cid.Cid, len(changes))
+	for i, change := range changes {
+		if change.Before != nil {
+			return nil, fmt.Errorf("create list delta has before value at %s", change.Coordinate.String())
 		}
-		entries[path] = entry.Target.CID()
-	}
-	return arcset.NewArcSetFromPaths(entries)
-}
-
-func canonicalListValues(set *arcset.CanonicalArcSet) ([]cid.Cid, error) {
-	entries := set.Entries()
-	values := make([]cid.Cid, len(entries))
-	for i, entry := range entries {
-		raw := entry.Coordinate.Bytes()
-		if len(raw) != 8 {
-			return nil, fmt.Errorf("invalid canonical list coordinate %q", entry.Coordinate.String())
+		if change.After == nil {
+			return nil, fmt.Errorf("create list delta deletes %s", change.Coordinate.String())
 		}
-		index := binary.BigEndian.Uint64(raw)
+		index, err := listChangeIndex(change)
+		if err != nil {
+			return nil, err
+		}
 		if index != uint64(i) {
-			return nil, fmt.Errorf("canonical list arcset is sparse at index %d", index)
+			return nil, fmt.Errorf("create list delta is sparse at index %d", index)
 		}
-		values[i] = entry.Target.CID()
+		values[i] = change.After.CID()
 	}
 	return values, nil
+}
+
+func listChangeIndex(change arcset.ArcChange) (uint64, error) {
+	raw := change.Coordinate.Bytes()
+	if len(raw) != 8 {
+		return 0, fmt.Errorf("invalid canonical list coordinate %q", change.Coordinate.String())
+	}
+	return binary.BigEndian.Uint64(raw), nil
+}
+
+func fixedAppendTotalSize(childCount, chunkSize, finalTotalSize uint64) uint64 {
+	total := childCount * chunkSize
+	if total > finalTotalSize {
+		return finalTotalSize
+	}
+	return total
 }
 
 func checkExpectedRoot(expectedRoot, actualRoot cid.Cid) error {

--- a/core/gateway/gateway.go
+++ b/core/gateway/gateway.go
@@ -271,8 +271,11 @@ func (e Executor) commitListDelta(ctx context.Context, namespace string, delta A
 				return cid.Undef, err
 			}
 			ok, err := e.Lists.Verify(delta.Object, index, query, proof)
-			if err != nil || !ok {
+			if err != nil {
 				return cid.Undef, err
+			}
+			if !ok {
+				return cid.Undef, fmt.Errorf("list proof failed at index %d", index)
 			}
 			if !query.Key.Equals(change.Before.CID()) {
 				return cid.Undef, fmt.Errorf("old value mismatch at list index %d", index)
@@ -374,8 +377,11 @@ func (e Executor) listLength(ctx context.Context, namespace string, root cid.Cid
 		return 0, err
 	}
 	ok, err := e.Lists.Verify(root, 0, query, proof)
-	if err != nil || !ok {
+	if err != nil {
 		return 0, err
+	}
+	if !ok {
+		return 0, errors.New("list length proof failed")
 	}
 	return query.Length, nil
 }

--- a/core/gateway/gateway_test.go
+++ b/core/gateway/gateway_test.go
@@ -21,8 +21,14 @@ import (
 func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
 	root := testCID("root")
 	payload := testCID("payload")
-	mapSet := mustCanonicalMap(t, map[string]cid.Cid{"@payload": payload})
-	listSet := mustCanonicalList(t, []cid.Cid{payload})
+	mapDelta := mustCanonicalDelta(t, arcset.KindMap, []deltaChangeSpec{{
+		Path:  "@payload",
+		After: arcset.NewCASTarget(payload),
+	}})
+	listDelta := mustCanonicalDelta(t, arcset.KindList, []deltaChangeSpec{{
+		Index: uint64Ptr(0),
+		After: arcset.NewCASTarget(payload),
+	}})
 
 	tests := []struct {
 		name string
@@ -32,40 +38,40 @@ func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
 		{
 			name: "missing base root",
 			mut: gateway.SemanticMutation{
-				Puts: []gateway.ArcSetPut{{
-					Object: root,
-					Kind:   arcset.KindMap,
-					ArcSet: mapSet,
+				Deltas: []gateway.ArcSetDelta{{
+					Object:  root,
+					Kind:    arcset.KindMap,
+					Changes: mapDelta,
 				}},
 			},
 			want: gateway.ErrInvalidBaseRoot,
 		},
 		{
-			name: "empty puts",
+			name: "empty deltas",
 			mut: gateway.SemanticMutation{
 				BaseRoot: root,
 			},
-			want: gateway.ErrEmptyPuts,
+			want: gateway.ErrEmptyDeltas,
 		},
 		{
-			name: "nil arcset",
+			name: "nil delta",
 			mut: gateway.SemanticMutation{
 				BaseRoot: root,
-				Puts: []gateway.ArcSetPut{{
+				Deltas: []gateway.ArcSetDelta{{
 					Object: root,
 					Kind:   arcset.KindMap,
 				}},
 			},
-			want: gateway.ErrNilArcSet,
+			want: gateway.ErrNilDelta,
 		},
 		{
-			name: "put kind mismatch",
+			name: "delta kind mismatch",
 			mut: gateway.SemanticMutation{
 				BaseRoot: root,
-				Puts: []gateway.ArcSetPut{{
-					Object: root,
-					Kind:   arcset.KindMap,
-					ArcSet: listSet,
+				Deltas: []gateway.ArcSetDelta{{
+					Object:  root,
+					Kind:    arcset.KindMap,
+					Changes: listDelta,
 				}},
 			},
 			want: gateway.ErrObjectKindMismatch,
@@ -74,10 +80,10 @@ func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
 			name: "object kind mismatch",
 			mut: gateway.SemanticMutation{
 				BaseRoot: root,
-				Puts: []gateway.ArcSetPut{{
-					Object: mustTypedRoot(t, codec.SemanticKindList),
-					Kind:   arcset.KindMap,
-					ArcSet: mapSet,
+				Deltas: []gateway.ArcSetDelta{{
+					Object:  mustTypedRoot(t, codec.SemanticKindList),
+					Kind:    arcset.KindMap,
+					Changes: mapDelta,
 				}},
 			},
 			want: gateway.ErrObjectKindMismatch,
@@ -97,14 +103,17 @@ func TestValidateSemanticMutationRejectsInvalidShape(t *testing.T) {
 func TestValidateSemanticMutationIsRootCentric(t *testing.T) {
 	root := testCID("root-centric-base")
 	payload := testCID("root-centric-payload")
-	set := mustCanonicalMap(t, map[string]cid.Cid{"@payload": payload})
+	delta := mustCanonicalDelta(t, arcset.KindMap, []deltaChangeSpec{{
+		Path:  "@payload",
+		After: arcset.NewCASTarget(payload),
+	}})
 
 	err := gateway.ValidateSemanticMutation(gateway.SemanticMutation{
 		BaseRoot: root,
-		Puts: []gateway.ArcSetPut{{
-			Object: root,
-			Kind:   arcset.KindMap,
-			ArcSet: set,
+		Deltas: []gateway.ArcSetDelta{{
+			Object:  root,
+			Kind:    arcset.KindMap,
+			Changes: delta,
 		}},
 	})
 	if err != nil {
@@ -119,25 +128,38 @@ func TestCanonicalMapWithoutPayloadIsRejected(t *testing.T) {
 	if !errors.Is(err, arcset.ErrMissingPayloadBinding) {
 		t.Fatalf("NewCanonicalMapArcSet error = %v, want %v", err, arcset.ErrMissingPayloadBinding)
 	}
+
+	exec := newExecutor(t)
+	_, err = exec.Apply(context.Background(), gateway.SemanticMutation{
+		BaseRoot: testCID("base"),
+		Deltas: []gateway.ArcSetDelta{{
+			Kind: arcset.KindMap,
+			Changes: mustCanonicalDelta(t, arcset.KindMap, []deltaChangeSpec{{
+				Path:  "child",
+				After: arcset.NewMapTarget(testCID("child")),
+			}}),
+		}},
+	})
+	if !errors.Is(err, arcset.ErrMissingPayloadBinding) {
+		t.Fatalf("map create delta error = %v, want %v", err, arcset.ErrMissingPayloadBinding)
+	}
 }
 
-func TestExecutorAppliesMapReplacementAndReturnsStableReceipt(t *testing.T) {
+func TestExecutorCreatesMapFromDeltaAndReturnsStableReceipt(t *testing.T) {
 	ctx := context.Background()
 	exec := newExecutor(t)
 	baseRoot := testCID("base")
 	payload := testCID("payload")
 	child := testCID("child")
-	set := mustCanonicalMap(t, map[string]cid.Cid{
-		"@payload": payload,
-		"child":    child,
-	})
 
 	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
 		BaseRoot: baseRoot,
-		Puts: []gateway.ArcSetPut{{
-			Object: baseRoot,
-			Kind:   arcset.KindMap,
-			ArcSet: set,
+		Deltas: []gateway.ArcSetDelta{{
+			Kind: arcset.KindMap,
+			Changes: mustCanonicalDelta(t, arcset.KindMap, []deltaChangeSpec{
+				{Path: "@payload", After: arcset.NewCASTarget(payload)},
+				{Path: "child", After: arcset.NewMapTarget(child)},
+			}),
 		}},
 	})
 	if err != nil {
@@ -149,8 +171,8 @@ func TestExecutorAppliesMapReplacementAndReturnsStableReceipt(t *testing.T) {
 	if codec.SemanticKindOf(receipt.NewRoot) != codec.SemanticKindMap {
 		t.Fatalf("new root kind = %s, want %s", codec.SemanticKindOf(receipt.NewRoot), codec.SemanticKindMap)
 	}
-	if receipt.PutCount != 1 {
-		t.Fatalf("put count = %d, want 1", receipt.PutCount)
+	if receipt.DeltaCount != 1 {
+		t.Fatalf("delta count = %d, want 1", receipt.DeltaCount)
 	}
 	if receipt.ArcCount != 2 {
 		t.Fatalf("arc count = %d, want 2", receipt.ArcCount)
@@ -173,20 +195,21 @@ func TestExecutorAppliesMapReplacementAndReturnsStableReceipt(t *testing.T) {
 	}
 }
 
-func TestExecutorAppliesListReplacementAndReturnsStableReceipt(t *testing.T) {
+func TestExecutorCreatesListFromDeltaAndReturnsStableReceipt(t *testing.T) {
 	ctx := context.Background()
 	exec := newExecutor(t)
 	baseRoot := testCID("base")
 	first := testCID("first")
 	second := testCID("second")
-	set := mustCanonicalList(t, []cid.Cid{first, second})
 
 	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
 		BaseRoot: baseRoot,
-		Puts: []gateway.ArcSetPut{{
-			Object: baseRoot,
-			Kind:   arcset.KindList,
-			ArcSet: set,
+		Deltas: []gateway.ArcSetDelta{{
+			Kind: arcset.KindList,
+			Changes: mustCanonicalDelta(t, arcset.KindList, []deltaChangeSpec{
+				{Index: uint64Ptr(0), After: arcset.NewCASTarget(first)},
+				{Index: uint64Ptr(1), After: arcset.NewCASTarget(second)},
+			}),
 		}},
 	})
 	if err != nil {
@@ -195,8 +218,8 @@ func TestExecutorAppliesListReplacementAndReturnsStableReceipt(t *testing.T) {
 	if codec.SemanticKindOf(receipt.NewRoot) != codec.SemanticKindList {
 		t.Fatalf("new root kind = %s, want %s", codec.SemanticKindOf(receipt.NewRoot), codec.SemanticKindList)
 	}
-	if receipt.PutCount != 1 {
-		t.Fatalf("put count = %d, want 1", receipt.PutCount)
+	if receipt.DeltaCount != 1 {
+		t.Fatalf("delta count = %d, want 1", receipt.DeltaCount)
 	}
 	if receipt.ArcCount != 2 {
 		t.Fatalf("arc count = %d, want 2", receipt.ArcCount)
@@ -262,10 +285,13 @@ func TestExecutorReplaysFixedMeasuredListToExpectedRoot(t *testing.T) {
 
 	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
 		BaseRoot: testCID("base"),
-		Puts: []gateway.ArcSetPut{{
+		Deltas: []gateway.ArcSetDelta{{
 			ExpectedRoot: expectedRoot,
 			Kind:         arcset.KindList,
-			ArcSet:       mustCanonicalList(t, chunks),
+			Changes: mustCanonicalDelta(t, arcset.KindList, []deltaChangeSpec{
+				{Index: uint64Ptr(0), After: arcset.NewCASTarget(chunks[0])},
+				{Index: uint64Ptr(1), After: arcset.NewCASTarget(chunks[1])},
+			}),
 			Commit: gateway.CommitDescriptor{
 				FixedList: &gateway.FixedListCommit{
 					TotalSize: totalSize,
@@ -296,30 +322,40 @@ func TestExecutorReplaysFixedMeasuredListToExpectedRoot(t *testing.T) {
 	}
 }
 
-func TestExecutorAppliesPutsInOrderAndUsesFinalRoot(t *testing.T) {
+func TestExecutorAppliesDeltasInOrderAndUsesFinalRoot(t *testing.T) {
 	ctx := context.Background()
 	exec := newExecutor(t)
 	baseRoot := testCID("base")
-	mapSet := mustCanonicalMap(t, map[string]cid.Cid{
-		"@payload": testCID("payload"),
-	})
-	listSet := mustCanonicalList(t, []cid.Cid{testCID("chunk")})
+	payload := testCID("payload")
+	chunk := testCID("chunk")
 
 	receipt, err := exec.Apply(ctx, gateway.SemanticMutation{
 		BaseRoot: baseRoot,
-		Puts: []gateway.ArcSetPut{
-			{Object: baseRoot, Kind: arcset.KindMap, ArcSet: mapSet},
-			{Object: cid.Undef, Kind: arcset.KindList, ArcSet: listSet},
+		Deltas: []gateway.ArcSetDelta{
+			{
+				Kind: arcset.KindMap,
+				Changes: mustCanonicalDelta(t, arcset.KindMap, []deltaChangeSpec{{
+					Path:  "@payload",
+					After: arcset.NewCASTarget(payload),
+				}}),
+			},
+			{
+				Kind: arcset.KindList,
+				Changes: mustCanonicalDelta(t, arcset.KindList, []deltaChangeSpec{{
+					Index: uint64Ptr(0),
+					After: arcset.NewCASTarget(chunk),
+				}}),
+			},
 		},
 	})
 	if err != nil {
 		t.Fatalf("Apply failed: %v", err)
 	}
 	if codec.SemanticKindOf(receipt.NewRoot) != codec.SemanticKindList {
-		t.Fatalf("new root kind = %s, want final put kind %s", codec.SemanticKindOf(receipt.NewRoot), codec.SemanticKindList)
+		t.Fatalf("new root kind = %s, want final delta kind %s", codec.SemanticKindOf(receipt.NewRoot), codec.SemanticKindList)
 	}
-	if receipt.PutCount != 2 {
-		t.Fatalf("put count = %d, want 2", receipt.PutCount)
+	if receipt.DeltaCount != 2 {
+		t.Fatalf("delta count = %d, want 2", receipt.DeltaCount)
 	}
 	if receipt.ArcCount != 2 {
 		t.Fatalf("arc count = %d, want 2", receipt.ArcCount)

--- a/core/gateway/gateway_test.go
+++ b/core/gateway/gateway_test.go
@@ -3,6 +3,7 @@ package gateway_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/dewebprotocol/malt/core/arctable/overwrite"
@@ -10,6 +11,7 @@ import (
 	"github.com/dewebprotocol/malt/core/commitment/kzg"
 	"github.com/dewebprotocol/malt/core/gateway"
 	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
+	"github.com/dewebprotocol/malt/core/structure"
 	"github.com/dewebprotocol/malt/core/structure/list"
 	listtree "github.com/dewebprotocol/malt/core/structure/list/tree"
 	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
@@ -241,6 +243,79 @@ func TestExecutorCreatesListFromDeltaAndReturnsStableReceipt(t *testing.T) {
 	}
 }
 
+func TestExecutorRejectsListLengthProofWhenVerifyReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+	exec := newExecutor(t)
+	first := testCID("first")
+	second := testCID("second")
+	inserted := testCID("inserted")
+	baseRoot, err := exec.Lists.Commit(ctx, exec.Namespace, list.NewViewFromSlice([]cid.Cid{first, second}))
+	if err != nil {
+		t.Fatalf("Commit base list failed: %v", err)
+	}
+	exec.Lists = &verifyFalseList{
+		Semantics: exec.Lists,
+		reject: func(index uint64, call int) bool {
+			return call == 1 && index == 0
+		},
+	}
+
+	_, err = exec.Apply(ctx, gateway.SemanticMutation{
+		BaseRoot: baseRoot,
+		Deltas: []gateway.ArcSetDelta{{
+			Object: baseRoot,
+			Kind:   arcset.KindList,
+			Changes: mustCanonicalDelta(t, arcset.KindList, []deltaChangeSpec{{
+				Index: uint64Ptr(0),
+				After: arcset.NewCASTarget(inserted),
+			}}),
+		}},
+	})
+	if err == nil {
+		t.Fatal("Apply succeeded with invalid list length proof")
+	}
+	if !strings.Contains(err.Error(), "list length proof failed") {
+		t.Fatalf("Apply error = %v, want list length proof failure", err)
+	}
+}
+
+func TestExecutorRejectsListPreconditionProofWhenVerifyReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+	exec := newExecutor(t)
+	first := testCID("first")
+	oldSecond := testCID("old-second")
+	newSecond := testCID("new-second")
+	baseRoot, err := exec.Lists.Commit(ctx, exec.Namespace, list.NewViewFromSlice([]cid.Cid{first, oldSecond}))
+	if err != nil {
+		t.Fatalf("Commit base list failed: %v", err)
+	}
+	exec.Lists = &verifyFalseList{
+		Semantics: exec.Lists,
+		reject: func(index uint64, call int) bool {
+			return index == 1
+		},
+	}
+
+	_, err = exec.Apply(ctx, gateway.SemanticMutation{
+		BaseRoot: baseRoot,
+		Deltas: []gateway.ArcSetDelta{{
+			Object: baseRoot,
+			Kind:   arcset.KindList,
+			Changes: mustCanonicalDelta(t, arcset.KindList, []deltaChangeSpec{{
+				Index:  uint64Ptr(1),
+				Before: arcset.NewCASTarget(oldSecond),
+				After:  arcset.NewCASTarget(newSecond),
+			}}),
+		}},
+	})
+	if err == nil {
+		t.Fatal("Apply succeeded with invalid list precondition proof")
+	}
+	if !strings.Contains(err.Error(), "list proof failed at index 1") {
+		t.Fatalf("Apply error = %v, want list precondition proof failure", err)
+	}
+}
+
 func TestExecutorReplaysFixedMeasuredListToExpectedRoot(t *testing.T) {
 	ctx := context.Background()
 	scheme, err := kzg.NewScheme()
@@ -387,6 +462,20 @@ func newExecutor(t *testing.T) gateway.Executor {
 		Lists:     lists,
 		ArcTable:  arcs,
 	}
+}
+
+type verifyFalseList struct {
+	list.Semantics
+	reject func(index uint64, call int) bool
+	calls  int
+}
+
+func (l *verifyFalseList) Verify(root cid.Cid, index uint64, expected list.Query, proof structure.Proof) (bool, error) {
+	l.calls++
+	if l.reject != nil && l.reject(index, l.calls) {
+		return false, nil
+	}
+	return l.Semantics.Verify(root, index, expected, proof)
 }
 
 func mustCanonicalMap(t *testing.T, entries map[string]cid.Cid) *arcset.CanonicalArcSet {

--- a/core/layout/malt/unixfs/layout_test.go
+++ b/core/layout/malt/unixfs/layout_test.go
@@ -14,6 +14,7 @@ import (
 	kvmemory "github.com/dewebprotocol/malt/core/kvstore/memory"
 	"github.com/dewebprotocol/malt/core/layout/malt/unixfs"
 	"github.com/dewebprotocol/malt/core/structure/list/tree"
+	"github.com/dewebprotocol/malt/core/structure/mapping"
 	mappingradix "github.com/dewebprotocol/malt/core/structure/mapping/radix"
 	cid "github.com/ipfs/go-cid"
 )
@@ -24,6 +25,11 @@ func newLayout(t *testing.T, chunkSize int) *unixfs.Layout {
 }
 
 func newLayoutWithBlocks(t *testing.T, chunkSize int, blocks cas.Client) *unixfs.Layout {
+	t.Helper()
+	return newLayoutWithMapDecorator(t, chunkSize, blocks, nil)
+}
+
+func newLayoutWithMapDecorator(t *testing.T, chunkSize int, blocks cas.Client, decorate func(mapping.Semantics) mapping.Semantics) *unixfs.Layout {
 	t.Helper()
 
 	kv := kvmemory.New()
@@ -39,6 +45,10 @@ func newLayoutWithBlocks(t *testing.T, chunkSize int, blocks cas.Client) *unixfs
 	if err != nil {
 		t.Fatalf("radix.NewMap failed: %v", err)
 	}
+	var mapSemantics mapping.Semantics = maps
+	if decorate != nil {
+		mapSemantics = decorate(mapSemantics)
+	}
 	lists, err := tree.NewList(scheme, arcs)
 	if err != nil {
 		t.Fatalf("tree.NewList failed: %v", err)
@@ -47,7 +57,7 @@ func newLayoutWithBlocks(t *testing.T, chunkSize int, blocks cas.Client) *unixfs
 	layout, err := unixfs.New(unixfs.Options{
 		Namespace: "unixfs-" + strings.ReplaceAll(t.Name(), "/", "-"),
 		ChunkSize: chunkSize,
-		Map:       maps,
+		Map:       mapSemantics,
 		List:      lists,
 		Blocks:    blocks,
 	})

--- a/core/layout/malt/unixfs/mutation.go
+++ b/core/layout/malt/unixfs/mutation.go
@@ -2,6 +2,7 @@ package unixfs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 
@@ -134,7 +135,10 @@ func (l *Layout) appendRootMutationDeltas(ctx context.Context, plan *MutationPla
 	}
 	oldKind, err := l.nodeType(ctx, oldNodeRoot)
 	if err != nil {
-		return l.appendRootCreationDeltas(ctx, plan, nodeRoot)
+		if errors.Is(err, ErrNotFound) {
+			return l.appendRootCreationDeltas(ctx, plan, nodeRoot)
+		}
+		return err
 	}
 	if oldKind != kind {
 		return l.appendRootCreationDeltas(ctx, plan, nodeRoot)

--- a/core/layout/malt/unixfs/mutation.go
+++ b/core/layout/malt/unixfs/mutation.go
@@ -11,21 +11,20 @@ import (
 	cid "github.com/ipfs/go-cid"
 )
 
-// MutationPlan is a layout-produced semantic mutation snapshot for one
-// UnixFS node. It is an adapter artifact for gateway-style consumers; the
-// gateway materializes the plan, while root publication remains application
-// policy.
+// MutationPlan is a layout-produced semantic mutation delta for one UnixFS
+// change. It is an adapter artifact for gateway-style consumers; the gateway
+// materializes the plan, while root publication remains application policy.
 type MutationPlan struct {
 	BaseRoot cid.Cid
-	Puts     []MutationPut
+	Deltas   []MutationDelta
 }
 
-// MutationPut binds one materialized semantic root to its canonical arc set.
-type MutationPut struct {
+// MutationDelta binds one semantic root transition to its canonical arc delta.
+type MutationDelta struct {
 	Object       cid.Cid
 	ExpectedRoot cid.Cid
 	Kind         arcset.Kind
-	ArcSet       *arcset.CanonicalArcSet
+	Changes      *arcset.CanonicalArcDelta
 	FixedList    *FixedListCommit
 }
 
@@ -36,10 +35,10 @@ type FixedListCommit struct {
 	ChunkSize uint64
 }
 
-// MutationPlanForPath exposes canonical map/list arcsets for the UnixFS node
-// already reachable at path. For directories it includes only the terminal
-// directory map, not descendant subtrees. For large files it includes the file
-// map plus the terminal payload list composed from individual list index reads.
+// MutationPlanForPath exposes creation deltas for the UnixFS node already
+// reachable at path. For directories it includes only the terminal directory
+// map, not descendant subtrees. For large files it includes the file map plus
+// the terminal payload list composed from individual list index reads.
 func (l *Layout) MutationPlanForPath(ctx context.Context, root cid.Cid, path string) (*MutationPlan, error) {
 	if !root.Defined() {
 		return nil, fmt.Errorf("root is undefined")
@@ -60,15 +59,12 @@ func (l *Layout) MutationPlanForPath(ctx context.Context, root cid.Cid, path str
 	}
 	plan := &MutationPlan{
 		BaseRoot: root,
-		Puts: []MutationPut{
-			{
-				Object:       nodeRoot,
-				ExpectedRoot: nodeRoot,
-				Kind:         arcset.KindMap,
-				ArcSet:       nodeArcSet,
-			},
-		},
 	}
+	nodeDelta, err := mutationDeltaFromArcSets(cid.Undef, nodeRoot, arcset.KindMap, nil, nodeArcSet)
+	if err != nil {
+		return nil, err
+	}
+	plan.Deltas = append(plan.Deltas, nodeDelta)
 
 	if kind != typeFile {
 		return plan, nil
@@ -97,19 +93,19 @@ func (l *Layout) MutationPlanForPath(ctx context.Context, root cid.Cid, path str
 	if err != nil {
 		return nil, err
 	}
-	plan.Puts = append(plan.Puts, MutationPut{
-		Object:       payload,
-		ExpectedRoot: payload,
-		Kind:         arcset.KindList,
-		ArcSet:       listArcSet,
-		FixedList:    fixedList,
-	})
+	listDelta, err := mutationDeltaFromArcSets(cid.Undef, payload, arcset.KindList, nil, listArcSet)
+	if err != nil {
+		return nil, err
+	}
+	listDelta.FixedList = fixedList
+	plan.Deltas = append(plan.Deltas, listDelta)
 	return plan, nil
 }
 
-// MutationPlanForRoot exposes canonical map/list arcsets for the complete
-// UnixFS tree rooted at root. Child payloads and maps are emitted before their
-// parent directories so the final put is the canonical current-root map.
+// MutationPlanForRoot exposes canonical map/list deltas for the complete UnixFS
+// tree transition from baseRoot to root. Child payloads and maps are emitted
+// before their parent directories so the final delta is the canonical current
+// root map.
 func (l *Layout) MutationPlanForRoot(ctx context.Context, baseRoot cid.Cid, root cid.Cid) (*MutationPlan, error) {
 	if !root.Defined() {
 		return nil, fmt.Errorf("root is undefined")
@@ -118,18 +114,134 @@ func (l *Layout) MutationPlanForRoot(ctx context.Context, baseRoot cid.Cid, root
 	plan := &MutationPlan{
 		BaseRoot: baseRoot,
 	}
-	if err := l.appendRootMutationPuts(ctx, plan, root); err != nil {
+	if err := l.appendRootMutationDeltas(ctx, plan, baseRoot, root); err != nil {
 		return nil, err
 	}
 	return plan, nil
 }
 
-func (l *Layout) appendRootMutationPuts(ctx context.Context, plan *MutationPlan, nodeRoot cid.Cid) error {
+func (l *Layout) appendRootMutationDeltas(ctx context.Context, plan *MutationPlan, oldNodeRoot, nodeRoot cid.Cid) error {
+	if oldNodeRoot.Defined() && oldNodeRoot.Equals(nodeRoot) {
+		return nil
+	}
+	if !oldNodeRoot.Defined() {
+		return l.appendRootCreationDeltas(ctx, plan, nodeRoot)
+	}
+
 	kind, err := l.nodeType(ctx, nodeRoot)
 	if err != nil {
 		return err
 	}
+	oldKind, err := l.nodeType(ctx, oldNodeRoot)
+	if err != nil {
+		return l.appendRootCreationDeltas(ctx, plan, nodeRoot)
+	}
+	if oldKind != kind {
+		return l.appendRootCreationDeltas(ctx, plan, nodeRoot)
+	}
 
+	switch kind {
+	case typeDirectory:
+		oldPayload, _, ok, err := l.lookup(ctx, oldNodeRoot, payloadPath)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("%w: missing @payload", ErrNotFound)
+		}
+		oldNames, err := l.loadDirectoryManifest(ctx, oldPayload)
+		if err != nil {
+			return err
+		}
+		oldChildren := make(map[string]cid.Cid, len(oldNames))
+		for _, name := range oldNames {
+			child, _, ok, err := l.lookup(ctx, oldNodeRoot, arcset.CanonicalizePath(name))
+			if err != nil {
+				return err
+			}
+			if ok {
+				oldChildren[name] = child
+			}
+		}
+
+		payload, _, ok, err := l.lookup(ctx, nodeRoot, payloadPath)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("%w: missing @payload", ErrNotFound)
+		}
+		names, err := l.loadDirectoryManifest(ctx, payload)
+		if err != nil {
+			return err
+		}
+		for _, name := range names {
+			child, _, ok, err := l.lookup(ctx, nodeRoot, arcset.CanonicalizePath(name))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("%w: missing directory entry %s", ErrNotFound, name)
+			}
+			if err := l.appendRootMutationDeltas(ctx, plan, oldChildren[name], child); err != nil {
+				return err
+			}
+		}
+	case typeFile:
+		oldPayload, _, oldPayloadOK, err := l.lookup(ctx, oldNodeRoot, payloadPath)
+		if err != nil {
+			return err
+		}
+		var oldInfo *fileInfo
+		if oldPayloadOK && codec.SemanticKindOf(oldPayload) == codec.SemanticKindList {
+			oldInfo, err = l.fileInfo(ctx, oldNodeRoot, oldPayload)
+			if err != nil {
+				return err
+			}
+		}
+		payload, _, ok, err := l.lookup(ctx, nodeRoot, payloadPath)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("%w: missing @payload", ErrNotFound)
+		}
+		if codec.SemanticKindOf(payload) == codec.SemanticKindList {
+			info, err := l.fileInfo(ctx, nodeRoot, payload)
+			if err != nil {
+				return err
+			}
+			if err := l.appendListMutationDelta(ctx, plan, oldPayload, oldInfo, payload, info); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported unixfs node kind %q", kind)
+	}
+
+	oldNodeArcSet, err := l.canonicalNodeArcSet(ctx, oldNodeRoot, oldKind)
+	if err != nil {
+		return err
+	}
+	nodeArcSet, err := l.canonicalNodeArcSet(ctx, nodeRoot, kind)
+	if err != nil {
+		return err
+	}
+	delta, err := mutationDeltaFromArcSets(oldNodeRoot, nodeRoot, arcset.KindMap, oldNodeArcSet, nodeArcSet)
+	if err != nil {
+		return err
+	}
+	if delta.Changes != nil {
+		plan.Deltas = append(plan.Deltas, delta)
+	}
+	return nil
+}
+
+func (l *Layout) appendRootCreationDeltas(ctx context.Context, plan *MutationPlan, nodeRoot cid.Cid) error {
+	kind, err := l.nodeType(ctx, nodeRoot)
+	if err != nil {
+		return err
+	}
 	switch kind {
 	case typeDirectory:
 		payload, _, ok, err := l.lookup(ctx, nodeRoot, payloadPath)
@@ -151,7 +263,7 @@ func (l *Layout) appendRootMutationPuts(ctx context.Context, plan *MutationPlan,
 			if !ok {
 				return fmt.Errorf("%w: missing directory entry %s", ErrNotFound, name)
 			}
-			if err := l.appendRootMutationPuts(ctx, plan, child); err != nil {
+			if err := l.appendRootCreationDeltas(ctx, plan, child); err != nil {
 				return err
 			}
 		}
@@ -168,21 +280,9 @@ func (l *Layout) appendRootMutationPuts(ctx context.Context, plan *MutationPlan,
 			if err != nil {
 				return err
 			}
-			listArcSet, err := l.canonicalListArcSet(ctx, payload, chunkCount(info.size, info.chunkSize))
-			if err != nil {
+			if err := l.appendListMutationDelta(ctx, plan, cid.Undef, nil, payload, info); err != nil {
 				return err
 			}
-			fixedList, err := l.fixedListCommitForPayload(ctx, payload, info)
-			if err != nil {
-				return err
-			}
-			plan.Puts = append(plan.Puts, MutationPut{
-				Object:       payload,
-				ExpectedRoot: payload,
-				Kind:         arcset.KindList,
-				ArcSet:       listArcSet,
-				FixedList:    fixedList,
-			})
 		}
 	default:
 		return fmt.Errorf("unsupported unixfs node kind %q", kind)
@@ -192,12 +292,11 @@ func (l *Layout) appendRootMutationPuts(ctx context.Context, plan *MutationPlan,
 	if err != nil {
 		return err
 	}
-	plan.Puts = append(plan.Puts, MutationPut{
-		Object:       nodeRoot,
-		ExpectedRoot: nodeRoot,
-		Kind:         arcset.KindMap,
-		ArcSet:       nodeArcSet,
-	})
+	delta, err := mutationDeltaFromArcSets(cid.Undef, nodeRoot, arcset.KindMap, nil, nodeArcSet)
+	if err != nil {
+		return err
+	}
+	plan.Deltas = append(plan.Deltas, delta)
 	return nil
 }
 
@@ -314,6 +413,60 @@ func (l *Layout) canonicalListArcSet(ctx context.Context, root cid.Cid, length u
 	return arcset.NewCanonicalArcSet(arcset.KindList, entries)
 }
 
+func (l *Layout) appendListMutationDelta(ctx context.Context, plan *MutationPlan, oldPayload cid.Cid, oldInfo *fileInfo, payload cid.Cid, info *fileInfo) error {
+	if oldPayload.Defined() && oldPayload.Equals(payload) {
+		return nil
+	}
+
+	newLen := chunkCount(info.size, info.chunkSize)
+	newArcSet, err := l.canonicalListArcSet(ctx, payload, newLen)
+	if err != nil {
+		return err
+	}
+	fixedList, err := l.fixedListCommitForPayload(ctx, payload, info)
+	if err != nil {
+		return err
+	}
+
+	object := cid.Undef
+	var oldArcSet *arcset.CanonicalArcSet
+	if oldPayload.Defined() && oldInfo != nil && oldInfo.chunkSize == info.chunkSize && canReuseMeasuredListDelta(oldInfo, info) {
+		oldLen := chunkCount(oldInfo.size, oldInfo.chunkSize)
+		oldArcSet, err = l.canonicalListArcSet(ctx, oldPayload, oldLen)
+		if err != nil {
+			return err
+		}
+		object = oldPayload
+	}
+
+	delta, err := mutationDeltaFromArcSets(object, payload, arcset.KindList, oldArcSet, newArcSet)
+	if err != nil {
+		return err
+	}
+	if delta.Changes == nil {
+		return nil
+	}
+	delta.FixedList = fixedList
+	plan.Deltas = append(plan.Deltas, delta)
+	return nil
+}
+
+func canReuseMeasuredListDelta(oldInfo, newInfo *fileInfo) bool {
+	if oldInfo == nil || newInfo == nil || oldInfo.chunkSize != newInfo.chunkSize {
+		return false
+	}
+	oldLen := chunkCount(oldInfo.size, oldInfo.chunkSize)
+	newLen := chunkCount(newInfo.size, newInfo.chunkSize)
+	switch {
+	case newLen == oldLen:
+		return oldInfo.size == newInfo.size
+	case newLen > oldLen:
+		return oldInfo.size == oldLen*oldInfo.chunkSize
+	default:
+		return false
+	}
+}
+
 func (l *Layout) fixedListCommitForPayload(ctx context.Context, payload cid.Cid, info *fileInfo) (*FixedListCommit, error) {
 	measured, ok := l.lists.(list.MeasuredSemantics)
 	if !ok {
@@ -337,6 +490,97 @@ func (l *Layout) fixedListCommitForPayload(ctx context.Context, payload cid.Cid,
 		TotalSize: result.Metadata.TotalSize,
 		ChunkSize: result.Metadata.ChunkSize,
 	}, nil
+}
+
+func mutationDeltaFromArcSets(object, expectedRoot cid.Cid, kind arcset.Kind, before, after *arcset.CanonicalArcSet) (MutationDelta, error) {
+	changes, err := canonicalArcSetChanges(kind, before, after)
+	if err != nil {
+		return MutationDelta{}, err
+	}
+	out := MutationDelta{
+		Object:       object,
+		ExpectedRoot: expectedRoot,
+		Kind:         kind,
+	}
+	if len(changes) == 0 {
+		return out, nil
+	}
+	delta, err := arcset.NewCanonicalArcDelta(kind, changes)
+	if err != nil {
+		return MutationDelta{}, err
+	}
+	out.Changes = delta
+	return out, nil
+}
+
+func canonicalArcSetChanges(kind arcset.Kind, before, after *arcset.CanonicalArcSet) ([]arcset.ArcChange, error) {
+	if before != nil && before.Kind() != kind {
+		return nil, fmt.Errorf("before arcset kind = %q, want %q", before.Kind(), kind)
+	}
+	if after != nil && after.Kind() != kind {
+		return nil, fmt.Errorf("after arcset kind = %q, want %q", after.Kind(), kind)
+	}
+
+	beforeEntries := canonicalEntriesByCoordinate(before)
+	afterEntries := canonicalEntriesByCoordinate(after)
+	seen := make(map[string]struct{}, len(beforeEntries)+len(afterEntries))
+	changes := make([]arcset.ArcChange, 0)
+
+	for key, beforeEntry := range beforeEntries {
+		seen[key] = struct{}{}
+		afterEntry, ok := afterEntries[key]
+		if !ok {
+			beforeTarget := beforeEntry.Target
+			changes = append(changes, arcset.ArcChange{
+				Coordinate: beforeEntry.Coordinate,
+				Before:     &beforeTarget,
+			})
+			continue
+		}
+		if targetRefEqual(beforeEntry.Target, afterEntry.Target) {
+			continue
+		}
+		beforeTarget := beforeEntry.Target
+		afterTarget := afterEntry.Target
+		changes = append(changes, arcset.ArcChange{
+			Coordinate: beforeEntry.Coordinate,
+			Before:     &beforeTarget,
+			After:      &afterTarget,
+		})
+	}
+	for key, afterEntry := range afterEntries {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		afterTarget := afterEntry.Target
+		changes = append(changes, arcset.ArcChange{
+			Coordinate: afterEntry.Coordinate,
+			After:      &afterTarget,
+		})
+	}
+	return changes, nil
+}
+
+func canonicalEntriesByCoordinate(set *arcset.CanonicalArcSet) map[string]arcset.ArcEntry {
+	if set == nil {
+		return nil
+	}
+	entries := set.Entries()
+	out := make(map[string]arcset.ArcEntry, len(entries))
+	for _, entry := range entries {
+		out[entry.Coordinate.String()] = entry
+	}
+	return out
+}
+
+func targetRefEqual(a, b arcset.TargetRef) bool {
+	if a.Kind() != b.Kind() {
+		return false
+	}
+	if !a.CID().Defined() && !b.CID().Defined() {
+		return true
+	}
+	return a.CID().Equals(b.CID())
 }
 
 func mapEntry(key string, target arcset.TargetRef) (arcset.ArcEntry, error) {

--- a/core/layout/malt/unixfs/mutation_test.go
+++ b/core/layout/malt/unixfs/mutation_test.go
@@ -3,11 +3,14 @@ package unixfs_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/dewebprotocol/malt/core/layout/malt/unixfs"
+	"github.com/dewebprotocol/malt/core/structure"
+	"github.com/dewebprotocol/malt/core/structure/mapping"
 	"github.com/dewebprotocol/malt/core/types/arcset"
 	cid "github.com/ipfs/go-cid"
 )
@@ -151,6 +154,66 @@ func TestRootMutationPlanIncludesDescendantsBeforeRoot(t *testing.T) {
 	}
 }
 
+func TestRootMutationPlanPropagatesOldRootNodeTypeError(t *testing.T) {
+	ctx := context.Background()
+	oldTypeErr := errors.New("old root type lookup failed")
+	failMap := &failingProveMap{err: oldTypeErr}
+	layout := newLayoutWithMapDecorator(t, 8, newSpyBatchCAS(), func(inner mapping.Semantics) mapping.Semantics {
+		failMap.Semantics = inner
+		return failMap
+	})
+
+	oldRoot, err := layout.AddFile(ctx, cid.Undef, "hello.txt", []byte("old"))
+	if err != nil {
+		t.Fatalf("AddFile old failed: %v", err)
+	}
+	newRoot, err := layout.AddFile(ctx, oldRoot, "hello.txt", []byte("new"))
+	if err != nil {
+		t.Fatalf("AddFile new failed: %v", err)
+	}
+	failMap.root = oldRoot
+
+	plan, err := layout.MutationPlanForRoot(ctx, oldRoot, newRoot)
+	if err == nil {
+		t.Fatalf("MutationPlanForRoot succeeded with %d deltas, want old root type error", len(plan.Deltas))
+	}
+	if !errors.Is(err, oldTypeErr) {
+		t.Fatalf("MutationPlanForRoot error = %v, want %v", err, oldTypeErr)
+	}
+}
+
+func TestRootMutationPlanFallsBackWhenOldRootNodeTypeNotFound(t *testing.T) {
+	ctx := context.Background()
+	failMap := &failingProveMap{err: fmt.Errorf("old root missing: %w", unixfs.ErrNotFound)}
+	layout := newLayoutWithMapDecorator(t, 8, newSpyBatchCAS(), func(inner mapping.Semantics) mapping.Semantics {
+		failMap.Semantics = inner
+		return failMap
+	})
+
+	oldRoot, err := layout.AddFile(ctx, cid.Undef, "hello.txt", []byte("old"))
+	if err != nil {
+		t.Fatalf("AddFile old failed: %v", err)
+	}
+	newRoot, err := layout.AddFile(ctx, oldRoot, "hello.txt", []byte("new"))
+	if err != nil {
+		t.Fatalf("AddFile new failed: %v", err)
+	}
+	failMap.root = oldRoot
+
+	plan, err := layout.MutationPlanForRoot(ctx, oldRoot, newRoot)
+	if err != nil {
+		t.Fatalf("MutationPlanForRoot failed: %v", err)
+	}
+	if len(plan.Deltas) == 0 {
+		t.Fatal("MutationPlanForRoot produced no creation deltas")
+	}
+	for i, delta := range plan.Deltas {
+		if delta.Object.Defined() {
+			t.Fatalf("delta %d object = %s, want undefined creation delta object", i, delta.Object)
+		}
+	}
+}
+
 func TestLargeFileAppendMutationPlanReusesOldMeasuredList(t *testing.T) {
 	ctx := context.Background()
 	layout := newLayout(t, 4)
@@ -209,6 +272,19 @@ func TestLargeFileAppendMutationPlanReusesOldMeasuredList(t *testing.T) {
 	if change.After == nil || change.After.Kind() != arcset.TargetKindCAS {
 		t.Fatalf("append change after = %v, want CAS target", change.After)
 	}
+}
+
+type failingProveMap struct {
+	mapping.Semantics
+	root cid.Cid
+	err  error
+}
+
+func (m *failingProveMap) Prove(ctx context.Context, namespace string, root cid.Cid, key arcset.Path) (mapping.Binding, structure.Proof, error) {
+	if m.root.Defined() && root.Equals(m.root) {
+		return mapping.Binding{}, nil, m.err
+	}
+	return m.Semantics.Prove(ctx, namespace, root, key)
 }
 
 func hasAfterChange(delta *arcset.CanonicalArcDelta, coordinate string, targetKind arcset.TargetKind) bool {

--- a/core/layout/malt/unixfs/mutation_test.go
+++ b/core/layout/malt/unixfs/mutation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/dewebprotocol/malt/core/layout/malt/unixfs"
@@ -27,18 +28,18 @@ func TestSmallFileMutationPlanIncludesMapPayload(t *testing.T) {
 	if !plan.BaseRoot.Equals(root) {
 		t.Fatalf("plan BaseRoot = %s, want %s", plan.BaseRoot, root)
 	}
-	if len(plan.Puts) != 1 {
-		t.Fatalf("put count = %d, want 1", len(plan.Puts))
+	if len(plan.Deltas) != 1 {
+		t.Fatalf("delta count = %d, want 1", len(plan.Deltas))
 	}
-	put := plan.Puts[0]
-	if put.Kind != arcset.KindMap {
-		t.Fatalf("put kind = %q, want map", put.Kind)
+	delta := plan.Deltas[0]
+	if delta.Kind != arcset.KindMap {
+		t.Fatalf("delta kind = %q, want map", delta.Kind)
 	}
-	if put.ArcSet.Kind() != arcset.KindMap {
-		t.Fatalf("arcset kind = %q, want map", put.ArcSet.Kind())
+	if delta.Changes.Kind() != arcset.KindMap {
+		t.Fatalf("delta changes kind = %q, want map", delta.Changes.Kind())
 	}
-	if !hasEntry(put.ArcSet, "@payload", arcset.TargetKindCAS) {
-		t.Fatal("file map arcset missing CAS @payload binding")
+	if !hasAfterChange(delta.Changes, "@payload", arcset.TargetKindCAS) {
+		t.Fatal("file map delta missing CAS @payload binding")
 	}
 }
 
@@ -55,36 +56,36 @@ func TestLargeFileMutationPlanIncludesFileMapAndOrderedList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MutationPlanForPath failed: %v", err)
 	}
-	if len(plan.Puts) != 2 {
-		t.Fatalf("put count = %d, want 2", len(plan.Puts))
+	if len(plan.Deltas) != 2 {
+		t.Fatalf("delta count = %d, want 2", len(plan.Deltas))
 	}
-	if plan.Puts[0].Kind != arcset.KindMap {
-		t.Fatalf("put 0 kind = %q, want map", plan.Puts[0].Kind)
+	if plan.Deltas[0].Kind != arcset.KindMap {
+		t.Fatalf("delta 0 kind = %q, want map", plan.Deltas[0].Kind)
 	}
-	if !hasEntry(plan.Puts[0].ArcSet, "@payload", arcset.TargetKindList) {
-		t.Fatal("file map arcset missing list @payload binding")
+	if !hasAfterChange(plan.Deltas[0].Changes, "@payload", arcset.TargetKindList) {
+		t.Fatal("file map delta missing list @payload binding")
 	}
-	if plan.Puts[1].Kind != arcset.KindList {
-		t.Fatalf("put 1 kind = %q, want list", plan.Puts[1].Kind)
+	if plan.Deltas[1].Kind != arcset.KindList {
+		t.Fatalf("delta 1 kind = %q, want list", plan.Deltas[1].Kind)
 	}
-	if !plan.Puts[1].ExpectedRoot.Equals(plan.Puts[1].Object) {
-		t.Fatalf("list put expected root = %s, want object %s", plan.Puts[1].ExpectedRoot, plan.Puts[1].Object)
+	if !plan.Deltas[1].ExpectedRoot.Defined() {
+		t.Fatal("list delta expected root is undefined")
 	}
-	if plan.Puts[1].FixedList == nil {
-		t.Fatal("large file list put missing fixed-list commit metadata")
+	if plan.Deltas[1].FixedList == nil {
+		t.Fatal("large file list delta missing fixed-list commit metadata")
 	}
-	if plan.Puts[1].FixedList.TotalSize != 12 || plan.Puts[1].FixedList.ChunkSize != 4 {
-		t.Fatalf("fixed list metadata = %+v, want total=12 chunk=4", plan.Puts[1].FixedList)
+	if plan.Deltas[1].FixedList.TotalSize != 12 || plan.Deltas[1].FixedList.ChunkSize != 4 {
+		t.Fatalf("fixed list metadata = %+v, want total=12 chunk=4", plan.Deltas[1].FixedList)
 	}
 
-	got := entryCoordinates(plan.Puts[1].ArcSet)
+	got := changeCoordinates(plan.Deltas[1].Changes)
 	want := []string{"0", "1", "2"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("list coordinates = %#v, want %#v", got, want)
 	}
-	for _, entry := range plan.Puts[1].ArcSet.Entries() {
-		if entry.Target.Kind() != arcset.TargetKindCAS {
-			t.Fatalf("list entry %s target kind = %q, want cas", entry.Coordinate.String(), entry.Target.Kind())
+	for _, change := range plan.Deltas[1].Changes.Changes() {
+		if change.After == nil || change.After.Kind() != arcset.TargetKindCAS {
+			t.Fatalf("list change %s after target kind = %v, want cas", change.Coordinate.String(), change.After)
 		}
 	}
 }
@@ -110,10 +111,10 @@ func TestDirectoryMutationPlanSortsEntriesAndRejectsReservedPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MutationPlanForPath(dir) failed: %v", err)
 	}
-	if len(plan.Puts) != 1 {
-		t.Fatalf("put count = %d, want 1", len(plan.Puts))
+	if len(plan.Deltas) != 1 {
+		t.Fatalf("delta count = %d, want 1", len(plan.Deltas))
 	}
-	got := entryCoordinates(plan.Puts[0].ArcSet)
+	got := changeCoordinates(plan.Deltas[0].Changes)
 	want := []string{"@payload", "@type", "a.txt", "b.txt"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("directory map coordinates = %#v, want %#v", got, want)
@@ -136,34 +137,94 @@ func TestRootMutationPlanIncludesDescendantsBeforeRoot(t *testing.T) {
 	if !plan.BaseRoot.Equals(cid.Undef) {
 		t.Fatalf("plan BaseRoot = %s, want undefined", plan.BaseRoot)
 	}
-	if len(plan.Puts) != 4 {
-		t.Fatalf("put count = %d, want 4", len(plan.Puts))
+	if len(plan.Deltas) != 4 {
+		t.Fatalf("delta count = %d, want 4", len(plan.Deltas))
 	}
-	if plan.Puts[0].Kind != arcset.KindList {
-		t.Fatalf("put 0 kind = %q, want list payload first", plan.Puts[0].Kind)
+	if plan.Deltas[0].Kind != arcset.KindList {
+		t.Fatalf("delta 0 kind = %q, want list payload first", plan.Deltas[0].Kind)
 	}
-	if plan.Puts[len(plan.Puts)-1].Kind != arcset.KindMap {
-		t.Fatalf("last put kind = %q, want root map", plan.Puts[len(plan.Puts)-1].Kind)
+	if plan.Deltas[len(plan.Deltas)-1].Kind != arcset.KindMap {
+		t.Fatalf("last delta kind = %q, want root map", plan.Deltas[len(plan.Deltas)-1].Kind)
 	}
-	if !plan.Puts[len(plan.Puts)-1].Object.Equals(root) {
-		t.Fatalf("last put object = %s, want root %s", plan.Puts[len(plan.Puts)-1].Object, root)
+	if !plan.Deltas[len(plan.Deltas)-1].ExpectedRoot.Equals(root) {
+		t.Fatalf("last delta expected root = %s, want root %s", plan.Deltas[len(plan.Deltas)-1].ExpectedRoot, root)
 	}
 }
 
-func hasEntry(set *arcset.CanonicalArcSet, coordinate string, targetKind arcset.TargetKind) bool {
-	for _, entry := range set.Entries() {
-		if entry.Coordinate.String() == coordinate && entry.Target.Kind() == targetKind {
+func TestLargeFileAppendMutationPlanReusesOldMeasuredList(t *testing.T) {
+	ctx := context.Background()
+	layout := newLayout(t, 4)
+	oldData := strings.Repeat("a", 255*4)
+	newData := oldData + "bbbb"
+
+	oldRoot, err := layout.AddFile(ctx, cid.Undef, "blob.bin", []byte(oldData))
+	if err != nil {
+		t.Fatalf("AddFile old failed: %v", err)
+	}
+	oldResolution, err := layout.Resolve(ctx, oldRoot, "blob.bin")
+	if err != nil {
+		t.Fatalf("Resolve old failed: %v", err)
+	}
+	newRoot, err := layout.AddFile(ctx, oldRoot, "blob.bin", []byte(newData))
+	if err != nil {
+		t.Fatalf("AddFile new failed: %v", err)
+	}
+	newResolution, err := layout.Resolve(ctx, newRoot, "blob.bin")
+	if err != nil {
+		t.Fatalf("Resolve new failed: %v", err)
+	}
+
+	plan, err := layout.MutationPlanForRoot(ctx, oldRoot, newRoot)
+	if err != nil {
+		t.Fatalf("MutationPlanForRoot failed: %v", err)
+	}
+	var listDelta *unixfs.MutationDelta
+	for i := range plan.Deltas {
+		if plan.Deltas[i].Kind == arcset.KindList {
+			listDelta = &plan.Deltas[i]
+			break
+		}
+	}
+	if listDelta == nil {
+		t.Fatal("plan missing list delta")
+	}
+	if !listDelta.Object.Equals(oldResolution.Payload) {
+		t.Fatalf("list delta object = %s, want old payload %s", listDelta.Object, oldResolution.Payload)
+	}
+	if !listDelta.ExpectedRoot.Equals(newResolution.Payload) {
+		t.Fatalf("list delta expected root = %s, want new payload %s", listDelta.ExpectedRoot, newResolution.Payload)
+	}
+	if listDelta.FixedList == nil || listDelta.FixedList.TotalSize != uint64(len(newData)) || listDelta.FixedList.ChunkSize != 4 {
+		t.Fatalf("fixed list metadata = %+v, want total=%d chunk=4", listDelta.FixedList, len(newData))
+	}
+	got := changeCoordinates(listDelta.Changes)
+	want := []string{"255"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("list delta coordinates = %#v, want %#v", got, want)
+	}
+	change := listDelta.Changes.Changes()[0]
+	if change.Before != nil {
+		t.Fatalf("append change before = %v, want nil", change.Before)
+	}
+	if change.After == nil || change.After.Kind() != arcset.TargetKindCAS {
+		t.Fatalf("append change after = %v, want CAS target", change.After)
+	}
+}
+
+func hasAfterChange(delta *arcset.CanonicalArcDelta, coordinate string, targetKind arcset.TargetKind) bool {
+	for _, change := range delta.Changes() {
+		if change.Coordinate.String() == coordinate && change.After != nil && change.After.Kind() == targetKind {
 			return true
 		}
 	}
 	return false
 }
 
-func entryCoordinates(set *arcset.CanonicalArcSet) []string {
-	entries := set.Entries()
-	out := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		out = append(out, entry.Coordinate.String())
+func changeCoordinates(delta *arcset.CanonicalArcDelta) []string {
+	changes := delta.Changes()
+	out := make([]string, 0, len(changes))
+	for _, change := range changes {
+		out = append(out, change.Coordinate.String())
 	}
 	return out
 }

--- a/core/structure/list/tree/tree.go
+++ b/core/structure/list/tree/tree.go
@@ -420,6 +420,103 @@ func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, k
 	return newRoot, newIndex, err
 }
 
+// AppendFixed extends a fixed-width measured list by one chunk and returns the
+// updated measured root. The existing measured list must end on a chunk
+// boundary; extending a partial final chunk requires replacing that chunk first.
+func (s *TreeList) AppendFixed(ctx context.Context, namespace string, root cid.Cid, key cid.Cid, totalSize uint64) (cid.Cid, uint64, error) {
+	if !key.Defined() {
+		return cid.Undef, 0, fmt.Errorf("key is undefined")
+	}
+	rootSlots, length, err := s.loadRoot(ctx, namespace, root)
+	if err != nil {
+		return cid.Undef, 0, err
+	}
+	meta, err := fixedRangeMetadata(rootSlots[0])
+	if err != nil {
+		return cid.Undef, 0, fmt.Errorf("root is not a fixed measured list")
+	}
+	if err := validateFixedMetadata(meta); err != nil {
+		return cid.Undef, 0, err
+	}
+	if meta.ChildCount != length {
+		return cid.Undef, 0, fmt.Errorf("measured child count %d does not match list length %d", meta.ChildCount, length)
+	}
+	if meta.TotalSize != meta.ChildCount*meta.ChunkSize {
+		return cid.Undef, 0, fmt.Errorf("fixed measured append requires chunk-aligned current total size")
+	}
+	newLength := chunkCount(totalSize, meta.ChunkSize)
+	if newLength != length+1 {
+		return cid.Undef, 0, fmt.Errorf("fixed measured append child count = %d, want %d", newLength, length+1)
+	}
+
+	newIndex := length
+	oldHeight := layout.RequiredHeight(length)
+	newHeight := layout.RequiredHeight(newLength)
+
+	if newHeight > oldHeight {
+		nextRootSlots := layout.EmptyRootSlots()
+		rootMarker, err := measuredNodeMetadata(newHeight, newLength, 0, meta.ChunkSize, totalSize)
+		if err != nil {
+			return cid.Undef, 0, err
+		}
+		nextRootSlots[0] = rootMarker
+		content := layout.ContentSlots(nextRootSlots, true)
+		content[0] = root
+
+		childSpan, err := layout.SubtreeCapacity(newHeight - 1)
+		if err != nil {
+			return cid.Undef, 0, err
+		}
+		rootDigit := int(newIndex / childSpan)
+		localIndex := newIndex % childSpan
+		childStart := uint64(rootDigit) * childSpan
+		childRoot, err := s.buildMeasuredSparseSubtree(ctx, namespace, newHeight-1, localIndex, childStart, key, meta.ChunkSize, totalSize)
+		if err != nil {
+			return cid.Undef, 0, err
+		}
+		content[rootDigit] = childRoot
+
+		newRoot, err := s.commitSlots(ctx, namespace, nextRootSlots)
+		return newRoot, newIndex, err
+	}
+
+	nextRootSlots := cloneSlots(rootSlots)
+	rootMarker, err := measuredNodeMetadata(newHeight, newLength, 0, meta.ChunkSize, totalSize)
+	if err != nil {
+		return cid.Undef, 0, err
+	}
+	nextRootSlots[0] = rootMarker
+	content := layout.ContentSlots(nextRootSlots, true)
+
+	if oldHeight == 0 {
+		if content[newIndex].Defined() {
+			return cid.Undef, 0, fmt.Errorf("append slot %d is already occupied", newIndex)
+		}
+		content[newIndex] = key
+		newRoot, err := s.commitSlots(ctx, namespace, nextRootSlots)
+		return newRoot, newIndex, err
+	}
+
+	childSpan, err := layout.SubtreeCapacity(oldHeight - 1)
+	if err != nil {
+		return cid.Undef, 0, err
+	}
+	digit := int(newIndex / childSpan)
+	localIndex := newIndex % childSpan
+	childStart := uint64(digit) * childSpan
+	if content[digit].Defined() {
+		content[digit], err = s.appendFixedInto(ctx, namespace, content[digit], oldHeight-1, localIndex, childStart, key, meta.ChunkSize, totalSize)
+	} else {
+		content[digit], err = s.buildMeasuredSparseSubtree(ctx, namespace, oldHeight-1, localIndex, childStart, key, meta.ChunkSize, totalSize)
+	}
+	if err != nil {
+		return cid.Undef, 0, err
+	}
+
+	newRoot, err := s.commitSlots(ctx, namespace, nextRootSlots)
+	return newRoot, newIndex, err
+}
+
 func (s *TreeList) Truncate(ctx context.Context, namespace string, root cid.Cid, newLen uint64) (cid.Cid, error) {
 	rootSlots, oldLen, err := s.loadRoot(ctx, namespace, root)
 	if err != nil {
@@ -755,6 +852,80 @@ func (s *TreeList) buildSparseSubtree(ctx context.Context, namespace string, hei
 	return s.commitSlots(ctx, namespace, slots)
 }
 
+func (s *TreeList) appendFixedInto(ctx context.Context, namespace string, root cid.Cid, height int, index, startIndex uint64, key cid.Cid, chunkSize, totalSize uint64) (cid.Cid, error) {
+	slots, err := s.loadNode(ctx, namespace, root, false)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	nextSlots := cloneSlots(slots)
+	marker, err := measuredNodeMetadata(height, index+1, startIndex, chunkSize, totalSize)
+	if err != nil {
+		return cid.Undef, err
+	}
+	nextSlots[0] = marker
+	content := layout.ContentSlots(nextSlots, false)
+
+	if height == 0 {
+		if index >= uint64(len(content)) {
+			return cid.Undef, fmt.Errorf("index %d out of leaf range", index)
+		}
+		if content[index].Defined() {
+			return cid.Undef, fmt.Errorf("append slot %d is already occupied", index)
+		}
+		content[index] = key
+		return s.commitSlots(ctx, namespace, nextSlots)
+	}
+
+	childSpan, err := layout.SubtreeCapacity(height - 1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	digit := int(index / childSpan)
+	localIndex := index % childSpan
+	childStart := startIndex + uint64(digit)*childSpan
+	if content[digit].Defined() {
+		content[digit], err = s.appendFixedInto(ctx, namespace, content[digit], height-1, localIndex, childStart, key, chunkSize, totalSize)
+	} else {
+		content[digit], err = s.buildMeasuredSparseSubtree(ctx, namespace, height-1, localIndex, childStart, key, chunkSize, totalSize)
+	}
+	if err != nil {
+		return cid.Undef, err
+	}
+	return s.commitSlots(ctx, namespace, nextSlots)
+}
+
+func (s *TreeList) buildMeasuredSparseSubtree(ctx context.Context, namespace string, height int, index, startIndex uint64, key cid.Cid, chunkSize, totalSize uint64) (cid.Cid, error) {
+	slots := layout.EmptyNodeSlots()
+	marker, err := measuredNodeMetadata(height, index+1, startIndex, chunkSize, totalSize)
+	if err != nil {
+		return cid.Undef, err
+	}
+	slots[0] = marker
+	content := layout.ContentSlots(slots, false)
+
+	if height == 0 {
+		if index >= uint64(len(content)) {
+			return cid.Undef, fmt.Errorf("index %d out of leaf range", index)
+		}
+		content[index] = key
+		return s.commitSlots(ctx, namespace, slots)
+	}
+
+	childSpan, err := layout.SubtreeCapacity(height - 1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	digit := int(index / childSpan)
+	localIndex := index % childSpan
+	childStart := startIndex + uint64(digit)*childSpan
+	content[digit], err = s.buildMeasuredSparseSubtree(ctx, namespace, height-1, localIndex, childStart, key, chunkSize, totalSize)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return s.commitSlots(ctx, namespace, slots)
+}
+
 func (s *TreeList) commitEmptyRoot(ctx context.Context, namespace string) (cid.Cid, error) {
 	slots := layout.EmptyRootSlots()
 	lengthMarker, err := plainNodeMetadata(0, 0)
@@ -944,6 +1115,22 @@ func plainNodeMetadata(height int, childCount uint64) (cid.Cid, error) {
 	return layout.EncodeNodeMetadata(layout.NodeMetadata{
 		Height:     uint64(height),
 		ChildCount: childCount,
+	})
+}
+
+func measuredNodeMetadata(height int, childCount, startIndex, chunkSize, totalSize uint64) (cid.Cid, error) {
+	if height < 0 {
+		return cid.Undef, fmt.Errorf("height must be non-negative")
+	}
+	nodeSize, err := measuredNodeSize(startIndex, childCount, chunkSize, totalSize)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return layout.EncodeNodeMetadata(layout.NodeMetadata{
+		Height:     uint64(height),
+		ChildCount: childCount,
+		TotalSize:  nodeSize,
+		ChunkSize:  chunkSize,
 	})
 }
 

--- a/core/types/arcset/canonical.go
+++ b/core/types/arcset/canonical.go
@@ -166,10 +166,26 @@ type ArcEntry struct {
 	Target     TargetRef
 }
 
+// ArcChange is one canonical coordinate transition in a semantic mutation.
+// A nil Before means the coordinate is expected to be absent. A nil After means
+// the coordinate is deleted.
+type ArcChange struct {
+	Coordinate CanonicalCoordinate
+	Before     *TargetRef
+	After      *TargetRef
+}
+
 // CanonicalArcSet is an immutable semantic representation of map or list entries.
 type CanonicalArcSet struct {
 	kind    Kind
 	entries []ArcEntry
+}
+
+// CanonicalArcDelta is an immutable semantic representation of coordinate
+// transitions for one map or list object.
+type CanonicalArcDelta struct {
+	kind    Kind
+	changes []ArcChange
 }
 
 // NewCanonicalArcSet creates a validated canonical arc set from entries.
@@ -270,12 +286,82 @@ func NewCanonicalListArcSetFromIndexed(arcs map[uint64]cid.Cid) (*CanonicalArcSe
 	return NewCanonicalArcSet(KindList, entries)
 }
 
+// NewCanonicalArcDelta creates a validated canonical delta from coordinate
+// transitions.
+func NewCanonicalArcDelta(kind Kind, changes []ArcChange) (*CanonicalArcDelta, error) {
+	if err := validateKind(kind); err != nil {
+		return nil, err
+	}
+	if len(changes) == 0 {
+		return nil, fmt.Errorf("canonical arc delta is empty")
+	}
+
+	normalized := make([]ArcChange, len(changes))
+	for i, change := range changes {
+		coord, err := validateCoordinate(kind, change.Coordinate)
+		if err != nil {
+			return nil, err
+		}
+		normalized[i] = ArcChange{Coordinate: coord}
+		if change.Before != nil {
+			before := *change.Before
+			if err := validateTarget(before); err != nil {
+				return nil, fmt.Errorf("before target: %w", err)
+			}
+			normalized[i].Before = &before
+		}
+		if change.After != nil {
+			after := *change.After
+			if err := validateTarget(after); err != nil {
+				return nil, fmt.Errorf("after target: %w", err)
+			}
+			normalized[i].After = &after
+		}
+		if normalized[i].Before == nil && normalized[i].After == nil {
+			return nil, fmt.Errorf("canonical arc delta change %s is empty", coord.String())
+		}
+		if normalized[i].Before != nil && normalized[i].After != nil && targetRefEqual(*normalized[i].Before, *normalized[i].After) {
+			return nil, fmt.Errorf("canonical arc delta change %s is a no-op", coord.String())
+		}
+	}
+
+	normalized = sortChanges(normalized)
+	if err := rejectDuplicateChanges(normalized); err != nil {
+		return nil, err
+	}
+	return &CanonicalArcDelta{kind: kind, changes: cloneChanges(normalized)}, nil
+}
+
 // Kind returns the semantic kind for this canonical arc set.
 func (s *CanonicalArcSet) Kind() Kind {
 	if s == nil {
 		return ""
 	}
 	return s.kind
+}
+
+// Kind returns the semantic kind for this canonical delta.
+func (d *CanonicalArcDelta) Kind() Kind {
+	if d == nil {
+		return ""
+	}
+	return d.kind
+}
+
+// Changes returns cloned canonical changes in deterministic coordinate order.
+func (d *CanonicalArcDelta) Changes() []ArcChange {
+	if d == nil {
+		return nil
+	}
+	return cloneChanges(d.changes)
+}
+
+// Len returns the number of canonical changes.
+func (d *CanonicalArcDelta) Len() int {
+	if d == nil {
+		return 0
+	}
+	return len(d.changes)
 }
 
 // Entries returns cloned canonical entries in deterministic coordinate order.
@@ -440,6 +526,28 @@ func sortAndCollapseEntries(entries []ArcEntry) []ArcEntry {
 	return out
 }
 
+func sortChanges(changes []ArcChange) []ArcChange {
+	out := cloneChanges(changes)
+	less := func(i, j int) bool {
+		return bytes.Compare(out[i].Coordinate.bytes, out[j].Coordinate.bytes) < 0
+	}
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && less(j, j-1); j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}
+
+func rejectDuplicateChanges(changes []ArcChange) error {
+	for i := 1; i < len(changes); i++ {
+		if bytes.Equal(changes[i-1].Coordinate.bytes, changes[i].Coordinate.bytes) {
+			return fmt.Errorf("%w: %s", ErrDuplicateCoordinate, changes[i].Coordinate.String())
+		}
+	}
+	return nil
+}
+
 func rejectConflictingDuplicates(entries []ArcEntry) error {
 	for i := 1; i < len(entries); i++ {
 		if bytes.Equal(entries[i-1].Coordinate.bytes, entries[i].Coordinate.bytes) &&
@@ -493,6 +601,30 @@ func cloneEntry(entry ArcEntry) ArcEntry {
 		Coordinate: entry.Coordinate.clone(),
 		Target:     entry.Target,
 	}
+}
+
+func cloneChanges(changes []ArcChange) []ArcChange {
+	if changes == nil {
+		return nil
+	}
+	out := make([]ArcChange, len(changes))
+	for i, change := range changes {
+		out[i] = cloneChange(change)
+	}
+	return out
+}
+
+func cloneChange(change ArcChange) ArcChange {
+	out := ArcChange{Coordinate: change.Coordinate.clone()}
+	if change.Before != nil {
+		before := *change.Before
+		out.Before = &before
+	}
+	if change.After != nil {
+		after := *change.After
+		out.After = &after
+	}
+	return out
 }
 
 func targetRefEqual(a, b TargetRef) bool {

--- a/httpapi/types.go
+++ b/httpapi/types.go
@@ -23,22 +23,41 @@ type MetricsResponse struct {
 
 // SemanticMutationRequest materializes a root-relative semantic mutation.
 type SemanticMutationRequest struct {
-	Puts []SemanticMutationPut `json:"puts"`
+	Deltas []SemanticMutationDelta `json:"deltas"`
 }
 
-// SemanticMutationPut replaces one semantic object's full canonical arc set.
-type SemanticMutationPut struct {
-	Object  string                  `json:"object,omitempty"`
-	Kind    string                  `json:"kind"`
-	Entries []SemanticMutationEntry `json:"entries"`
+// SemanticMutationDelta applies coordinate-level changes to one semantic object.
+type SemanticMutationDelta struct {
+	Object       string                    `json:"object,omitempty"`
+	ExpectedRoot string                    `json:"expected_root,omitempty"`
+	Kind         string                    `json:"kind"`
+	Changes      []SemanticMutationChange  `json:"changes"`
+	Commit       *SemanticCommitDescriptor `json:"commit,omitempty"`
 }
 
-// SemanticMutationEntry is one canonical coordinate-to-target binding.
-type SemanticMutationEntry struct {
-	Path       string  `json:"path,omitempty"`
-	Index      *uint64 `json:"index,omitempty"`
-	Target     string  `json:"target"`
-	TargetKind string  `json:"target_kind,omitempty"`
+// SemanticMutationChange is one canonical coordinate transition.
+type SemanticMutationChange struct {
+	Path   string                  `json:"path,omitempty"`
+	Index  *uint64                 `json:"index,omitempty"`
+	Before *SemanticMutationTarget `json:"before,omitempty"`
+	After  *SemanticMutationTarget `json:"after,omitempty"`
+}
+
+// SemanticMutationTarget is a typed mutation target CID.
+type SemanticMutationTarget struct {
+	Target     string `json:"target"`
+	TargetKind string `json:"target_kind,omitempty"`
+}
+
+// SemanticCommitDescriptor records the commit profile for a delta.
+type SemanticCommitDescriptor struct {
+	FixedList *SemanticFixedListCommit `json:"fixed_list,omitempty"`
+}
+
+// SemanticFixedListCommit describes a measured fixed-width list commit.
+type SemanticFixedListCommit struct {
+	TotalSize uint64 `json:"total_size"`
+	ChunkSize uint64 `json:"chunk_size"`
 }
 
 // SemanticMutationResponse returns a gateway materialization receipt.
@@ -46,7 +65,7 @@ type SemanticMutationResponse struct {
 	BaseRoot        string `json:"base_root"`
 	NewRoot         string `json:"new_root"`
 	ResultRoot      string `json:"result_root,omitempty"`
-	PutCount        int    `json:"put_count"`
+	DeltaCount      int    `json:"delta_count"`
 	ArcCount        int    `json:"arc_count"`
 	MALTObjectCount int    `json:"malt_object_count,omitempty"`
 	MapCount        int    `json:"map_count,omitempty"`

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -211,7 +211,7 @@ func (s *Server) handleSemanticMutation(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	mut, err := semanticMutationFromRequest(baseRoot, req.Puts)
+	mut, err := semanticMutationFromRequest(baseRoot, req.Deltas)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -227,11 +227,11 @@ func (s *Server) handleSemanticMutation(w http.ResponseWriter, r *http.Request) 
 		BaseRoot:        receipt.BaseRoot.String(),
 		NewRoot:         receipt.NewRoot.String(),
 		ResultRoot:      receipt.NewRoot.String(),
-		PutCount:        receipt.PutCount,
+		DeltaCount:      receipt.DeltaCount,
 		ArcCount:        receipt.ArcCount,
-		MALTObjectCount: receipt.PutCount,
-		MapCount:        countSemanticPuts(mut.Puts, arcset.KindMap),
-		ListCount:       countSemanticPuts(mut.Puts, arcset.KindList),
+		MALTObjectCount: receipt.DeltaCount,
+		MapCount:        countSemanticDeltas(mut.Deltas, arcset.KindMap),
+		ListCount:       countSemanticDeltas(mut.Deltas, arcset.KindList),
 	})
 }
 
@@ -835,24 +835,24 @@ func semanticMutationFromUnixFSPlan(plan *unixfs.MutationPlan, fallbackRoot cid.
 
 	mut := gateway.SemanticMutation{
 		BaseRoot: baseRoot,
-		Puts:     make([]gateway.ArcSetPut, 0, len(plan.Puts)),
+		Deltas:   make([]gateway.ArcSetDelta, 0, len(plan.Deltas)),
 	}
-	for _, put := range plan.Puts {
+	for _, delta := range plan.Deltas {
 		// UnixFS replay rematerializes deterministic roots; do not treat the
 		// already-materialized object as a versioned ArcTable parent.
-		gatewayPut := gateway.ArcSetPut{
-			Object:       cid.Undef,
-			ExpectedRoot: put.ExpectedRoot,
-			Kind:         put.Kind,
-			ArcSet:       put.ArcSet,
+		gatewayDelta := gateway.ArcSetDelta{
+			Object:       delta.Object,
+			ExpectedRoot: delta.ExpectedRoot,
+			Kind:         delta.Kind,
+			Changes:      delta.Changes,
 		}
-		if put.FixedList != nil {
-			gatewayPut.Commit.FixedList = &gateway.FixedListCommit{
-				TotalSize: put.FixedList.TotalSize,
-				ChunkSize: put.FixedList.ChunkSize,
+		if delta.FixedList != nil {
+			gatewayDelta.Commit.FixedList = &gateway.FixedListCommit{
+				TotalSize: delta.FixedList.TotalSize,
+				ChunkSize: delta.FixedList.ChunkSize,
 			}
 		}
-		mut.Puts = append(mut.Puts, gatewayPut)
+		mut.Deltas = append(mut.Deltas, gatewayDelta)
 	}
 	return mut
 }
@@ -1197,96 +1197,123 @@ func parseArcMap(raw map[string]string) (map[string]cid.Cid, error) {
 	return out, nil
 }
 
-func semanticMutationFromRequest(baseRoot cid.Cid, putRequests []httpapi.SemanticMutationPut) (gateway.SemanticMutation, error) {
-	puts := make([]gateway.ArcSetPut, 0, len(putRequests))
-	for i, putReq := range putRequests {
-		put, err := semanticPutFromRequest(putReq)
+func semanticMutationFromRequest(baseRoot cid.Cid, deltaRequests []httpapi.SemanticMutationDelta) (gateway.SemanticMutation, error) {
+	deltas := make([]gateway.ArcSetDelta, 0, len(deltaRequests))
+	for i, deltaReq := range deltaRequests {
+		delta, err := semanticDeltaFromRequest(deltaReq)
 		if err != nil {
-			return gateway.SemanticMutation{}, fmt.Errorf("put %d: %w", i, err)
+			return gateway.SemanticMutation{}, fmt.Errorf("delta %d: %w", i, err)
 		}
-		puts = append(puts, put)
+		deltas = append(deltas, delta)
 	}
 
 	return gateway.SemanticMutation{
 		BaseRoot: baseRoot,
-		Puts:     puts,
+		Deltas:   deltas,
 	}, nil
 }
 
-func semanticPutFromRequest(req httpapi.SemanticMutationPut) (gateway.ArcSetPut, error) {
+func semanticDeltaFromRequest(req httpapi.SemanticMutationDelta) (gateway.ArcSetDelta, error) {
 	object := cid.Undef
 	if req.Object != "" {
 		parsed, err := decodeCID(req.Object)
 		if err != nil {
-			return gateway.ArcSetPut{}, fmt.Errorf("invalid object: %w", err)
+			return gateway.ArcSetDelta{}, fmt.Errorf("invalid object: %w", err)
 		}
 		object = parsed
 	}
+	expectedRoot := cid.Undef
+	if req.ExpectedRoot != "" {
+		parsed, err := decodeCID(req.ExpectedRoot)
+		if err != nil {
+			return gateway.ArcSetDelta{}, fmt.Errorf("invalid expected root: %w", err)
+		}
+		expectedRoot = parsed
+	}
 
 	kind := arcset.Kind(req.Kind)
-	entries := make([]arcset.ArcEntry, 0, len(req.Entries))
-	for i, entryReq := range req.Entries {
-		entry, err := semanticEntryFromRequest(kind, entryReq)
+	changes := make([]arcset.ArcChange, 0, len(req.Changes))
+	for i, changeReq := range req.Changes {
+		change, err := semanticChangeFromRequest(kind, changeReq)
 		if err != nil {
-			return gateway.ArcSetPut{}, fmt.Errorf("entry %d: %w", i, err)
+			return gateway.ArcSetDelta{}, fmt.Errorf("change %d: %w", i, err)
 		}
-		entries = append(entries, entry)
+		changes = append(changes, change)
 	}
 
-	set, err := arcset.NewCanonicalArcSet(kind, entries)
+	delta, err := arcset.NewCanonicalArcDelta(kind, changes)
 	if err != nil {
-		return gateway.ArcSetPut{}, err
+		return gateway.ArcSetDelta{}, err
 	}
-	return gateway.ArcSetPut{
-		Object: object,
-		Kind:   kind,
-		ArcSet: set,
-	}, nil
+	out := gateway.ArcSetDelta{
+		Object:       object,
+		ExpectedRoot: expectedRoot,
+		Kind:         kind,
+		Changes:      delta,
+	}
+	if req.Commit != nil && req.Commit.FixedList != nil {
+		out.Commit.FixedList = &gateway.FixedListCommit{
+			TotalSize: req.Commit.FixedList.TotalSize,
+			ChunkSize: req.Commit.FixedList.ChunkSize,
+		}
+	}
+	return out, nil
 }
 
-func semanticEntryFromRequest(kind arcset.Kind, req httpapi.SemanticMutationEntry) (arcset.ArcEntry, error) {
-	target, err := decodeCID(req.Target)
-	if err != nil {
-		return arcset.ArcEntry{}, fmt.Errorf("invalid target: %w", err)
-	}
-
-	targetRef, err := semanticTargetRef(req.TargetKind, target)
-	if err != nil {
-		return arcset.ArcEntry{}, err
-	}
-
+func semanticChangeFromRequest(kind arcset.Kind, req httpapi.SemanticMutationChange) (arcset.ArcChange, error) {
 	var coord arcset.CanonicalCoordinate
+	var err error
 	switch kind {
 	case arcset.KindMap:
 		if req.Path == "" {
-			return arcset.ArcEntry{}, fmt.Errorf("path is required for map entries")
+			return arcset.ArcChange{}, fmt.Errorf("path is required for map changes")
 		}
 		coord, err = arcset.NewMapCoordinate(req.Path)
 	case arcset.KindList:
 		if req.Index == nil {
-			return arcset.ArcEntry{}, fmt.Errorf("index is required for list entries")
+			return arcset.ArcChange{}, fmt.Errorf("index is required for list changes")
 		}
 		if *req.Index > uint64(1<<63-1) {
-			return arcset.ArcEntry{}, fmt.Errorf("index is too large")
+			return arcset.ArcChange{}, fmt.Errorf("index is too large")
 		}
 		coord, err = arcset.NewListCoordinate(int64(*req.Index))
 	default:
-		return arcset.ArcEntry{}, fmt.Errorf("%w: %q", arcset.ErrInvalidKind, kind)
+		return arcset.ArcChange{}, fmt.Errorf("%w: %q", arcset.ErrInvalidKind, kind)
 	}
 	if err != nil {
-		return arcset.ArcEntry{}, err
+		return arcset.ArcChange{}, err
 	}
 
-	return arcset.ArcEntry{
-		Coordinate: coord,
-		Target:     targetRef,
-	}, nil
+	change := arcset.ArcChange{Coordinate: coord}
+	if req.Before != nil {
+		before, err := semanticTargetFromRequest(*req.Before)
+		if err != nil {
+			return arcset.ArcChange{}, fmt.Errorf("before: %w", err)
+		}
+		change.Before = &before
+	}
+	if req.After != nil {
+		after, err := semanticTargetFromRequest(*req.After)
+		if err != nil {
+			return arcset.ArcChange{}, fmt.Errorf("after: %w", err)
+		}
+		change.After = &after
+	}
+	return change, nil
 }
 
-func countSemanticPuts(puts []gateway.ArcSetPut, kind arcset.Kind) int {
+func semanticTargetFromRequest(req httpapi.SemanticMutationTarget) (arcset.TargetRef, error) {
+	target, err := decodeCID(req.Target)
+	if err != nil {
+		return arcset.TargetRef{}, fmt.Errorf("invalid target: %w", err)
+	}
+	return semanticTargetRef(req.TargetKind, target)
+}
+
+func countSemanticDeltas(deltas []gateway.ArcSetDelta, kind arcset.Kind) int {
 	count := 0
-	for _, put := range puts {
-		if put.Kind == kind {
+	for _, delta := range deltas {
+		if delta.Kind == kind {
 			count++
 		}
 	}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -802,6 +802,16 @@ func (s *Server) prepareUnixFSRoot(ctx context.Context, g *graph.Graph, layout *
 }
 
 func (s *Server) applyUnixFSLayoutMutation(ctx context.Context, g *graph.Graph, layout *unixfs.Layout, oldRoot cid.Cid, newRoot cid.Cid) (gateway.WriteReceipt, error) {
+	if oldRoot.Defined() && oldRoot.Equals(newRoot) {
+		if codec.SemanticKindOf(newRoot) != codec.SemanticKindMap {
+			return gateway.WriteReceipt{}, fmt.Errorf("unixfs mutation result must be a map current root")
+		}
+		return gateway.WriteReceipt{
+			BaseRoot: oldRoot,
+			NewRoot:  newRoot,
+		}, nil
+	}
+
 	plan, err := layout.MutationPlanForRoot(ctx, oldRoot, newRoot)
 	if err != nil {
 		return gateway.WriteReceipt{}, err

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1374,6 +1374,63 @@ func TestServerUnixFSWritesPublishGatewayReadableRoot(t *testing.T) {
 	}
 }
 
+func TestServerUnixFSIdempotentFileWriteReturnsSameRoot(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"dummy": fakeCIDString("dummy")}),
+	})
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create structure status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+
+	body := []byte("stable contents")
+	resp, err = http.Post(ts.URL+"/"+createResp.Root+"/docs/readme.txt", "application/octet-stream", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("initial unixfs write failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("initial unixfs write status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var firstWrite httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&firstWrite); err != nil {
+		t.Fatalf("decode initial write response: %v", err)
+	}
+	resp.Body.Close()
+
+	resp, err = http.Post(ts.URL+"/"+firstWrite.NewRoot+"/docs/readme.txt", "application/octet-stream", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("idempotent unixfs write failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		errorBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("idempotent unixfs write status = %d, want %d: %s", resp.StatusCode, http.StatusCreated, string(errorBody))
+	}
+	var secondWrite httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&secondWrite); err != nil {
+		t.Fatalf("decode idempotent write response: %v", err)
+	}
+	if secondWrite.NewRoot != firstWrite.NewRoot {
+		t.Fatalf("idempotent write root = %q, want same root %q", secondWrite.NewRoot, firstWrite.NewRoot)
+	}
+	if secondWrite.ArcCount != 0 {
+		t.Fatalf("idempotent write arc_count = %d, want 0", secondWrite.ArcCount)
+	}
+}
+
 func TestServerResolveHeadAndReadShareUnixFSDirectoryTarget(t *testing.T) {
 	node := newTestNode(t)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1017,12 +1017,20 @@ func TestServerSemanticMutationUpdatesRoot(t *testing.T) {
 	nextPayload := fakeCIDString("next-payload")
 	nextName := fakeCIDString("next-name")
 	mutationBody, _ := json.Marshal(&httpapi.SemanticMutationRequest{
-		Puts: []httpapi.SemanticMutationPut{{
+		Deltas: []httpapi.SemanticMutationDelta{{
 			Object: createResp.Root,
 			Kind:   "map",
-			Entries: []httpapi.SemanticMutationEntry{
-				{Path: "@payload", Target: nextPayload},
-				{Path: "name", Target: nextName},
+			Changes: []httpapi.SemanticMutationChange{
+				{
+					Path:   "@payload",
+					Before: &httpapi.SemanticMutationTarget{Target: initialPayload},
+					After:  &httpapi.SemanticMutationTarget{Target: nextPayload},
+				},
+				{
+					Path:   "name",
+					Before: &httpapi.SemanticMutationTarget{Target: fakeCIDString("initial-name")},
+					After:  &httpapi.SemanticMutationTarget{Target: nextName},
+				},
 			},
 		}},
 	})
@@ -1044,8 +1052,8 @@ func TestServerSemanticMutationUpdatesRoot(t *testing.T) {
 	if mutationResp.NewRoot == "" || mutationResp.NewRoot == createResp.Root {
 		t.Fatalf("new_root = %q, want a new defined root", mutationResp.NewRoot)
 	}
-	if mutationResp.PutCount != 1 || mutationResp.ArcCount != 2 {
-		t.Fatalf("receipt counts = puts %d arcs %d, want 1/2", mutationResp.PutCount, mutationResp.ArcCount)
+	if mutationResp.DeltaCount != 1 || mutationResp.ArcCount != 2 {
+		t.Fatalf("receipt counts = deltas %d arcs %d, want 1/2", mutationResp.DeltaCount, mutationResp.ArcCount)
 	}
 	requireNoKVPrefix(t, node, "lineage:")
 	requireNoKVPrefix(t, node, "children:")
@@ -1091,25 +1099,26 @@ func TestServerSemanticMutationRejectsInvalidRoot(t *testing.T) {
 		{
 			name: "list only root",
 			req: httpapi.SemanticMutationRequest{
-				Puts: []httpapi.SemanticMutationPut{{
+				Deltas: []httpapi.SemanticMutationDelta{{
 					Object: createResp.Root,
 					Kind:   "list",
-					Entries: []httpapi.SemanticMutationEntry{{
-						Index:  &index,
-						Target: fakeCIDString("chunk"),
+					Changes: []httpapi.SemanticMutationChange{{
+						Index: &index,
+						After: &httpapi.SemanticMutationTarget{Target: fakeCIDString("chunk")},
 					}},
 				}},
 			},
 		},
 		{
-			name: "map missing payload",
+			name: "map old value mismatch",
 			req: httpapi.SemanticMutationRequest{
-				Puts: []httpapi.SemanticMutationPut{{
+				Deltas: []httpapi.SemanticMutationDelta{{
 					Object: createResp.Root,
 					Kind:   "map",
-					Entries: []httpapi.SemanticMutationEntry{{
+					Changes: []httpapi.SemanticMutationChange{{
 						Path:   "name",
-						Target: fakeCIDString("next-name"),
+						Before: &httpapi.SemanticMutationTarget{Target: fakeCIDString("wrong-old-name")},
+						After:  &httpapi.SemanticMutationTarget{Target: fakeCIDString("next-name")},
 					}},
 				}},
 			},
@@ -1128,6 +1137,45 @@ func TestServerSemanticMutationRejectsInvalidRoot(t *testing.T) {
 				t.Fatalf("semantic mutation status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
 			}
 		})
+	}
+}
+
+func TestServerSemanticMutationRejectsLegacyPuts(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBody, _ := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"name": fakeCIDString("initial-name")}),
+	})
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create structure request failed: %v", err)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"puts": []map[string]any{{
+			"object": createResp.Root,
+			"kind":   "map",
+			"entries": []map[string]string{{
+				"path":   "name",
+				"target": fakeCIDString("next-name"),
+			}},
+		}},
+	})
+	resp, err = http.Post(ts.URL+"/"+createResp.Root+"/_mutate", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("legacy puts mutation request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("legacy puts status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
 	}
 }
 
@@ -1157,12 +1205,20 @@ func TestServerRootSemanticMutationMaterializesWithoutPublishingRoot(t *testing.
 
 	nextName := fakeCIDString("root-next-name")
 	mutationBody, _ := json.Marshal(map[string]any{
-		"puts": []map[string]any{{
+		"deltas": []map[string]any{{
 			"object": createResp.Root,
 			"kind":   "map",
-			"entries": []map[string]string{
-				{"path": "@payload", "target": fakeCIDString("root-next-payload")},
-				{"path": "name", "target": nextName},
+			"changes": []map[string]any{
+				{
+					"path":   "@payload",
+					"before": map[string]string{"target": fakeCIDString("payload")},
+					"after":  map[string]string{"target": fakeCIDString("root-next-payload")},
+				},
+				{
+					"path":   "name",
+					"before": map[string]string{"target": fakeCIDString("initial-name")},
+					"after":  map[string]string{"target": nextName},
+				},
 			},
 		}},
 	})


### PR DESCRIPTION
## Summary
- replace gateway full arcset puts with canonical before/after arc deltas
- update HTTP mutation requests, client tests, CLI staging, and UnixFS mutation plans to use deltas
- add fixed measured-list append support so append deltas can reuse existing list roots across growth boundaries

## Tests
- env GOCACHE=/tmp/go-build-cache go test ./...
- git diff --check

Stacked on #70 (codex/one-time/feature/measured-list-range).