### PR TITLE
feat: allow browser proof tools

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -572,7 +572,8 @@ Current config shape:
 ```json
 {
   "rpc": {
-    "listen": "127.0.0.1:4317"
+    "listen": "127.0.0.1:4317",
+    "cors_allowed_origins": []
   },
   "state": {
     "root_dir": "D:/malt-state",
@@ -603,6 +604,8 @@ Allowed runtime values:
 
 - `state.kvstore.type`: `badger`, `memory`, or `fs`
 - `structure.default_backend`: `kzg` or `ipa`
+- `rpc.cors_allowed_origins`: exact browser origins allowed to call local
+  read/proof routes and `POST /verify`
 
 This config is a packaging and runtime decision. It does not define the core
 MALT semantic abstraction.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Current operator flow:
 Current schema:
 
 - `rpc.listen`
+- `rpc.cors_allowed_origins`
 - `state.root_dir`
 - `state.kvstore`
 - `state.kvstore.type` accepts `badger`, `memory`, or `fs`
@@ -397,6 +398,7 @@ Current defaults:
 - structure backend: `kzg`
 - ArcTable type: `versioned`
 - CAS mode: `embedded-mock`
+- browser CORS origins: empty unless explicitly configured
 
 ## Repo Layout
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
   "rpc": {
-    "listen": "127.0.0.1:4317"
+    "listen": "127.0.0.1:4317",
+    "cors_allowed_origins": []
   },
   "state": {
     "root_dir": "~/.malt/state",

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,8 @@ type Config struct {
 
 // RPCConfig configures the local daemon HTTP endpoint.
 type RPCConfig struct {
-	Listen string `json:"listen"`
+	Listen             string   `json:"listen"`
+	CORSAllowedOrigins []string `json:"cors_allowed_origins,omitempty"`
 }
 
 // StateConfig configures local durable runtime state.
@@ -232,6 +233,7 @@ func (c *Config) applyDefaults() {
 	if c.RPC.Listen == "" {
 		c.RPC.Listen = defaults.RPC.Listen
 	}
+	c.RPC.CORSAllowedOrigins = cleanStringList(c.RPC.CORSAllowedOrigins)
 	if c.State.RootDir == "" {
 		c.State.RootDir = defaults.State.RootDir
 	}
@@ -326,6 +328,21 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+func cleanStringList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := values[:0]
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
 }
 
 // ConfigDir returns the parent directory of the config file.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,6 +14,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.RPC.Listen != "127.0.0.1:4317" {
 		t.Fatalf("RPC.Listen = %q", cfg.RPC.Listen)
 	}
+	if len(cfg.RPC.CORSAllowedOrigins) != 0 {
+		t.Fatalf("RPC.CORSAllowedOrigins = %v, want empty by default", cfg.RPC.CORSAllowedOrigins)
+	}
 	if cfg.State.KVStore.Type != "badger" {
 		t.Fatalf("State.KVStore.Type = %q", cfg.State.KVStore.Type)
 	}
@@ -55,7 +58,8 @@ func TestLoadFromFile_NewSchema(t *testing.T) {
 	path := filepath.Join(tmpDir, "malt.json")
 	content := `{
   "rpc": {
-    "listen": "127.0.0.1:9999"
+    "listen": "127.0.0.1:9999",
+    "cors_allowed_origins": ["http://localhost:5173", "https://docs.example"]
   },
   "state": {
     "root_dir": "~/custom-state",
@@ -99,6 +103,9 @@ func TestLoadFromFile_NewSchema(t *testing.T) {
 
 	if cfg.RPC.Listen != "127.0.0.1:9999" {
 		t.Fatalf("RPC.Listen = %q", cfg.RPC.Listen)
+	}
+	if got := cfg.RPC.CORSAllowedOrigins; len(got) != 2 || got[0] != "http://localhost:5173" || got[1] != "https://docs.example" {
+		t.Fatalf("RPC.CORSAllowedOrigins = %#v", got)
 	}
 	if cfg.CAS.Mode != "external" {
 		t.Fatalf("CAS.Mode = %q", cfg.CAS.Mode)

--- a/daemon/run.go
+++ b/daemon/run.go
@@ -82,7 +82,12 @@ func Run(cfg *config.Config, opts RunOptions) error {
 	}
 	defer node.Close()
 
-	srv := server.New(node, effective.RPC.Listen, server.WithLifecycleToken(opts.LifecycleToken))
+	srv := server.New(
+		node,
+		effective.RPC.Listen,
+		server.WithLifecycleToken(opts.LifecycleToken),
+		server.WithBrowserOrigins(effective.RPC.CORSAllowedOrigins),
+	)
 	srvErr := make(chan error, 1)
 	go func() {
 		if err := srv.Start(); err != nil && err != http.ErrServerClosed {

--- a/server/cors.go
+++ b/server/cors.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+)
+
+const browserCORSAllowHeaders = "Content-Type, Range, X-Malt-Proof"
+const browserCORSExposeHeaders = "X-Malt-ProofList, X-Malt-ProofList-Encoding, Content-Range, X-Malt-Kind, X-Malt-Storage-Kind, X-Malt-Key, X-Malt-Payload"
+const browserCORSAllowMethods = "GET, HEAD, POST, OPTIONS"
+
+func browserOriginSet(origins []string) map[string]struct{} {
+	if len(origins) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(origins))
+	for _, origin := range origins {
+		origin = strings.TrimSpace(origin)
+		if origin == "" {
+			continue
+		}
+		set[origin] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
+}
+
+func (s *Server) browserCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if _, ok := s.browserOrigins[origin]; !ok {
+			http.Error(w, "origin is not allowed", http.StatusForbidden)
+			return
+		}
+
+		method := r.Method
+		if method == http.MethodOptions {
+			method = r.Header.Get("Access-Control-Request-Method")
+		}
+		if !browserCORSRouteAllowed(method, r.URL.Path) {
+			http.Error(w, "route is not allowed for browser access", http.StatusForbidden)
+			return
+		}
+
+		writeBrowserCORSHeaders(w, origin)
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func writeBrowserCORSHeaders(w http.ResponseWriter, origin string) {
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Access-Control-Allow-Methods", browserCORSAllowMethods)
+	w.Header().Set("Access-Control-Allow-Headers", browserCORSAllowHeaders)
+	w.Header().Set("Access-Control-Expose-Headers", browserCORSExposeHeaders)
+	w.Header().Set("Access-Control-Max-Age", "600")
+	addVaryHeader(w, "Origin")
+}
+
+func browserCORSRouteAllowed(method, rawPath string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead:
+		return browserCORSReadPathAllowed(rawPath)
+	case http.MethodPost:
+		return rawPath == "/verify"
+	default:
+		return false
+	}
+}
+
+func browserCORSReadPathAllowed(rawPath string) bool {
+	if rawPath == "/health" {
+		return true
+	}
+	if strings.HasPrefix(rawPath, "/resolve/") {
+		return true
+	}
+	trimmed := strings.Trim(rawPath, "/")
+	if trimmed == "" {
+		return false
+	}
+	first, _, _ := strings.Cut(trimmed, "/")
+	switch first {
+	case "health", "metrics", "metrics:reset", "resolve", "verify", "lineage", "_", "_unixfs":
+		return false
+	default:
+		return true
+	}
+}

--- a/server/cors_test.go
+++ b/server/cors_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBrowserCORSAllowsConfiguredResolveAndVerifyRoutes(t *testing.T) {
+	s := New(nil, "127.0.0.1:0", WithBrowserOrigins([]string{"https://docs.example"}))
+	handler := s.Handler()
+
+	t.Run("resolve GET preflight exposes proof headers", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/resolve/bafkqaaa/docs/readme", nil)
+		req.Header.Set("Origin", "https://docs.example")
+		req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("preflight status = %d, want %d", rec.Code, http.StatusNoContent)
+		}
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://docs.example" {
+			t.Fatalf("Access-Control-Allow-Origin = %q, want configured origin", got)
+		}
+		if got := rec.Header().Values("Vary"); !containsHeaderValue(got, "Origin") {
+			t.Fatalf("Vary headers = %v, want Origin", got)
+		}
+		expose := rec.Header().Get("Access-Control-Expose-Headers")
+		for _, want := range []string{"X-Malt-ProofList", "X-Malt-ProofList-Encoding", "Content-Range", "X-Malt-Key"} {
+			if !strings.Contains(expose, want) {
+				t.Fatalf("Access-Control-Expose-Headers = %q, want %s", expose, want)
+			}
+		}
+	})
+
+	t.Run("verify POST preflight", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/verify", nil)
+		req.Header.Set("Origin", "https://docs.example")
+		req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+		req.Header.Set("Access-Control-Request-Headers", "content-type")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("preflight status = %d, want %d", rec.Code, http.StatusNoContent)
+		}
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://docs.example" {
+			t.Fatalf("Access-Control-Allow-Origin = %q, want configured origin", got)
+		}
+		if methods := rec.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(methods, http.MethodPost) {
+			t.Fatalf("Access-Control-Allow-Methods = %q, want POST", methods)
+		}
+		if headers := strings.ToLower(rec.Header().Get("Access-Control-Allow-Headers")); !strings.Contains(headers, "content-type") {
+			t.Fatalf("Access-Control-Allow-Headers = %q, want content-type", headers)
+		}
+	})
+}
+
+func TestBrowserCORSDeniesUnconfiguredOriginsAndWriteRoutes(t *testing.T) {
+	s := New(nil, "127.0.0.1:0", WithBrowserOrigins([]string{"https://docs.example"}))
+	handler := s.Handler()
+
+	t.Run("unconfigured origin", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Header.Set("Origin", "https://elsewhere.example")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Fatalf("Access-Control-Allow-Origin = %q, want empty", got)
+		}
+	})
+
+	t.Run("write route preflight", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/bafkqaaa/file.txt", nil)
+		req.Header.Set("Origin", "https://docs.example")
+		req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+		req.Header.Set("Access-Control-Request-Headers", "content-type")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("write preflight status = %d, want %d", rec.Code, http.StatusForbidden)
+		}
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Fatalf("Access-Control-Allow-Origin = %q, want empty", got)
+		}
+	})
+}
+
+func containsHeaderValue(values []string, want string) bool {
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), want) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,7 @@ type Server struct {
 	node           *node.Node
 	addr           string
 	lifecycleToken string
+	browserOrigins map[string]struct{}
 	server         *http.Server
 	defaultGraph   graph.Runtime
 	graphMu        sync.Mutex
@@ -36,6 +37,14 @@ type Option func(*Server)
 func WithLifecycleToken(token string) Option {
 	return func(s *Server) {
 		s.lifecycleToken = token
+	}
+}
+
+// WithBrowserOrigins allows browser-based read and proof verification tools to
+// call the local daemon from the configured origins.
+func WithBrowserOrigins(origins []string) Option {
+	return func(s *Server) {
+		s.browserOrigins = browserOriginSet(origins)
 	}
 }
 
@@ -55,13 +64,17 @@ func New(node *node.Node, addr string, opts ...Option) *Server {
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	s.registerRoutes(mux)
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isRemovedPublicRoute(r.Method, r.URL.Path) {
 			s.handleRemovedPublicRoute(w, r)
 			return
 		}
 		mux.ServeHTTP(w, r)
 	})
+	if len(s.browserOrigins) == 0 {
+		return handler
+	}
+	return s.browserCORS(handler)
 }
 
 // Start starts the HTTP server.


### PR DESCRIPTION
## Summary
- add rpc.cors_allowed_origins for configured browser origins
- expose CORS only for read/proof routes and POST /verify, not write routes
- document the browser CORS setting for the web resolve/verify tools

## Tests
- env GOCACHE=/tmp/go-build-cache go test ./server ./config ./daemon
- env GOCACHE=/tmp/go-build-cache go test ./...