### PR TITLE
fix: require explicit legacy unixfs migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,9 +282,13 @@ Current boundary:
   `writer.SemanticMutation` values.
 - `POST /{root}/_mutate` is the writer mutation route. The root-centric daemon
   also exposes `POST /_unixfs?path=...` for creating a fresh UnixFS root and
-  `POST /{root}/{path}` as UnixFS layout conveniences: they stage file or
-  directory operations, convert the resulting layout state into semantic
-  mutations, and then use the same writer route semantics as `_mutate`.
+  `POST /{root}/{path}` as a UnixFS layout convenience for roots that are
+  already in the UnixFS layout. Legacy map roots can be migrated only when the
+  caller explicitly adds `migrate=1`; default browser uploads fail fast instead
+  of silently traversing and migrating the whole legacy tree. These convenience
+  routes stage file or directory operations, convert the resulting layout state
+  into semantic mutations, and then use the same writer route semantics as
+  `_mutate`.
 - The public CLI currently exposes write ingestion through `malt add`; reads
   are available through the daemon API and proof-bearing resolve/content
   endpoints.

--- a/cmd/eval/internal/eval/readbench/runner.go
+++ b/cmd/eval/internal/eval/readbench/runner.go
@@ -122,7 +122,7 @@ func (r *Runner) PrepareFixture(ctx context.Context, cfg FixtureConfig) (*Fixtur
 	}
 	r.root = rootResp.Root
 
