### PR TITLE
refactor: split eval run outputs

### DIFF
--- a/cmd/eval/helper/evalrun/command.go
+++ b/cmd/eval/helper/evalrun/command.go
@@ -14,6 +14,7 @@ const PlanSchemaPath = "cmd/eval/schemas/run-plan.schema.json"
 type options struct {
 	planPath  string
 	outputDir string
+	resultDir string
 	runID     string
 }
 
@@ -22,7 +23,7 @@ func NewCommand(registry framework.Registry) *cobra.Command {
 	opts := &options{}
 	cmd := &cobra.Command{
 		Use:         "run",
-		Short:       "Run an evaluation plan and write a structured result directory",
+		Short:       "Run an evaluation plan and write structured result/work directories",
 		Args:        cobra.NoArgs,
 		Annotations: map[string]string{"malt.plan_schema": PlanSchemaPath},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -30,7 +31,9 @@ func NewCommand(registry framework.Registry) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.planPath, "plan", opts.planPath, "Evaluation plan JSON file")
-	cmd.Flags().StringVar(&opts.outputDir, "out", opts.outputDir, "Override output directory")
+	cmd.Flags().StringVar(&opts.resultDir, "out", opts.resultDir, "Override result directory")
+	cmd.Flags().StringVar(&opts.resultDir, "result-dir", opts.resultDir, "Override result directory")
+	cmd.Flags().StringVar(&opts.outputDir, "output-dir", opts.outputDir, "Override disposable output workspace directory")
 	cmd.Flags().StringVar(&opts.runID, "run-id", opts.runID, "Override run identifier")
 	return cmd
 }
