### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"path"
 	"strconv"
@@ -340,6 +341,9 @@ func (s *Server) unixFSPathStat(ctx context.Context, g graph.Runtime, root cid.C
 			Entries:     stat.Entries,
 		}, nil
 	case "file":
+		if stat.Size > math.MaxInt64 {
+			return nil, fmt.Errorf("unixfs file size %d exceeds max int64", stat.Size)
+		}
 		size := int64(stat.Size)
 		return &httpapi.PathStatResponse{
 			Kind:        "file",


### PR DESCRIPTION
Potential fix for [https://github.com/DeWebProtocol/malt/security/code-scanning/1](https://github.com/DeWebProtocol/malt/security/code-scanning/1)

Use an explicit range check before converting `stat.Size` (`uint64`) to `int64`.  
Best fix (without changing intended functionality): in `server/handlers.go` inside `unixFSPathStat`, file branch, reject values above `math.MaxInt64` with a clear error; otherwise safely cast.

Changes needed:
- Add `math` import in `server/handlers.go`.
- Replace `size := int64(stat.Size)` with:
  - `if stat.Size > math.MaxInt64 { return nil, fmt.Errorf(...) }`
  - then `size := int64(stat.Size)`.

This preserves existing API shape (`Size` remains `*int64`) and prevents overflow/wraparound.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
