### PR TITLE
fix(cas): pass node KV store to mock CAS in mock mode

### DIFF
--- a/runtime/node/node.go
+++ b/runtime/node/node.go
@@ -28,6 +28,8 @@ import (
 	kvprefix "github.com/dewebprotocol/malt/storage/kv/prefix"
 )
 
+const mockCASKeyPrefix = "cas/"
+
 func canonicalArcTableType(t string) string {
 	switch t {
 	case "simple":
@@ -207,7 +209,7 @@ func (n *Node) initCAS() (cas.Reader, error) {
 		), nil
 	case "mock":
 		// Keep this mode only for tests or direct in-process injection paths.
-		return casmock.NewCAS(casmock.WithoutLatency(), casmock.WithKVStore(kvprefix.New(n.kv, []byte("cas/")))), nil
+		return casmock.NewCAS(casmock.WithoutLatency(), casmock.WithKVStore(kvprefix.New(n.kv, []byte(mockCASKeyPrefix)))), nil
 	default:
 		return nil, fmt.Errorf("unknown cas mode: %s", n.cfg.CAS.Mode)
 	}

--- a/runtime/node/node.go
+++ b/runtime/node/node.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dewebprotocol/malt/storage/kv/badger"
 	"github.com/dewebprotocol/malt/storage/kv/fs"
 	kvmemory "github.com/dewebprotocol/malt/storage/kv/memory"
+	kvprefix "github.com/dewebprotocol/malt/storage/kv/prefix"
 )
 
 func canonicalArcTableType(t string) string {
@@ -206,7 +207,7 @@ func (n *Node) initCAS() (cas.Reader, error) {
 		), nil
 	case "mock":
 		// Keep this mode only for tests or direct in-process injection paths.
-		return casmock.NewCAS(casmock.WithoutLatency(), casmock.WithKVStore(n.kv)), nil
+		return casmock.NewCAS(casmock.WithoutLatency(), casmock.WithKVStore(kvprefix.New(n.kv, []byte("cas/")))), nil
 	default:
 		return nil, fmt.Errorf("unknown cas mode: %s", n.cfg.CAS.Mode)
 	}

--- a/runtime/node/node.go
+++ b/runtime/node/node.go
@@ -206,7 +206,7 @@ func (n *Node) initCAS() (cas.Reader, error) {
 		), nil
 	case "mock":
 		// Keep this mode only for tests or direct in-process injection paths.
-		return casmock.NewCAS(casmock.WithoutLatency()), nil
+		return casmock.NewCAS(casmock.WithoutLatency(), casmock.WithKVStore(n.kv)), nil
 	default:
 		return nil, fmt.Errorf("unknown cas mode: %s", n.cfg.CAS.Mode)
 	}

--- a/runtime/node/node_test.go
+++ b/runtime/node/node_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dewebprotocol/malt/config"
 	"github.com/dewebprotocol/malt/graph"
 	runtimegraph "github.com/dewebprotocol/malt/runtime/graph"
+	"github.com/dewebprotocol/malt/storage/cas"
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -140,6 +141,44 @@ func TestNewNodeWithFsKVStore(t *testing.T) {
 
 	if node.KVStore() == nil {
 		t.Fatal("expected fs kvstore to be initialized")
+	}
+}
+
+func TestMockCASPersistsBlocksAcrossNodeRestart(t *testing.T) {
+	cfg := testConfig(t)
+	ctx := context.Background()
+
+	first, err := NewNode(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("NewNode first failed: %v", err)
+	}
+	firstCAS, ok := first.CAS().(cas.Client)
+	if !ok {
+		t.Fatalf("first CAS = %T, want cas.Client", first.CAS())
+	}
+	block, err := firstCAS.Put(ctx, []byte("persistent mock block"))
+	if err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first node: %v", err)
+	}
+
+	second, err := NewNode(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("NewNode second failed: %v", err)
+	}
+	defer second.Close()
+	secondCAS, ok := second.CAS().(cas.Client)
+	if !ok {
+		t.Fatalf("second CAS = %T, want cas.Client", second.CAS())
+	}
+	got, err := secondCAS.Get(ctx, block)
+	if err != nil {
+		t.Fatalf("second Get: %v", err)
+	}
+	if string(got) != "persistent mock block" {
+		t.Fatalf("block payload = %q, want persistent mock block", got)
 	}
 }
 