-	if writeResp, err := r.client.AddUnixFSFile(ctx, r.root, data.smallPath, data.smallData); err != nil {
+	if writeResp, err := r.client.AddUnixFSFileWithLegacyMigration(ctx, r.root, data.smallPath, data.smallData); err != nil {
 		return nil, fmt.Errorf("write small fixture: %w", err)
 	} else {
 		r.root = writeResp.NewRoot

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -264,8 +264,19 @@ func (c *Client) AddUnixFSFile(ctx context.Context, root, rawPath string, data [
 
 // AddUnixFSFileStream streams a file into a root's UnixFS tree.
 func (c *Client) AddUnixFSFileStream(ctx context.Context, root, rawPath string, r io.Reader) (*httpapi.UnixFSWriteResponse, error) {
+	return c.addUnixFSFileStream(ctx, root, rawPath, r, unixFSWriteOptions{})
+}
+
+// AddUnixFSFileWithLegacyMigration uploads a file while opting into legacy root
+// migration when root is not already a UnixFS root.
+func (c *Client) AddUnixFSFileWithLegacyMigration(ctx context.Context, root, rawPath string, data []byte) (*httpapi.UnixFSWriteResponse, error) {
+	return c.addUnixFSFileStream(ctx, root, rawPath, bytes.NewReader(data), unixFSWriteOptions{migrateLegacy: true})
+}
+
+func (c *Client) addUnixFSFileStream(ctx context.Context, root, rawPath string, r io.Reader, opts unixFSWriteOptions) (*httpapi.UnixFSWriteResponse, error) {
 	var resp httpapi.UnixFSWriteResponse
 	route, query := unixFSWriteRoute(root, rawPath)
+	applyUnixFSWriteOptions(root, query, opts)
 	if err := c.doRaw(ctx, http.MethodPost, route, query, "application/octet-stream", r, &resp); err != nil {
 		return nil, err
 	}
@@ -288,6 +299,16 @@ func unixFSWriteRoute(root, rawPath string) (string, map[string]string) {
 		return "/_unixfs", map[string]string{"path": rawPath}
 	}
 	return "/" + url.PathEscape(root) + "/" + rawPath, map[string]string{}
+}
+
+type unixFSWriteOptions struct {
+	migrateLegacy bool
+}
+
+func applyUnixFSWriteOptions(root string, query map[string]string, opts unixFSWriteOptions) {
+	if opts.migrateLegacy && strings.TrimSpace(root) != "" {
+		query["migrate"] = "1"
+	}
 }
 
 // CreateRootStructure creates a root-scoped structure.

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -622,11 +622,7 @@ func TestClientContentRangeReadReturnsProofListHeader(t *testing.T) {
 	client := New(cfg)
 	ctx := context.Background()
 
-	createResp, err := client.CreatePayloadRoot(ctx, nil)
-	if err != nil {
-		t.Fatalf("create root structure: %v", err)
-	}
-	writeResp, err := client.AddUnixFSFile(ctx, createResp.Root, "f.txt", []byte("abcdef"))
+	writeResp, err := client.AddUnixFSFile(ctx, "", "f.txt", []byte("abcdef"))
 	if err != nil {
 		t.Fatalf("add unixfs file: %v", err)
 	}
@@ -671,11 +667,7 @@ func TestClientAddUnixFSFileStream(t *testing.T) {
 	client := New(cfg)
 	ctx := context.Background()
 
-	createResp, err := client.CreatePayloadRoot(ctx, nil)
-	if err != nil {
-		t.Fatalf("create root structure: %v", err)
-	}
-	writeResp, err := client.AddUnixFSFileStream(ctx, createResp.Root, "stream.txt", strings.NewReader("streamed body"))
+	writeResp, err := client.AddUnixFSFileStream(ctx, "", "stream.txt", strings.NewReader("streamed body"))
 	if err != nil {
 		t.Fatalf("add unixfs file stream: %v", err)
 	}
@@ -708,12 +700,8 @@ func TestClientListBackedContentReadReturnsListIndexProof(t *testing.T) {
 	client := New(cfg)
 	ctx := context.Background()
 
-	createResp, err := client.CreatePayloadRoot(ctx, nil)
-	if err != nil {
-		t.Fatalf("create root structure: %v", err)
-	}
 	fileBody := append(bytes.Repeat([]byte{'a'}, unixfs.DefaultChunkSize), []byte("tail")...)
-	writeResp, err := client.AddUnixFSFile(ctx, createResp.Root, "large.bin", fileBody)
+	writeResp, err := client.AddUnixFSFile(ctx, "", "large.bin", fileBody)
 	if err != nil {
 		t.Fatalf("add unixfs file: %v", err)
 	}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -31,7 +31,8 @@ type pathResolution struct {
 }
 
 var (
-	errPathNotFound = errors.New("path not found")
+	errPathNotFound                     = errors.New("path not found")
+	errLegacyRootRequiresMigrationOptIn = errors.New("root is not a UnixFS root; pass migrate=1 to opt into legacy tree migration")
 )
 
 func (s *Server) statForResolvedKey(ctx context.Context, g graph.Runtime, key cid.Cid) (*httpapi.PathStatResponse, cid.Cid, error) {
@@ -178,14 +179,18 @@ func (s *Server) unixFSLayout(g graph.Runtime) (*unixfs.Layout, error) {
 	})
 }
 
-func (s *Server) prepareUnixFSRoot(ctx context.Context, g graph.Runtime, layout *unixfs.Layout, root cid.Cid) (cid.Cid, error) {
+func (s *Server) prepareUnixFSRoot(ctx context.Context, g graph.Runtime, layout *unixfs.Layout, root cid.Cid, allowLegacyMigration bool) (cid.Cid, error) {
 	if !root.Defined() {
 		return cid.Undef, nil
 	}
 	if stat, err := layout.Stat(ctx, root, ""); err == nil && stat.Kind == "directory" {
 		return root, nil
 	}
-	// Try legacy migration; if that fails, treat as fresh root.
+	if !allowLegacyMigration {
+		return cid.Undef, errLegacyRootRequiresMigrationOptIn
+	}
+	// Preserve the explicit legacy-compatibility behavior: when a caller opts
+	// in but the source cannot be migrated, the write starts a fresh UnixFS root.
 	if migrated, err := s.migrateLegacyTreeToUnixFS(ctx, g, layout, root); err == nil {
 		return migrated, nil
 	}

--- a/server/routes_unixfs_compat.go
+++ b/server/routes_unixfs_compat.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/dewebprotocol/malt/api/http"
 	cid "github.com/ipfs/go-cid"
@@ -38,7 +39,7 @@ func (s *Server) handleUnixFSWrite(w http.ResponseWriter, r *http.Request, root 
 		return
 	}
 
-	baseRoot, err := s.prepareUnixFSRoot(r.Context(), g, layout, root)
+	baseRoot, err := s.prepareUnixFSRoot(r.Context(), g, layout, root, unixFSMigrationRequested(r))
 	if err != nil {
 		writeError(w, http.StatusConflict, err.Error())
 		return
@@ -88,4 +89,9 @@ func (s *Server) handleUnixFSWrite(w http.ResponseWriter, r *http.Request, root 
 		resp.OldRoot = root.String()
 	}
 	writeJSON(w, http.StatusCreated, resp)
+}
+
+func unixFSMigrationRequested(r *http.Request) bool {
+	value := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("migrate")))
+	return value == "1" || value == "true"
 }

--- a/server/server.go
+++ b/server/server.go
@@ -122,8 +122,8 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /resolve/{root}/{path...}", s.handleResolve)
 
 	// Core read/write (/{root}/{path...} format). POST is a UnixFS layout
-	// convenience that converts file operations into semantic mutations before
-	// writer application.
+	// convenience for UnixFS roots; legacy root migration requires explicit
+	// opt-in before file operations are converted into semantic mutations.
 	mux.HandleFunc("GET /{root}", s.handleContent)
 	mux.HandleFunc("GET /{root}/{path...}", s.handleContent)
 	mux.HandleFunc("POST /{root}/{path...}", s.handleWrite)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -175,6 +175,63 @@ func TestFreshUnixFSWriteCreatesRoot(t *testing.T) {
 	}
 }
 
+func TestServerUnixFSWriteRejectsLegacyRootWithoutMigrationOptIn(t *testing.T) {
+	node := newTestNode(t)
+	mockCAS, ok := node.CAS().(*casmock.CAS)
+	if !ok {
+		t.Fatal("expected mock CAS")
+	}
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	manifestCID, err := mockCAS.Put(t.Context(), []byte(`{"entries":["existing.txt"]}`))
+	if err != nil {
+		t.Fatalf("put legacy manifest: %v", err)
+	}
+	existingCID, err := mockCAS.Put(t.Context(), []byte("existing content"))
+	if err != nil {
+		t.Fatalf("put legacy file: %v", err)
+	}
+	createBody, err := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: map[string]string{
+			"@payload":     manifestCID.String(),
+			"existing.txt": existingCID.String(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal create request: %v", err)
+	}
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create legacy root: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create legacy root status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+
+	resp, err = http.Post(ts.URL+"/"+createResp.Root+"/upload.txt", "application/octet-stream", strings.NewReader("new content"))
+	if err != nil {
+		t.Fatalf("write legacy root: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("legacy root write status = %d, want %d: %s", resp.StatusCode, http.StatusConflict, string(body))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read error body: %v", err)
+	}
+	if !strings.Contains(string(body), "migrate=1") {
+		t.Fatalf("legacy root write error = %q, want migrate opt-in hint", string(body))
+	}
+}
+
 func TestServerCreateRootOnlyAcceptsUnderscoreRoute(t *testing.T) {
 	node := newTestNode(t)
 	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
@@ -1432,7 +1489,7 @@ func TestServerUnixFSWritesPublishWriterReadableRoot(t *testing.T) {
 	resp.Body.Close()
 	root := createResp.Root
 
-	resp, err = http.Post(ts.URL+"/"+root+"/docs?type=dir", "application/json", nil)
+	resp, err = http.Post(ts.URL+"/"+root+"/docs?type=dir&migrate=1", "application/json", nil)
 	if err != nil {
 		t.Fatalf("create unixfs directory request failed: %v", err)
 	}
@@ -1449,7 +1506,7 @@ func TestServerUnixFSWritesPublishWriterReadableRoot(t *testing.T) {
 	}
 
 	fileBody := []byte("hello from writer unixfs")
-	resp, err = http.Post(ts.URL+"/"+root+"/docs/readme.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	resp, err = http.Post(ts.URL+"/"+root+"/docs/readme.txt?migrate=1", "application/octet-stream", bytes.NewReader(fileBody))
 	if err != nil {
 		t.Fatalf("create unixfs file request failed: %v", err)
 	}
@@ -1548,7 +1605,7 @@ func TestServerUnixFSIdempotentFileWriteReturnsSameRoot(t *testing.T) {
 	resp.Body.Close()
 
 	body := []byte("stable contents")
-	resp, err = http.Post(ts.URL+"/"+createResp.Root+"/docs/readme.txt", "application/octet-stream", bytes.NewReader(body))
+	resp, err = http.Post(ts.URL+"/"+createResp.Root+"/docs/readme.txt?migrate=1", "application/octet-stream", bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("initial unixfs write failed: %v", err)
 	}
@@ -1604,7 +1661,7 @@ func TestServerResolveHeadAndReadShareUnixFSDirectoryTarget(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	resp, err = http.Post(ts.URL+"/"+createResp.Root+"/docs?type=dir", "application/json", nil)
+	resp, err = http.Post(ts.URL+"/"+createResp.Root+"/docs?type=dir&migrate=1", "application/json", nil)
 	if err != nil {
 		t.Fatalf("create unixfs directory request failed: %v", err)
 	}
@@ -1693,7 +1750,7 @@ func TestServerHeadGetAndResolveSharePathResolution(t *testing.T) {
 	resp.Body.Close()
 
 	fileBody := []byte("shared path target")
-	resp, err = http.Post(ts.URL+"/"+createResp.Root+"/docs/nested/readme.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	resp, err = http.Post(ts.URL+"/"+createResp.Root+"/docs/nested/readme.txt?migrate=1", "application/octet-stream", bytes.NewReader(fileBody))
 	if err != nil {
 		t.Fatalf("create unixfs file request failed: %v", err)
 	}
@@ -1815,7 +1872,7 @@ func TestServerUnixFSWriteRootDoesNotSelfParent(t *testing.T) {
 	resp.Body.Close()
 	root := createResp.Root
 
-	resp, err = http.Post(ts.URL+"/"+root+"/readme.txt", "application/octet-stream", bytes.NewReader([]byte("hello")))
+	resp, err = http.Post(ts.URL+"/"+root+"/readme.txt?migrate=1", "application/octet-stream", bytes.NewReader([]byte("hello")))
 	if err != nil {
 		t.Fatalf("create unixfs file request failed: %v", err)
 	}
@@ -2047,7 +2104,7 @@ func TestServerDefaultGETSmallUnixFSFileIncludesPayloadProof(t *testing.T) {
 	root := createResp.Root
 
 	fileBody := []byte("hello content proof")
-	resp, err = http.Post(ts.URL+"/"+root+"/docs/readme.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	resp, err = http.Post(ts.URL+"/"+root+"/docs/readme.txt?migrate=1", "application/octet-stream", bytes.NewReader(fileBody))
 	if err != nil {
 		t.Fatalf("create unixfs file: %v", err)
 	}
@@ -2150,7 +2207,7 @@ func TestServerDefaultGETRangeIncludesMeasuredListRangeStep(t *testing.T) {
 	root := createResp.Root
 
 	fileBody := append(bytes.Repeat([]byte{'a'}, unixfs.DefaultChunkSize), []byte("bcdef")...)
-	resp, err = http.Post(ts.URL+"/"+root+"/large.bin", "application/octet-stream", bytes.NewReader(fileBody))
+	resp, err = http.Post(ts.URL+"/"+root+"/large.bin?migrate=1", "application/octet-stream", bytes.NewReader(fileBody))
 	if err != nil {
 		t.Fatalf("create unixfs large file: %v", err)
 	}
@@ -2326,7 +2383,7 @@ func TestServerDefaultGETReturnsProofHeader(t *testing.T) {
 
 	// Write a small file via UnixFS
 	fileBody := []byte("hello proof header")
-	resp, err = http.Post(ts.URL+"/"+root+"/readme.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	resp, err = http.Post(ts.URL+"/"+root+"/readme.txt?migrate=1", "application/octet-stream", bytes.NewReader(fileBody))
 	if err != nil {
 		t.Fatalf("create unixfs file: %v", err)
 	}
@@ -2405,7 +2462,7 @@ func TestServerDefaultGETProofHeaderWithProofFalse(t *testing.T) {
 	root := createResp.Root
 
 	fileBody := []byte("opt-out proof")
-	resp, err = http.Post(ts.URL+"/"+root+"/file.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	resp, err = http.Post(ts.URL+"/"+root+"/file.txt?migrate=1", "application/octet-stream", bytes.NewReader(fileBody))
 	if err != nil {
 		t.Fatalf("create unixfs file: %v", err)
 	}
@@ -2463,7 +2520,7 @@ func TestServerDefaultGETProofHeaderWithXMaltProofOmit(t *testing.T) {
 	root := createResp.Root
 
 	fileBody := []byte("header opt-out proof")
-	resp, err = http.Post(ts.URL+"/"+root+"/file2.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	resp, err = http.Post(ts.URL+"/"+root+"/file2.txt?migrate=1", "application/octet-stream", bytes.NewReader(fileBody))
 	if err != nil {
 		t.Fatalf("create unixfs file: %v", err)
 	}
@@ -2523,7 +2580,7 @@ func TestServerDefaultGETDirectoryProofHeader(t *testing.T) {
 	root := createResp.Root
 
 	// Create a directory
-	resp, err = http.Post(ts.URL+"/"+root+"/docs?type=dir", "application/json", nil)
+	resp, err = http.Post(ts.URL+"/"+root+"/docs?type=dir&migrate=1", "application/json", nil)
 	if err != nil {
 		t.Fatalf("create directory: %v", err)
 	}
@@ -2620,7 +2677,7 @@ func TestServerDefaultGETRangeProofHeader(t *testing.T) {
 
 	// Create a large file that spans multiple chunks
 	fileBody := append(bytes.Repeat([]byte{'a'}, unixfs.DefaultChunkSize), []byte("bcdef")...)
-	resp, err = http.Post(ts.URL+"/"+root+"/large.bin", "application/octet-stream", bytes.NewReader(fileBody))
+	resp, err = http.Post(ts.URL+"/"+root+"/large.bin?migrate=1", "application/octet-stream", bytes.NewReader(fileBody))
 	if err != nil {
 		t.Fatalf("create unixfs large file: %v", err)
 	}
@@ -2720,7 +2777,7 @@ func TestServerHEADDoesNotReturnProofHeaders(t *testing.T) {
 	root := createResp.Root
 
 	fileBody := []byte("head test file")
-	resp, err = http.Post(ts.URL+"/"+root+"/head.txt", "application/octet-stream", bytes.NewReader(fileBody))
+	resp, err = http.Post(ts.URL+"/"+root+"/head.txt?migrate=1", "application/octet-stream", bytes.NewReader(fileBody))
 	if err != nil {
 		t.Fatalf("create unixfs file: %v", err)
 	}


### PR DESCRIPTION
## Summary
- make root-scoped UnixFS writes reject non-UnixFS roots by default unless callers pass migrate=1
- keep legacy migration available through an explicit SDK helper for readbench compatibility paths
- update implementation docs and tests for the new browser upload contract

## Verification
- env GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./server ./sdk/client ./cmd/eval/internal/eval/readbench -count=1
- env GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./...
- git diff --check