### PR TITLE
fix: create fixed lists for large adds

### DIFF
--- a/cmd/malt/add.go
+++ b/cmd/malt/add.go
@@ -1069,7 +1069,7 @@ func stageSingleFile(ctx context.Context, root *addNode, casClient addCASClient,
 		}
 		key = blockCID
 	} else {
-		listRoot, err := uploadAsList(ctx, casClient, daemon, localPath)
+		listRoot, err := uploadAsList(ctx, casClient, daemon, localPath, uint64(info.Size()))
 		if err != nil {
 			return 0, 0, err
 		}
@@ -1083,7 +1083,7 @@ func stageSingleFile(ctx context.Context, root *addNode, casClient addCASClient,
 	return info.Size(), listObjects, nil
 }
 
-func uploadAsList(ctx context.Context, casClient addCASClient, daemon *daemonclient.Client, localPath string) (cid.Cid, error) {
+func uploadAsList(ctx context.Context, casClient addCASClient, daemon *daemonclient.Client, localPath string, totalSize uint64) (cid.Cid, error) {
 	chunks, err := uploadFlatChunks(ctx, casClient, localPath)
 	if err != nil {
 		return cid.Undef, err
@@ -1112,6 +1112,12 @@ func uploadAsList(ctx context.Context, casClient addCASClient, daemon *daemoncli
 		Deltas: []httpapi.SemanticMutationDelta{{
 			Kind:    "list",
 			Changes: changes,
+			Commit: &httpapi.SemanticCommitDescriptor{
+				FixedList: &httpapi.SemanticFixedListCommit{
+					TotalSize: totalSize,
+					ChunkSize: addFixedChunkSize,
+				},
+			},
 		}},
 	})
 	if err != nil {

--- a/cmd/malt/add_test.go
+++ b/cmd/malt/add_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -797,19 +798,25 @@ func TestAddInputsWithUnixFSLargeFileThroughStaging(t *testing.T) {
 		t.Fatal("large body mismatch")
 	}
 
-	rangeBody, status, headers, err := daemon.GetContent(ctx, result.NewRoot, base+"/large.bin", "bytes=262142-262145")
+	rangeStart := addFixedChunkSize - 2
+	rangeEndExclusive := addFixedChunkSize + 2
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", rangeStart, rangeEndExclusive-1)
+	rangeBody, status, headers, err := daemon.GetContent(ctx, result.NewRoot, base+"/large.bin", rangeHeader)
 	if err != nil {
 		t.Fatalf("get large range: %v", err)
 	}
 	if status != http.StatusPartialContent {
 		t.Fatalf("large range status = %d, want %d", status, http.StatusPartialContent)
 	}
-	if string(rangeBody) != string(large[262142:262146]) {
-		t.Fatalf("large range body = %q, want %q", rangeBody, large[262142:262146])
+	if string(rangeBody) != string(large[rangeStart:rangeEndExclusive]) {
+		t.Fatalf("large range body = %q, want %q", rangeBody, large[rangeStart:rangeEndExclusive])
 	}
 	pl, err := daemonclient.ProofListFromHeaders(headers)
 	if err != nil {
 		t.Fatalf("large range prooflist: %v", err)
+	}
+	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
+		t.Fatalf("large range prooflist shape: %v", err)
 	}
 	hasRangeStep := false
 	for _, step := range pl.Steps {

--- a/cmd/malt/add_test.go
+++ b/cmd/malt/add_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/dewebprotocol/malt/core/cas/ipfs"
 	casmock "github.com/dewebprotocol/malt/core/cas/mock"
 	"github.com/dewebprotocol/malt/core/codec"
+	"github.com/dewebprotocol/malt/core/types/prooflist"
 	"github.com/dewebprotocol/malt/server"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -793,6 +795,31 @@ func TestAddInputsWithUnixFSLargeFileThroughStaging(t *testing.T) {
 	}
 	if len(body) != len(large) || string(body[:64]) != string(large[:64]) {
 		t.Fatal("large body mismatch")
+	}
+
+	rangeBody, status, headers, err := daemon.GetContent(ctx, result.NewRoot, base+"/large.bin", "bytes=262142-262145")
+	if err != nil {
+		t.Fatalf("get large range: %v", err)
+	}
+	if status != http.StatusPartialContent {
+		t.Fatalf("large range status = %d, want %d", status, http.StatusPartialContent)
+	}
+	if string(rangeBody) != string(large[262142:262146]) {
+		t.Fatalf("large range body = %q, want %q", rangeBody, large[262142:262146])
+	}
+	pl, err := daemonclient.ProofListFromHeaders(headers)
+	if err != nil {
+		t.Fatalf("large range prooflist: %v", err)
+	}
+	hasRangeStep := false
+	for _, step := range pl.Steps {
+		if step.Kind == prooflist.KindListRange {
+			hasRangeStep = true
+			break
+		}
+	}
+	if !hasRangeStep {
+		t.Fatalf("large range ProofList is missing list_range step: %+v", pl.Steps)
 	}
 }
 


### PR DESCRIPTION
## Summary

- route staged `malt add` large-file list creation through fixed-list commit metadata
- keep the CLI large-file path aligned with measured-list range ProofList evidence
- add a regression test for range GET returning a `list_range` step after `malt add`

## Test Plan

- `env GOCACHE=/tmp/go-build-cache go test ./cmd/malt -run TestAddInputsWithUnixFSLargeFileThroughStaging -count=1`
- `env GOCACHE=/tmp/go-build-cache go test ./cmd/malt`
- `env GOCACHE=/tmp/go-build-cache go test ./core/gateway ./core/layout/malt/unixfs ./core/structure/list/tree ./server`
- `git diff --check`
- `env GOCACHE=/tmp/go-build-cache go test ./...`
