### PR TITLE
Refactor daemon lifecycle CLI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -222,9 +222,8 @@ Current command model:
 
 - `malt init`
   - creates the local configuration file and state-root directory
-- `malt daemon`
-  - foreground long-running local process
-  - `malt daemon start/status/stop/restart` manage a background local daemon
+- `malt start/status/stop/restart`
+  - manage the local daemon as a background process
   - owns hot structure state
   - serves local HTTP/JSON API requests
 - `malt add ...`
@@ -564,8 +563,7 @@ The target operator flow is:
 1. run `malt init`
 2. create `~/.malt/malt.json`
 3. choose a local state root
-4. run `malt daemon` in the foreground, or `malt daemon start` for a managed
-   background daemon
+4. run `malt start` for a managed background daemon
 
 Current config shape:
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,8 @@ Current runtime shape:
 
 - `malt init`
   - creates the local configuration file and state-root directory
-- `malt daemon`
-  - foreground long-running local process
-  - `malt daemon start/status/stop/restart` manage a background local daemon
+- `malt start/status/stop/restart`
+  - manage the local daemon as a background process
   - owns hot proving/index state
 - `malt add`
   - uploads payload directly to CAS
@@ -380,8 +379,7 @@ Current operator flow:
 1. run `malt init`
 2. create `~/.malt/malt.json`
 3. choose a local state root
-4. run `malt daemon` in the foreground, or `malt daemon start` for a managed
-   background daemon
+4. run `malt start` for a managed background daemon
 
 Current schema:
 

--- a/cmd/malt/daemon.go
+++ b/cmd/malt/daemon.go
@@ -12,25 +12,27 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(daemonCmd)
-	daemonCmd.PersistentFlags().StringVar(&daemonListenOverride, "listen", "", "override daemon listen address")
-	daemonCmd.AddCommand(daemonStartCmd)
-	daemonCmd.AddCommand(daemonStatusCmd)
-	daemonCmd.AddCommand(daemonStopCmd)
-	daemonCmd.AddCommand(daemonRestartCmd)
+	rootCmd.AddCommand(daemonStartCmd)
+	rootCmd.AddCommand(daemonStatusCmd)
+	rootCmd.AddCommand(daemonStopCmd)
+	rootCmd.AddCommand(daemonRestartCmd)
+	for _, cmd := range []*cobra.Command{daemonStartCmd, daemonStatusCmd, daemonStopCmd, daemonRestartCmd} {
+		cmd.Flags().StringVar(&daemonListenOverride, "listen", "", "override daemon listen address")
+	}
 }
+
+const (
+	managedDaemonProcessEnv = "MALT_DAEMON_PROCESS"
+	managedDaemonConfigEnv  = "MALT_DAEMON_CONFIG"
+	managedDaemonListenEnv  = "MALT_DAEMON_LISTEN"
+)
 
 var daemonListenOverride string