@@ -48,6 +51,9 @@ func run(cmd *cobra.Command, registry framework.Registry, opts *options) error {
 	}
 	if strings.TrimSpace(opts.outputDir) != "" {
 		plan.OverrideOutputDir(opts.outputDir)
+	}
+	if strings.TrimSpace(opts.resultDir) != "" {
+		plan.OverrideResultDir(opts.resultDir)
 	}
 	if strings.TrimSpace(opts.runID) != "" {
 		plan.OverrideRunID(opts.runID)

--- a/cmd/eval/helper/evalrun/command_test.go
+++ b/cmd/eval/helper/evalrun/command_test.go
@@ -24,15 +24,16 @@ func TestCommandRunsPlanWithOverrides(t *testing.T) {
 	if err := reg.Register(fakeSuite{}); err != nil {
 		t.Fatalf("register fake suite: %v", err)
 	}
-	outDir := filepath.Join(tmp, "out")
+	resultDir := filepath.Join(tmp, "result-out")
+	outputDir := filepath.Join(tmp, "output-work")
 	cmd := NewCommand(reg)
-	cmd.SetArgs([]string{"--plan", planPath, "--out", outDir, "--run-id", "from-flags"})
+	cmd.SetArgs([]string{"--plan", planPath, "--out", resultDir, "--output-dir", outputDir, "--run-id", "from-flags"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 
-	manifestBytes, err := os.ReadFile(filepath.Join(outDir, "manifest.json"))
+	manifestBytes, err := os.ReadFile(filepath.Join(resultDir, "manifest.json"))
 	if err != nil {
 		t.Fatalf("read manifest: %v", err)
 	}
@@ -43,12 +44,15 @@ func TestCommandRunsPlanWithOverrides(t *testing.T) {
 	if manifest.RunID != "from-flags" {
 		t.Fatalf("manifest run id = %q, want from-flags", manifest.RunID)
 	}
-	if _, err := os.Stat(filepath.Join(outDir, "raw", "fake_suite.jsonl")); err != nil {
+	if _, err := os.Stat(filepath.Join(resultDir, "raw", "fake_suite.jsonl")); err != nil {
 		t.Fatalf("raw suite output missing: %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(outputDir, "logs")); err != nil || !info.IsDir() {
+		t.Fatalf("output workspace logs dir missing, info=%v err=%v", info, err)
 	}
 }
 
-func TestCommandRunIDOverrideUpdatesDefaultOutputDir(t *testing.T) {
+func TestCommandRunIDOverrideUpdatesDefaultOutputAndResultDirs(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)
 	planPath := filepath.Join(tmp, "plan.json")
@@ -70,12 +74,19 @@ func TestCommandRunIDOverrideUpdatesDefaultOutputDir(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 
-	expected := filepath.Join(tmp, "results", "from-flags", "manifest.json")
+	expected := filepath.Join(tmp, "result", "from-flags", "manifest.json")
 	if _, err := os.Stat(expected); err != nil {
 		t.Fatalf("expected manifest at %s: %v", expected, err)
 	}
-	old := filepath.Join(tmp, "results", "from-plan", "manifest.json")
+	if _, err := os.Stat(filepath.Join(tmp, "output", "from-flags", "logs")); err != nil {
+		t.Fatalf("expected output workspace for run-id override: %v", err)
+	}
+	old := filepath.Join(tmp, "result", "from-plan", "manifest.json")
 	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Fatalf("old result path should not exist, stat err=%v", err)
+	}
+	oldOutput := filepath.Join(tmp, "output", "from-plan")
+	if _, err := os.Stat(oldOutput); !os.IsNotExist(err) {
 		t.Fatalf("old output path should not exist, stat err=%v", err)
 	}
 }

--- a/cmd/eval/helper/evalwrite/command.go
+++ b/cmd/eval/helper/evalwrite/command.go
@@ -60,7 +60,7 @@ func newCommand(use, short string) *cobra.Command {
 	cmd.Flags().StringVar(&opts.repoPath, "repo-path", opts.repoPath, "Existing local Git repository path to replay")
 	cmd.Flags().StringVar(&opts.repoRef, "repo-ref", opts.repoRef, "Git ref to replay")
 	cmd.Flags().IntVar(&opts.commitLimit, "limit", opts.commitLimit, "Maximum commits to replay; 0 means all")
-	cmd.Flags().StringVar(&opts.cacheDir, "cache-dir", opts.cacheDir, "Repository clone cache directory")
+	cmd.Flags().StringVar(&opts.cacheDir, "cache-dir", opts.cacheDir, "Managed repository clone base directory")
 	cmd.Flags().StringVar(&opts.storeDir, "store-dir", opts.storeDir, "Evaluation store directory for fs/badger backends")
 	cmd.Flags().StringVar(&opts.storeMode, "store-mode", opts.storeMode, "Store mode: isolated or shared")
 	cmd.Flags().StringVar(&opts.storeBackend, "store-backend", opts.storeBackend, "Store backend: memory, fs, or badger")
@@ -96,12 +96,12 @@ func run(cmd *cobra.Command, opts *options) error {
 
 	enc := json.NewEncoder(writer)
 	source := gittrace.Source{
-		RepoURL:     opts.repoURL,
-		RepoPath:    opts.repoPath,
-		CacheDir:    opts.cacheDir,
-		Ref:         opts.repoRef,
-		Limit:       opts.commitLimit,
-		FirstParent: opts.firstParent,
+		RepoURL:      opts.repoURL,
+		RepoPath:     opts.repoPath,
+		CloneBaseDir: opts.cacheDir,
+		Ref:          opts.repoRef,
+		Limit:        opts.commitLimit,
+		FirstParent:  opts.firstParent,
 	}
 	return source.Walk(cmd.Context(), func(commit replay.CommitMutation) error {
 		return replay.RunCommit(cmd.Context(), commit, systems, enc)

--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -17,12 +17,12 @@ import (
 
 // Source streams Git object commit snapshots as replay.CommitMutation values.
 type Source struct {
-	RepoURL     string
-	RepoPath    string
-	CacheDir    string
-	Ref         string
-	Limit       int
-	FirstParent bool
+	RepoURL      string
+	RepoPath     string
+	CloneBaseDir string
+	Ref          string
+	Limit        int
+	FirstParent  bool
 }
 
 // Walk visits commits in chronological replay order.
@@ -78,28 +78,26 @@ func (s Source) repositoryPath(ctx context.Context) (string, error) {
 	if strings.TrimSpace(s.RepoPath) != "" {
 		return filepath.Abs(s.RepoPath)
 	}
-	return EnsureClone(ctx, s.RepoURL, s.CacheDir)
+	return CloneForReplay(ctx, s.RepoURL, s.CloneBaseDir)
 }
 
-// EnsureClone returns a local clone for repoURL under cacheDir.
-func EnsureClone(ctx context.Context, repoURL, cacheDir string) (string, error) {
-	if cacheDir == "" {
-		cacheDir = filepath.Join(".eval-cache", "repos")
+// CloneForReplay creates a fresh managed clone for repoURL under baseDir.
+func CloneForReplay(ctx context.Context, repoURL, baseDir string) (string, error) {
+	if baseDir == "" {
+		baseDir = filepath.Join(".eval-cache", "repos")
 	}
-	path, err := CachePathForURL(cacheDir, repoURL)
+	path, err := ClonePathForURL(baseDir, repoURL)
 	if err != nil {
 		return "", err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return "", err
 	}
-	if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
-		if err := verifyCachedOrigin(ctx, path, repoURL); err != nil {
-			return "", err
-		}
-		return path, nil
+	if err := os.RemoveAll(path); err != nil {
+		return "", fmt.Errorf("remove stale managed clone %s: %w", path, err)
 	}
 	if err := runGit(ctx, "", "clone", repoURL, path); err != nil {
+		_ = os.RemoveAll(path)
 		return "", err
 	}
 	return path, nil
@@ -303,9 +301,9 @@ func CanonicalRepoIDFromURL(repoURL string) (string, error) {
 	return "github.com/" + repo.owner + "/" + repo.name, nil
 }
 
-// CachePathForURL returns the local clone path for a GitHub HTTPS repository
+// ClonePathForURL returns the local clone path for a GitHub HTTPS repository
 // under baseDir.
-func CachePathForURL(baseDir, repoURL string) (string, error) {
+func ClonePathForURL(baseDir, repoURL string) (string, error) {
 	repo, err := parseGitHubHTTPSRepoURL(repoURL)
 	if err != nil {
 		return "", err
@@ -342,29 +340,36 @@ func parseGitHubHTTPSRepoURL(repoURL string) (githubRepo, error) {
 	if strings.HasSuffix(name, ".git") {
 		name = name[:len(name)-len(".git")]
 	}
-	if owner == "" || name == "" || owner == "." || owner == ".." || name == "." || name == ".." {
-		return githubRepo{}, fmt.Errorf("repo URL %q must include non-empty owner and repo", repoURL)
+	if !isGitHubOwnerComponent(owner) || !isGitHubRepoComponent(name) {
+		return githubRepo{}, fmt.Errorf("repo URL %q must use safe GitHub owner and repo components", repoURL)
 	}
 	return githubRepo{owner: owner, name: name}, nil
 }
 
-func verifyCachedOrigin(ctx context.Context, path, repoURL string) error {
-	out, err := gitOutput(ctx, path, "remote", "get-url", "origin")
-	if err != nil {
-		return fmt.Errorf("verify cached origin for %s: %w", path, err)
+func isGitHubOwnerComponent(value string) bool {
+	if value == "" || len(value) > 39 || value[0] == '-' || value[len(value)-1] == '-' {
+		return false
 	}
-	got, err := CanonicalRepoIDFromURL(strings.TrimSpace(out))
-	if err != nil {
-		return fmt.Errorf("cached repo %s origin is not a GitHub HTTPS repo URL: %w", path, err)
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			continue
+		}
+		return false
 	}
-	want, err := CanonicalRepoIDFromURL(repoURL)
-	if err != nil {
-		return err
+	return true
+}
+
+func isGitHubRepoComponent(value string) bool {
+	if value == "" || value == "." || value == ".." {
+		return false
 	}
-	if got != want {
-		return fmt.Errorf("cached repo %s origin mismatch: got %q want %q", path, got, want)
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return false
 	}
-	return nil
+	return true
 }
 
 type objectSnapshot struct {

--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -309,6 +309,7 @@ func repoName(path, repoURL string) string {
 // namespace path rather than the local cache path or branch/ref name.
 func CanonicalRepoIDFromURL(repoURL string) (string, error) {
 	host, path := repoIdentityParts(repoURL)
+	path = unescapeRepoPath(path)
 	path = strings.TrimRight(strings.TrimSpace(path), `/\`)
 	if strings.HasSuffix(strings.ToLower(path), ".git") {
 		path = path[:len(path)-len(".git")]
@@ -372,12 +373,20 @@ func repoIdentityParts(repoURL string) (string, string) {
 		if path == "" && strings.EqualFold(parsed.Scheme, "file") {
 			path = parsed.Opaque
 		}
-		if unescaped, err := url.PathUnescape(path); err == nil {
-			path = unescaped
-		}
 		return parsed.Host, path
 	}
 	return "", trimmed
+}
+
+func unescapeRepoPath(path string) string {
+	for i := 0; i < 4; i++ {
+		unescaped, err := url.PathUnescape(path)
+		if err != nil || unescaped == path {
+			return path
+		}
+		path = unescaped
+	}
+	return path
 }
 
 const (

--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -4,8 +4,6 @@ package git
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"net/url"
 	"os"
@@ -85,21 +83,18 @@ func (s Source) repositoryPath(ctx context.Context) (string, error) {
 
 // EnsureClone returns a local clone for repoURL under cacheDir.
 func EnsureClone(ctx context.Context, repoURL, cacheDir string) (string, error) {
-	if strings.TrimSpace(repoURL) == "" {
-		return "", fmt.Errorf("repo URL is required")
-	}
 	if cacheDir == "" {
 		cacheDir = filepath.Join(".eval-cache", "repos")
 	}
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	path, err := CachePathForURL(cacheDir, repoURL)
+	if err != nil {
 		return "", err
 	}
-	path := filepath.Join(cacheDir, CacheNameForURL(repoURL))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return "", err
+	}
 	if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
 		if err := verifyCachedOrigin(ctx, path, repoURL); err != nil {
-			return "", err
-		}
-		if err := runGit(ctx, path, "fetch", "--prune", "origin"); err != nil {
 			return "", err
 		}
 		return path, nil
@@ -292,125 +287,65 @@ func pathDepth(path string) int {
 }
 
 func repoName(path, repoURL string) string {
-	if repoURL != "" {
-		trimmed := strings.TrimSuffix(repoURL, ".git")
-		parts := strings.FieldsFunc(trimmed, func(r rune) bool {
-			return r == '/' || r == '\\' || r == ':'
-		})
-		if len(parts) > 0 {
-			return parts[len(parts)-1]
-		}
+	if repoID, err := CanonicalRepoIDFromURL(repoURL); err == nil {
+		return repoID
 	}
 	return filepath.Base(path)
 }
 
-// CanonicalRepoIDFromURL derives the evaluation repository identity from a Git
-// URL. The identity is semantic result metadata, so it uses host plus the full
-// namespace path rather than the local cache path or branch/ref name.
+// CanonicalRepoIDFromURL derives the evaluation repository identity from a
+// GitHub HTTPS repository URL.
 func CanonicalRepoIDFromURL(repoURL string) (string, error) {
-	host, path := repoIdentityParts(repoURL)
-	path = unescapeRepoPath(path)
-	path = strings.TrimRight(strings.TrimSpace(path), `/\`)
-	if strings.HasSuffix(strings.ToLower(path), ".git") {
-		path = path[:len(path)-len(".git")]
+	repo, err := parseGitHubHTTPSRepoURL(repoURL)
+	if err != nil {
+		return "", err
 	}
-	path = strings.ReplaceAll(path, "\\", "/")
-	path = strings.Trim(path, "/")
-	if path == "" {
-		return "", fmt.Errorf("repo URL %q does not contain a repository path", repoURL)
-	}
-	filtered := nonEmptyPathParts(path)
-	if len(filtered) == 0 {
-		return "", fmt.Errorf("repo URL %q does not contain a repository path", repoURL)
-	}
-	if host = strings.ToLower(strings.TrimSpace(host)); host != "" {
-		return host + "/" + strings.ToLower(strings.Join(filtered, "/")), nil
-	}
-	if hostIndex := firstHostPathSegment(filtered); hostIndex >= 0 && hostIndex < len(filtered)-1 {
-		return strings.ToLower(strings.Join(filtered[hostIndex:], "/")), nil
-	}
-	switch {
-	case len(filtered) >= 2:
-		return strings.ToLower(filtered[len(filtered)-2] + "/" + filtered[len(filtered)-1]), nil
-	case len(filtered) == 1:
-		return strings.ToLower(filtered[0]), nil
-	default:
-		return "", fmt.Errorf("repo URL %q does not contain a repository path", repoURL)
-	}
+	return "github.com/" + repo.owner + "/" + repo.name, nil
 }
 
-func nonEmptyPathParts(path string) []string {
-	parts := strings.Split(path, "/")
-	filtered := parts[:0]
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part != "" {
-			filtered = append(filtered, part)
-		}
+// CachePathForURL returns the local clone path for a GitHub HTTPS repository
+// under baseDir.
+func CachePathForURL(baseDir, repoURL string) (string, error) {
+	repo, err := parseGitHubHTTPSRepoURL(repoURL)
+	if err != nil {
+		return "", err
 	}
-	return filtered
+	return filepath.Join(baseDir, repo.owner, repo.name), nil
 }
 
-func firstHostPathSegment(parts []string) int {
-	for i, part := range parts {
-		if strings.Contains(part, ".") {
-			return i
-		}
-	}
-	return -1
+type githubRepo struct {
+	owner string
+	name  string
 }
 
-func repoIdentityParts(repoURL string) (string, string) {
+func parseGitHubHTTPSRepoURL(repoURL string) (githubRepo, error) {
 	trimmed := strings.TrimSpace(repoURL)
-	if !strings.Contains(trimmed, "://") && strings.Contains(trimmed, "@") {
-		afterUser := strings.SplitN(trimmed, "@", 2)[1]
-		if host, path, ok := strings.Cut(afterUser, ":"); ok {
-			return host, path
-		}
+	if trimmed == "" {
+		return githubRepo{}, fmt.Errorf("repo URL is required")
 	}
-	if parsed, err := url.Parse(trimmed); err == nil && parsed.Scheme != "" {
-		path := parsed.Path
-		if path == "" && strings.EqualFold(parsed.Scheme, "file") {
-			path = parsed.Opaque
-		}
-		return parsed.Host, path
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return githubRepo{}, fmt.Errorf("parse repo URL %q: %w", repoURL, err)
 	}
-	return "", trimmed
-}
-
-func unescapeRepoPath(path string) string {
-	for i := 0; i < 4; i++ {
-		unescaped, err := url.PathUnescape(path)
-		if err != nil || unescaped == path {
-			return path
-		}
-		path = unescaped
+	if parsed.Scheme != "https" || strings.ToLower(parsed.Host) != "github.com" {
+		return githubRepo{}, fmt.Errorf("repo URL %q must be https://github.com/<owner>/<repo>", repoURL)
 	}
-	return path
-}
-
-const (
-	cacheNameHashLen = 12
-	maxCacheNameLen  = 80
-)
-
-// CacheNameForURL returns a deterministic cache directory name for a full repo URL.
-func CacheNameForURL(repoURL string) string {
-	normalized := normalizeRepoURL(repoURL)
-	sum := sha256.Sum256([]byte(normalized))
-	prefix := sanitizeCachePrefix(normalized)
-	if prefix == "" {
-		prefix = "repo"
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return githubRepo{}, fmt.Errorf("repo URL %q must not include query or fragment", repoURL)
 	}
-	hash := hex.EncodeToString(sum[:])[:cacheNameHashLen]
-	maxPrefixLen := maxCacheNameLen - cacheNameHashLen - len("-")
-	if len(prefix) > maxPrefixLen {
-		prefix = strings.Trim(prefix[:maxPrefixLen], "-")
-		if prefix == "" {
-			prefix = "repo"
-		}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 2 {
+		return githubRepo{}, fmt.Errorf("repo URL %q must be https://github.com/<owner>/<repo>", repoURL)
 	}
-	return fmt.Sprintf("%s-%s", prefix, hash)
+	owner := strings.ToLower(strings.TrimSpace(parts[0]))
+	name := strings.ToLower(strings.TrimSpace(parts[1]))
+	if strings.HasSuffix(name, ".git") {
+		name = name[:len(name)-len(".git")]
+	}
+	if owner == "" || name == "" || owner == "." || owner == ".." || name == "." || name == ".." {
+		return githubRepo{}, fmt.Errorf("repo URL %q must include non-empty owner and repo", repoURL)
+	}
+	return githubRepo{owner: owner, name: name}, nil
 }
 
 func verifyCachedOrigin(ctx context.Context, path, repoURL string) error {
@@ -418,50 +353,18 @@ func verifyCachedOrigin(ctx context.Context, path, repoURL string) error {
 	if err != nil {
 		return fmt.Errorf("verify cached origin for %s: %w", path, err)
 	}
-	got := normalizeRepoURL(strings.TrimSpace(out))
-	want := normalizeRepoURL(repoURL)
+	got, err := CanonicalRepoIDFromURL(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("cached repo %s origin is not a GitHub HTTPS repo URL: %w", path, err)
+	}
+	want, err := CanonicalRepoIDFromURL(repoURL)
+	if err != nil {
+		return err
+	}
 	if got != want {
 		return fmt.Errorf("cached repo %s origin mismatch: got %q want %q", path, got, want)
 	}
 	return nil
-}
-
-func normalizeRepoURL(repoURL string) string {
-	trimmed := strings.TrimSpace(repoURL)
-	trimmed = strings.TrimRight(trimmed, "/")
-	if strings.HasSuffix(strings.ToLower(trimmed), ".git") {
-		trimmed = trimmed[:len(trimmed)-len(".git")]
-	}
-	if !strings.Contains(trimmed, "://") && strings.Contains(trimmed, "@") {
-		afterUser := strings.SplitN(trimmed, "@", 2)[1]
-		host, path, ok := strings.Cut(afterUser, ":")
-		if ok {
-			return strings.ToLower(host) + "/" + strings.Trim(path, "/")
-		}
-	}
-	if parsed, err := url.Parse(trimmed); err == nil && parsed.Host != "" {
-		return strings.ToLower(parsed.Host) + "/" + strings.Trim(parsed.Path, "/")
-	}
-	return trimmed
-}
-
-func sanitizeCachePrefix(value string) string {
-	lowered := strings.ToLower(value)
-	var builder strings.Builder
-	lastDash := false
-	for _, r := range lowered {
-		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '_'
-		if ok {
-			builder.WriteRune(r)
-			lastDash = false
-			continue
-		}
-		if !lastDash {
-			builder.WriteByte('-')
-			lastDash = true
-		}
-	}
-	return strings.Trim(builder.String(), "-")
 }
 
 type objectSnapshot struct {

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -173,12 +173,15 @@ func TestCacheNameForURLIncludesFullRepositoryIdentity(t *testing.T) {
 
 func TestCanonicalRepoIDFromURLUsesOwnerAndRepo(t *testing.T) {
 	cases := map[string]string{
-		"https://github.com/ipfs/kubo.git":                                                          "github.com/ipfs/kubo",
-		"git@github.com:ethereum/go-ethereum.git":                                                   "github.com/ethereum/go-ethereum",
-		"file:///tmp/eval/repos/github.com/fork/kubo.git":                                           "github.com/fork/kubo",
-		"file:/c:%5cusers%5cadmini~1%5cappdata%5clocal%5ctemp%5c001%5cgithub.com%5cipfs%5ckubo.git": "github.com/ipfs/kubo",
-		"file:C:%5cUsers%5cAdmini~1%5cAppData%5cLocal%5cTemp%5c001%5cgithub.com%5cipfs%5ckubo.git":  "github.com/ipfs/kubo",
-		"https://gitlab.com/group/subgroup/project.git":                                             "gitlab.com/group/subgroup/project",
+		"https://github.com/ipfs/kubo.git":                                                                                              "github.com/ipfs/kubo",
+		"git@github.com:ethereum/go-ethereum.git":                                                                                       "github.com/ethereum/go-ethereum",
+		"file:///tmp/eval/repos/github.com/fork/kubo.git":                                                                               "github.com/fork/kubo",
+		"file:/c:%5cusers%5cadmini~1%5cappdata%5clocal%5ctemp%5c001%5cgithub.com%5cipfs%5ckubo.git":                                     "github.com/ipfs/kubo",
+		"file:/c:%5cusers%5cadmini~1%5cappdata%5clocal%5ctemp%5c001%5cgithub.com%5cipfs%5ckubo":                                         "github.com/ipfs/kubo",
+		"file:/c:%255cusers%255cadmini~1%255cappdata%255clocal%255ctemp%255c001%255cgithub.com%255cipfs%255ckubo.git":                   "github.com/ipfs/kubo",
+		"file:/c:%25255cusers%25255cadmini~1%25255cappdata%25255clocal%25255ctemp%25255c001%25255cgithub.com%25255cipfs%25255ckubo.git": "github.com/ipfs/kubo",
+		"file:C:%5cUsers%5cAdmini~1%5cAppData%5cLocal%5cTemp%5c001%5cgithub.com%5cipfs%5ckubo.git":                                      "github.com/ipfs/kubo",
+		"https://gitlab.com/group/subgroup/project.git":                                                                                 "gitlab.com/group/subgroup/project",
 	}
 	for raw, want := range cases {
 		got, err := gittrace.CanonicalRepoIDFromURL(raw)

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -163,25 +163,11 @@ func TestSourceWalkDoesNotMutateRepoPathCheckoutOnFailure(t *testing.T) {
 	}
 }
 
-func TestCacheNameForURLIncludesFullRepositoryIdentity(t *testing.T) {
-	first := gittrace.CacheNameForURL("https://github.com/orgA/project.git")
-	second := gittrace.CacheNameForURL("https://github.com/orgB/project.git")
-	if first == second {
-		t.Fatalf("cache names collide: %q", first)
-	}
-}
-
-func TestCanonicalRepoIDFromURLUsesOwnerAndRepo(t *testing.T) {
+func TestCanonicalRepoIDFromURLUsesGitHubHTTPSOwnerAndRepo(t *testing.T) {
 	cases := map[string]string{
-		"https://github.com/ipfs/kubo.git":                                                                                              "github.com/ipfs/kubo",
-		"git@github.com:ethereum/go-ethereum.git":                                                                                       "github.com/ethereum/go-ethereum",
-		"file:///tmp/eval/repos/github.com/fork/kubo.git":                                                                               "github.com/fork/kubo",
-		"file:/c:%5cusers%5cadmini~1%5cappdata%5clocal%5ctemp%5c001%5cgithub.com%5cipfs%5ckubo.git":                                     "github.com/ipfs/kubo",
-		"file:/c:%5cusers%5cadmini~1%5cappdata%5clocal%5ctemp%5c001%5cgithub.com%5cipfs%5ckubo":                                         "github.com/ipfs/kubo",
-		"file:/c:%255cusers%255cadmini~1%255cappdata%255clocal%255ctemp%255c001%255cgithub.com%255cipfs%255ckubo.git":                   "github.com/ipfs/kubo",
-		"file:/c:%25255cusers%25255cadmini~1%25255cappdata%25255clocal%25255ctemp%25255c001%25255cgithub.com%25255cipfs%25255ckubo.git": "github.com/ipfs/kubo",
-		"file:C:%5cUsers%5cAdmini~1%5cAppData%5cLocal%5cTemp%5c001%5cgithub.com%5cipfs%5ckubo.git":                                      "github.com/ipfs/kubo",
-		"https://gitlab.com/group/subgroup/project.git":                                                                                 "gitlab.com/group/subgroup/project",
+		"https://github.com/ipfs/kubo.git":        "github.com/ipfs/kubo",
+		"https://github.com/IPFS/Kubo":            "github.com/ipfs/kubo",
+		"https://github.com/ethereum/go-ethereum": "github.com/ethereum/go-ethereum",
 	}
 	for raw, want := range cases {
 		got, err := gittrace.CanonicalRepoIDFromURL(raw)
@@ -194,10 +180,31 @@ func TestCanonicalRepoIDFromURLUsesOwnerAndRepo(t *testing.T) {
 	}
 }
 
-func TestCacheNameForURLIsBoundedForLongLocalPaths(t *testing.T) {
-	name := gittrace.CacheNameForURL("C:\\" + strings.Repeat("long-path-segment\\", 20) + "project.git")
-	if len(name) > 80 {
-		t.Fatalf("cache name length = %d, want <= 80: %q", len(name), name)
+func TestCanonicalRepoIDFromURLRejectsNonGitHubHTTPSFormats(t *testing.T) {
+	for _, raw := range []string{
+		"git@github.com:ethereum/go-ethereum.git",
+		"file:///tmp/eval/repos/github.com/fork/kubo.git",
+		"file:/c:%5cusers%5cadmini~1%5cappdata%5clocal%5ctemp%5c001%5cgithub.com%5cipfs%5ckubo",
+		"http://github.com/ipfs/kubo.git",
+		"https://gitlab.com/group/project.git",
+		"https://github.com/ipfs",
+		"https://github.com/ipfs/kubo/extra",
+	} {
+		if _, err := gittrace.CanonicalRepoIDFromURL(raw); err == nil {
+			t.Fatalf("CanonicalRepoIDFromURL(%q) should reject non-GitHub HTTPS repo URL", raw)
+		}
+	}
+}
+
+func TestCachePathForURLUsesOwnerRepoUnderBasePath(t *testing.T) {
+	base := filepath.Join("tmp", "eval-cache")
+	got, err := gittrace.CachePathForURL(base, "https://github.com/ipfs/kubo.git")
+	if err != nil {
+		t.Fatalf("CachePathForURL: %v", err)
+	}
+	want := filepath.Join(base, "ipfs", "kubo")
+	if got != want {
+		t.Fatalf("cache path = %q, want %q", got, want)
 	}
 }
 
@@ -208,7 +215,10 @@ func TestEnsureCloneRejectsMismatchedExistingOrigin(t *testing.T) {
 	ctx := context.Background()
 	cacheDir := t.TempDir()
 	url := "https://github.com/orgA/project.git"
-	cachePath := filepath.Join(cacheDir, gittrace.CacheNameForURL(url))
+	cachePath, err := gittrace.CachePathForURL(cacheDir, url)
+	if err != nil {
+		t.Fatalf("CachePathForURL: %v", err)
+	}
 	if err := os.MkdirAll(cachePath, 0755); err != nil {
 		t.Fatalf("mkdir cache path: %v", err)
 	}

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -3,6 +3,7 @@ package git_test
 import (
 	"context"
 	"errors"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -189,6 +190,9 @@ func TestCanonicalRepoIDFromURLRejectsNonGitHubHTTPSFormats(t *testing.T) {
 		"https://gitlab.com/group/project.git",
 		"https://github.com/ipfs",
 		"https://github.com/ipfs/kubo/extra",
+		"https://github.com/org/..\\..\\outside.git",
+		"https://github.com/org/repo:name.git",
+		"https://github.com/-org/repo.git",
 	} {
 		if _, err := gittrace.CanonicalRepoIDFromURL(raw); err == nil {
 			t.Fatalf("CanonicalRepoIDFromURL(%q) should reject non-GitHub HTTPS repo URL", raw)
@@ -196,43 +200,97 @@ func TestCanonicalRepoIDFromURLRejectsNonGitHubHTTPSFormats(t *testing.T) {
 	}
 }
 
-func TestCachePathForURLUsesOwnerRepoUnderBasePath(t *testing.T) {
+func TestClonePathForURLUsesOwnerRepoUnderBasePath(t *testing.T) {
 	base := filepath.Join("tmp", "eval-cache")
-	got, err := gittrace.CachePathForURL(base, "https://github.com/ipfs/kubo.git")
+	got, err := gittrace.ClonePathForURL(base, "https://github.com/ipfs/kubo.git")
 	if err != nil {
-		t.Fatalf("CachePathForURL: %v", err)
+		t.Fatalf("ClonePathForURL: %v", err)
 	}
 	want := filepath.Join(base, "ipfs", "kubo")
 	if got != want {
-		t.Fatalf("cache path = %q, want %q", got, want)
+		t.Fatalf("clone path = %q, want %q", got, want)
 	}
 }
 
-func TestEnsureCloneRejectsMismatchedExistingOrigin(t *testing.T) {
+func TestSourceWalkClonesGitHubURLForReplayInWorkDir(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git binary not available")
 	}
 	ctx := context.Background()
-	cacheDir := t.TempDir()
-	url := "https://github.com/orgA/project.git"
-	cachePath, err := gittrace.CachePathForURL(cacheDir, url)
-	if err != nil {
-		t.Fatalf("CachePathForURL: %v", err)
-	}
-	if err := os.MkdirAll(cachePath, 0755); err != nil {
-		t.Fatalf("mkdir cache path: %v", err)
-	}
-	runGit(t, cachePath, "init")
-	runGit(t, cachePath, "remote", "add", "origin", "https://github.com/orgB/project.git")
+	sourceBase := filepath.Join(t.TempDir(), "github.com")
+	initTraceRepoAt(t, filepath.Join(sourceBase, "ipfs", "kubo.git"))
+	installGitHubInsteadOf(t, sourceBase)
 
-	if _, err := gittrace.EnsureClone(ctx, url, cacheDir); err == nil {
-		t.Fatal("expected mismatched origin error")
+	cacheDir := t.TempDir()
+	repoURL := "https://github.com/ipfs/kubo.git"
+	clonePath := filepath.Join(cacheDir, "ipfs", "kubo")
+	staleMarker := filepath.Join(clonePath, "stale.txt")
+	writeFile(t, clonePath, "stale.txt", "stale clone must be replaced")
+
+	source := gittrace.Source{
+		RepoURL:      repoURL,
+		CloneBaseDir: cacheDir,
+		Ref:          "HEAD",
+		Limit:        1,
+	}
+	var sawCommit bool
+	err := source.Walk(ctx, func(commit replay.CommitMutation) error {
+		sawCommit = true
+		if commit.Repo != "github.com/ipfs/kubo" {
+			t.Fatalf("commit repo = %q, want canonical github.com/ipfs/kubo", commit.Repo)
+		}
+		if _, err := os.Stat(filepath.Join(clonePath, ".git")); err != nil {
+			t.Fatalf("clone path was not populated during replay: %v", err)
+		}
+		if _, err := os.Stat(staleMarker); !os.IsNotExist(err) {
+			t.Fatalf("stale clone marker still exists: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if !sawCommit {
+		t.Fatal("Walk did not emit a commit")
+	}
+	if _, err := os.Stat(filepath.Join(clonePath, ".git")); err != nil {
+		t.Fatalf("clone path should remain in work dir after replay: %v", err)
+	}
+}
+
+func installGitHubInsteadOf(t *testing.T, githubRoot string) {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "gitconfig")
+	baseURL := (&url.URL{Scheme: "file", Path: filepath.ToSlash(githubRoot) + "/"}).String()
+	data := []byte("[url \"" + baseURL + "\"]\n\tinsteadOf = https://github.com/\n")
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		t.Fatalf("write git config: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", configPath)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+}
+
+func TestCloneForReplayRejectsUnsafeClonePathComponents(t *testing.T) {
+	for _, raw := range []string{
+		"https://github.com/org/..\\..\\outside.git",
+		"https://github.com/org/repo:name.git",
+	} {
+		if _, err := gittrace.ClonePathForURL(t.TempDir(), raw); err == nil {
+			t.Fatalf("ClonePathForURL(%q) should reject unsafe path components", raw)
+		}
 	}
 }
 
 func initTraceRepo(t *testing.T) string {
 	t.Helper()
-	repo := t.TempDir()
+	return initTraceRepoAt(t, t.TempDir())
+}
+
+func initTraceRepoAt(t *testing.T, repo string) string {
+	t.Helper()
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
 	runGit(t, repo, "init", "-b", "main")
 	runGit(t, repo, "config", "user.email", "bench@example.test")
 	runGit(t, repo, "config", "user.name", "Bench Test")

--- a/cmd/eval/internal/eval/framework/env.go
+++ b/cmd/eval/internal/eval/framework/env.go
@@ -12,12 +12,33 @@ import (
 type Env struct {
 	RunID     string
 	OutputDir string
+	ResultDir string
 	clock     func() time.Time
 }
 
 // RawPath returns the JSONL path for a suite's raw result stream.
 func (e Env) RawPath(suite string) string {
-	return filepath.Join(e.OutputDir, "raw", suite+".jsonl")
+	return filepath.Join(e.resultDir(), "raw", suite+".jsonl")
+}
+
+// WorkPath returns a path under the disposable run workspace.
+func (e Env) WorkPath(parts ...string) string {
+	all := append([]string{e.workDir()}, parts...)
+	return filepath.Join(all...)
+}
+
+func (e Env) resultDir() string {
+	if e.ResultDir != "" {
+		return e.ResultDir
+	}
+	return e.OutputDir
+}
+
+func (e Env) workDir() string {
+	if e.OutputDir != "" {
+		return e.OutputDir
+	}
+	return e.ResultDir
 }
 
 // WriteRecord appends one raw result record using the common envelope.

--- a/cmd/eval/internal/eval/framework/plan.go
+++ b/cmd/eval/internal/eval/framework/plan.go
@@ -17,8 +17,10 @@ const SchemaVersion = "malt-eval/v1"
 type Plan struct {
 	RunID             string      `json:"run_id"`
 	OutputDir         string      `json:"output_dir,omitempty"`
+	ResultDir         string      `json:"result_dir,omitempty"`
 	Suites            []SuitePlan `json:"suites"`
 	outputDirExplicit bool
+	resultDirExplicit bool
 }
 
 // SuitePlan configures one registered evaluation suite.
@@ -56,6 +58,7 @@ func LoadPlan(path string) (Plan, error) {
 		return Plan{}, fmt.Errorf("parse plan: %w", err)
 	}
 	plan.outputDirExplicit = jsonHasKey(data, "output_dir")
+	plan.resultDirExplicit = jsonHasKey(data, "result_dir")
 	if err := plan.Normalize(); err != nil {
 		return Plan{}, err
 	}
@@ -76,9 +79,17 @@ func (p *Plan) Normalize() error {
 		}
 	}
 	if strings.TrimSpace(p.OutputDir) == "" {
-		p.OutputDir = filepath.Join("results", p.RunID)
+		p.OutputDir = filepath.Join("output", p.RunID)
 	} else {
 		p.OutputDir = filepath.Clean(p.OutputDir)
+	}
+	if strings.TrimSpace(p.ResultDir) == "" {
+		p.ResultDir = filepath.Join("result", p.RunID)
+	} else {
+		p.ResultDir = filepath.Clean(p.ResultDir)
+	}
+	if pathsOverlap(p.OutputDir, p.ResultDir) {
+		return fmt.Errorf("output_dir and result_dir must not overlap")
 	}
 	if len(p.Suites) == 0 {
 		return fmt.Errorf("at least one suite is required")
@@ -104,8 +115,8 @@ func validateRunID(runID string) error {
 }
 
 // OverrideRunID applies a CLI run-id override. If the plan did not explicitly
-// configure output_dir, the output directory is recomputed from the final run id
-// during the next Normalize call.
+// configure output_dir or result_dir, those directories are recomputed from the
+// final run id during the next Normalize call.
 func (p *Plan) OverrideRunID(runID string) {
 	if p == nil {
 		return
@@ -116,6 +127,9 @@ func (p *Plan) OverrideRunID(runID string) {
 	p.RunID = strings.TrimSpace(runID)
 	if !p.outputDirExplicit {
 		p.OutputDir = ""
+	}
+	if !p.resultDirExplicit {
+		p.ResultDir = ""
 	}
 }
 
@@ -130,6 +144,45 @@ func (p *Plan) OverrideOutputDir(outputDir string) {
 	}
 	p.OutputDir = strings.TrimSpace(outputDir)
 	p.outputDirExplicit = true
+}
+
+// OverrideResultDir applies a CLI result-dir override and marks the directory
+// as explicit so later run-id overrides do not rewrite it.
+func (p *Plan) OverrideResultDir(resultDir string) {
+	if p == nil {
+		return
+	}
+	if strings.TrimSpace(resultDir) == "" {
+		return
+	}
+	p.ResultDir = strings.TrimSpace(resultDir)
+	p.resultDirExplicit = true
+}
+
+func pathsOverlap(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	cleanA := cleanAbsPath(a)
+	cleanB := cleanAbsPath(b)
+	return pathContains(cleanA, cleanB) || pathContains(cleanB, cleanA)
+}
+
+func cleanAbsPath(path string) string {
+	clean := filepath.Clean(path)
+	abs, err := filepath.Abs(clean)
+	if err != nil {
+		return clean
+	}
+	return filepath.Clean(abs)
+}
+
+func pathContains(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return parent == child
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
 }
 
 func jsonHasKey(data []byte, key string) bool {

--- a/cmd/eval/internal/eval/framework/plan_test.go
+++ b/cmd/eval/internal/eval/framework/plan_test.go
@@ -39,8 +39,11 @@ func TestLoadPlanDefaultsAndPreservesSuiteConfig(t *testing.T) {
 	if plan.RunID != "paper-eval" {
 		t.Fatalf("run id = %q, want paper-eval", plan.RunID)
 	}
-	if plan.OutputDir != filepath.Join("results", "paper-eval") {
+	if plan.OutputDir != filepath.Join("output", "paper-eval") {
 		t.Fatalf("output dir = %q", plan.OutputDir)
+	}
+	if plan.ResultDir != filepath.Join("result", "paper-eval") {
+		t.Fatalf("result dir = %q", plan.ResultDir)
 	}
 	if len(plan.Suites) != 2 {
 		t.Fatalf("suites len = %d, want 2", len(plan.Suites))
@@ -64,12 +67,71 @@ func TestLoadPlanDefaultsAndPreservesSuiteConfig(t *testing.T) {
 	}
 }
 
+func TestLoadPlanSupportsExplicitOutputAndResultDirs(t *testing.T) {
+	tmp := t.TempDir()
+	planPath := filepath.Join(tmp, "plan.json")
+	raw := `{
+		"run_id": "paper-eval",
+		"output_dir": "output/custom-work",
+		"result_dir": "result/custom-result",
+		"suites": [{"name": "write_trace"}]
+	}`
+	if err := os.WriteFile(planPath, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	plan, err := LoadPlan(planPath)
+	if err != nil {
+		t.Fatalf("LoadPlan: %v", err)
+	}
+	if plan.OutputDir != filepath.Join("output", "custom-work") {
+		t.Fatalf("output dir = %q", plan.OutputDir)
+	}
+	if plan.ResultDir != filepath.Join("result", "custom-result") {
+		t.Fatalf("result dir = %q", plan.ResultDir)
+	}
+}
+
+func TestPlanRejectsOverlappingOutputAndResultDirs(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		outputDir string
+		resultDir string
+	}{
+		{
+			name:      "same",
+			outputDir: filepath.Join("runs", "same-dir"),
+			resultDir: filepath.Join("runs", "same-dir"),
+		},
+		{
+			name:      "result inside output",
+			outputDir: filepath.Join("runs", "same-dir"),
+			resultDir: filepath.Join("runs", "same-dir", "result"),
+		},
+		{
+			name:      "output inside result",
+			outputDir: filepath.Join("runs", "same-dir", "output"),
+			resultDir: filepath.Join("runs", "same-dir"),
+		},
+	} {
+		plan := Plan{
+			RunID:     "same-dir",
+			OutputDir: tc.outputDir,
+			ResultDir: tc.resultDir,
+			Suites:    []SuitePlan{{Name: "write_trace"}},
+		}
+		if err := plan.Normalize(); err == nil {
+			t.Fatalf("%s: Normalize should reject overlapping output_dir and result_dir", tc.name)
+		}
+	}
+}
+
 func TestLoadPlanRejectsUnknownTopLevelFields(t *testing.T) {
 	tmp := t.TempDir()
 	planPath := filepath.Join(tmp, "plan.json")
 	raw := `{
 		"run_id": "paper-eval",
-		"output_dr": "results/wrong",
+		"output_dr": "output/wrong",
 		"suites": [{"name": "write_trace"}]
 	}`
 	if err := os.WriteFile(planPath, []byte(raw), 0o644); err != nil {

--- a/cmd/eval/internal/eval/framework/runner.go
+++ b/cmd/eval/internal/eval/framework/runner.go
@@ -28,6 +28,9 @@ func Run(ctx context.Context, plan Plan, registry Registry, opts RunOptions) err
 	if clock == nil {
 		clock = time.Now
 	}
+	if err := prepareResultLayout(plan.ResultDir); err != nil {
+		return err
+	}
 	if err := prepareOutputLayout(plan.OutputDir); err != nil {
 		return err
 	}
@@ -36,6 +39,7 @@ func Run(ctx context.Context, plan Plan, registry Registry, opts RunOptions) err
 	env := Env{
 		RunID:     plan.RunID,
 		OutputDir: plan.OutputDir,
+		ResultDir: plan.ResultDir,
 		clock:     clock,
 	}
 	manifest := Manifest{
@@ -58,11 +62,11 @@ func Run(ctx context.Context, plan Plan, registry Registry, opts RunOptions) err
 		}
 		manifest.Suites = append(manifest.Suites, SuiteManifest{Name: suitePlan.Name})
 	}
-	if err := summary.Summarize(plan.OutputDir, filepath.Join(plan.OutputDir, "summary")); err != nil {
+	if err := summary.Summarize(plan.ResultDir, filepath.Join(plan.ResultDir, "summary")); err != nil {
 		return fmt.Errorf("summarize run: %w", err)
 	}
 	manifest.FinishedAt = clock().UTC().Format(time.RFC3339Nano)
-	return writeManifest(plan.OutputDir, manifest)
+	return writeManifest(plan.ResultDir, manifest)
 }
 
 func preflightSuites(plan Plan, registry Registry) error {
@@ -77,13 +81,13 @@ func preflightSuites(plan Plan, registry Registry) error {
 	return nil
 }
 
-func prepareOutputLayout(outputDir string) error {
-	manifestPath := filepath.Join(outputDir, "manifest.json")
+func prepareResultLayout(resultDir string) error {
+	manifestPath := filepath.Join(resultDir, "manifest.json")
 	if err := os.Remove(manifestPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	for _, dir := range []string{"raw", "summary", "logs"} {
-		path := filepath.Join(outputDir, dir)
+	for _, dir := range []string{"raw", "summary"} {
+		path := filepath.Join(resultDir, dir)
 		if err := os.RemoveAll(path); err != nil {
 			return err
 		}
@@ -94,11 +98,23 @@ func prepareOutputLayout(outputDir string) error {
 	return nil
 }
 
-func writeManifest(outputDir string, manifest Manifest) error {
+func prepareOutputLayout(outputDir string) error {
+	if err := os.RemoveAll(outputDir); err != nil {
+		return err
+	}
+	for _, dir := range []string{"", "logs"} {
+		if err := os.MkdirAll(filepath.Join(outputDir, dir), 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeManifest(resultDir string, manifest Manifest) error {
 	data, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
 		return err
 	}
 	data = append(data, '\n')
-	return os.WriteFile(filepath.Join(outputDir, "manifest.json"), data, 0o644)
+	return os.WriteFile(filepath.Join(resultDir, "manifest.json"), data, 0o644)
 }

--- a/cmd/eval/internal/eval/framework/runner_test.go
+++ b/cmd/eval/internal/eval/framework/runner_test.go
@@ -20,7 +20,8 @@ func TestRunnerCreatesEvaluationOutputLayout(t *testing.T) {
 	}
 	plan := Plan{
 		RunID:     "run-001",
-		OutputDir: filepath.Join(tmp, "run-001"),
+		OutputDir: filepath.Join(tmp, "output", "run-001"),
+		ResultDir: filepath.Join(tmp, "result", "run-001"),
 		Suites: []SuitePlan{
 			{Name: "write_trace", Config: json.RawMessage(`{"limit": 2}`)},
 			{Name: "proof_overhead", Enabled: boolPtr(false)},
@@ -32,13 +33,22 @@ func TestRunnerCreatesEvaluationOutputLayout(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	for _, dir := range []string{"raw", "summary", "logs"} {
-		if info, err := os.Stat(filepath.Join(plan.OutputDir, dir)); err != nil || !info.IsDir() {
-			t.Fatalf("expected %s directory, info=%v err=%v", dir, info, err)
+	for _, dir := range []string{"raw", "summary"} {
+		if info, err := os.Stat(filepath.Join(plan.ResultDir, dir)); err != nil || !info.IsDir() {
+			t.Fatalf("expected result %s directory, info=%v err=%v", dir, info, err)
 		}
 	}
+	if info, err := os.Stat(filepath.Join(plan.OutputDir, "logs")); err != nil || !info.IsDir() {
+		t.Fatalf("expected output logs directory, info=%v err=%v", info, err)
+	}
+	if _, err := os.Stat(filepath.Join(plan.OutputDir, "raw")); !os.IsNotExist(err) {
+		t.Fatalf("raw should live under result_dir, output raw stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(plan.OutputDir, "summary")); !os.IsNotExist(err) {
+		t.Fatalf("summary should live under result_dir, output summary stat err=%v", err)
+	}
 
-	rawPath := filepath.Join(plan.OutputDir, "raw", "write_trace.jsonl")
+	rawPath := filepath.Join(plan.ResultDir, "raw", "write_trace.jsonl")
 	f, err := os.Open(rawPath)
 	if err != nil {
 		t.Fatalf("open raw output: %v", err)
@@ -56,7 +66,7 @@ func TestRunnerCreatesEvaluationOutputLayout(t *testing.T) {
 		t.Fatalf("record envelope = %#v", record)
 	}
 
-	manifestBytes, err := os.ReadFile(filepath.Join(plan.OutputDir, "manifest.json"))
+	manifestBytes, err := os.ReadFile(filepath.Join(plan.ResultDir, "manifest.json"))
 	if err != nil {
 		t.Fatalf("read manifest: %v", err)
 	}
@@ -71,7 +81,7 @@ func TestRunnerCreatesEvaluationOutputLayout(t *testing.T) {
 		t.Fatalf("manifest times = %s/%s", manifest.StartedAt, manifest.FinishedAt)
 	}
 
-	summaryBytes, err := os.ReadFile(filepath.Join(plan.OutputDir, "summary", "figure_write_trace.csv"))
+	summaryBytes, err := os.ReadFile(filepath.Join(plan.ResultDir, "summary", "figure_write_trace.csv"))
 	if err != nil {
 		t.Fatalf("read summary csv: %v", err)
 	}
@@ -88,7 +98,8 @@ func TestRunnerRefreshesOutputDirectoriesBeforeRun(t *testing.T) {
 	}
 	plan := Plan{
 		RunID:     "rerun",
-		OutputDir: filepath.Join(tmp, "rerun"),
+		OutputDir: filepath.Join(tmp, "output", "rerun"),
+		ResultDir: filepath.Join(tmp, "result", "rerun"),
 		Suites: []SuitePlan{{
 			Name:   "write_trace",
 			Config: json.RawMessage(`{"limit": 1}`),
@@ -98,11 +109,14 @@ func TestRunnerRefreshesOutputDirectoriesBeforeRun(t *testing.T) {
 	if err := Run(context.Background(), plan, reg, RunOptions{}); err != nil {
 		t.Fatalf("first Run: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(plan.OutputDir, "summary", "stale.csv"), []byte("stale\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(plan.ResultDir, "summary", "stale.csv"), []byte("stale\n"), 0o644); err != nil {
 		t.Fatalf("write stale summary: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(plan.OutputDir, "logs", "stale.log"), []byte("stale\n"), 0o644); err != nil {
 		t.Fatalf("write stale log: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(plan.OutputDir, "stale-work.txt"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatalf("write stale work file: %v", err)
 	}
 
 	plan.Suites[0].Config = json.RawMessage(`{"limit": 2}`)
@@ -110,7 +124,7 @@ func TestRunnerRefreshesOutputDirectoriesBeforeRun(t *testing.T) {
 		t.Fatalf("second Run: %v", err)
 	}
 
-	rawBytes, err := os.ReadFile(filepath.Join(plan.OutputDir, "raw", "write_trace.jsonl"))
+	rawBytes, err := os.ReadFile(filepath.Join(plan.ResultDir, "raw", "write_trace.jsonl"))
 	if err != nil {
 		t.Fatalf("read raw output: %v", err)
 	}
@@ -125,11 +139,14 @@ func TestRunnerRefreshesOutputDirectoriesBeforeRun(t *testing.T) {
 	if strings.Contains(string(envelope.Record), `"limit":1`) || !strings.Contains(string(envelope.Record), `"limit":2`) {
 		t.Fatalf("rerun record = %s, want only latest limit", envelope.Record)
 	}
-	if _, err := os.Stat(filepath.Join(plan.OutputDir, "summary", "stale.csv")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(plan.ResultDir, "summary", "stale.csv")); !os.IsNotExist(err) {
 		t.Fatalf("stale summary file still present or stat failed unexpectedly: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(plan.OutputDir, "logs", "stale.log")); !os.IsNotExist(err) {
 		t.Fatalf("stale log file still present or stat failed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(plan.OutputDir, "stale-work.txt")); !os.IsNotExist(err) {
+		t.Fatalf("stale work file still present or stat failed unexpectedly: %v", err)
 	}
 }
 
@@ -141,7 +158,8 @@ func TestRunnerRemovesStaleManifestBeforeFailedRerun(t *testing.T) {
 	}
 	plan := Plan{
 		RunID:     "failed-rerun",
-		OutputDir: filepath.Join(tmp, "failed-rerun"),
+		OutputDir: filepath.Join(tmp, "output", "failed-rerun"),
+		ResultDir: filepath.Join(tmp, "result", "failed-rerun"),
 		Suites: []SuitePlan{{
 			Name:   "write_trace",
 			Config: json.RawMessage(`{"limit": 1}`),
@@ -151,7 +169,7 @@ func TestRunnerRemovesStaleManifestBeforeFailedRerun(t *testing.T) {
 	if err := Run(context.Background(), plan, successRegistry, RunOptions{}); err != nil {
 		t.Fatalf("first Run: %v", err)
 	}
-	manifestPath := filepath.Join(plan.OutputDir, "manifest.json")
+	manifestPath := filepath.Join(plan.ResultDir, "manifest.json")
 	if _, err := os.Stat(manifestPath); err != nil {
 		t.Fatalf("initial manifest missing: %v", err)
 	}
@@ -170,16 +188,20 @@ func TestRunnerRemovesStaleManifestBeforeFailedRerun(t *testing.T) {
 
 func TestRunnerPreflightsSuitesBeforeRefreshingOutput(t *testing.T) {
 	tmp := t.TempDir()
-	outputDir := filepath.Join(tmp, "preflight")
-	for _, dir := range []string{"raw", "summary", "logs"} {
-		if err := os.MkdirAll(filepath.Join(outputDir, dir), 0o755); err != nil {
+	outputDir := filepath.Join(tmp, "output", "preflight")
+	resultDir := filepath.Join(tmp, "result", "preflight")
+	for _, dir := range []string{"raw", "summary"} {
+		if err := os.MkdirAll(filepath.Join(resultDir, dir), 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
 	}
+	if err := os.MkdirAll(filepath.Join(outputDir, "logs"), 0o755); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
 	sentinels := map[string]string{
-		filepath.Join(outputDir, "manifest.json"):            "previous manifest\n",
-		filepath.Join(outputDir, "raw", "write_trace.jsonl"): "previous raw\n",
-		filepath.Join(outputDir, "summary", "stale.csv"):     "previous summary\n",
+		filepath.Join(resultDir, "manifest.json"):            "previous manifest\n",
+		filepath.Join(resultDir, "raw", "write_trace.jsonl"): "previous raw\n",
+		filepath.Join(resultDir, "summary", "stale.csv"):     "previous summary\n",
 		filepath.Join(outputDir, "logs", "previous-run.log"): "previous logs\n",
 	}
 	for path, content := range sentinels {
@@ -190,6 +212,7 @@ func TestRunnerPreflightsSuitesBeforeRefreshingOutput(t *testing.T) {
 	plan := Plan{
 		RunID:     "preflight",
 		OutputDir: outputDir,
+		ResultDir: resultDir,
 		Suites:    []SuitePlan{{Name: "missing"}},
 	}
 
@@ -210,7 +233,8 @@ func TestRunnerPreflightsSuitesBeforeRefreshingOutput(t *testing.T) {
 func TestRunnerFailsForUnknownEnabledSuite(t *testing.T) {
 	plan := Plan{
 		RunID:     "run-unknown",
-		OutputDir: filepath.Join(t.TempDir(), "run-unknown"),
+		OutputDir: filepath.Join(t.TempDir(), "output", "run-unknown"),
+		ResultDir: filepath.Join(t.TempDir(), "result", "run-unknown"),
 		Suites:    []SuitePlan{{Name: "missing"}},
 	}
 	if err := Run(context.Background(), plan, NewRegistry(), RunOptions{}); err == nil {

--- a/cmd/eval/internal/eval/suites/readquery/suite_test.go
+++ b/cmd/eval/internal/eval/suites/readquery/suite_test.go
@@ -164,7 +164,8 @@ func TestFrameworkRunWritesEnvelopedReadQueryRecords(t *testing.T) {
 	}
 	plan := framework.Plan{
 		RunID:     "run-read-query",
-		OutputDir: filepath.Join(tmp, "out"),
+		OutputDir: filepath.Join(tmp, "output"),
+		ResultDir: filepath.Join(tmp, "result"),
 		Suites: []framework.SuitePlan{{
 			Name: Name,
 			Config: json.RawMessage(`{
@@ -179,7 +180,7 @@ func TestFrameworkRunWritesEnvelopedReadQueryRecords(t *testing.T) {
 		t.Fatalf("framework.Run() error = %v", err)
 	}
 
-	envelopes := readRawEnvelopes(t, filepath.Join(plan.OutputDir, "raw", "read_query.jsonl"))
+	envelopes := readRawEnvelopes(t, filepath.Join(plan.ResultDir, "raw", "read_query.jsonl"))
 	if len(envelopes) != 2 {
 		t.Fatalf("envelope count = %d, want 2", len(envelopes))
 	}

--- a/cmd/eval/internal/eval/suites/writetrace/config.go
+++ b/cmd/eval/internal/eval/suites/writetrace/config.go
@@ -17,8 +17,6 @@ const SuiteName = "write_trace"
 type Config struct {
 	RepoURLs          []string   `json:"repo_urls,omitempty"`
 	MaxCommitsPerRepo int        `json:"max_commits_per_repo,omitempty"`
-	CacheDir          string     `json:"cache_dir,omitempty"`
-	StoreDir          string     `json:"store_dir,omitempty"`
 	StoreMode         string     `json:"store_mode,omitempty"`
 	StoreBackend      string     `json:"store_backend,omitempty"`
 	Systems           SystemList `json:"systems,omitempty"`
@@ -35,11 +33,9 @@ type RepositoryTarget struct {
 // SystemList accepts either a JSON array or a comma-separated JSON string.
 type SystemList []string
 
-// DefaultConfig returns the same replay defaults used by malt-eval write.
+// DefaultConfig returns framework-managed write-trace replay defaults.
 func DefaultConfig() Config {
 	return Config{
-		CacheDir:     ".eval-cache/repos",
-		StoreDir:     ".eval-cache/write-stores",
 		StoreMode:    string(evalstore.StoreModeIsolated),
 		StoreBackend: string(evalstore.StoreBackendMemory),
 		Systems:      SystemList{"maltflat", "merkledag", "hamt"},

--- a/cmd/eval/internal/eval/suites/writetrace/suite.go
+++ b/cmd/eval/internal/eval/suites/writetrace/suite.go
@@ -44,7 +44,7 @@ func runRepository(ctx context.Context, env framework.Env, cfg Config, repo Repo
 	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
 		Mode:    evalstore.StoreMode(cfg.StoreMode),
 		Backend: evalstore.StoreBackend(cfg.StoreBackend),
-		RootDir: storeDirForRepository(cfg.StoreDir, repo, index, repoCount),
+		RootDir: storeDirForRepository(env.WorkPath("write-stores"), repo, index, repoCount),
 	})
 	if err != nil {
 		return err
@@ -61,11 +61,11 @@ func runRepository(ctx context.Context, env framework.Env, cfg Config, repo Repo
 	}
 
 	source := gittrace.Source{
-		RepoURL:     repo.RepoURL,
-		CacheDir:    cfg.CacheDir,
-		Ref:         "HEAD",
-		Limit:       cfg.MaxCommitsPerRepo,
-		FirstParent: cfg.FirstParent,
+		RepoURL:      repo.RepoURL,
+		CloneBaseDir: env.WorkPath("repos"),
+		Ref:          "HEAD",
+		Limit:        cfg.MaxCommitsPerRepo,
+		FirstParent:  cfg.FirstParent,
 	}
 	return source.Walk(ctx, func(commit replay.CommitMutation) error {
 		commit.Repo = repo.RepoID

--- a/cmd/eval/internal/eval/suites/writetrace/suite_test.go
+++ b/cmd/eval/internal/eval/suites/writetrace/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,8 +26,6 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
 		"repo_urls": ["https://github.com/ipfs/kubo.git"],
 		"max_commits_per_repo": 7,
-		"cache_dir": "/tmp/cache",
-		"store_dir": "/tmp/stores",
 		"store_mode": "shared",
 		"store_backend": "fs",
 		"systems": ["maltflat", "hamt"],
@@ -38,8 +37,8 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	if len(cfg.RepoURLs) != 1 || cfg.RepoURLs[0] != "https://github.com/ipfs/kubo.git" {
 		t.Fatalf("repo config = %+v, want JSON values", cfg)
 	}
-	if cfg.MaxCommitsPerRepo != 7 || cfg.CacheDir != "/tmp/cache" || cfg.StoreDir != "/tmp/stores" {
-		t.Fatalf("storage/limit config = %+v, want JSON values", cfg)
+	if cfg.MaxCommitsPerRepo != 7 {
+		t.Fatalf("limit config = %+v, want JSON value", cfg)
 	}
 	if cfg.StoreMode != "shared" || cfg.StoreBackend != "fs" || cfg.FirstParent {
 		t.Fatalf("mode config = %+v, want JSON values", cfg)
@@ -52,9 +51,6 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseConfig defaults: %v", err)
 	}
-	if defaults.CacheDir != ".eval-cache/repos" || defaults.StoreDir != ".eval-cache/write-stores" {
-		t.Fatalf("defaults = %+v, want write command paths/ref", defaults)
-	}
 	if defaults.StoreMode != "isolated" || defaults.StoreBackend != "memory" || !defaults.FirstParent {
 		t.Fatalf("defaults = %+v, want isolated memory first-parent", defaults)
 	}
@@ -66,7 +62,6 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 func TestParseConfigBuildsRepositoryTargetsFromURLList(t *testing.T) {
 	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
 		"max_commits_per_repo": 10,
-		"cache_dir": "/tmp/shared-cache",
 		"first_parent": true,
 		"repo_urls": [
 			"https://github.com/ipfs/kubo.git",
@@ -90,7 +85,7 @@ func TestParseConfigBuildsRepositoryTargetsFromURLList(t *testing.T) {
 	if repos[1].RepoID != "github.com/ethereum/go-ethereum" || repos[1].RepoURL != "https://github.com/ethereum/go-ethereum" {
 		t.Fatalf("repo 1 target = %+v", repos[1])
 	}
-	if cfg.MaxCommitsPerRepo != 10 || cfg.CacheDir != "/tmp/shared-cache" || !cfg.FirstParent {
+	if cfg.MaxCommitsPerRepo != 10 || !cfg.FirstParent {
 		t.Fatalf("suite defaults = %+v", cfg)
 	}
 }
@@ -164,6 +159,8 @@ func TestParseConfigRejectsLegacyRepositoryFields(t *testing.T) {
 		`{"repo_url": "https://github.com/ipfs/kubo.git"}`,
 		`{"repo_ref": "main"}`,
 		`{"commit_limit": 7}`,
+		`{"cache_dir": "/tmp/cache"}`,
+		`{"store_dir": "/tmp/stores"}`,
 		`{"repositories": [{"repo_url": "https://github.com/ipfs/kubo.git"}]}`,
 	} {
 		if _, err := writetrace.ParseConfig(json.RawMessage(raw)); err == nil {
@@ -177,30 +174,34 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 		t.Skip("git binary not available")
 	}
 	ctx := context.Background()
-	repo := initWriteTraceRepo(t, "github.com", "ipfs", "kubo.git")
-	outDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(outDir, "raw"), 0755); err != nil {
+	sourceBase := filepath.Join(t.TempDir(), "github.com")
+	initWriteTraceRepoAt(t, filepath.Join(sourceBase, "ipfs", "kubo.git"))
+	installGitHubInsteadOf(t, sourceBase)
+	resultDir := t.TempDir()
+	outputDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(resultDir, "raw"), 0755); err != nil {
 		t.Fatalf("mkdir raw dir: %v", err)
 	}
-	cacheDir := t.TempDir()
-	seedCachedWriteTraceRepo(t, cacheDir, repo, "ipfs", "kubo")
 
 	cfg := json.RawMessage(`{
 		"repo_urls": [` + strconvQuote(githubRepoURL("ipfs", "kubo")) + `],
 		"max_commits_per_repo": 3,
-		"cache_dir": ` + strconvQuote(cacheDir) + `,
 		"store_backend": "memory",
 		"systems": ["maltflat"]
 	}`)
 	err := (writetrace.Suite{}).Run(ctx, framework.Env{
 		RunID:     "run-write-trace-test",
-		OutputDir: outDir,
+		OutputDir: outputDir,
+		ResultDir: resultDir,
 	}, cfg)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(outputDir, "repos", "ipfs", "kubo", ".git")); err != nil {
+		t.Fatalf("managed clone should remain under output workspace: %v", err)
+	}
 
-	envelopes := readWriteTraceEnvelopes(t, filepath.Join(outDir, "raw", "write_trace.jsonl"))
+	envelopes := readWriteTraceEnvelopes(t, filepath.Join(resultDir, "raw", "write_trace.jsonl"))
 	if len(envelopes) != 3 {
 		t.Fatalf("envelope count = %d, want 3", len(envelopes))
 	}
@@ -243,21 +244,20 @@ func TestSuiteRunReplaysRepoURLListWithCanonicalRepoLabels(t *testing.T) {
 		t.Skip("git binary not available")
 	}
 	ctx := context.Background()
-	repoA := initWriteTraceRepo(t, "github.com", "ipfs", "kubo.git")
-	repoB := initWriteTraceRepo(t, "github.com", "fork", "kubo.git")
-	outDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(outDir, "raw"), 0755); err != nil {
+	sourceBase := filepath.Join(t.TempDir(), "github.com")
+	initWriteTraceRepoAt(t, filepath.Join(sourceBase, "ipfs", "kubo.git"))
+	initWriteTraceRepoAt(t, filepath.Join(sourceBase, "fork", "kubo.git"))
+	installGitHubInsteadOf(t, sourceBase)
+	resultDir := t.TempDir()
+	outputDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(resultDir, "raw"), 0755); err != nil {
 		t.Fatalf("mkdir raw dir: %v", err)
 	}
-	cacheDir := t.TempDir()
-	seedCachedWriteTraceRepo(t, cacheDir, repoA, "ipfs", "kubo")
-	seedCachedWriteTraceRepo(t, cacheDir, repoB, "fork", "kubo")
 
 	cfg := json.RawMessage(`{
 		"store_backend": "memory",
 		"systems": ["maltflat"],
 		"max_commits_per_repo": 1,
-		"cache_dir": ` + strconvQuote(cacheDir) + `,
 		"repo_urls": [
 			` + strconvQuote(githubRepoURL("ipfs", "kubo")) + `,
 			` + strconvQuote(githubRepoURL("fork", "kubo")) + `
@@ -265,13 +265,22 @@ func TestSuiteRunReplaysRepoURLListWithCanonicalRepoLabels(t *testing.T) {
 	}`)
 	err := (writetrace.Suite{}).Run(ctx, framework.Env{
 		RunID:     "run-write-trace-repos-test",
-		OutputDir: outDir,
+		OutputDir: outputDir,
+		ResultDir: resultDir,
 	}, cfg)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
+	for _, path := range []string{
+		filepath.Join(outputDir, "repos", "ipfs", "kubo", ".git"),
+		filepath.Join(outputDir, "repos", "fork", "kubo", ".git"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("managed clone %s should remain under output workspace: %v", path, err)
+		}
+	}
 
-	envelopes := readWriteTraceEnvelopes(t, filepath.Join(outDir, "raw", "write_trace.jsonl"))
+	envelopes := readWriteTraceEnvelopes(t, filepath.Join(resultDir, "raw", "write_trace.jsonl"))
 	if len(envelopes) != 2 {
 		t.Fatalf("envelope count = %d, want 2", len(envelopes))
 	}
@@ -291,9 +300,8 @@ func TestSuiteRunReplaysRepoURLListWithCanonicalRepoLabels(t *testing.T) {
 	}
 }
 
-func initWriteTraceRepo(t *testing.T, pathParts ...string) string {
+func initWriteTraceRepoAt(t *testing.T, repo string) string {
 	t.Helper()
-	repo := filepath.Join(append([]string{t.TempDir()}, pathParts...)...)
 	if err := os.MkdirAll(repo, 0755); err != nil {
 		t.Fatalf("mkdir repo: %v", err)
 	}
@@ -322,15 +330,16 @@ func initWriteTraceRepo(t *testing.T, pathParts ...string) string {
 	return repo
 }
 
-func seedCachedWriteTraceRepo(t *testing.T, cacheDir, sourceRepo, owner, name string) string {
+func installGitHubInsteadOf(t *testing.T, githubRoot string) {
 	t.Helper()
-	cachePath := filepath.Join(cacheDir, owner, name)
-	if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err != nil {
-		t.Fatalf("mkdir cache parent: %v", err)
+	configPath := filepath.Join(t.TempDir(), "gitconfig")
+	baseURL := (&url.URL{Scheme: "file", Path: filepath.ToSlash(githubRoot) + "/"}).String()
+	data := []byte("[url \"" + baseURL + "\"]\n\tinsteadOf = https://github.com/\n")
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		t.Fatalf("write git config: %v", err)
 	}
-	runGit(t, "", "clone", sourceRepo, cachePath)
-	runGit(t, cachePath, "remote", "set-url", "origin", githubRepoURL(owner, name))
-	return cachePath
+	t.Setenv("GIT_CONFIG_GLOBAL", configPath)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
 }
 
 func githubRepoURL(owner, name string) string {

--- a/cmd/eval/internal/eval/suites/writetrace/suite_test.go
+++ b/cmd/eval/internal/eval/suites/writetrace/suite_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -71,7 +70,7 @@ func TestParseConfigBuildsRepositoryTargetsFromURLList(t *testing.T) {
 		"first_parent": true,
 		"repo_urls": [
 			"https://github.com/ipfs/kubo.git",
-			"git@github.com:ethereum/go-ethereum.git"
+			"https://github.com/ethereum/go-ethereum"
 		]
 	}`))
 	if err != nil {
@@ -88,7 +87,7 @@ func TestParseConfigBuildsRepositoryTargetsFromURLList(t *testing.T) {
 	if repos[0].RepoID != "github.com/ipfs/kubo" || repos[0].RepoURL != "https://github.com/ipfs/kubo.git" {
 		t.Fatalf("repo 0 target = %+v", repos[0])
 	}
-	if repos[1].RepoID != "github.com/ethereum/go-ethereum" || repos[1].RepoURL != "git@github.com:ethereum/go-ethereum.git" {
+	if repos[1].RepoID != "github.com/ethereum/go-ethereum" || repos[1].RepoURL != "https://github.com/ethereum/go-ethereum" {
 		t.Fatalf("repo 1 target = %+v", repos[1])
 	}
 	if cfg.MaxCommitsPerRepo != 10 || cfg.CacheDir != "/tmp/shared-cache" || !cfg.FirstParent {
@@ -96,10 +95,13 @@ func TestParseConfigBuildsRepositoryTargetsFromURLList(t *testing.T) {
 	}
 }
 
-func TestParseConfigCanonicalizesWindowsFileURLList(t *testing.T) {
+func TestParseConfigRejectsNonGitHubHTTPSRepoURLs(t *testing.T) {
 	cases := []string{
+		"git@github.com:ipfs/kubo.git",
+		"file:///tmp/eval/repos/github.com/ipfs/kubo.git",
 		"file:/c:%5cusers%5cadmini~1%5cappdata%5clocal%5ctemp%5c001%5cgithub.com%5cipfs%5ckubo",
-		"file:/c:%25255cusers%25255cadmini~1%25255cappdata%25255clocal%25255ctemp%25255c001%25255cgithub.com%25255cipfs%25255ckubo.git",
+		"http://github.com/ipfs/kubo.git",
+		"https://gitlab.com/ipfs/kubo.git",
 	}
 	for _, repoURL := range cases {
 		cfg, err := writetrace.ParseConfig(json.RawMessage(`{
@@ -108,12 +110,8 @@ func TestParseConfigCanonicalizesWindowsFileURLList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ParseConfig: %v", err)
 		}
-		repos, err := cfg.RepositoryTargets()
-		if err != nil {
-			t.Fatalf("RepositoryTargets: %v", err)
-		}
-		if len(repos) != 1 || repos[0].RepoID != "github.com/ipfs/kubo" {
-			t.Fatalf("repo targets = %+v, want canonical github.com/ipfs/kubo", repos)
+		if _, err := cfg.RepositoryTargets(); err == nil {
+			t.Fatalf("RepositoryTargets should reject %q", repoURL)
 		}
 	}
 }
@@ -144,7 +142,7 @@ func TestParseConfigRejectsDuplicateCanonicalRepoIDs(t *testing.T) {
 	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
 		"repo_urls": [
 			"https://github.com/ipfs/kubo.git",
-			"git@github.com:ipfs/kubo.git"
+			"https://github.com/ipfs/kubo"
 		]
 	}`))
 	if err != nil {
@@ -185,9 +183,10 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 		t.Fatalf("mkdir raw dir: %v", err)
 	}
 	cacheDir := t.TempDir()
+	seedCachedWriteTraceRepo(t, cacheDir, repo, "ipfs", "kubo")
 
 	cfg := json.RawMessage(`{
-		"repo_urls": [` + strconvQuote(fileURL(repo)) + `],
+		"repo_urls": [` + strconvQuote(githubRepoURL("ipfs", "kubo")) + `],
 		"max_commits_per_repo": 3,
 		"cache_dir": ` + strconvQuote(cacheDir) + `,
 		"store_backend": "memory",
@@ -251,6 +250,8 @@ func TestSuiteRunReplaysRepoURLListWithCanonicalRepoLabels(t *testing.T) {
 		t.Fatalf("mkdir raw dir: %v", err)
 	}
 	cacheDir := t.TempDir()
+	seedCachedWriteTraceRepo(t, cacheDir, repoA, "ipfs", "kubo")
+	seedCachedWriteTraceRepo(t, cacheDir, repoB, "fork", "kubo")
 
 	cfg := json.RawMessage(`{
 		"store_backend": "memory",
@@ -258,8 +259,8 @@ func TestSuiteRunReplaysRepoURLListWithCanonicalRepoLabels(t *testing.T) {
 		"max_commits_per_repo": 1,
 		"cache_dir": ` + strconvQuote(cacheDir) + `,
 		"repo_urls": [
-			` + strconvQuote(fileURL(repoA)) + `,
-			` + strconvQuote(fileURL(repoB)) + `
+			` + strconvQuote(githubRepoURL("ipfs", "kubo")) + `,
+			` + strconvQuote(githubRepoURL("fork", "kubo")) + `
 		]
 	}`)
 	err := (writetrace.Suite{}).Run(ctx, framework.Env{
@@ -321,8 +322,19 @@ func initWriteTraceRepo(t *testing.T, pathParts ...string) string {
 	return repo
 }
 
-func fileURL(path string) string {
-	return (&url.URL{Scheme: "file", Path: path}).String()
+func seedCachedWriteTraceRepo(t *testing.T, cacheDir, sourceRepo, owner, name string) string {
+	t.Helper()
+	cachePath := filepath.Join(cacheDir, owner, name)
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err != nil {
+		t.Fatalf("mkdir cache parent: %v", err)
+	}
+	runGit(t, "", "clone", sourceRepo, cachePath)
+	runGit(t, cachePath, "remote", "set-url", "origin", githubRepoURL(owner, name))
+	return cachePath
+}
+
+func githubRepoURL(owner, name string) string {
+	return "https://github.com/" + owner + "/" + name + ".git"
 }
 
 func readWriteTraceEnvelopes(t *testing.T, path string) []framework.RecordEnvelope {

--- a/cmd/eval/internal/eval/suites/writetrace/suite_test.go
+++ b/cmd/eval/internal/eval/suites/writetrace/suite_test.go
@@ -96,6 +96,28 @@ func TestParseConfigBuildsRepositoryTargetsFromURLList(t *testing.T) {
 	}
 }
 
+func TestParseConfigCanonicalizesWindowsFileURLList(t *testing.T) {
+	cases := []string{
+		"file:/c:%5cusers%5cadmini~1%5cappdata%5clocal%5ctemp%5c001%5cgithub.com%5cipfs%5ckubo",
+		"file:/c:%25255cusers%25255cadmini~1%25255cappdata%25255clocal%25255ctemp%25255c001%25255cgithub.com%25255cipfs%25255ckubo.git",
+	}
+	for _, repoURL := range cases {
+		cfg, err := writetrace.ParseConfig(json.RawMessage(`{
+			"repo_urls": [` + strconvQuote(repoURL) + `]
+		}`))
+		if err != nil {
+			t.Fatalf("ParseConfig: %v", err)
+		}
+		repos, err := cfg.RepositoryTargets()
+		if err != nil {
+			t.Fatalf("RepositoryTargets: %v", err)
+		}
+		if len(repos) != 1 || repos[0].RepoID != "github.com/ipfs/kubo" {
+			t.Fatalf("repo targets = %+v, want canonical github.com/ipfs/kubo", repos)
+		}
+	}
+}
+
 func TestRepositoryStoreNameUsesIndexedCanonicalRepoID(t *testing.T) {
 	cfg, err := writetrace.ParseConfig(json.RawMessage(`{
 		"repo_urls": [

--- a/cmd/eval/schemas/run-plan.schema.json
+++ b/cmd/eval/schemas/run-plan.schema.json
@@ -10,11 +10,17 @@
       "type": "string",
       "minLength": 1,
       "pattern": "^(?!\\.\\.?$)[^/\\\\]+$",
-      "description": "Run identifier used for result metadata and the default results/<run_id> output path. It must not be a dot segment or contain path separators."
+      "description": "Run identifier used for result metadata and the default output/<run_id> workspace plus result/<run_id> result path. It must not be a dot segment or contain path separators."
     },
     "output_dir": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "Disposable run workspace directory. The runner removes and recreates this directory before each run."
+    },
+    "result_dir": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Durable result directory for manifest, raw envelopes, and summary outputs."
     },
     "suites": {
       "type": "array",


### PR DESCRIPTION
## Summary
- split framework runs into disposable output_dir workspaces and durable result_dir results
- keep manifest, raw envelopes, and summary CSVs under result/<run_id>; refresh output/<run_id> before each run
- constrain write_trace repo_urls to GitHub HTTPS, fresh-clone under output/repos/<owner>/<repo>, and reject legacy cache/store suite dirs
- reject unsafe repo path components and overlapping output/result directories

## Tests
- env GOCACHE=/tmp/go-build-cache go test ./...
- git diff --check