### PR TITLE
feat: add daemon lifecycle commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -223,7 +223,8 @@ Current command model:
 - `malt init`
   - creates the local configuration file and state-root directory
 - `malt daemon`
-  - long-running local process
+  - foreground long-running local process
+  - `malt daemon start/status/stop/restart` manage a background local daemon
   - owns hot structure state
   - serves local HTTP/JSON API requests
 - `malt add ...`
@@ -563,7 +564,8 @@ The target operator flow is:
 1. run `malt init`
 2. create `~/.malt/malt.json`
 3. choose a local state root
-4. start `malt daemon`
+4. run `malt daemon` in the foreground, or `malt daemon start` for a managed
+   background daemon
 
 Current config shape:
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Current runtime shape:
 - `malt init`
   - creates the local configuration file and state-root directory
 - `malt daemon`
-  - long-running local process
+  - foreground long-running local process
+  - `malt daemon start/status/stop/restart` manage a background local daemon
   - owns hot proving/index state
 - `malt add`
   - uploads payload directly to CAS
@@ -371,7 +372,8 @@ Current operator flow:
 1. run `malt init`
 2. create `~/.malt/malt.json`
 3. choose a local state root
-4. run `malt daemon`
+4. run `malt daemon` in the foreground, or `malt daemon start` for a managed
+   background daemon
 
 Current schema:
 

--- a/api/http/types.go
+++ b/api/http/types.go
@@ -12,7 +12,8 @@ type ErrorResponse struct {
 
 // HealthResponse is returned by the daemon health endpoint.
 type HealthResponse struct {
-	Status string `json:"status"`
+	Status         string `json:"status"`
+	LifecycleToken string `json:"lifecycle_token,omitempty"`
 }
 
 // MetricsResponse wraps a node-local metrics snapshot.

--- a/cmd/malt/daemon.go
+++ b/cmd/malt/daemon.go
@@ -69,6 +69,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	return daemonapp.Run(cfg, daemonapp.RunOptions{
 		ListenOverride: daemonListenOverride,
 		APILabel:       "malt daemon",
+		LifecycleToken: os.Getenv(daemonapp.LifecycleTokenEnv),
 		Stdout:         os.Stdout,
 		Stderr:         os.Stderr,
 	})

--- a/cmd/malt/daemon.go
+++ b/cmd/malt/daemon.go
@@ -1,21 +1,55 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"io"
 	"os"
 
+	"github.com/dewebprotocol/malt/config"
 	daemonapp "github.com/dewebprotocol/malt/daemon"
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	rootCmd.AddCommand(daemonCmd)
-	daemonCmd.Flags().String("listen", "", "override daemon listen address")
+	daemonCmd.PersistentFlags().StringVar(&daemonListenOverride, "listen", "", "override daemon listen address")
+	daemonCmd.AddCommand(daemonStartCmd)
+	daemonCmd.AddCommand(daemonStatusCmd)
+	daemonCmd.AddCommand(daemonStopCmd)
+	daemonCmd.AddCommand(daemonRestartCmd)
 }
+
+var daemonListenOverride string
 
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
-	Short: "Run the local MALT daemon",
+	Short: "Run or manage the local MALT daemon",
 	RunE:  runDaemon,
+}
+
+var daemonStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the local MALT daemon in the background",
+	RunE:  runDaemonStart,
+}
+
+var daemonStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show the local MALT daemon status",
+	RunE:  runDaemonStatus,
+}
+
+var daemonStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the managed local MALT daemon",
+	RunE:  runDaemonStop,
+}
+
+var daemonRestartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restart the managed local MALT daemon",
+	RunE:  runDaemonRestart,
 }
 
 func runDaemon(cmd *cobra.Command, args []string) error {
@@ -24,11 +58,185 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	override, _ := cmd.Flags().GetString("listen")
 	return daemonapp.Run(cfg, daemonapp.RunOptions{
-		ListenOverride: override,
+		ListenOverride: daemonListenOverride,
 		APILabel:       "malt daemon",
 		Stdout:         os.Stdout,
 		Stderr:         os.Stderr,
 	})
+}
+
+func runDaemonStart(cmd *cobra.Command, args []string) error {
+	cfg, err := loadDaemonLifecycleConfig()
+	if err != nil {
+		return err
+	}
+	manager, err := newDaemonLifecycleManager()
+	if err != nil {
+		return err
+	}
+	status, err := manager.Start(cmd.Context(), cfg)
+	if err != nil {
+		return err
+	}
+	printDaemonRunningStatus(os.Stdout, status)
+	return nil
+}
+
+func runDaemonStatus(cmd *cobra.Command, args []string) error {
+	cfg, err := loadDaemonLifecycleConfig()
+	if err != nil {
+		return err
+	}
+	manager, err := newDaemonLifecycleManager()
+	if err != nil {
+		return err
+	}
+	status, err := manager.Status(cmd.Context(), cfg)
+	if err != nil {
+		return err
+	}
+	printDaemonStatus(os.Stdout, status)
+	if !status.Running {
+		return fmt.Errorf("daemon is not running")
+	}
+	return nil
+}
+
+func runDaemonStop(cmd *cobra.Command, args []string) error {
+	cfg, err := loadDaemonLifecycleConfig()
+	if err != nil {
+		return err
+	}
+	manager, err := newDaemonLifecycleManager()
+	if err != nil {
+		return err
+	}
+	status, err := manager.Stop(cmd.Context(), cfg)
+	if errors.Is(err, daemonapp.ErrDaemonStateNotFound) {
+		return fmt.Errorf("no managed daemon state found")
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "malt daemon stopped\n")
+	if status.PID > 0 {
+		fmt.Fprintf(os.Stdout, "pid: %d\n", status.PID)
+	}
+	return nil
+}
+
+func runDaemonRestart(cmd *cobra.Command, args []string) error {
+	cfg, err := loadDaemonLifecycleConfig()
+	if err != nil {
+		return err
+	}
+	manager, err := newDaemonLifecycleManager()
+	if err != nil {
+		return err
+	}
+	status, err := manager.Restart(cmd.Context(), cfg)
+	if err != nil {
+		return err
+	}
+	printDaemonRunningStatus(os.Stdout, status)
+	return nil
+}
+
+func loadDaemonLifecycleConfig() (*config.Config, error) {
+	cfg, err := loadRuntimeConfig()
+	if err != nil {
+		return nil, err
+	}
+	if daemonListenOverride != "" {
+		cfg.RPC.Listen = daemonListenOverride
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func newDaemonLifecycleManager() (*daemonapp.LifecycleManager, error) {
+	configPath, err := config.ResolveConfigPath(cfgFile)
+	if err != nil {
+		return nil, err
+	}
+	statePath, err := daemonapp.ResolveDaemonStatePath(cfgFile)
+	if err != nil {
+		return nil, err
+	}
+	logPath, err := daemonapp.ResolveDaemonLogPath(cfgFile)
+	if err != nil {
+		return nil, err
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("determine executable: %w", err)
+	}
+	return daemonapp.NewLifecycleManager(daemonapp.LifecycleOptions{
+		ConfigPath:     configPath,
+		StatePath:      statePath,
+		LogPath:        logPath,
+		Executable:     exe,
+		ForegroundArgs: daemonForegroundArgs(),
+		Env:            os.Environ(),
+	}), nil
+}
+
+func daemonForegroundArgs() []string {
+	var args []string
+	if cfgFile != "" {
+		args = append(args, "--config", cfgFile)
+	}
+	args = append(args, "daemon")
+	if daemonListenOverride != "" {
+		args = append(args, "--listen", daemonListenOverride)
+	}
+	return args
+}
+
+func printDaemonRunningStatus(w io.Writer, status *daemonapp.DaemonStatus) {
+	if status.Managed {
+		fmt.Fprintf(w, "malt daemon running\n")
+	} else {
+		fmt.Fprintf(w, "malt daemon already running\n")
+	}
+	printDaemonStatusFields(w, status)
+}
+
+func printDaemonStatus(w io.Writer, status *daemonapp.DaemonStatus) {
+	if status.Running {
+		printDaemonRunningStatus(w, status)
+		return
+	}
+	fmt.Fprintf(w, "malt daemon stopped\n")
+	printDaemonStatusFields(w, status)
+	if status.HealthError != nil {
+		fmt.Fprintf(w, "health_error: %v\n", status.HealthError)
+	}
+}
+
+func printDaemonStatusFields(w io.Writer, status *daemonapp.DaemonStatus) {
+	if status.PID > 0 {
+		fmt.Fprintf(w, "pid: %d\n", status.PID)
+	}
+	if status.Listen != "" {
+		fmt.Fprintf(w, "listen: %s\n", status.Listen)
+	}
+	if status.BaseURL != "" {
+		fmt.Fprintf(w, "api: %s\n", status.BaseURL)
+	}
+	if status.ConfigPath != "" {
+		fmt.Fprintf(w, "config: %s\n", status.ConfigPath)
+	}
+	if status.StatePath != "" {
+		fmt.Fprintf(w, "state: %s\n", status.StatePath)
+	}
+	if status.LogPath != "" {
+		fmt.Fprintf(w, "log: %s\n", status.LogPath)
+	}
+	if !status.StartedAt.IsZero() {
+		fmt.Fprintf(w, "started_at: %s\n", status.StartedAt.Format("2006-01-02T15:04:05Z07:00"))
+	}
 }

--- a/cmd/malt/daemon.go
+++ b/cmd/malt/daemon.go
@@ -29,27 +29,35 @@ var daemonCmd = &cobra.Command{
 }
 
 var daemonStartCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Start the local MALT daemon in the background",
-	RunE:  runDaemonStart,
+	Use:           "start",
+	Short:         "Start the local MALT daemon in the background",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runDaemonStart,
 }
 
 var daemonStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show the local MALT daemon status",
-	RunE:  runDaemonStatus,
+	Use:           "status",
+	Short:         "Show the local MALT daemon status",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runDaemonStatus,
 }
 
 var daemonStopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Stop the managed local MALT daemon",
