### PR TITLE
docs: align implementation docs with MIPs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,11 @@ This repository contains the Go implementation of MALT:
   owns the list/map semantic definitions.
 - explicit resolution is a compatibility layer above map reads.
 - list semantics use first-class index reads and logical range reads over index
-  intervals. The target range verifier model composes file-layout metadata
-  proof with per-index list proofs; the current prototype emits path/`@payload`
-  proof plus per-index list proofs, while explicit `@size`/`@chunksize`
-  metadata proof and body/range binding remain ProofList-schema TODOs. List
-  semantics use append/replace/truncate writes, not path resolution.
+  intervals. Current range evidence uses path/`@payload` proof plus one
+  measured-list `list_range` step carrying authenticated fixed chunk metadata,
+  segment CIDs, and metadata/index proof payload; response-body range binding
+  remains a ProofList-schema TODO. List semantics use
+  append/replace/truncate writes, not path resolution.
 - every map semantic object carries reserved `@payload` as its terminal materialization binding.
 - layouts translate source-domain data into MALT semantic mutations.
 - the server executes resolver/writer ports; reads return `result + ProofList`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -353,7 +353,8 @@ The current interface exposes:
 This already approximates the target list semantic shape:
 
 - `Prove` is the list read path for index queries
-- first-class `Range` proof support remains a TODO for file range workloads
+- optional `MeasuredSemantics` exposes `ProveRange` and `VerifyRange` for
+  byte-addressable fixed-chunk lists
 - `Verify` validates read proof
 - `Append`, `Replace`, and `Truncate` are list write operations
 
@@ -455,8 +456,8 @@ Current boundary:
   remain runtime and compatibility adapters rather than semantic owners.
 - The current writer semantic-mutation and `ProofList` schemas are
   implemented. Paper-facing formalization, write metadata semantics,
-  graph-node terminology, and benchmark-facing proof reporting remain open TODO
-  items.
+  graph-node terminology, and benchmark-facing proof reporting remain tracked
+  as proposal-stage MIPs in the sibling documents repository.
 - Graph manager metadata is limited to lifecycle and runtime profile
   compatibility. It does not store an authoritative current root or publish
   freshness. The current daemon path creates an ad hoc default `Graph` through
@@ -479,7 +480,7 @@ Metrics:
 - proof size
 - write amplification
 
-Open TODOs for the next discussion:
+Open proposal-stage MIPs for the next discussion:
 
 - define graph node and arc terminology precisely enough to map onto current
   map/list semantics

--- a/README.md
+++ b/README.md
@@ -291,7 +291,8 @@ Current boundary:
   `core/resolver` the semantic owners.
 - Graph-level node/arc terminology, paper-facing formalization of writer
   semantic mutations and `ProofList` schemas, write receipt semantics, and
-  benchmark-facing proof reporting remain explicit TODO items.
+  benchmark-facing proof reporting remain proposal-stage MIPs in the sibling
+  documents repository.
 
 ## CAS Boundary
 


### PR DESCRIPTION
## Summary
- update implementation docs to describe the current measured-list list_range range-evidence model
- replace stale implementation TODO wording with proposal-stage MIP terminology
- align AGENTS guidance with the current ProofList/range evidence description

## Verification
- git diff --check
- targeted rg scans for stale gateway/range/TODO wording in implementation Markdown