### PR TITLE
fix: persist embedded CAS payloads

### DIFF
--- a/daemon/run.go
+++ b/daemon/run.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/dewebprotocol/malt/runtime/node"
 	"github.com/dewebprotocol/malt/server"
 	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
+	kvfs "github.com/dewebprotocol/malt/storage/kv/fs"
 )
 
 // RunOptions configures daemon process startup.
@@ -57,14 +59,16 @@ func Run(cfg *config.Config, opts RunOptions) error {
 		mockSrv     *casmock.HTTPServer
 		mockSrvErr  chan error
 		mockCASInst *casmock.CAS
+		closeCAS    func() error
 	)
 
 	if effective.CAS.Mode == "embedded-mock" {
-		mockOpts, err := embeddedMockCASOptions(&effective)
+		var err error
+		mockCASInst, closeCAS, err = newEmbeddedMockCAS(&effective)
 		if err != nil {
 			return err
 		}
-		mockCASInst = casmock.NewCAS(mockOpts...)
+		defer func() { _ = closeCAS() }()
 		nodeOpts = append(nodeOpts, node.WithCAS(mockCASInst))
 		mockSrv = casmock.NewHTTPServer(effective.CAS.EmbeddedMock.Listen, mockCASInst)
 		mockSrvErr = make(chan error, 1)
@@ -122,6 +126,22 @@ func Run(cfg *config.Config, opts RunOptions) error {
 		return err
 	}
 	return nil
+}
+
+func newEmbeddedMockCAS(cfg *config.Config) (*casmock.CAS, func() error, error) {
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("config is nil")
+	}
+	mockOpts, err := embeddedMockCASOptions(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	kv, err := kvfs.New(filepath.Join(cfg.State.RootDir, "cas"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("initialize embedded mock CAS store: %w", err)
+	}
+	mockOpts = append(mockOpts, casmock.WithKVStore(kv))
+	return casmock.NewCAS(mockOpts...), kv.Close, nil
 }
 
 func mockServerError(ch chan error) <-chan error {

--- a/daemon/run_test.go
+++ b/daemon/run_test.go
@@ -25,3 +25,34 @@ func TestEmbeddedMockCASOptionsDefaultToNoLatency(t *testing.T) {
 		t.Fatalf("default embedded mock Put took %s, want no artificial latency", elapsed)
 	}
 }
+
+func TestNewEmbeddedMockCASPersistsBlocksUnderStateRoot(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.State.RootDir = t.TempDir()
+
+	first, closeFirst, err := newEmbeddedMockCAS(cfg)
+	if err != nil {
+		t.Fatalf("new first embedded mock CAS: %v", err)
+	}
+	block, err := first.Put(t.Context(), []byte("persistent payload"))
+	if err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	if err := closeFirst(); err != nil {
+		t.Fatalf("close first embedded mock CAS: %v", err)
+	}
+
+	second, closeSecond, err := newEmbeddedMockCAS(cfg)
+	if err != nil {
+		t.Fatalf("new second embedded mock CAS: %v", err)
+	}
+	defer closeSecond()
+
+	got, err := second.Get(t.Context(), block)
+	if err != nil {
+		t.Fatalf("second Get: %v", err)
+	}
+	if string(got) != "persistent payload" {
+		t.Fatalf("payload = %q, want persistent payload", got)
+	}
+}

--- a/server/routes_content.go
+++ b/server/routes_content.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dewebprotocol/malt/api/http"
 	"github.com/dewebprotocol/malt/graph"
 	"github.com/dewebprotocol/malt/graph/resolver"
+	"github.com/dewebprotocol/malt/storage/cas"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -62,7 +63,6 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if stat.Kind == "dir" {
-		// Return JSON directory listing
 		if resolved.proofList != nil {
 			if err := writeProofListHeader(w, *resolved.proofList); err != nil {
 				writeError(w, http.StatusInternalServerError, err.Error())
@@ -70,8 +70,15 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 			}
 			s.node.RecordProofList(*resolved.proofList)
 		}
+		payload, err := readDirectoryContentPayload(r.Context(), s.node.CAS(), stat)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
 		addVaryHeader(w, "X-Malt-Proof")
-		writeJSON(w, http.StatusOK, stat)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
 		return
 	}
 
@@ -135,4 +142,18 @@ func (s *Server) readContentPayload(ctx context.Context, g graph.Runtime, stat *
 	default:
 		return nil, fmt.Errorf("unsupported storage kind for content")
 	}
+}
+
+func readDirectoryContentPayload(ctx context.Context, blocks cas.Reader, stat *httpapi.PathStatResponse) ([]byte, error) {
+	if stat == nil || stat.Kind != "dir" {
+		return nil, fmt.Errorf("directory stat is required")
+	}
+	if stat.Payload == "" {
+		return nil, fmt.Errorf("directory payload is missing")
+	}
+	payloadCID, err := decodeCID(stat.Payload)
+	if err != nil {
+		return nil, err
+	}
+	return blocks.Get(ctx, payloadCID)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1891,11 +1891,13 @@ func TestServerManifestRootUsesManifestDirectoryPath(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("GET manifest status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
-	var got httpapi.PathStatResponse
-	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
-		t.Fatalf("decode manifest stat: %v", err)
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read manifest body: %v", err)
 	}
-	requireManifestStat(t, &got, manifestCID, []string{"large.bin", "raw.txt"})
+	if !bytes.Equal(got, manifestData) {
+		t.Fatalf("GET manifest body = %q, want %q", got, manifestData)
+	}
 }
 
 func requireManifestStat(t *testing.T, stat *httpapi.PathStatResponse, manifestCID cid.Cid, entries []string) {
@@ -2531,8 +2533,18 @@ func TestServerDefaultGETDirectoryProofHeader(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	// Default GET on directory should include proof header
-	resp, err = http.Get(ts.URL + "/" + dirResp.NewRoot + "/docs")
+	resp, err = http.Post(ts.URL+"/"+dirResp.NewRoot+"/docs/readme.txt", "application/octet-stream", bytes.NewReader([]byte("hello")))
+	if err != nil {
+		t.Fatalf("create nested file: %v", err)
+	}
+	var fileResp httpapi.UnixFSWriteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fileResp); err != nil {
+		t.Fatalf("decode file response: %v", err)
+	}
+	resp.Body.Close()
+
+	// Default GET on directory should serve the directory manifest payload with a proof header.
+	resp, err = http.Get(ts.URL + "/" + fileResp.NewRoot + "/docs")
 	if err != nil {
 		t.Fatalf("GET directory: %v", err)
 	}
@@ -2542,12 +2554,12 @@ func TestServerDefaultGETDirectoryProofHeader(t *testing.T) {
 		t.Fatalf("GET directory status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
-	var dirStat httpapi.PathStatResponse
-	if err := json.NewDecoder(resp.Body).Decode(&dirStat); err != nil {
-		t.Fatalf("decode directory response: %v", err)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read directory body: %v", err)
 	}
-	if dirStat.Kind != "dir" {
-		t.Fatalf("dir stat kind = %q, want %q", dirStat.Kind, "dir")
+	if got, want := string(body), `{"entries":["readme.txt"]}`; got != want {
+		t.Fatalf("directory body = %q, want manifest %q", got, want)
 	}
 
 	proofListHeader := resp.Header.Get("X-Malt-ProofList")

--- a/storage/cas/mock/mock.go
+++ b/storage/cas/mock/mock.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/dewebprotocol/malt/storage/cas"
+	kvstore "github.com/dewebprotocol/malt/storage/kv"
 	"github.com/dewebprotocol/malt/storage/kv/memory"
 	cid "github.com/ipfs/go-cid"
 )
@@ -32,7 +33,7 @@ const (
 
 // CAS is a mock CAS for testing, backed by KVStore with simulated latency.
 type CAS struct {
-	kv         *memory.KV
+	kv         kvstore.KVStore
 	getLatency time.Duration
 	putLatency time.Duration
 	hasLatency time.Duration
@@ -51,6 +52,7 @@ type options struct {
 	putLatency time.Duration
 	hasLatency time.Duration
 	jitter     time.Duration
+	kv         kvstore.KVStore
 }
 
 func defaultOptions() *options {
@@ -100,6 +102,13 @@ func WithoutLatency() Option {
 	}
 }
 
+// WithKVStore stores mock CAS blocks in the supplied KVStore.
+func WithKVStore(kv kvstore.KVStore) Option {
+	return func(o *options) {
+		o.kv = kv
+	}
+}
+
 // NewCAS creates a mock CAS backed by an in-memory KVStore.
 // By default, operations simulate ProbeLab Kubo v0.39.0 e2e latency.
 // Use WithoutLatency for fast unit tests, or individual WithXLatency to tune.
@@ -108,9 +117,13 @@ func NewCAS(opts ...Option) *CAS {
 	for _, opt := range opts {
 		opt(options)
 	}
+	kv := options.kv
+	if kv == nil {
+		kv = memory.New()
+	}
 
 	return &CAS{
-		kv:         memory.New(),
+		kv:         kv,
 		getLatency: options.getLatency,
 		putLatency: options.putLatency,
 		hasLatency: options.hasLatency,


### PR DESCRIPTION
## Summary
- persist the embedded mock CAS under the daemon state root so local daemon restarts keep published payload blocks readable
- serve directory/map content reads as the directory manifest payload instead of path stat JSON
- keep ProofList headers on directory reads and update manifest-root compatibility coverage

## Verification
- env GOCACHE=/tmp/go-build-cache go test ./...
- git diff --check
- local daemon smoke: upload malt/api/http/types.go, read directory manifest content, restart daemon, read the same file successfully