--- a/runtime/node/node_test.go
+++ b/runtime/node/node_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/dewebprotocol/malt/graph"
 	runtimegraph "github.com/dewebprotocol/malt/runtime/graph"
 	"github.com/dewebprotocol/malt/storage/cas"
+	kvstore "github.com/dewebprotocol/malt/storage/kv"
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -179,6 +181,36 @@ func TestMockCASPersistsBlocksAcrossNodeRestart(t *testing.T) {
 	}
 	if string(got) != "persistent mock block" {
 		t.Fatalf("block payload = %q, want persistent mock block", got)
+	}
+}
+
+func TestMockCASUsesSeparateKVNamespace(t *testing.T) {
+	cfg := testConfig(t)
+	ctx := context.Background()
+
+	node, err := NewNode(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+	defer node.Close()
+	mockCAS, ok := node.CAS().(cas.Client)
+	if !ok {
+		t.Fatalf("CAS = %T, want cas.Client", node.CAS())
+	}
+	block, err := mockCAS.Put(ctx, []byte("namespaced mock block"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	if _, err := node.KVStore().Get(ctx, []byte("block/"+block.String())); !errors.Is(err, kvstore.ErrNotFound) {
+		t.Fatalf("unprefixed block key error = %v, want ErrNotFound", err)
+	}
+	got, err := node.KVStore().Get(ctx, []byte("cas/block/"+block.String()))
+	if err != nil {
+		t.Fatalf("prefixed block key Get: %v", err)
+	}
+	if string(got) != "namespaced mock block" {
+		t.Fatalf("prefixed block payload = %q, want namespaced mock block", got)
 	}
 }
 

--- a/storage/kv/prefix/prefix.go
+++ b/storage/kv/prefix/prefix.go
@@ -82,9 +82,17 @@ func (k *KV) NewIterator(ctx context.Context, start, end []byte) kvstore.Iterato
 		prefixedEnd = k.prefixed(end)
 	}
 	return &iterator{
-		inner:  k.inner.NewIterator(ctx, prefixedStart, prefixedEnd),
-		prefix: append([]byte(nil), k.prefix...),
+		inner:      k.inner.NewIterator(ctx, prefixedStart, prefixedEnd),
+		prefix:     append([]byte(nil), k.prefix...),
+		scanPrefix: iteratorScanPrefix(start, end),
 	}
+}
+
+func iteratorScanPrefix(start, end []byte) []byte {
+	if start == nil || end != nil {
+		return nil
+	}
+	return append([]byte(nil), start...)
 }
 
 func (k *KV) Batch() kvstore.Batch {
@@ -97,9 +105,10 @@ func (k *KV) Close() error {
 }
 
 type iterator struct {
-	inner  kvstore.Iterator
-	prefix []byte
-	key    []byte
+	inner      kvstore.Iterator
+	prefix     []byte
+	scanPrefix []byte
+	key        []byte
 }
 
 func (it *iterator) Next() bool {
@@ -108,7 +117,11 @@ func (it *iterator) Next() bool {
 		if !bytes.HasPrefix(key, it.prefix) {
 			return false
 		}
-		it.key = append(it.key[:0], key[len(it.prefix):]...)
+		stripped := key[len(it.prefix):]
+		if it.scanPrefix != nil && !bytes.HasPrefix(stripped, it.scanPrefix) {
+			return false
+		}
+		it.key = append(it.key[:0], stripped...)
 		return true
 	}
 	return false

--- a/storage/kv/prefix/prefix.go
+++ b/storage/kv/prefix/prefix.go
@@ -28,6 +28,9 @@ func (k *KV) prefixed(key []byte) []byte {
 }
 
 func (k *KV) strip(key []byte) []byte {
+	if !bytes.HasPrefix(key, k.prefix) {
+		return nil
+	}
 	return append([]byte(nil), key[len(k.prefix):]...)
 }
 

--- a/storage/kv/prefix/prefix.go
+++ b/storage/kv/prefix/prefix.go
@@ -1,0 +1,158 @@
+// Package prefix provides a KVStore view that transparently prefixes keys.
+package prefix
+
+import (
+	"bytes"
+	"context"
+
+	kvstore "github.com/dewebprotocol/malt/storage/kv"
+)
+
+// KV is a non-owning prefixed view over another KVStore.
+type KV struct {
+	inner  kvstore.KVStore
+	prefix []byte
+}
+
+// New returns a KVStore view that maps every key to prefix + key.
+func New(inner kvstore.KVStore, prefix []byte) *KV {
+	p := append([]byte(nil), prefix...)
+	return &KV{inner: inner, prefix: p}
+}
+
+func (k *KV) prefixed(key []byte) []byte {
+	out := make([]byte, 0, len(k.prefix)+len(key))
+	out = append(out, k.prefix...)
+	out = append(out, key...)
+	return out
+}
+
+func (k *KV) strip(key []byte) []byte {
+	return append([]byte(nil), key[len(k.prefix):]...)
+}
+
+func (k *KV) Get(ctx context.Context, key []byte) ([]byte, error) {
+	return k.inner.Get(ctx, k.prefixed(key))
+}
+
+func (k *KV) BatchGet(ctx context.Context, keys [][]byte) (map[string][]byte, error) {
+	prefixedKeys := make([][]byte, len(keys))
+	for i, key := range keys {
+		prefixedKeys[i] = k.prefixed(key)
+	}
+	found, err := k.inner.BatchGet(ctx, prefixedKeys)
+	if err != nil {
+		return nil, err
+	}
+	results := make(map[string][]byte, len(found))
+	for key, value := range found {
+		keyBytes := []byte(key)
+		if !bytes.HasPrefix(keyBytes, k.prefix) {
+			continue
+		}
+		results[string(k.strip(keyBytes))] = value
+	}
+	return results, nil
+}
+
+func (k *KV) Put(ctx context.Context, key, value []byte) error {
+	return k.inner.Put(ctx, k.prefixed(key), value)
+}
+
+func (k *KV) Delete(ctx context.Context, key []byte) error {
+	return k.inner.Delete(ctx, k.prefixed(key))
+}
+
+func (k *KV) Has(ctx context.Context, key []byte) (bool, error) {
+	return k.inner.Has(ctx, k.prefixed(key))
+}
+
+func (k *KV) NewIterator(ctx context.Context, start, end []byte) kvstore.Iterator {
+	var prefixedStart []byte
+	if start == nil {
+		prefixedStart = append([]byte(nil), k.prefix...)
+	} else {
+		prefixedStart = k.prefixed(start)
+	}
+	var prefixedEnd []byte
+	if end != nil {
+		prefixedEnd = k.prefixed(end)
+	}
+	return &iterator{
+		inner:  k.inner.NewIterator(ctx, prefixedStart, prefixedEnd),
+		prefix: append([]byte(nil), k.prefix...),
+	}
+}
+
+func (k *KV) Batch() kvstore.Batch {
+	return &batch{inner: k.inner.Batch(), prefix: append([]byte(nil), k.prefix...)}
+}
+
+// Close is intentionally non-owning; callers must close the wrapped store.
+func (k *KV) Close() error {
+	return nil
+}
+
+type iterator struct {
+	inner  kvstore.Iterator
+	prefix []byte
+	key    []byte
+}
+
+func (it *iterator) Next() bool {
+	for it.inner.Next() {
+		key := it.inner.Key()
+		if !bytes.HasPrefix(key, it.prefix) {
+			return false
+		}
+		it.key = append(it.key[:0], key[len(it.prefix):]...)
+		return true
+	}
+	return false
+}
+
+func (it *iterator) Key() []byte {
+	return append([]byte(nil), it.key...)
+}
+
+func (it *iterator) Value() []byte {
+	return it.inner.Value()
+}
+
+func (it *iterator) Err() error {
+	return it.inner.Err()
+}
+
+func (it *iterator) Close() {
+	it.inner.Close()
+}
+
+type batch struct {
+	inner  kvstore.Batch
+	prefix []byte
+}
+
+func (b *batch) prefixed(key []byte) []byte {
+	out := make([]byte, 0, len(b.prefix)+len(key))
+	out = append(out, b.prefix...)
+	out = append(out, key...)
+	return out
+}
+
+func (b *batch) Put(key, value []byte) error {
+	return b.inner.Put(b.prefixed(key), value)
+}
+
+func (b *batch) Delete(key []byte) error {
+	return b.inner.Delete(b.prefixed(key))
+}
+
+func (b *batch) Commit(ctx context.Context) error {
+	return b.inner.Commit(ctx)
+}
+
+func (b *batch) Cancel() {
+	b.inner.Cancel()
+}
+
+var _ kvstore.KVStore = (*KV)(nil)

--- a/storage/kv/prefix/prefix_test.go
+++ b/storage/kv/prefix/prefix_test.go
@@ -1,0 +1,73 @@
+package prefix
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	kvstore "github.com/dewebprotocol/malt/storage/kv"
+	"github.com/dewebprotocol/malt/storage/kv/memory"
+)
+
+func TestKVPrefixesPointOperations(t *testing.T) {
+	ctx := context.Background()
+	base := memory.New()
+	view := New(base, []byte("cas/"))
+
+	if err := view.Put(ctx, []byte("block/a"), []byte("payload")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if _, err := base.Get(ctx, []byte("block/a")); err != kvstore.ErrNotFound {
+		t.Fatalf("base unprefixed Get error = %v, want ErrNotFound", err)
+	}
+	got, err := base.Get(ctx, []byte("cas/block/a"))
+	if err != nil {
+		t.Fatalf("base prefixed Get: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("prefixed payload = %q, want payload", got)
+	}
+}
+
+func TestKVStripsIteratorAndBatchGetKeys(t *testing.T) {
+	ctx := context.Background()
+	base := memory.New()
+	view := New(base, []byte("cas/"))
+
+	if err := view.Put(ctx, []byte("a"), []byte("one")); err != nil {
+		t.Fatalf("Put a: %v", err)
+	}
+	if err := view.Put(ctx, []byte("b"), []byte("two")); err != nil {
+		t.Fatalf("Put b: %v", err)
+	}
+	if err := base.Put(ctx, []byte("other"), []byte("skip")); err != nil {
+		t.Fatalf("base Put: %v", err)
+	}
+
+	found, err := view.BatchGet(ctx, [][]byte{[]byte("a"), []byte("missing"), []byte("b")})
+	if err != nil {
+		t.Fatalf("BatchGet: %v", err)
+	}
+	if got := map[string]string{
+		"a": string(found["a"]),
+		"b": string(found["b"]),
+	}; !reflect.DeepEqual(got, map[string]string{"a": "one", "b": "two"}) {
+		t.Fatalf("BatchGet = %#v", got)
+	}
+	if _, ok := found["cas/a"]; ok {
+		t.Fatalf("BatchGet returned prefixed key")
+	}
+
+	var keys []string
+	it := view.NewIterator(ctx, nil, nil)
+	defer it.Close()
+	for it.Next() {
+		keys = append(keys, string(it.Key()))
+	}
+	if err := it.Err(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if !reflect.DeepEqual(keys, []string{"a", "b"}) {
+		t.Fatalf("iterator keys = %#v, want [a b]", keys)
+	}
+}

--- a/storage/kv/prefix/prefix_test.go
+++ b/storage/kv/prefix/prefix_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	kvstore "github.com/dewebprotocol/malt/storage/kv"
+	"github.com/dewebprotocol/malt/storage/kv/badger"
 	"github.com/dewebprotocol/malt/storage/kv/memory"
 )
 
@@ -69,6 +70,39 @@ func TestKVStripsIteratorAndBatchGetKeys(t *testing.T) {
 	}
 	if !reflect.DeepEqual(keys, []string{"a", "b"}) {
 		t.Fatalf("iterator keys = %#v, want [a b]", keys)
+	}
+}
+
+func TestKVIteratorBoundsNestedPrefixScan(t *testing.T) {
+	ctx := context.Background()
+	base, err := badger.New(badger.WithInMemory(true))
+	if err != nil {
+		t.Fatalf("badger.New: %v", err)
+	}
+	defer base.Close()
+	view := New(base, []byte("cas/"))
+
+	for key, value := range map[string]string{
+		"block/a": "one",
+		"block/b": "two",
+		"foo":     "skip",
+	} {
+		if err := view.Put(ctx, []byte(key), []byte(value)); err != nil {
+			t.Fatalf("Put %s: %v", key, err)
+		}
+	}
+
+	var keys []string
+	it := view.NewIterator(ctx, []byte("block/"), nil)
+	defer it.Close()
+	for it.Next() {
+		keys = append(keys, string(it.Key()))
+	}
+	if err := it.Err(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if !reflect.DeepEqual(keys, []string{"block/a", "block/b"}) {
+		t.Fatalf("iterator keys = %#v, want [block/a block/b]", keys)
 	}
 }
 

--- a/storage/kv/prefix/prefix_test.go
+++ b/storage/kv/prefix/prefix_test.go
@@ -71,3 +71,53 @@ func TestKVStripsIteratorAndBatchGetKeys(t *testing.T) {
 		t.Fatalf("iterator keys = %#v, want [a b]", keys)
 	}
 }
+
+func TestKVPrefixesHasDeleteAndBatch(t *testing.T) {
+	ctx := context.Background()
+	base := memory.New()
+	view := New(base, []byte("cas/"))
+
+	batch := view.Batch()
+	if err := batch.Put([]byte("a"), []byte("one")); err != nil {
+		t.Fatalf("batch Put a: %v", err)
+	}
+	if err := batch.Put([]byte("b"), []byte("two")); err != nil {
+		t.Fatalf("batch Put b: %v", err)
+	}
+	if err := batch.Commit(ctx); err != nil {
+		t.Fatalf("batch Commit: %v", err)
+	}
+
+	exists, err := view.Has(ctx, []byte("a"))
+	if err != nil {
+		t.Fatalf("Has a: %v", err)
+	}
+	if !exists {
+		t.Fatal("Has a = false, want true")
+	}
+	if exists, err := base.Has(ctx, []byte("a")); err != nil || exists {
+		t.Fatalf("base Has unprefixed a = %v, %v; want false, nil", exists, err)
+	}
+
+	batch = view.Batch()
+	if err := batch.Delete([]byte("a")); err != nil {
+		t.Fatalf("batch Delete a: %v", err)
+	}
+	if err := batch.Commit(ctx); err != nil {
+		t.Fatalf("delete batch Commit: %v", err)
+	}
+	if exists, err := view.Has(ctx, []byte("a")); err != nil || exists {
+		t.Fatalf("Has deleted a = %v, %v; want false, nil", exists, err)
+	}
+	if exists, err := view.Has(ctx, []byte("b")); err != nil || !exists {
+		t.Fatalf("Has b after deleting a = %v, %v; want true, nil", exists, err)
+	}
+}
+
+func TestKVStripRejectsUnprefixedKey(t *testing.T) {
+	view := New(memory.New(), []byte("cas/"))
+
+	if got := view.strip([]byte("block/a")); got != nil {
+		t.Fatalf("strip unprefixed key = %q, want nil", got)
+	}
+}


### PR DESCRIPTION
When CAS.Mode is "mock", the mock CAS defaulted to memory.New(), causing data loss on restart. Now passes n.kv via casmock.WithKVStore(n.kv).