### PR TITLE
fix: prevent daemon from being killed when Windows console closes

### DIFF
--- a/cmd/malt/daemon_windows.go
+++ b/cmd/malt/daemon_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+func init() {
+	if os.Getenv(managedDaemonProcessEnv) == "1" {
+		detachConsole()
+	}
+}
+
+// detachConsole releases the process's association with the parent console.
+// This prevents the daemon from being terminated when the console window is
+// closed (CTRL_CLOSE_EVENT), which CREATE_NEW_PROCESS_GROUP alone cannot block.
+func detachConsole() {
+	proc := kernel32.NewProc("FreeConsole")
+	proc.Call()
+}

--- a/daemon/process_windows.go
+++ b/daemon/process_windows.go
@@ -8,10 +8,15 @@ import (
 	"syscall"
 )
 
-const createNewProcessGroup = 0x00000200
+const (
+	createNewProcessGroup = 0x00000200
+	detachProcess         = 0x00000008
+)
 
 func configureBackgroundCommand(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNewProcessGroup}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: createNewProcessGroup | detachProcess,
+	}
 }
 
 func defaultSignalProcess(pid int) error {


### PR DESCRIPTION
## Problem

On Windows, closing the terminal window sends `CTRL_CLOSE_EVENT` to all processes attached to that console. The daemon process gets terminated because `CREATE_NEW_PROCESS_GROUP` only isolates against `Ctrl+C` / `Ctrl+Break` — it cannot block `CTRL_CLOSE_EVENT`.

## Fix

Two safeguards, either of which is sufficient on its own:

1. **`DETACHED_PROCESS` flag** — the child process is created without inheriting the parent console, so it never receives `CTRL_CLOSE_EVENT` in the first place.
2. **`FreeConsole()` in daemon init** — Windows-only `init()` that calls the Win32 API to fully detach from the console as a belt-and-suspenders measure.

The daemon's stdout/stderr are already redirected to `~/.malt/daemon.log` and it does not use stdin, so detaching from the console has no functional impact.