-
-var daemonCmd = &cobra.Command{
-	Use:   "daemon",
-	Short: "Run or manage the local MALT daemon",
-	RunE:  runDaemon,
-}
 
 var daemonStartCmd = &cobra.Command{
 	Use:           "start",
 	Short:         "Start the local MALT daemon in the background",
+	Args:          cobra.NoArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          runDaemonStart,
@@ -39,6 +41,7 @@ var daemonStartCmd = &cobra.Command{
 var daemonStatusCmd = &cobra.Command{
 	Use:           "status",
 	Short:         "Show the local MALT daemon status",
+	Args:          cobra.NoArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          runDaemonStatus,
@@ -47,6 +50,7 @@ var daemonStatusCmd = &cobra.Command{
 var daemonStopCmd = &cobra.Command{
 	Use:           "stop",
 	Short:         "Stop the managed local MALT daemon",
+	Args:          cobra.NoArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          runDaemonStop,
@@ -55,19 +59,30 @@ var daemonStopCmd = &cobra.Command{
 var daemonRestartCmd = &cobra.Command{
 	Use:           "restart",
 	Short:         "Restart the managed local MALT daemon",
+	Args:          cobra.NoArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          runDaemonRestart,
 }
 
-func runDaemon(cmd *cobra.Command, args []string) error {
-	cfg, err := loadRuntimeConfig()
+func runManagedDaemonProcess() error {
+	cfg, err := loadManagedDaemonConfig()
 	if err != nil {
 		return err
 	}
+	return runDaemonComponent(cfg, os.Getenv(managedDaemonListenEnv))
+}
 
+func loadManagedDaemonConfig() (*config.Config, error) {
+	if configFile := os.Getenv(managedDaemonConfigEnv); configFile != "" {
+		return config.LoadFromFile(configFile)
+	}
+	return config.Load()
+}
+
+func runDaemonComponent(cfg *config.Config, listenOverride string) error {
 	return daemonapp.Run(cfg, daemonapp.RunOptions{
-		ListenOverride: daemonListenOverride,
+		ListenOverride: listenOverride,
 		APILabel:       "malt daemon",
 		LifecycleToken: os.Getenv(daemonapp.LifecycleTokenEnv),
 		Stdout:         os.Stdout,
@@ -184,25 +199,53 @@ func newDaemonLifecycleManager() (*daemonapp.LifecycleManager, error) {
 		return nil, fmt.Errorf("determine executable: %w", err)
 	}
 	return daemonapp.NewLifecycleManager(daemonapp.LifecycleOptions{
-		ConfigPath:     configPath,
-		StatePath:      statePath,
-		LogPath:        logPath,
-		Executable:     exe,
-		ForegroundArgs: daemonForegroundArgs(),
-		Env:            os.Environ(),
+		ConfigPath:  configPath,
+		StatePath:   statePath,
+		LogPath:     logPath,
+		Executable:  exe,
+		ProcessArgs: daemonProcessArgs(),
+		Env:         daemonProcessEnv(os.Environ(), cfgFile, daemonListenOverride),
 	}), nil
 }
 
-func daemonForegroundArgs() []string {
-	var args []string
-	if cfgFile != "" {
-		args = append(args, "--config", cfgFile)
+func daemonProcessArgs() []string {
+	return nil
+}
+
+func daemonProcessEnv(env []string, configFile string, listenOverride string) []string {
+	out := withoutEnvKeys(env, managedDaemonProcessEnv, managedDaemonConfigEnv, managedDaemonListenEnv)
+	out = append(out, managedDaemonProcessEnv+"=1")
+	if configFile != "" {
+		out = append(out, managedDaemonConfigEnv+"="+configFile)
 	}
-	args = append(args, "daemon")
-	if daemonListenOverride != "" {
-		args = append(args, "--listen", daemonListenOverride)
+	if listenOverride != "" {
+		out = append(out, managedDaemonListenEnv+"="+listenOverride)
 	}
-	return args
+	return out
+}
+
+func withoutEnvKeys(env []string, keys ...string) []string {
+	prefixes := make([]string, 0, len(keys))
+	for _, key := range keys {
+		prefixes = append(prefixes, key+"=")
+	}
+	out := make([]string, 0, len(env)+len(keys))
+	for _, entry := range env {
+		if hasAnyPrefix(entry, prefixes) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if len(s) >= len(prefix) && s[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
 }
 
 func printDaemonRunningStatus(w io.Writer, status *daemonapp.DaemonStatus) {

--- a/cmd/malt/daemon_process_test.go
+++ b/cmd/malt/daemon_process_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestDaemonLifecycleProcessEnvSelectsInternalComponent(t *testing.T) {
+	env := daemonProcessEnv([]string{
+		managedDaemonProcessEnv + "=old",
+		managedDaemonConfigEnv + "=old-config",
+		managedDaemonListenEnv + "=old-listen",
+		"PATH=/bin",
+	}, "/tmp/malt.json", "127.0.0.1:4321")
+
+	if !slices.Contains(env, managedDaemonProcessEnv+"=1") {
+		t.Fatalf("env missing internal daemon process selector: %v", env)
+	}
+	if !slices.Contains(env, managedDaemonConfigEnv+"=/tmp/malt.json") {
+		t.Fatalf("env missing daemon config path: %v", env)
+	}
+	if !slices.Contains(env, managedDaemonListenEnv+"=127.0.0.1:4321") {
+		t.Fatalf("env missing daemon listen override: %v", env)
+	}
+	if !slices.Contains(env, "PATH=/bin") {
+		t.Fatalf("env removed unrelated entry: %v", env)
+	}
+	if slices.Contains(env, managedDaemonProcessEnv+"=old") ||
+		slices.Contains(env, managedDaemonConfigEnv+"=old-config") ||
+		slices.Contains(env, managedDaemonListenEnv+"=old-listen") {
+		t.Fatalf("env retained stale daemon process entries: %v", env)
+	}
+}
+
+func TestDaemonLifecycleProcessArgsAreEmpty(t *testing.T) {
+	if args := daemonProcessArgs(); len(args) != 0 {
+		t.Fatalf("daemon process args = %v, want none", args)
+	}
+}

--- a/cmd/malt/main.go
+++ b/cmd/malt/main.go
@@ -20,7 +20,10 @@ var rootCmd = &cobra.Command{
 
 Primary commands:
   init        Create ~/.malt/malt.json and choose local state paths
-  daemon      Run or manage the local MALT daemon
+  start       Start the local MALT daemon in the background
+  status      Show the local MALT daemon status
+  stop        Stop the managed local MALT daemon
+  restart     Restart the managed local MALT daemon
   add         Upload local files/directories to CAS and merge into the current root
   resolve     Resolve a path via the daemon
   verify      Verify a ProofList`,
@@ -35,6 +38,13 @@ func init() {
 }
 
 func main() {
+	if os.Getenv(managedDaemonProcessEnv) == "1" {
+		if err := runManagedDaemonProcess(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/malt/public_surface_test.go
+++ b/cmd/malt/public_surface_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRootCommandOnlyExposesProductCommands(t *testing.T) {
-	want := []string{"add", "daemon", "init", "resolve", "verify"}
+	want := []string{"add", "init", "resolve", "restart", "start", "status", "stop", "verify"}
 
 	var got []string
 	for _, cmd := range rootCmd.Commands() {
@@ -21,23 +21,6 @@ func TestRootCommandOnlyExposesProductCommands(t *testing.T) {
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("public commands = %v, want %v", got, want)
-	}
-}
-
-func TestDaemonCommandExposesLifecycleSubcommands(t *testing.T) {
-	want := []string{"restart", "start", "status", "stop"}
-
-	var got []string
-	for _, cmd := range daemonCmd.Commands() {
-		if cmd.Hidden {
-			continue
-		}
-		got = append(got, cmd.Name())
-	}
-	slices.Sort(got)
-
-	if !slices.Equal(got, want) {
-		t.Fatalf("daemon subcommands = %v, want %v", got, want)
 	}
 }
 

--- a/daemon/lifecycle.go
+++ b/daemon/lifecycle.go
@@ -52,8 +52,8 @@ type DaemonStatus struct {
 	HealthError error
 }
 
-// BackgroundProcessSpec describes the foreground daemon process to launch in
-// the background.
+// BackgroundProcessSpec describes the daemon process to launch in the
+// background.
 type BackgroundProcessSpec struct {
 	Executable string
 	Args       []string
@@ -63,64 +63,64 @@ type BackgroundProcessSpec struct {
 
 // LifecycleOptions configures local managed daemon process operations.
 type LifecycleOptions struct {
-	ConfigPath     string
-	StatePath      string
-	LogPath        string
-	Executable     string
-	ForegroundArgs []string
-	Env            []string
-	Now            func() time.Time
-	StartTimeout   time.Duration
-	StopTimeout    time.Duration
-	PollInterval   time.Duration
-	Sleep          func(time.Duration)
-	StartProcess   func(BackgroundProcessSpec) (int, error)
-	SignalProcess  func(int) error
-	HealthCheck    func(context.Context, string) error
-	IdentityCheck  func(context.Context, string, string) error
-	GenerateToken  func() (string, error)
+	ConfigPath    string
+	StatePath     string
+	LogPath       string
+	Executable    string
+	ProcessArgs   []string
+	Env           []string
+	Now           func() time.Time
+	StartTimeout  time.Duration
+	StopTimeout   time.Duration
+	PollInterval  time.Duration
+	Sleep         func(time.Duration)
+	StartProcess  func(BackgroundProcessSpec) (int, error)
+	SignalProcess func(int) error
+	HealthCheck   func(context.Context, string) error
+	IdentityCheck func(context.Context, string, string) error
+	GenerateToken func() (string, error)
 }
 
-// LifecycleManager manages a daemon process started by `malt daemon start`.
+// LifecycleManager manages a daemon process started by `malt start`.
 type LifecycleManager struct {
-	configPath     string
-	statePath      string
-	logPath        string
-	executable     string
-	foregroundArgs []string
-	env            []string
-	now            func() time.Time
-	startTimeout   time.Duration
-	stopTimeout    time.Duration
-	pollInterval   time.Duration
-	sleep          func(time.Duration)
-	startProcess   func(BackgroundProcessSpec) (int, error)
-	signalProcess  func(int) error
-	healthCheck    func(context.Context, string) error
-	identityCheck  func(context.Context, string, string) error
-	generateToken  func() (string, error)
+	configPath    string
+	statePath     string
+	logPath       string
+	executable    string
+	processArgs   []string
+	env           []string
+	now           func() time.Time
+	startTimeout  time.Duration
+	stopTimeout   time.Duration
+	pollInterval  time.Duration
+	sleep         func(time.Duration)
+	startProcess  func(BackgroundProcessSpec) (int, error)
+	signalProcess func(int) error
+	healthCheck   func(context.Context, string) error
+	identityCheck func(context.Context, string, string) error
+	generateToken func() (string, error)
 }
 
 // NewLifecycleManager creates a lifecycle manager with production defaults for
 // any operation not supplied in opts.
 func NewLifecycleManager(opts LifecycleOptions) *LifecycleManager {
 	m := &LifecycleManager{
-		configPath:     opts.ConfigPath,
-		statePath:      opts.StatePath,
-		logPath:        opts.LogPath,
-		executable:     opts.Executable,
-		foregroundArgs: append([]string(nil), opts.ForegroundArgs...),
-		env:            append([]string(nil), opts.Env...),
-		now:            opts.Now,
-		startTimeout:   opts.StartTimeout,
-		stopTimeout:    opts.StopTimeout,
-		pollInterval:   opts.PollInterval,
-		sleep:          opts.Sleep,
-		startProcess:   opts.StartProcess,
-		signalProcess:  opts.SignalProcess,
-		healthCheck:    opts.HealthCheck,
-		identityCheck:  opts.IdentityCheck,
-		generateToken:  opts.GenerateToken,
+		configPath:    opts.ConfigPath,
+		statePath:     opts.StatePath,
+		logPath:       opts.LogPath,
+		executable:    opts.Executable,
+		processArgs:   append([]string(nil), opts.ProcessArgs...),
+		env:           append([]string(nil), opts.Env...),
+		now:           opts.Now,
+		startTimeout:  opts.StartTimeout,
+		stopTimeout:   opts.StopTimeout,
+		pollInterval:  opts.PollInterval,
+		sleep:         opts.Sleep,
+		startProcess:  opts.StartProcess,
+		signalProcess: opts.SignalProcess,
+		healthCheck:   opts.HealthCheck,
+		identityCheck: opts.IdentityCheck,
+		generateToken: opts.GenerateToken,
 	}
 	if m.now == nil {
 		m.now = time.Now
@@ -276,7 +276,7 @@ func (m *LifecycleManager) Start(ctx context.Context, cfg *config.Config) (*Daem
 
 	spec := BackgroundProcessSpec{
 		Executable: m.executable,
-		Args:       append([]string(nil), m.foregroundArgs...),
+		Args:       append([]string(nil), m.processArgs...),
 		Env:        withLifecycleTokenEnv(m.env, token),
 		LogPath:    m.logPath,
 	}

--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -21,14 +21,14 @@ func TestLifecycleStartWritesManagedState(t *testing.T) {
 	processStarted := false
 
 	manager := NewLifecycleManager(LifecycleOptions{
-		ConfigPath:     configPath,
-		StatePath:      statePath,
-		LogPath:        logPath,
-		Executable:     "/usr/local/bin/malt",
-		ForegroundArgs: []string{"--config", configPath, "daemon", "--listen", cfg.RPC.Listen},
-		Env:            []string{LifecycleTokenEnv + "=old-token", "PATH=/bin"},
-		Now:            func() time.Time { return startedAt },
-		GenerateToken:  func() (string, error) { return "managed-token", nil },
+		ConfigPath:    configPath,
+		StatePath:     statePath,
+		LogPath:       logPath,
+		Executable:    "/usr/local/bin/malt",
+		ProcessArgs:   []string{"--internal-daemon-test"},
+		Env:           []string{LifecycleTokenEnv + "=old-token", "PATH=/bin"},
+		Now:           func() time.Time { return startedAt },
+		GenerateToken: func() (string, error) { return "managed-token", nil },
 		StartProcess: func(spec BackgroundProcessSpec) (int, error) {
 			started = spec
 			processStarted = true
@@ -61,7 +61,7 @@ func TestLifecycleStartWritesManagedState(t *testing.T) {
 	if started.Executable != "/usr/local/bin/malt" {
 		t.Fatalf("started executable = %q", started.Executable)
 	}
-	if !slices.Equal(started.Args, []string{"--config", configPath, "daemon", "--listen", cfg.RPC.Listen}) {
+	if !slices.Equal(started.Args, []string{"--internal-daemon-test"}) {
 		t.Fatalf("started args = %v", started.Args)
 	}
 	if started.LogPath != logPath {


### PR DESCRIPTION
## Summary
- promote daemon lifecycle operations to top-level malt start/status/stop/restart commands
- start managed daemon processes through an internal environment-selected component path instead of a public or hidden daemon CLI subcommand
- update implementation docs for the new command model

## Verification
- env GOCACHE=/tmp/go-build-cache go test ./...
- git diff --check