### PR TITLE
fix: stabilize eval suite records

### DIFF
--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -368,7 +368,14 @@ func repoIdentityParts(repoURL string) (string, string) {
 		}
 	}
 	if parsed, err := url.Parse(trimmed); err == nil && parsed.Scheme != "" {
-		return parsed.Host, parsed.Path
+		path := parsed.Path
+		if path == "" && strings.EqualFold(parsed.Scheme, "file") {
+			path = parsed.Opaque
+		}
+		if unescaped, err := url.PathUnescape(path); err == nil {
+			path = unescaped
+		}
+		return parsed.Host, path
 	}
 	return "", trimmed
 }

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -173,10 +173,12 @@ func TestCacheNameForURLIncludesFullRepositoryIdentity(t *testing.T) {
 
 func TestCanonicalRepoIDFromURLUsesOwnerAndRepo(t *testing.T) {
 	cases := map[string]string{
-		"https://github.com/ipfs/kubo.git":                "github.com/ipfs/kubo",
-		"git@github.com:ethereum/go-ethereum.git":         "github.com/ethereum/go-ethereum",
-		"file:///tmp/eval/repos/github.com/fork/kubo.git": "github.com/fork/kubo",
-		"https://gitlab.com/group/subgroup/project.git":   "gitlab.com/group/subgroup/project",
+		"https://github.com/ipfs/kubo.git":                                                          "github.com/ipfs/kubo",
+		"git@github.com:ethereum/go-ethereum.git":                                                   "github.com/ethereum/go-ethereum",
+		"file:///tmp/eval/repos/github.com/fork/kubo.git":                                           "github.com/fork/kubo",
+		"file:/c:%5cusers%5cadmini~1%5cappdata%5clocal%5ctemp%5c001%5cgithub.com%5cipfs%5ckubo.git": "github.com/ipfs/kubo",
+		"file:C:%5cUsers%5cAdmini~1%5cAppData%5cLocal%5cTemp%5c001%5cgithub.com%5cipfs%5ckubo.git":  "github.com/ipfs/kubo",
+		"https://gitlab.com/group/subgroup/project.git":                                             "gitlab.com/group/subgroup/project",
 	}
 	for raw, want := range cases {
 		got, err := gittrace.CanonicalRepoIDFromURL(raw)

--- a/cmd/eval/internal/eval/readbench/baseline.go
+++ b/cmd/eval/internal/eval/readbench/baseline.go
@@ -110,7 +110,7 @@ func (b *baselineSystem) measureOperation(ctx context.Context, iteration int, fi
 	default:
 		return nil, fmt.Errorf("unsupported operation kind %q", op.kind)
 	}
-	elapsed := time.Since(start).Nanoseconds()
+	elapsed := positiveElapsedNS(start, time.Now())
 	casStats := b.store.SnapshotStats()
 
 	return &Result{

--- a/cmd/eval/internal/eval/readbench/runner.go
+++ b/cmd/eval/internal/eval/readbench/runner.go
@@ -253,7 +253,7 @@ func (r *Runner) measureOperation(ctx context.Context, iteration int, fixture st
 	default:
 		return nil, fmt.Errorf("unsupported operation kind %q", op.kind)
 	}
-	elapsed := time.Since(start).Nanoseconds()
+	elapsed := positiveElapsedNS(start, time.Now())
 
 	snapshot, err := r.metricsSnapshot(ctx)
 	if err != nil {
@@ -276,6 +276,14 @@ func (r *Runner) measureOperation(ctx context.Context, iteration int, fixture st
 		ArcTable:           snapshot.ArcTable,
 		Proof:              snapshot.Proof,
 	}, nil
+}
+
+func positiveElapsedNS(start, end time.Time) int64 {
+	elapsed := end.Sub(start).Nanoseconds()
+	if elapsed <= 0 {
+		return 1
+	}
+	return elapsed
 }
 
 func (r *Runner) resetMetrics(ctx context.Context) error {

--- a/cmd/eval/internal/eval/readbench/runner_test.go
+++ b/cmd/eval/internal/eval/readbench/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dewebprotocol/malt/api/http"
 	"github.com/dewebprotocol/malt/config"
@@ -335,6 +336,13 @@ func TestRunJSONLEmitsUnixFSBaselines(t *testing.T) {
 		if result.ContentBytes == nil || *result.ContentBytes != 13 {
 			t.Fatalf("%s content bytes = %v, want 13", result.System, result.ContentBytes)
 		}
+	}
+}
+
+func TestPositiveElapsedNSClampsSameTickMeasurement(t *testing.T) {
+	now := time.Now()
+	if got := positiveElapsedNS(now, now); got != 1 {
+		t.Fatalf("positiveElapsedNS(same tick) = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
Fixes eval suite platform flakes: canonicalizes opaque Windows file URLs when deriving write-trace repo IDs, and clamps same-tick readbench operation timings to 1ns so executed records do not serialize elapsed_ns as zero. Verification: env GOCACHE=/tmp/go-build-cache go test ./...