-	RunE:  runDaemonStop,
+	Use:           "stop",
+	Short:         "Stop the managed local MALT daemon",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runDaemonStop,
 }
 
 var daemonRestartCmd = &cobra.Command{
-	Use:   "restart",
-	Short: "Restart the managed local MALT daemon",
-	RunE:  runDaemonRestart,
+	Use:           "restart",
+	Short:         "Restart the managed local MALT daemon",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runDaemonRestart,
 }
 
 func runDaemon(cmd *cobra.Command, args []string) error {

--- a/cmd/malt/main.go
+++ b/cmd/malt/main.go
@@ -20,7 +20,7 @@ var rootCmd = &cobra.Command{
 
 Primary commands:
   init        Create ~/.malt/malt.json and choose local state paths
-  daemon      Run the local MALT daemon
+  daemon      Run or manage the local MALT daemon
   add         Upload local files/directories to CAS and merge into the current root
   resolve     Resolve a path via the daemon
   verify      Verify a ProofList`,

--- a/cmd/malt/public_surface_test.go
+++ b/cmd/malt/public_surface_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"slices"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestRootCommandOnlyExposesProductCommands(t *testing.T) {
@@ -36,5 +38,16 @@ func TestDaemonCommandExposesLifecycleSubcommands(t *testing.T) {
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("daemon subcommands = %v, want %v", got, want)
+	}
+}
+
+func TestDaemonLifecycleSubcommandsSuppressUsageAndErrorsForRuntimeErrors(t *testing.T) {
+	for _, cmd := range []*cobra.Command{daemonStartCmd, daemonStatusCmd, daemonStopCmd, daemonRestartCmd} {
+		if !cmd.SilenceUsage {
+			t.Fatalf("%s SilenceUsage = false, want true", cmd.Name())
+		}
+		if !cmd.SilenceErrors {
+			t.Fatalf("%s SilenceErrors = false, want true", cmd.Name())
+		}
 	}
 }

--- a/cmd/malt/public_surface_test.go
+++ b/cmd/malt/public_surface_test.go
@@ -21,3 +21,20 @@ func TestRootCommandOnlyExposesProductCommands(t *testing.T) {
 		t.Fatalf("public commands = %v, want %v", got, want)
 	}
 }
+
+func TestDaemonCommandExposesLifecycleSubcommands(t *testing.T) {
+	want := []string{"restart", "start", "status", "stop"}
+
+	var got []string
+	for _, cmd := range daemonCmd.Commands() {
+		if cmd.Hidden {
+			continue
+		}
+		got = append(got, cmd.Name())
+	}
+	slices.Sort(got)
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("daemon subcommands = %v, want %v", got, want)
+	}
+}

--- a/daemon/lifecycle.go
+++ b/daemon/lifecycle.go
@@ -2,15 +2,19 @@ package daemon
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/dewebprotocol/malt/api/http"
 	"github.com/dewebprotocol/malt/config"
 )
 
@@ -18,6 +22,7 @@ const (
 	defaultLifecycleStartTimeout = 15 * time.Second
 	defaultLifecycleStopTimeout  = 10 * time.Second
 	defaultLifecyclePollInterval = 100 * time.Millisecond
+	LifecycleTokenEnv            = "MALT_DAEMON_LIFECYCLE_TOKEN"
 )
 
 // ErrDaemonStateNotFound is returned when no managed daemon state file exists.
@@ -25,11 +30,12 @@ var ErrDaemonStateNotFound = errors.New("daemon state not found")
 
 // DaemonState is the local state recorded for a managed background daemon.
 type DaemonState struct {
-	PID        int       `json:"pid"`
-	Listen     string    `json:"listen"`
-	BaseURL    string    `json:"base_url"`
-	ConfigPath string    `json:"config_path"`
-	StartedAt  time.Time `json:"started_at"`
+	PID            int       `json:"pid"`
+	Listen         string    `json:"listen"`
+	BaseURL        string    `json:"base_url"`
+	ConfigPath     string    `json:"config_path"`
+	LifecycleToken string    `json:"lifecycle_token,omitempty"`
+	StartedAt      time.Time `json:"started_at"`
 }
 
 // DaemonStatus describes the observed daemon lifecycle state.
@@ -71,6 +77,8 @@ type LifecycleOptions struct {
 	StartProcess   func(BackgroundProcessSpec) (int, error)
 	SignalProcess  func(int) error
 	HealthCheck    func(context.Context, string) error
+	IdentityCheck  func(context.Context, string, string) error
+	GenerateToken  func() (string, error)
 }
 
 // LifecycleManager manages a daemon process started by `malt daemon start`.
@@ -89,6 +97,8 @@ type LifecycleManager struct {
 	startProcess   func(BackgroundProcessSpec) (int, error)
 	signalProcess  func(int) error
 	healthCheck    func(context.Context, string) error
+	identityCheck  func(context.Context, string, string) error
+	generateToken  func() (string, error)
 }
 
 // NewLifecycleManager creates a lifecycle manager with production defaults for
@@ -109,6 +119,8 @@ func NewLifecycleManager(opts LifecycleOptions) *LifecycleManager {
 		startProcess:   opts.StartProcess,
 		signalProcess:  opts.SignalProcess,
 		healthCheck:    opts.HealthCheck,
+		identityCheck:  opts.IdentityCheck,
+		generateToken:  opts.GenerateToken,
 	}
 	if m.now == nil {
 		m.now = time.Now
@@ -133,6 +145,12 @@ func NewLifecycleManager(opts LifecycleOptions) *LifecycleManager {
 	}
 	if m.healthCheck == nil {
 		m.healthCheck = defaultHealthCheck
+	}
+	if m.identityCheck == nil {
+		m.identityCheck = defaultIdentityCheck
+	}
+	if m.generateToken == nil {
+		m.generateToken = generateLifecycleToken
 	}
 	return m
 }
@@ -208,6 +226,9 @@ func (m *LifecycleManager) Status(ctx context.Context, cfg *config.Config) (*Dae
 		baseURL = state.BaseURL
 	}
 	healthErr := m.healthCheck(ctx, baseURL)
+	if state != nil {
+		healthErr = m.daemonIdentityError(ctx, state)
+	}
 	status := &DaemonStatus{
 		Running:     healthErr == nil,
 		Managed:     state != nil,
@@ -245,11 +266,18 @@ func (m *LifecycleManager) Start(ctx context.Context, cfg *config.Config) (*Daem
 	if current.Managed {
 		_ = os.Remove(m.statePath)
 	}
+	token, err := m.generateToken()
+	if err != nil {
+		return nil, fmt.Errorf("generate daemon lifecycle token: %w", err)
+	}
+	if token == "" {
+		return nil, fmt.Errorf("generate daemon lifecycle token: empty token")
+	}
 
 	spec := BackgroundProcessSpec{
 		Executable: m.executable,
 		Args:       append([]string(nil), m.foregroundArgs...),
-		Env:        append([]string(nil), m.env...),
+		Env:        withLifecycleTokenEnv(m.env, token),
 		LogPath:    m.logPath,
 	}
 	pid, err := m.startProcess(spec)
@@ -258,17 +286,18 @@ func (m *LifecycleManager) Start(ctx context.Context, cfg *config.Config) (*Daem
 	}
 
 	state := &DaemonState{
-		PID:        pid,
-		Listen:     effective.RPC.Listen,
-		BaseURL:    effective.APIBaseURL(),
-		ConfigPath: m.configPath,
-		StartedAt:  m.now().UTC(),
+		PID:            pid,
+		Listen:         effective.RPC.Listen,
+		BaseURL:        effective.APIBaseURL(),
+		ConfigPath:     m.configPath,
+		LifecycleToken: token,
+		StartedAt:      m.now().UTC(),
 	}
 	if err := WriteDaemonState(m.statePath, state); err != nil {
 		_ = m.signalProcess(pid)
 		return nil, err
 	}
-	if err := m.waitForHealth(ctx, state.BaseURL, m.startTimeout); err != nil {
+	if err := m.waitForIdentity(ctx, state.BaseURL, state.LifecycleToken, m.startTimeout); err != nil {
 		_ = m.signalProcess(pid)
 		_ = os.Remove(m.statePath)
 		return nil, err
@@ -285,26 +314,15 @@ func (m *LifecycleManager) Stop(ctx context.Context, cfg *config.Config) (*Daemo
 	if err != nil {
 		return nil, err
 	}
-	if healthErr := m.healthCheck(ctx, state.BaseURL); healthErr != nil {
+	if identityErr := m.daemonIdentityError(ctx, state); identityErr != nil {
 		if err := os.Remove(m.statePath); err != nil && !os.IsNotExist(err) {
 			return nil, fmt.Errorf("remove stale daemon state: %w", err)
 		}
-		return &DaemonStatus{
-			Running:     false,
-			Managed:     true,
-			PID:         state.PID,
-			Listen:      state.Listen,
-			BaseURL:     state.BaseURL,
-			ConfigPath:  state.ConfigPath,
-			StatePath:   m.statePath,
-			LogPath:     m.logPath,
-			StartedAt:   state.StartedAt,
-			HealthError: healthErr,
-		}, nil
+		return m.stoppedStatus(state, identityErr), nil
 	}
 	if state.PID <= 0 {
 		_ = os.Remove(m.statePath)
-		return nil, fmt.Errorf("daemon state has invalid pid %d", state.PID)
+		return m.stoppedStatus(state, fmt.Errorf("daemon state has invalid pid %d", state.PID)), nil
 	}
 	if err := m.signalProcess(state.PID); err != nil {
 		return nil, fmt.Errorf("stop daemon process %d: %w", state.PID, err)
@@ -315,17 +333,7 @@ func (m *LifecycleManager) Stop(ctx context.Context, cfg *config.Config) (*Daemo
 	if err := os.Remove(m.statePath); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("remove daemon state: %w", err)
 	}
-	return &DaemonStatus{
-		Running:    false,
-		Managed:    true,
-		PID:        state.PID,
-		Listen:     state.Listen,
-		BaseURL:    state.BaseURL,
-		ConfigPath: state.ConfigPath,
-		StatePath:  m.statePath,
-		LogPath:    m.logPath,
-		StartedAt:  state.StartedAt,
-	}, nil
+	return m.stoppedStatus(state, nil), nil
 }
 
 // Restart stops a managed daemon when present, then starts a new managed daemon.
@@ -359,11 +367,11 @@ func effectiveLifecycleConfig(cfg *config.Config) (config.Config, error) {
 	return effective, nil
 }
 
-func (m *LifecycleManager) waitForHealth(ctx context.Context, baseURL string, timeout time.Duration) error {
+func (m *LifecycleManager) waitForIdentity(ctx context.Context, baseURL string, token string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for {
-		if err := m.healthCheck(ctx, baseURL); err == nil {
+		if err := m.identityCheck(ctx, baseURL, token); err == nil {
 			return nil
 		} else {
 			lastErr = err
@@ -374,6 +382,34 @@ func (m *LifecycleManager) waitForHealth(ctx context.Context, baseURL string, ti
 		if err := sleepWithContext(ctx, m.sleep, m.pollInterval); err != nil {
 			return err
 		}
+	}
+}
+
+func (m *LifecycleManager) daemonIdentityError(ctx context.Context, state *DaemonState) error {
+	if state == nil {
+		return errors.New("daemon state is nil")
+	}
+	if state.PID <= 0 {
+		return fmt.Errorf("daemon state has invalid pid %d", state.PID)
+	}
+	if state.LifecycleToken == "" {
+		return errors.New("daemon state is missing lifecycle token")
+	}
+	return m.identityCheck(ctx, state.BaseURL, state.LifecycleToken)
+}
+
+func (m *LifecycleManager) stoppedStatus(state *DaemonState, healthErr error) *DaemonStatus {
+	return &DaemonStatus{
+		Running:     false,
+		Managed:     true,
+		PID:         state.PID,
+		Listen:      state.Listen,
+		BaseURL:     state.BaseURL,
+		ConfigPath:  state.ConfigPath,
+		StatePath:   m.statePath,
+		LogPath:     m.logPath,
+		StartedAt:   state.StartedAt,
+		HealthError: healthErr,
 	}
 }
 
@@ -401,19 +437,62 @@ func sleepWithContext(ctx context.Context, sleep func(time.Duration), d time.Dur
 }
 
 func defaultHealthCheck(ctx context.Context, baseURL string) error {
+	_, err := fetchHealth(ctx, baseURL)
+	return err
+}
+
+func defaultIdentityCheck(ctx context.Context, baseURL string, token string) error {
+	if token == "" {
+		return errors.New("missing expected lifecycle token")
+	}
+	health, err := fetchHealth(ctx, baseURL)
+	if err != nil {
+		return err
+	}
+	if health.LifecycleToken != token {
+		return fmt.Errorf("daemon lifecycle token mismatch")
+	}
+	return nil
+}
+
+func fetchHealth(ctx context.Context, baseURL string) (*httpapi.HealthResponse, error) {
 	u := strings.TrimRight(baseURL, "/") + "/health"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	client := &http.Client{Timeout: time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("health status %d", resp.StatusCode)
+		return nil, fmt.Errorf("health status %d", resp.StatusCode)
 	}
-	return nil
+	var health httpapi.HealthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil && err != io.EOF {
+		return nil, fmt.Errorf("decode health response: %w", err)
+	}
+	return &health, nil
+}
+
+func generateLifecycleToken() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
+}
+
+func withLifecycleTokenEnv(env []string, token string) []string {
+	prefix := LifecycleTokenEnv + "="
+	out := make([]string, 0, len(env)+1)
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return append(out, prefix+token)
 }

--- a/daemon/lifecycle.go
+++ b/daemon/lifecycle.go
@@ -1,0 +1,419 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dewebprotocol/malt/config"
+)
+
+const (
+	defaultLifecycleStartTimeout = 15 * time.Second
+	defaultLifecycleStopTimeout  = 10 * time.Second
+	defaultLifecyclePollInterval = 100 * time.Millisecond
+)
+
+// ErrDaemonStateNotFound is returned when no managed daemon state file exists.
+var ErrDaemonStateNotFound = errors.New("daemon state not found")
+
+// DaemonState is the local state recorded for a managed background daemon.
+type DaemonState struct {
+	PID        int       `json:"pid"`
+	Listen     string    `json:"listen"`
+	BaseURL    string    `json:"base_url"`
+	ConfigPath string    `json:"config_path"`
+	StartedAt  time.Time `json:"started_at"`
+}
+
+// DaemonStatus describes the observed daemon lifecycle state.
+type DaemonStatus struct {
+	Running     bool
+	Managed     bool
+	PID         int
+	Listen      string
+	BaseURL     string
+	ConfigPath  string
+	StatePath   string
+	LogPath     string
+	StartedAt   time.Time
+	HealthError error
+}
+
+// BackgroundProcessSpec describes the foreground daemon process to launch in
+// the background.
+type BackgroundProcessSpec struct {
+	Executable string
+	Args       []string
+	Env        []string
+	LogPath    string
+}
+
+// LifecycleOptions configures local managed daemon process operations.
+type LifecycleOptions struct {
+	ConfigPath     string
+	StatePath      string
+	LogPath        string
+	Executable     string
+	ForegroundArgs []string
+	Env            []string
+	Now            func() time.Time
+	StartTimeout   time.Duration
+	StopTimeout    time.Duration
+	PollInterval   time.Duration
+	Sleep          func(time.Duration)
+	StartProcess   func(BackgroundProcessSpec) (int, error)
+	SignalProcess  func(int) error
+	HealthCheck    func(context.Context, string) error
+}
+
+// LifecycleManager manages a daemon process started by `malt daemon start`.
+type LifecycleManager struct {
+	configPath     string
+	statePath      string
+	logPath        string
+	executable     string
+	foregroundArgs []string
+	env            []string
+	now            func() time.Time
+	startTimeout   time.Duration
+	stopTimeout    time.Duration
+	pollInterval   time.Duration
+	sleep          func(time.Duration)
+	startProcess   func(BackgroundProcessSpec) (int, error)
+	signalProcess  func(int) error
+	healthCheck    func(context.Context, string) error
+}
+
+// NewLifecycleManager creates a lifecycle manager with production defaults for
+// any operation not supplied in opts.
+func NewLifecycleManager(opts LifecycleOptions) *LifecycleManager {
+	m := &LifecycleManager{
+		configPath:     opts.ConfigPath,
+		statePath:      opts.StatePath,
+		logPath:        opts.LogPath,
+		executable:     opts.Executable,
+		foregroundArgs: append([]string(nil), opts.ForegroundArgs...),
+		env:            append([]string(nil), opts.Env...),
+		now:            opts.Now,
+		startTimeout:   opts.StartTimeout,
+		stopTimeout:    opts.StopTimeout,
+		pollInterval:   opts.PollInterval,
+		sleep:          opts.Sleep,
+		startProcess:   opts.StartProcess,
+		signalProcess:  opts.SignalProcess,
+		healthCheck:    opts.HealthCheck,
+	}
+	if m.now == nil {
+		m.now = time.Now
+	}
+	if m.startTimeout <= 0 {
+		m.startTimeout = defaultLifecycleStartTimeout
+	}
+	if m.stopTimeout <= 0 {
+		m.stopTimeout = defaultLifecycleStopTimeout
+	}
+	if m.pollInterval <= 0 {
+		m.pollInterval = defaultLifecyclePollInterval
+	}
+	if m.sleep == nil {
+		m.sleep = time.Sleep
+	}
+	if m.startProcess == nil {
+		m.startProcess = defaultStartProcess
+	}
+	if m.signalProcess == nil {
+		m.signalProcess = defaultSignalProcess
+	}
+	if m.healthCheck == nil {
+		m.healthCheck = defaultHealthCheck
+	}
+	return m
+}
+
+// ResolveDaemonStatePath returns the managed daemon state file path for a
+// config selection.
+func ResolveDaemonStatePath(configFile string) (string, error) {
+	dir, err := config.ConfigDir(configFile)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "daemon.json"), nil
+}
+
+// ResolveDaemonLogPath returns the managed daemon log file path for a config
+// selection.
+func ResolveDaemonLogPath(configFile string) (string, error) {
+	dir, err := config.ConfigDir(configFile)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "daemon.log"), nil
+}
+
+// LoadDaemonState loads a managed daemon state file.
+func LoadDaemonState(path string) (*DaemonState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrDaemonStateNotFound
+		}
+		return nil, fmt.Errorf("read daemon state: %w", err)
+	}
+	var state DaemonState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("decode daemon state: %w", err)
+	}
+	return &state, nil
+}
+
+// WriteDaemonState writes a managed daemon state file.
+func WriteDaemonState(path string, state *DaemonState) error {
+	if state == nil {
+		return fmt.Errorf("daemon state is nil")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create daemon state dir: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode daemon state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write daemon state: %w", err)
+	}
+	return nil
+}
+
+// Status reports whether the configured daemon endpoint is healthy.
+func (m *LifecycleManager) Status(ctx context.Context, cfg *config.Config) (*DaemonStatus, error) {
+	effective, err := effectiveLifecycleConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	state, stateErr := LoadDaemonState(m.statePath)
+	if stateErr != nil && !errors.Is(stateErr, ErrDaemonStateNotFound) {
+		return nil, stateErr
+	}
+
+	baseURL := effective.APIBaseURL()
+	if state != nil && state.BaseURL != "" {
+		baseURL = state.BaseURL
+	}
+	healthErr := m.healthCheck(ctx, baseURL)
+	status := &DaemonStatus{
+		Running:     healthErr == nil,
+		Managed:     state != nil,
+		BaseURL:     baseURL,
+		StatePath:   m.statePath,
+		LogPath:     m.logPath,
+		HealthError: healthErr,
+	}
+	if state != nil {
+		status.PID = state.PID
+		status.Listen = state.Listen
+		status.ConfigPath = state.ConfigPath
+		status.StartedAt = state.StartedAt
+		return status, nil
+	}
+	status.Listen = effective.RPC.Listen
+	status.ConfigPath = m.configPath
+	return status, nil
+}
+
+// Start launches the daemon in the background unless a healthy daemon is
+// already running for the configured endpoint.
+func (m *LifecycleManager) Start(ctx context.Context, cfg *config.Config) (*DaemonStatus, error) {
+	effective, err := effectiveLifecycleConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	current, err := m.Status(ctx, &effective)
+	if err != nil {
+		return nil, err
+	}
+	if current.Running {
+		return current, nil
+	}
+	if current.Managed {
+		_ = os.Remove(m.statePath)
+	}
+
+	spec := BackgroundProcessSpec{
+		Executable: m.executable,
+		Args:       append([]string(nil), m.foregroundArgs...),
+		Env:        append([]string(nil), m.env...),
+		LogPath:    m.logPath,
+	}
+	pid, err := m.startProcess(spec)
+	if err != nil {
+		return nil, fmt.Errorf("start daemon process: %w", err)
+	}
+
+	state := &DaemonState{
+		PID:        pid,
+		Listen:     effective.RPC.Listen,
+		BaseURL:    effective.APIBaseURL(),
+		ConfigPath: m.configPath,
+		StartedAt:  m.now().UTC(),
+	}
+	if err := WriteDaemonState(m.statePath, state); err != nil {
+		_ = m.signalProcess(pid)
+		return nil, err
+	}
+	if err := m.waitForHealth(ctx, state.BaseURL, m.startTimeout); err != nil {
+		_ = m.signalProcess(pid)
+		_ = os.Remove(m.statePath)
+		return nil, err
+	}
+	return m.Status(ctx, &effective)
+}
+
+// Stop terminates a managed daemon process and removes its state file.
+func (m *LifecycleManager) Stop(ctx context.Context, cfg *config.Config) (*DaemonStatus, error) {
+	if _, err := effectiveLifecycleConfig(cfg); err != nil {
+		return nil, err
+	}
+	state, err := LoadDaemonState(m.statePath)
+	if err != nil {
+		return nil, err
+	}
+	if healthErr := m.healthCheck(ctx, state.BaseURL); healthErr != nil {
+		if err := os.Remove(m.statePath); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("remove stale daemon state: %w", err)
+		}
+		return &DaemonStatus{
+			Running:     false,
+			Managed:     true,
+			PID:         state.PID,
+			Listen:      state.Listen,
+			BaseURL:     state.BaseURL,
+			ConfigPath:  state.ConfigPath,
+			StatePath:   m.statePath,
+			LogPath:     m.logPath,
+			StartedAt:   state.StartedAt,
+			HealthError: healthErr,
+		}, nil
+	}
+	if state.PID <= 0 {
+		_ = os.Remove(m.statePath)
+		return nil, fmt.Errorf("daemon state has invalid pid %d", state.PID)
+	}
+	if err := m.signalProcess(state.PID); err != nil {
+		return nil, fmt.Errorf("stop daemon process %d: %w", state.PID, err)
+	}
+	if err := m.waitForStopped(ctx, state.BaseURL, m.stopTimeout); err != nil {
+		return nil, err
+	}
+	if err := os.Remove(m.statePath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("remove daemon state: %w", err)
+	}
+	return &DaemonStatus{
+		Running:    false,
+		Managed:    true,
+		PID:        state.PID,
+		Listen:     state.Listen,
+		BaseURL:    state.BaseURL,
+		ConfigPath: state.ConfigPath,
+		StatePath:  m.statePath,
+		LogPath:    m.logPath,
+		StartedAt:  state.StartedAt,
+	}, nil
+}
+
+// Restart stops a managed daemon when present, then starts a new managed daemon.
+func (m *LifecycleManager) Restart(ctx context.Context, cfg *config.Config) (*DaemonStatus, error) {
+	if _, err := LoadDaemonState(m.statePath); err == nil {
+		if _, err := m.Stop(ctx, cfg); err != nil {
+			return nil, err
+		}
+	} else if !errors.Is(err, ErrDaemonStateNotFound) {
+		return nil, err
+	} else {
+		status, statusErr := m.Status(ctx, cfg)
+		if statusErr != nil {
+			return nil, statusErr
+		}
+		if status.Running {
+			return nil, fmt.Errorf("daemon is running at %s but no managed state file exists at %s", status.BaseURL, m.statePath)
+		}
+	}
+	return m.Start(ctx, cfg)
+}
+
+func effectiveLifecycleConfig(cfg *config.Config) (config.Config, error) {
+	if cfg == nil {
+		return config.Config{}, fmt.Errorf("config is nil")
+	}
+	effective := *cfg
+	if err := effective.Validate(); err != nil {
+		return config.Config{}, err
+	}
+	return effective, nil
+}
+
+func (m *LifecycleManager) waitForHealth(ctx context.Context, baseURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		if err := m.healthCheck(ctx, baseURL); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("daemon did not become healthy at %s within %s: %w", baseURL, timeout, lastErr)
+		}
+		if err := sleepWithContext(ctx, m.sleep, m.pollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+func (m *LifecycleManager) waitForStopped(ctx context.Context, baseURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := m.healthCheck(ctx, baseURL); err != nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("daemon at %s did not stop within %s", baseURL, timeout)
+		}
+		if err := sleepWithContext(ctx, m.sleep, m.pollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+func sleepWithContext(ctx context.Context, sleep func(time.Duration), d time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	sleep(d)
+	return ctx.Err()
+}
+
+func defaultHealthCheck(ctx context.Context, baseURL string) error {
+	u := strings.TrimRight(baseURL, "/") + "/health"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -1,0 +1,243 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/dewebprotocol/malt/config"
+)
+
+func TestLifecycleStartWritesManagedState(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RPC.Listen = "127.0.0.1:54321"
+	statePath := t.TempDir() + "/daemon.json"
+	logPath := t.TempDir() + "/daemon.log"
+	configPath := t.TempDir() + "/malt.json"
+	startedAt := time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC)
+	var started BackgroundProcessSpec
+	processStarted := false
+
+	manager := NewLifecycleManager(LifecycleOptions{
+		ConfigPath:     configPath,
+		StatePath:      statePath,
+		LogPath:        logPath,
+		Executable:     "/usr/local/bin/malt",
+		ForegroundArgs: []string{"--config", configPath, "daemon", "--listen", cfg.RPC.Listen},
+		Now:            func() time.Time { return startedAt },
+		StartProcess: func(spec BackgroundProcessSpec) (int, error) {
+			started = spec
+			processStarted = true
+			return 4242, nil
+		},
+		HealthCheck: func(context.Context, string) error {
+			if processStarted {
+				return nil
+			}
+			return errors.New("daemon not running")
+		},
+	})
+
+	status, err := manager.Start(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !status.Running || !status.Managed || status.PID != 4242 {
+		t.Fatalf("status = %+v, want managed running pid 4242", status)
+	}
+	if started.Executable != "/usr/local/bin/malt" {
+		t.Fatalf("started executable = %q", started.Executable)
+	}
+	if !slices.Equal(started.Args, []string{"--config", configPath, "daemon", "--listen", cfg.RPC.Listen}) {
+		t.Fatalf("started args = %v", started.Args)
+	}
+	if started.LogPath != logPath {
+		t.Fatalf("started log path = %q, want %q", started.LogPath, logPath)
+	}
+
+	state, err := LoadDaemonState(statePath)
+	if err != nil {
+		t.Fatalf("LoadDaemonState: %v", err)
+	}
+	if state.PID != 4242 || state.Listen != cfg.RPC.Listen || state.BaseURL != cfg.APIBaseURL() {
+		t.Fatalf("state = %+v", state)
+	}
+	if state.ConfigPath != configPath || state.StartedAt != startedAt {
+		t.Fatalf("state metadata = %+v", state)
+	}
+}
+
+func TestLifecycleStartDoesNotLaunchWhenDaemonIsHealthy(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RPC.Listen = "127.0.0.1:54322"
+	statePath := t.TempDir() + "/daemon.json"
+	if err := WriteDaemonState(statePath, &DaemonState{
+		PID:        1111,
+		Listen:     cfg.RPC.Listen,
+		BaseURL:    cfg.APIBaseURL(),
+		ConfigPath: "config.json",
+		StartedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteDaemonState: %v", err)
+	}
+
+	manager := NewLifecycleManager(LifecycleOptions{
+		StatePath: statePath,
+		StartProcess: func(BackgroundProcessSpec) (int, error) {
+			t.Fatal("StartProcess should not be called for a healthy daemon")
+			return 0, nil
+		},
+		HealthCheck: func(context.Context, string) error { return nil },
+	})
+
+	status, err := manager.Start(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !status.Running || !status.Managed || status.PID != 1111 {
+		t.Fatalf("status = %+v, want existing managed daemon", status)
+	}
+}
+
+func TestLifecycleStopSignalsManagedDaemonAndRemovesState(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RPC.Listen = "127.0.0.1:54323"
+	statePath := t.TempDir() + "/daemon.json"
+	if err := WriteDaemonState(statePath, &DaemonState{
+		PID:        1234,
+		Listen:     cfg.RPC.Listen,
+		BaseURL:    cfg.APIBaseURL(),
+		ConfigPath: "config.json",
+		StartedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteDaemonState: %v", err)
+	}
+
+	signaled := false
+	manager := NewLifecycleManager(LifecycleOptions{
+		StatePath:    statePath,
+		PollInterval: time.Nanosecond,
+		Sleep:        func(time.Duration) {},
+		SignalProcess: func(pid int) error {
+			if pid != 1234 {
+				t.Fatalf("signal pid = %d, want 1234", pid)
+			}
+			signaled = true
+			return nil
+		},
+		HealthCheck: func(context.Context, string) error {
+			if signaled {
+				return errors.New("daemon stopped")
+			}
+			return nil
+		},
+	})
+
+	status, err := manager.Stop(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if !signaled {
+		t.Fatal("daemon process was not signaled")
+	}
+	if status.Running {
+		t.Fatalf("status = %+v, want stopped", status)
+	}
+	if _, err := LoadDaemonState(statePath); !errors.Is(err, ErrDaemonStateNotFound) {
+		t.Fatalf("LoadDaemonState after stop = %v, want ErrDaemonStateNotFound", err)
+	}
+}
+
+func TestLifecycleStopRemovesStaleStateWithoutSignaling(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RPC.Listen = "127.0.0.1:54325"
+	statePath := t.TempDir() + "/daemon.json"
+	if err := WriteDaemonState(statePath, &DaemonState{
+		PID:        9999,
+		Listen:     cfg.RPC.Listen,
+		BaseURL:    cfg.APIBaseURL(),
+		ConfigPath: "config.json",
+		StartedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteDaemonState: %v", err)
+	}
+
+	manager := NewLifecycleManager(LifecycleOptions{
+		StatePath: statePath,
+		SignalProcess: func(int) error {
+			t.Fatal("stale daemon state should not signal a process")
+			return nil
+		},
+		HealthCheck: func(context.Context, string) error {
+			return errors.New("daemon stopped")
+		},
+	})
+
+	status, err := manager.Stop(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if status.Running {
+		t.Fatalf("status = %+v, want stopped", status)
+	}
+	if _, err := LoadDaemonState(statePath); !errors.Is(err, ErrDaemonStateNotFound) {
+		t.Fatalf("LoadDaemonState after stale stop = %v, want ErrDaemonStateNotFound", err)
+	}
+}
+
+func TestLifecycleRestartStopsThenStarts(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RPC.Listen = "127.0.0.1:54324"
+	statePath := t.TempDir() + "/daemon.json"
+	if err := WriteDaemonState(statePath, &DaemonState{
+		PID:        1234,
+		Listen:     cfg.RPC.Listen,
+		BaseURL:    cfg.APIBaseURL(),
+		ConfigPath: "config.json",
+		StartedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteDaemonState: %v", err)
+	}
+
+	running := true
+	var signaledPID int
+	var startCalls int
+	manager := NewLifecycleManager(LifecycleOptions{
+		StatePath:    statePath,
+		Executable:   "/usr/local/bin/malt",
+		PollInterval: time.Nanosecond,
+		Sleep:        func(time.Duration) {},
+		SignalProcess: func(pid int) error {
+			signaledPID = pid
+			running = false
+			return nil
+		},
+		StartProcess: func(BackgroundProcessSpec) (int, error) {
+			startCalls++
+			running = true
+			return 5678, nil
+		},
+		HealthCheck: func(context.Context, string) error {
+			if running {
+				return nil
+			}
+			return errors.New("daemon stopped")
+		},
+	})
+
+	status, err := manager.Restart(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	if signaledPID != 1234 {
+		t.Fatalf("signaled pid = %d, want 1234", signaledPID)
+	}
+	if startCalls != 1 {
+		t.Fatalf("start calls = %d, want 1", startCalls)
+	}
+	if !status.Running || status.PID != 5678 {
+		t.Fatalf("status = %+v, want restarted pid 5678", status)
+	}
+}

--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -26,13 +26,24 @@ func TestLifecycleStartWritesManagedState(t *testing.T) {
 		LogPath:        logPath,
 		Executable:     "/usr/local/bin/malt",
 		ForegroundArgs: []string{"--config", configPath, "daemon", "--listen", cfg.RPC.Listen},
+		Env:            []string{LifecycleTokenEnv + "=old-token", "PATH=/bin"},
 		Now:            func() time.Time { return startedAt },
+		GenerateToken:  func() (string, error) { return "managed-token", nil },
 		StartProcess: func(spec BackgroundProcessSpec) (int, error) {
 			started = spec
 			processStarted = true
 			return 4242, nil
 		},
 		HealthCheck: func(context.Context, string) error {
+			if processStarted {
+				return nil
+			}
+			return errors.New("daemon not running")
+		},
+		IdentityCheck: func(_ context.Context, _ string, token string) error {
+			if token != "managed-token" {
+				t.Fatalf("identity token = %q, want managed-token", token)
+			}
 			if processStarted {
 				return nil
 			}
@@ -56,6 +67,12 @@ func TestLifecycleStartWritesManagedState(t *testing.T) {
 	if started.LogPath != logPath {
 		t.Fatalf("started log path = %q, want %q", started.LogPath, logPath)
 	}
+	if !slices.Contains(started.Env, LifecycleTokenEnv+"=managed-token") {
+		t.Fatalf("started env missing lifecycle token: %v", started.Env)
+	}
+	if slices.Contains(started.Env, LifecycleTokenEnv+"=old-token") {
+		t.Fatalf("started env retained stale lifecycle token: %v", started.Env)
+	}
 
 	state, err := LoadDaemonState(statePath)
 	if err != nil {
@@ -67,6 +84,9 @@ func TestLifecycleStartWritesManagedState(t *testing.T) {
 	if state.ConfigPath != configPath || state.StartedAt != startedAt {
 		t.Fatalf("state metadata = %+v", state)
 	}
+	if state.LifecycleToken != "managed-token" {
+		t.Fatalf("state lifecycle token = %q, want managed-token", state.LifecycleToken)
+	}
 }
 
 func TestLifecycleStartDoesNotLaunchWhenDaemonIsHealthy(t *testing.T) {
@@ -74,11 +94,12 @@ func TestLifecycleStartDoesNotLaunchWhenDaemonIsHealthy(t *testing.T) {
 	cfg.RPC.Listen = "127.0.0.1:54322"
 	statePath := t.TempDir() + "/daemon.json"
 	if err := WriteDaemonState(statePath, &DaemonState{
-		PID:        1111,
-		Listen:     cfg.RPC.Listen,
-		BaseURL:    cfg.APIBaseURL(),
-		ConfigPath: "config.json",
-		StartedAt:  time.Now(),
+		PID:            1111,
+		Listen:         cfg.RPC.Listen,
+		BaseURL:        cfg.APIBaseURL(),
+		ConfigPath:     "config.json",
+		LifecycleToken: "managed-token",
+		StartedAt:      time.Now(),
 	}); err != nil {
 		t.Fatalf("WriteDaemonState: %v", err)
 	}
@@ -89,7 +110,8 @@ func TestLifecycleStartDoesNotLaunchWhenDaemonIsHealthy(t *testing.T) {
 			t.Fatal("StartProcess should not be called for a healthy daemon")
 			return 0, nil
 		},
-		HealthCheck: func(context.Context, string) error { return nil },
+		HealthCheck:   func(context.Context, string) error { return nil },
+		IdentityCheck: func(context.Context, string, string) error { return nil },
 	})
 
 	status, err := manager.Start(context.Background(), cfg)
@@ -106,11 +128,12 @@ func TestLifecycleStopSignalsManagedDaemonAndRemovesState(t *testing.T) {
 	cfg.RPC.Listen = "127.0.0.1:54323"
 	statePath := t.TempDir() + "/daemon.json"
 	if err := WriteDaemonState(statePath, &DaemonState{
-		PID:        1234,
-		Listen:     cfg.RPC.Listen,
-		BaseURL:    cfg.APIBaseURL(),
-		ConfigPath: "config.json",
-		StartedAt:  time.Now(),
+		PID:            1234,
+		Listen:         cfg.RPC.Listen,
+		BaseURL:        cfg.APIBaseURL(),
+		ConfigPath:     "config.json",
+		LifecycleToken: "managed-token",
+		StartedAt:      time.Now(),
 	}); err != nil {
 		t.Fatalf("WriteDaemonState: %v", err)
 	}
@@ -133,6 +156,7 @@ func TestLifecycleStopSignalsManagedDaemonAndRemovesState(t *testing.T) {
 			}
 			return nil
 		},
+		IdentityCheck: func(context.Context, string, string) error { return nil },
 	})
 
 	status, err := manager.Stop(context.Background(), cfg)
@@ -147,6 +171,45 @@ func TestLifecycleStopSignalsManagedDaemonAndRemovesState(t *testing.T) {
 	}
 	if _, err := LoadDaemonState(statePath); !errors.Is(err, ErrDaemonStateNotFound) {
 		t.Fatalf("LoadDaemonState after stop = %v, want ErrDaemonStateNotFound", err)
+	}
+}
+
+func TestLifecycleStopRemovesStateWithoutSignalingWhenIdentityMismatches(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RPC.Listen = "127.0.0.1:54326"
+	statePath := t.TempDir() + "/daemon.json"
+	if err := WriteDaemonState(statePath, &DaemonState{
+		PID:            9999,
+		Listen:         cfg.RPC.Listen,
+		BaseURL:        cfg.APIBaseURL(),
+		ConfigPath:     "config.json",
+		LifecycleToken: "managed-token",
+		StartedAt:      time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteDaemonState: %v", err)
+	}
+
+	manager := NewLifecycleManager(LifecycleOptions{
+		StatePath: statePath,
+		SignalProcess: func(int) error {
+			t.Fatal("mismatched daemon identity should not signal a process")
+			return nil
+		},
+		HealthCheck: func(context.Context, string) error { return nil },
+		IdentityCheck: func(context.Context, string, string) error {
+			return errors.New("lifecycle token mismatch")
+		},
+	})
+
+	status, err := manager.Stop(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if status.Running {
+		t.Fatalf("status = %+v, want stopped", status)
+	}
+	if _, err := LoadDaemonState(statePath); !errors.Is(err, ErrDaemonStateNotFound) {
+		t.Fatalf("LoadDaemonState after identity mismatch = %v, want ErrDaemonStateNotFound", err)
 	}
 }
 
@@ -192,11 +255,12 @@ func TestLifecycleRestartStopsThenStarts(t *testing.T) {
 	cfg.RPC.Listen = "127.0.0.1:54324"
 	statePath := t.TempDir() + "/daemon.json"
 	if err := WriteDaemonState(statePath, &DaemonState{
-		PID:        1234,
-		Listen:     cfg.RPC.Listen,
-		BaseURL:    cfg.APIBaseURL(),
-		ConfigPath: "config.json",
-		StartedAt:  time.Now(),
+		PID:            1234,
+		Listen:         cfg.RPC.Listen,
+		BaseURL:        cfg.APIBaseURL(),
+		ConfigPath:     "config.json",
+		LifecycleToken: "managed-token",
+		StartedAt:      time.Now(),
 	}); err != nil {
 		t.Fatalf("WriteDaemonState: %v", err)
 	}
@@ -220,6 +284,12 @@ func TestLifecycleRestartStopsThenStarts(t *testing.T) {
 			return 5678, nil
 		},
 		HealthCheck: func(context.Context, string) error {
+			if running {
+				return nil
+			}
+			return errors.New("daemon stopped")
+		},
+		IdentityCheck: func(context.Context, string, string) error {
 			if running {
 				return nil
 			}

--- a/daemon/process.go
+++ b/daemon/process.go
@@ -1,0 +1,39 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func defaultStartProcess(spec BackgroundProcessSpec) (int, error) {
+	if spec.Executable == "" {
+		return 0, fmt.Errorf("daemon executable is empty")
+	}
+	cmd := exec.Command(spec.Executable, spec.Args...)
+	if len(spec.Env) > 0 {
+		cmd.Env = spec.Env
+	}
+	if spec.LogPath != "" {
+		if err := os.MkdirAll(filepath.Dir(spec.LogPath), 0o755); err != nil {
+			return 0, fmt.Errorf("create daemon log dir: %w", err)
+		}
+		log, err := os.OpenFile(spec.LogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			return 0, fmt.Errorf("open daemon log: %w", err)
+		}
+		defer log.Close()
+		cmd.Stdout = log
+		cmd.Stderr = log
+	}
+	configureBackgroundCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Process.Release(); err != nil {
+		return 0, err
+	}
+	return pid, nil
+}

--- a/daemon/process_other.go
+++ b/daemon/process_other.go
@@ -1,0 +1,18 @@
+//go:build !linux && !darwin && !freebsd && !netbsd && !openbsd && !dragonfly && !windows
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+)
+
+func configureBackgroundCommand(*exec.Cmd) {}
+
+func defaultSignalProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Kill()
+}

--- a/daemon/process_unix.go
+++ b/daemon/process_unix.go
@@ -1,0 +1,21 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureBackgroundCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func defaultSignalProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Signal(syscall.SIGTERM)
+}

--- a/daemon/process_windows.go
+++ b/daemon/process_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+const createNewProcessGroup = 0x00000200
+
+func configureBackgroundCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNewProcessGroup}
+}
+
+func defaultSignalProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Kill()
+}

--- a/daemon/run.go
+++ b/daemon/run.go
@@ -21,6 +21,7 @@ import (
 type RunOptions struct {
 	ListenOverride string
 	APILabel       string
+	LifecycleToken string
 	Stdout         io.Writer
 	Stderr         io.Writer
 }
@@ -81,7 +82,7 @@ func Run(cfg *config.Config, opts RunOptions) error {
 	}
 	defer node.Close()
 
-	srv := server.New(node, effective.RPC.Listen)
+	srv := server.New(node, effective.RPC.Listen, server.WithLifecycleToken(opts.LifecycleToken))
 	srvErr := make(chan error, 1)
 	go func() {
 		if err := srv.Start(); err != nil && err != http.ErrServerClosed {

--- a/server/routes_admin.go
+++ b/server/routes_admin.go
@@ -8,7 +8,10 @@ import (
 )
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, &httpapi.HealthResponse{Status: "ok"})
+	writeJSON(w, http.StatusOK, &httpapi.HealthResponse{
+		Status:         "ok",
+		LifecycleToken: s.lifecycleToken,
+	})
 }
 
 func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {

--- a/server/server.go
+++ b/server/server.go
@@ -20,19 +20,35 @@ const defaultRootGraphID = "default"
 
 // Server serves the daemon HTTP API.
 type Server struct {
-	node         *node.Node
-	addr         string
-	server       *http.Server
-	defaultGraph graph.Runtime
-	graphMu      sync.Mutex
+	node           *node.Node
+	addr           string
+	lifecycleToken string
+	server         *http.Server
+	defaultGraph   graph.Runtime
+	graphMu        sync.Mutex
+}
+
+// Option configures the daemon server.
+type Option func(*Server)
+
+// WithLifecycleToken exposes the managed-process identity token through
+// /health for local lifecycle commands.
+func WithLifecycleToken(token string) Option {
+	return func(s *Server) {
+		s.lifecycleToken = token
+	}
 }
 
 // New creates a new daemon server.
-func New(node *node.Node, addr string) *Server {
-	return &Server{
+func New(node *node.Node, addr string, opts ...Option) *Server {
+	s := &Server{
 		node: node,
 		addr: addr,
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Handler returns the configured HTTP handler.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -70,6 +70,9 @@ func TestServerHealthAndRootLifecycle(t *testing.T) {
 	if health.Status != "ok" {
 		t.Fatalf("health status payload = %q, want %q", health.Status, "ok")
 	}
+	if health.LifecycleToken != "" {
+		t.Fatalf("health lifecycle token = %q, want empty", health.LifecycleToken)
+	}
 
 	createBody, err := json.Marshal(&httpapi.CreateStructureRequest{
 		Arcs: withPayloadBinding(map[string]string{"test": fakeCIDString("test")}),
@@ -101,6 +104,30 @@ func TestServerHealthAndRootLifecycle(t *testing.T) {
 	}
 	if rootResp.Root == "" {
 		t.Fatalf("root = %q, want non-empty root", rootResp.Root)
+	}
+}
+
+func TestServerHealthIncludesLifecycleTokenWhenConfigured(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0", WithLifecycleToken("managed-token")).Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatalf("health request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var health httpapi.HealthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if health.Status != "ok" {
+		t.Fatalf("health status payload = %q, want %q", health.Status, "ok")
+	}
+	if health.LifecycleToken != "managed-token" {
+		t.Fatalf("health lifecycle token = %q, want managed-token", health.LifecycleToken)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep bare `malt daemon` as the foreground server mode
- add managed background lifecycle commands: `malt daemon start`, `status`, `stop`, and `restart`
- record daemon state/log paths next to the selected config and avoid signaling stale PID files
- update implementation README for the foreground/background split

## Verification
- `env GOCACHE=/tmp/go-build-cache go test ./...`
- `git diff --check`
- `env GOOS=windows GOARCH=amd64 GOCACHE=/tmp/go-build-cache go test -c ./daemon -o /tmp/malt-daemon-windows.test.exe`
- smoke: built temporary CLI, ran daemon start/status/restart/stop on a temp config outside the sandbox network restrictions