### PR TITLE
feat(cas): add standalone CAS CLI with lifecycle management

### DIFF
--- a/cmd/cas/commands.go
+++ b/cmd/cas/commands.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(startCmd)
+	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(stopCmd)
+	rootCmd.AddCommand(restartCmd)
+}
+
+var startCmd = &cobra.Command{
+	Use:           "start",
+	Short:         "Start the CAS daemon in the background",
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runStart,
+}
+
+var statusCmd = &cobra.Command{
+	Use:           "status",
+	Short:         "Show the CAS daemon status",
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runStatus,
+}
+
+var stopCmd = &cobra.Command{
+	Use:           "stop",
+	Short:         "Stop the managed CAS daemon",
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runStop,
+}
+
+var restartCmd = &cobra.Command{
+	Use:           "restart",
+	Short:         "Restart the managed CAS daemon",
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runRestart,
+}
+
+func runStart(cmd *cobra.Command, args []string) error {
+	cfg, err := Load(configFile)
+	if err != nil {
+		return err
+	}
+	statePath, err := ResolveStatePath()
+	if err != nil {
+		return err
+	}
+	logPath, err := ResolveLogPath()
+	if err != nil {
+		return err
+	}
+	status, err := daemonStart(cmd.Context(), statePath, logPath, cfg)
+	if err != nil {
+		return err
+	}
+	printRunningStatus(os.Stdout, status)
+	return nil
+}
+
+func runStatus(cmd *cobra.Command, args []string) error {
+	cfg, err := Load(configFile)
+	if err != nil {
+		return err
+	}
+	statePath, err := ResolveStatePath()
+	if err != nil {
+		return err
+	}
+	status := daemonStatus(statePath, cfg)
+	printStatus(os.Stdout, status)
+	if !status.Running {
+		return fmt.Errorf("CAS daemon is not running")
+	}
+	return nil
+}
+
+func runStop(cmd *cobra.Command, args []string) error {
+	statePath, err := ResolveStatePath()
+	if err != nil {
+		return err
+	}
+	status, err := daemonStop(cmd.Context(), statePath)
+	if errors.Is(err, ErrDaemonStateNotFound) {
+		return fmt.Errorf("no managed CAS daemon state found")
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "CAS daemon stopped\n")
+	if status.PID > 0 {
+		fmt.Fprintf(os.Stdout, "pid: %d\n", status.PID)
+	}
+	return nil
+}
+
+func runRestart(cmd *cobra.Command, args []string) error {
+	cfg, err := Load(configFile)
+	if err != nil {
+		return err
+	}
+	statePath, err := ResolveStatePath()
+	if err != nil {
+		return err
+	}
+	logPath, err := ResolveLogPath()
+	if err != nil {
+		return err
+	}
+	status, err := daemonRestart(cmd.Context(), statePath, logPath, cfg)
+	if err != nil {
+		return err
+	}
+	printRunningStatus(os.Stdout, status)
+	return nil
+}
+
+func printRunningStatus(w io.Writer, status *DaemonStatus) {
+	if status.Managed {
+		fmt.Fprintf(w, "CAS daemon running\n")
+	} else {
+		fmt.Fprintf(w, "CAS daemon already running\n")
+	}
+	printStatusFields(w, status)
+}
+
+func printStatus(w io.Writer, status *DaemonStatus) {
+	if status.Running {
+		printRunningStatus(w, status)
+		return
+	}
+	fmt.Fprintf(w, "CAS daemon stopped\n")
+	printStatusFields(w, status)
+	if status.HealthError != nil {
+		fmt.Fprintf(w, "health_error: %v\n", status.HealthError)
+	}
+}
+
+func printStatusFields(w io.Writer, status *DaemonStatus) {
+	if status.PID > 0 {
+		fmt.Fprintf(w, "pid: %d\n", status.PID)
+	}
+	if status.Listen != "" {
+		fmt.Fprintf(w, "listen: %s\n", status.Listen)
+	}
+	if status.ConfigPath != "" {
+		fmt.Fprintf(w, "config: %s\n", status.ConfigPath)
+	}
+	if status.StatePath != "" {
+		fmt.Fprintf(w, "state: %s\n", status.StatePath)
+	}
+	if status.LogPath != "" {
+		fmt.Fprintf(w, "log: %s\n", status.LogPath)
+	}
+	if !status.StartedAt.IsZero() {
+		fmt.Fprintf(w, "started_at: %s\n", status.StartedAt.Format("2006-01-02T15:04:05Z07:00"))
+	}
+}

--- a/cmd/cas/commands.go
+++ b/cmd/cas/commands.go
@@ -65,7 +65,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	status, err := daemonStart(cmd.Context(), statePath, logPath, cfg)
+	if listen != "" {
+		cfg.Listen = listen
+	}
+	status, err := daemonStart(cmd.Context(), statePath, logPath, cfg, daemonOverridesFromGlobals())
 	if err != nil {
 		return err
 	}
@@ -84,9 +87,6 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 	status := daemonStatus(statePath, cfg)
 	printStatus(os.Stdout, status)
-	if !status.Running {
-		return fmt.Errorf("CAS daemon is not running")
-	}
 	return nil
 }
 
@@ -122,7 +122,10 @@ func runRestart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	status, err := daemonRestart(cmd.Context(), statePath, logPath, cfg)
+	if listen != "" {
+		cfg.Listen = listen
+	}
+	status, err := daemonRestart(cmd.Context(), statePath, logPath, cfg, daemonOverridesFromGlobals())
 	if err != nil {
 		return err
 	}

--- a/cmd/cas/config.go
+++ b/cmd/cas/config.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	defaultListen      = "127.0.0.1:4318"
+	defaultKVStoreType = "badger"
+	defaultDataDir     = "data"
+)
+
+// Config is the CAS server configuration.
+type Config struct {
+	Listen  string        `json:"listen"`
+	KVStore KVStoreConfig `json:"kvstore"`
+}
+
+// KVStoreConfig configures the CAS block store backend.
+type KVStoreConfig struct {
+	Type    string `json:"type"`
+	DataDir string `json:"data_dir"`
+}
+
+// DefaultConfig returns the default CAS configuration.
+func DefaultConfig() *Config {
+	return &Config{
+		Listen: defaultListen,
+		KVStore: KVStoreConfig{
+			Type:    defaultKVStoreType,
+			DataDir: defaultDataDir,
+		},
+	}
+}
+
+// DefaultConfigDir returns ~/.malt/cas.
+func DefaultConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determine home dir: %w", err)
+	}
+	return filepath.Join(home, ".malt", "cas"), nil
+}
+
+// DefaultConfigPath returns ~/.malt/cas/settings.json.
+func DefaultConfigPath() (string, error) {
+	dir, err := DefaultConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "settings.json"), nil
+}
+
+// ResolveConfigPath returns the explicit path if provided, otherwise the default.
+func ResolveConfigPath(explicit string) (string, error) {
+	if explicit != "" {
+		return expandPath(explicit)
+	}
+	return DefaultConfigPath()
+}
+
+// Load loads configuration from the given path, falling back to defaults.
+func Load(path string) (*Config, error) {
+	resolved, err := ResolveConfigPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		if os.IsNotExist(err) {
+			cfg := DefaultConfig()
+			return cfg, cfg.Validate()
+		}
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	cfg := DefaultConfig()
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	cfg.applyDefaults()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// WriteToFile writes the config as pretty JSON.
+func WriteToFile(path string, cfg *Config) error {
+	resolved, err := expandPath(path)
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		return fmt.Errorf("config is nil")
+	}
+
+	cfg.applyDefaults()
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(resolved), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile(resolved, data, 0o644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	return nil
+}
+
+func (c *Config) applyDefaults() {
+	defaults := DefaultConfig()
+	if c.Listen == "" {
+		c.Listen = defaults.Listen
+	}
+	if c.KVStore.Type == "" {
+		c.KVStore.Type = defaults.KVStore.Type
+	}
+	if c.KVStore.DataDir == "" {
+		c.KVStore.DataDir = defaults.KVStore.DataDir
+	}
+}
+
+// Validate checks the config values.
+func (c *Config) Validate() error {
+	if c.Listen == "" {
+		return fmt.Errorf("listen address is required")
+	}
+
+	switch c.KVStore.Type {
+	case "badger", "memory", "fs":
+	default:
+		return fmt.Errorf("unsupported kvstore.type %q (use badger, memory, or fs)", c.KVStore.Type)
+	}
+
+	if c.KVStore.Type != "memory" && c.KVStore.DataDir == "" {
+		return fmt.Errorf("kvstore.data_dir is required for %q store", c.KVStore.Type)
+	}
+
+	return nil
+}
+
+// KVStorePath returns the resolved absolute path for the KV store data directory.
+func (c *Config) KVStorePath() string {
+	if filepath.IsAbs(c.KVStore.DataDir) {
+		return c.KVStore.DataDir
+	}
+	dir, _ := DefaultConfigDir()
+	return filepath.Join(dir, c.KVStore.DataDir)
+}
+
+// SettingsPath returns the default settings file path.
+func (c *Config) SettingsPath() string {
+	path, _ := DefaultConfigPath()
+	return path
+}
+
+func expandPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	if path == "~" || strings.HasPrefix(path, "~/") || strings.HasPrefix(path, "~\\") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("determine home dir: %w", err)
+		}
+		trimmed := strings.TrimPrefix(strings.TrimPrefix(path, "~/"), "~\\")
+		return filepath.Clean(filepath.Join(home, trimmed)), nil
+	}
+	return filepath.Clean(path), nil
+}

--- a/cmd/cas/config.go
+++ b/cmd/cas/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -143,6 +144,9 @@ func (c *Config) Validate() error {
 	if c.Listen == "" {
 		return fmt.Errorf("listen address is required")
 	}
+	if _, _, err := net.SplitHostPort(c.Listen); err != nil {
+		return fmt.Errorf("listen address must be host:port: %w", err)
+	}
 
 	switch c.KVStore.Type {
 	case "badger", "memory", "fs":
@@ -157,21 +161,35 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+// ResolveKVStorePath returns the resolved absolute path for the KV store data directory.
+func (c *Config) ResolveKVStorePath() (string, error) {
+	if filepath.IsAbs(c.KVStore.DataDir) {
+		return c.KVStore.DataDir, nil
+	}
+	dir, err := DefaultConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, c.KVStore.DataDir), nil
+}
+
 // KVStorePath returns the resolved absolute path for the KV store data directory.
 func (c *Config) KVStorePath() string {
-	if filepath.IsAbs(c.KVStore.DataDir) {
-		return c.KVStore.DataDir
+	path, _ := c.ResolveKVStorePath()
+	return path
+}
+
+// ResolveSettingsPath returns the resolved settings file path.
+func (c *Config) ResolveSettingsPath() (string, error) {
+	if c != nil && c.settingsPath != "" {
+		return c.settingsPath, nil
 	}
-	dir, _ := DefaultConfigDir()
-	return filepath.Join(dir, c.KVStore.DataDir)
+	return DefaultConfigPath()
 }
 
 // SettingsPath returns the default settings file path.
 func (c *Config) SettingsPath() string {
-	if c != nil && c.settingsPath != "" {
-		return c.settingsPath
-	}
-	path, _ := DefaultConfigPath()
+	path, _ := c.ResolveSettingsPath()
 	return path
 }
 

--- a/cmd/cas/config.go
+++ b/cmd/cas/config.go
@@ -16,8 +16,9 @@ const (
 
 // Config is the CAS server configuration.
 type Config struct {
-	Listen  string        `json:"listen"`
-	KVStore KVStoreConfig `json:"kvstore"`
+	Listen       string        `json:"listen"`
+	KVStore      KVStoreConfig `json:"kvstore"`
+	settingsPath string
 }
 
 // KVStoreConfig configures the CAS block store backend.
@@ -74,12 +75,14 @@ func Load(path string) (*Config, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			cfg := DefaultConfig()
+			cfg.settingsPath = resolved
 			return cfg, cfg.Validate()
 		}
 		return nil, fmt.Errorf("read config: %w", err)
 	}
 
 	cfg := DefaultConfig()
+	cfg.settingsPath = resolved
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
@@ -165,6 +168,9 @@ func (c *Config) KVStorePath() string {
 
 // SettingsPath returns the default settings file path.
 func (c *Config) SettingsPath() string {
+	if c != nil && c.settingsPath != "" {
+		return c.settingsPath
+	}
 	path, _ := DefaultConfigPath()
 	return path
 }

--- a/cmd/cas/config_test.go
+++ b/cmd/cas/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -25,5 +26,30 @@ func TestLoadRemembersExplicitSettingsPath(t *testing.T) {
 
 	if got := cfg.SettingsPath(); got != settingsPath {
 		t.Fatalf("SettingsPath() = %q, want %q", got, settingsPath)
+	}
+}
+
+func TestValidateRejectsInvalidListenAddress(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Listen = "127.0.0.1"
+
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "listen") {
+		t.Fatalf("Validate error = %v, want listen validation error", err)
+	}
+}
+
+func TestResolvePathsReportHomeDirErrors(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+
+	cfg := DefaultConfig()
+	cfg.KVStore.DataDir = "data"
+	if _, err := cfg.ResolveKVStorePath(); err == nil {
+		t.Fatal("ResolveKVStorePath should report missing home directory")
+	}
+	if _, err := cfg.ResolveSettingsPath(); err == nil {
+		t.Fatal("ResolveSettingsPath should report missing home directory")
 	}
 }

--- a/cmd/cas/config_test.go
+++ b/cmd/cas/config_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadRemembersExplicitSettingsPath(t *testing.T) {
+	tmp := t.TempDir()
+	settingsPath := filepath.Join(tmp, "custom-settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{
+  "listen": "127.0.0.1:4999",
+  "kvstore": {
+    "type": "memory"
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	cfg, err := Load(settingsPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got := cfg.SettingsPath(); got != settingsPath {
+		t.Fatalf("SettingsPath() = %q, want %q", got, settingsPath)
+	}
+}

--- a/cmd/cas/initcmd.go
+++ b/cmd/cas/initcmd.go
@@ -50,7 +50,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 		cfg.KVStore.DataDir = promptString(reader, "Data directory", initDataDir, cfg.KVStore.DataDir, initNonInteractive)
 	}
 
-	dir, _ := DefaultConfigDir()
+	dir, err := DefaultConfigDir()
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
@@ -60,7 +63,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stdout, "wrote settings to %s\n", configPath)
 	fmt.Fprintf(os.Stdout, "listen: %s\n", cfg.Listen)
-	fmt.Fprintf(os.Stdout, "kvstore: type=%s data_dir=%s\n", cfg.KVStore.Type, cfg.KVStorePath())
+	kvPath, err := cfg.ResolveKVStorePath()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "kvstore: type=%s data_dir=%s\n", cfg.KVStore.Type, kvPath)
 	return nil
 }
 

--- a/cmd/cas/initcmd.go
+++ b/cmd/cas/initcmd.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -35,7 +36,7 @@ var initCmd = &cobra.Command{
 func runInit(cmd *cobra.Command, args []string) error {
 	cfg := DefaultConfig()
 
-	configPath, err := DefaultConfigPath()
+	configPath, err := ResolveConfigPath(configFile)
 	if err != nil {
 		return err
 	}
@@ -50,11 +51,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		cfg.KVStore.DataDir = promptString(reader, "Data directory", initDataDir, cfg.KVStore.DataDir, initNonInteractive)
 	}
 
-	dir, err := DefaultConfigDir()
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
 	if err := WriteToFile(configPath, cfg); err != nil {

--- a/cmd/cas/initcmd.go
+++ b/cmd/cas/initcmd.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	initForce          bool
+	initNonInteractive bool
+	initListen         string
+	initKVStoreType    string
+	initDataDir        string
+)
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+	initCmd.Flags().BoolVar(&initForce, "force", false, "overwrite an existing settings file")
+	initCmd.Flags().BoolVar(&initNonInteractive, "non-interactive", false, "do not prompt; use defaults and explicit flags")
+	initCmd.Flags().StringVar(&initListen, "listen", "", "listen address")
+	initCmd.Flags().StringVar(&initKVStoreType, "kvstore-type", "", "KV store type: badger, memory, or fs")
+	initCmd.Flags().StringVar(&initDataDir, "data-dir", "", "KV store data directory")
+}
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Create ~/.malt/cas/settings.json",
+	RunE:  runInit,
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	cfg := DefaultConfig()
+
+	configPath, err := DefaultConfigPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(configPath); err == nil && !initForce {
+		return fmt.Errorf("settings already exist at %s (use --force to overwrite)", configPath)
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	cfg.Listen = promptString(reader, "Listen address", initListen, cfg.Listen, initNonInteractive)
+	cfg.KVStore.Type = promptString(reader, "KV store type (badger|memory|fs)", initKVStoreType, cfg.KVStore.Type, initNonInteractive)
+	if cfg.KVStore.Type != "memory" {
+		cfg.KVStore.DataDir = promptString(reader, "Data directory", initDataDir, cfg.KVStore.DataDir, initNonInteractive)
+	}
+
+	dir, _ := DefaultConfigDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	if err := WriteToFile(configPath, cfg); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "wrote settings to %s\n", configPath)
+	fmt.Fprintf(os.Stdout, "listen: %s\n", cfg.Listen)
+	fmt.Fprintf(os.Stdout, "kvstore: type=%s data_dir=%s\n", cfg.KVStore.Type, cfg.KVStorePath())
+	return nil
+}
+
+func promptString(reader *bufio.Reader, label string, explicit string, fallback string, nonInteractive bool) string {
+	if explicit != "" {
+		return explicit
+	}
+	if nonInteractive {
+		return fallback
+	}
+
+	fmt.Fprintf(os.Stdout, "%s [%s]: ", label, fallback)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return fallback
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return fallback
+	}
+	return line
+}

--- a/cmd/cas/initcmd_test.go
+++ b/cmd/cas/initcmd_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInitUsesExplicitConfigPath(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+
+	oldConfigFile := configFile
+	oldInitForce := initForce
+	oldInitNonInteractive := initNonInteractive
+	oldInitListen := initListen
+	oldInitKVStoreType := initKVStoreType
+	oldInitDataDir := initDataDir
+	t.Cleanup(func() {
+		configFile = oldConfigFile
+		initForce = oldInitForce
+		initNonInteractive = oldInitNonInteractive
+		initListen = oldInitListen
+		initKVStoreType = oldInitKVStoreType
+		initDataDir = oldInitDataDir
+	})
+
+	configFile = filepath.Join(tmp, "custom", "settings.json")
+	initForce = false
+	initNonInteractive = true
+	initListen = ""
+	initKVStoreType = "memory"
+	initDataDir = ""
+
+	if err := runInit(nil, nil); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	if _, err := os.Stat(configFile); err != nil {
+		t.Fatalf("explicit config path was not written: %v", err)
+	}
+
+	defaultPath := filepath.Join(home, ".malt", "cas", "settings.json")
+	if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
+		t.Fatalf("default config path should not be written when --config is explicit, stat err=%v", err)
+	}
+}

--- a/cmd/cas/lifecycle.go
+++ b/cmd/cas/lifecycle.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,10 +25,11 @@ var ErrDaemonStateNotFound = errors.New("daemon state not found")
 
 // DaemonState is the local state recorded for a managed CAS daemon.
 type DaemonState struct {
-	PID        int       `json:"pid"`
-	Listen     string    `json:"listen"`
-	ConfigPath string    `json:"config_path"`
-	StartedAt  time.Time `json:"started_at"`
+	PID           int       `json:"pid"`
+	Listen        string    `json:"listen"`
+	ConfigPath    string    `json:"config_path"`
+	ShutdownToken string    `json:"shutdown_token,omitempty"`
+	StartedAt     time.Time `json:"started_at"`
 }
 
 // DaemonStatus describes the observed CAS daemon lifecycle state.
@@ -81,7 +84,8 @@ func WriteState(path string, state *DaemonState) error {
 	if state == nil {
 		return fmt.Errorf("daemon state is nil")
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create daemon state dir: %w", err)
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
@@ -89,8 +93,26 @@ func WriteState(path string, state *DaemonState) error {
 		return fmt.Errorf("encode daemon state: %w", err)
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return fmt.Errorf("write daemon state: %w", err)
+	tmp, err := os.CreateTemp(dir, ".daemon-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create daemon state temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write daemon state temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close daemon state temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
+			return fmt.Errorf("replace daemon state: remove old state: %w", removeErr)
+		}
+		if renameErr := os.Rename(tmpPath, path); renameErr != nil {
+			return fmt.Errorf("replace daemon state: %w", renameErr)
+		}
 	}
 	return nil
 }
@@ -109,11 +131,11 @@ func daemonStatus(statePath string, cfg *Config) *DaemonStatus {
 
 	healthErr := healthCheck(baseURL)
 	status := &DaemonStatus{
-		Running:    healthErr == nil,
-		Managed:    state != nil,
-		Listen:     cfg.Listen,
-		ConfigPath: cfg.SettingsPath(),
-		StatePath:  statePath,
+		Running:     healthErr == nil,
+		Managed:     state != nil,
+		Listen:      cfg.Listen,
+		ConfigPath:  cfg.SettingsPath(),
+		StatePath:   statePath,
 		HealthError: healthErr,
 	}
 	if state != nil {
@@ -126,7 +148,13 @@ func daemonStatus(statePath string, cfg *Config) *DaemonStatus {
 }
 
 // daemonStart launches the CAS daemon in the background.
-func daemonStart(ctx context.Context, statePath, logPath string, cfg *Config) (*DaemonStatus, error) {
+func daemonStart(ctx context.Context, statePath, logPath string, cfg *Config, overrides DaemonOverrides) (*DaemonStatus, error) {
+	release, err := acquireDaemonLock(statePath + ".lock")
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	status := daemonStatus(statePath, cfg)
 	if status.Running {
 		return status, nil
@@ -140,17 +168,23 @@ func daemonStart(ctx context.Context, statePath, logPath string, cfg *Config) (*
 		return nil, fmt.Errorf("determine executable: %w", err)
 	}
 
-	env := daemonProcessEnv(os.Environ(), cfg.SettingsPath(), "")
+	token, err := newShutdownToken()
+	if err != nil {
+		return nil, err
+	}
+	overrides.ShutdownToken = token
+	env := daemonProcessEnv(os.Environ(), cfg.SettingsPath(), overrides)
 	pid, err := startBackgroundProcess(exe, nil, env, logPath)
 	if err != nil {
 		return nil, fmt.Errorf("start daemon process: %w", err)
 	}
 
 	state := &DaemonState{
-		PID:        pid,
-		Listen:     cfg.Listen,
-		ConfigPath: cfg.SettingsPath(),
-		StartedAt:  time.Now().UTC(),
+		PID:           pid,
+		Listen:        cfg.Listen,
+		ConfigPath:    cfg.SettingsPath(),
+		ShutdownToken: token,
+		StartedAt:     time.Now().UTC(),
 	}
 	if err := WriteState(statePath, state); err != nil {
 		_ = signalProcess(pid)
@@ -180,8 +214,10 @@ func daemonStop(ctx context.Context, statePath string) (*DaemonStatus, error) {
 		return stoppedStatus(state, statePath), nil
 	}
 
-	if err := signalProcess(state.PID); err != nil {
-		return nil, fmt.Errorf("stop daemon process %d: %w", state.PID, err)
+	if err := requestShutdown(ctx, baseURL, state.ShutdownToken); err != nil {
+		if signalErr := signalProcess(state.PID); signalErr != nil {
+			return nil, fmt.Errorf("stop daemon process %d: shutdown request failed: %v; signal failed: %w", state.PID, err, signalErr)
+		}
 	}
 	if err := waitForStopped(ctx, baseURL, defaultStopTimeout); err != nil {
 		return nil, err
@@ -191,7 +227,7 @@ func daemonStop(ctx context.Context, statePath string) (*DaemonStatus, error) {
 }
 
 // daemonRestart stops a managed daemon if present, then starts a new one.
-func daemonRestart(ctx context.Context, statePath, logPath string, cfg *Config) (*DaemonStatus, error) {
+func daemonRestart(ctx context.Context, statePath, logPath string, cfg *Config, overrides DaemonOverrides) (*DaemonStatus, error) {
 	if _, err := LoadState(statePath); err == nil {
 		if _, err := daemonStop(ctx, statePath); err != nil {
 			return nil, err
@@ -204,7 +240,7 @@ func daemonRestart(ctx context.Context, statePath, logPath string, cfg *Config) 
 			return nil, fmt.Errorf("CAS daemon is running at %s but no managed state file exists", status.Listen)
 		}
 	}
-	return daemonStart(ctx, statePath, logPath, cfg)
+	return daemonStart(ctx, statePath, logPath, cfg, overrides)
 }
 
 func stoppedStatus(state *DaemonState, statePath string) *DaemonStatus {
@@ -249,30 +285,93 @@ func healthCheck(baseURL string) error {
 }
 
 func waitForHealth(ctx context.Context, baseURL string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	var lastErr error
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := healthCheck(baseURL); err == nil {
 			return nil
 		} else {
 			lastErr = err
 		}
-		if time.Now().After(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
 			return fmt.Errorf("CAS daemon at %s did not become healthy within %s: %w", baseURL, timeout, lastErr)
+		case <-time.After(defaultPollInterval):
 		}
-		time.Sleep(defaultPollInterval)
 	}
 }
 
 func waitForStopped(ctx context.Context, baseURL string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := healthCheck(baseURL); err != nil {
 			return nil
 		}
-		if time.Now().After(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
 			return fmt.Errorf("CAS daemon at %s did not stop within %s", baseURL, timeout)
+		case <-time.After(defaultPollInterval):
 		}
-		time.Sleep(defaultPollInterval)
 	}
+}
+
+func acquireDaemonLock(path string) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create daemon lock dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil, fmt.Errorf("CAS daemon start already in progress: %s", path)
+		}
+		return nil, fmt.Errorf("create daemon lock: %w", err)
+	}
+	fmt.Fprintf(f, "%d\n", os.Getpid())
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("close daemon lock: %w", err)
+	}
+	return func() { _ = os.Remove(path) }, nil
+}
+
+func newShutdownToken() (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate shutdown token: %w", err)
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func requestShutdown(ctx context.Context, baseURL, token string) error {
+	if token == "" {
+		return fmt.Errorf("daemon state has no shutdown token")
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, baseURL+"/shutdown", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-MALT-CAS-Shutdown-Token", token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("shutdown status %d", resp.StatusCode)
+	}
+	return nil
 }

--- a/cmd/cas/lifecycle.go
+++ b/cmd/cas/lifecycle.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	defaultStartTimeout = 15 * time.Second
+	defaultStopTimeout  = 10 * time.Second
+	defaultPollInterval = 200 * time.Millisecond
+)
+
+// ErrDaemonStateNotFound is returned when no daemon state file exists.
+var ErrDaemonStateNotFound = errors.New("daemon state not found")
+
+// DaemonState is the local state recorded for a managed CAS daemon.
+type DaemonState struct {
+	PID        int       `json:"pid"`
+	Listen     string    `json:"listen"`
+	ConfigPath string    `json:"config_path"`
+	StartedAt  time.Time `json:"started_at"`
+}
+
+// DaemonStatus describes the observed CAS daemon lifecycle state.
+type DaemonStatus struct {
+	Running     bool
+	Managed     bool
+	PID         int
+	Listen      string
+	ConfigPath  string
+	StatePath   string
+	LogPath     string
+	StartedAt   time.Time
+	HealthError error
+}
+
+// ResolveStatePath returns ~/.malt/cas/daemon.json.
+func ResolveStatePath() (string, error) {
+	dir, err := DefaultConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "daemon.json"), nil
+}
+
+// ResolveLogPath returns ~/.malt/cas/cas.log.
+func ResolveLogPath() (string, error) {
+	dir, err := DefaultConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "cas.log"), nil
+}
+
+// LoadState loads a daemon state file.
+func LoadState(path string) (*DaemonState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrDaemonStateNotFound
+		}
+		return nil, fmt.Errorf("read daemon state: %w", err)
+	}
+	var state DaemonState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("decode daemon state: %w", err)
+	}
+	return &state, nil
+}
+
+// WriteState writes a daemon state file atomically.
+func WriteState(path string, state *DaemonState) error {
+	if state == nil {
+		return fmt.Errorf("daemon state is nil")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create daemon state dir: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode daemon state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write daemon state: %w", err)
+	}
+	return nil
+}
+
+// Status reports whether the configured CAS daemon is healthy.
+func daemonStatus(statePath string, cfg *Config) *DaemonStatus {
+	state, stateErr := LoadState(statePath)
+	if stateErr != nil && !errors.Is(stateErr, ErrDaemonStateNotFound) {
+		return &DaemonStatus{HealthError: stateErr}
+	}
+
+	baseURL := "http://" + cfg.Listen
+	if state != nil {
+		baseURL = "http://" + state.Listen
+	}
+
+	healthErr := healthCheck(baseURL)
+	status := &DaemonStatus{
+		Running:    healthErr == nil,
+		Managed:    state != nil,
+		Listen:     cfg.Listen,
+		ConfigPath: cfg.SettingsPath(),
+		StatePath:  statePath,
+		HealthError: healthErr,
+	}
+	if state != nil {
+		status.PID = state.PID
+		status.Listen = state.Listen
+		status.ConfigPath = state.ConfigPath
+		status.StartedAt = state.StartedAt
+	}
+	return status
+}
+
+// daemonStart launches the CAS daemon in the background.
+func daemonStart(ctx context.Context, statePath, logPath string, cfg *Config) (*DaemonStatus, error) {
+	status := daemonStatus(statePath, cfg)
+	if status.Running {
+		return status, nil
+	}
+	if status.Managed {
+		_ = os.Remove(statePath)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("determine executable: %w", err)
+	}
+
+	env := daemonProcessEnv(os.Environ(), cfg.SettingsPath(), "")
+	pid, err := startBackgroundProcess(exe, nil, env, logPath)
+	if err != nil {
+		return nil, fmt.Errorf("start daemon process: %w", err)
+	}
+
+	state := &DaemonState{
+		PID:        pid,
+		Listen:     cfg.Listen,
+		ConfigPath: cfg.SettingsPath(),
+		StartedAt:  time.Now().UTC(),
+	}
+	if err := WriteState(statePath, state); err != nil {
+		_ = signalProcess(pid)
+		return nil, err
+	}
+
+	baseURL := "http://" + cfg.Listen
+	if err := waitForHealth(ctx, baseURL, defaultStartTimeout); err != nil {
+		_ = signalProcess(pid)
+		_ = os.Remove(statePath)
+		return nil, err
+	}
+	return daemonStatus(statePath, cfg), nil
+}
+
+// daemonStop terminates a managed CAS daemon.
+func daemonStop(ctx context.Context, statePath string) (*DaemonStatus, error) {
+	state, err := LoadState(statePath)
+	if err != nil {
+		return nil, err
+	}
+
+	baseURL := "http://" + state.Listen
+	if err := healthCheck(baseURL); err != nil {
+		// Daemon is already dead — clean up stale state.
+		_ = os.Remove(statePath)
+		return stoppedStatus(state, statePath), nil
+	}
+
+	if err := signalProcess(state.PID); err != nil {
+		return nil, fmt.Errorf("stop daemon process %d: %w", state.PID, err)
+	}
+	if err := waitForStopped(ctx, baseURL, defaultStopTimeout); err != nil {
+		return nil, err
+	}
+	_ = os.Remove(statePath)
+	return stoppedStatus(state, statePath), nil
+}
+
+// daemonRestart stops a managed daemon if present, then starts a new one.
+func daemonRestart(ctx context.Context, statePath, logPath string, cfg *Config) (*DaemonStatus, error) {
+	if _, err := LoadState(statePath); err == nil {
+		if _, err := daemonStop(ctx, statePath); err != nil {
+			return nil, err
+		}
+	} else if !errors.Is(err, ErrDaemonStateNotFound) {
+		return nil, err
+	} else {
+		status := daemonStatus(statePath, cfg)
+		if status.Running {
+			return nil, fmt.Errorf("CAS daemon is running at %s but no managed state file exists", status.Listen)
+		}
+	}
+	return daemonStart(ctx, statePath, logPath, cfg)
+}
+
+func stoppedStatus(state *DaemonState, statePath string) *DaemonStatus {
+	return &DaemonStatus{
+		Running:    false,
+		Managed:    true,
+		PID:        state.PID,
+		Listen:     state.Listen,
+		ConfigPath: state.ConfigPath,
+		StatePath:  statePath,
+		StartedAt:  state.StartedAt,
+	}
+}
+
+func healthCheck(baseURL string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	u := baseURL + "/health"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health status %d", resp.StatusCode)
+	}
+	var h struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&h); err != nil && err != io.EOF {
+		return fmt.Errorf("decode health: %w", err)
+	}
+	if h.Status != "ok" {
+		return fmt.Errorf("health status %q", h.Status)
+	}
+	return nil
+}
+
+func waitForHealth(ctx context.Context, baseURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		if err := healthCheck(baseURL); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("CAS daemon at %s did not become healthy within %s: %w", baseURL, timeout, lastErr)
+		}
+		time.Sleep(defaultPollInterval)
+	}
+}
+
+func waitForStopped(ctx context.Context, baseURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := healthCheck(baseURL); err != nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("CAS daemon at %s did not stop within %s", baseURL, timeout)
+		}
+		time.Sleep(defaultPollInterval)
+	}
+}

--- a/cmd/cas/lifecycle.go
+++ b/cmd/cas/lifecycle.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -129,12 +131,22 @@ func daemonStatus(statePath string, cfg *Config) *DaemonStatus {
 		baseURL = "http://" + state.Listen
 	}
 
-	healthErr := healthCheck(baseURL)
+	settingsPath, pathErr := cfg.ResolveSettingsPath()
+	if pathErr != nil {
+		return &DaemonStatus{
+			Managed:     state != nil,
+			Listen:      cfg.Listen,
+			StatePath:   statePath,
+			HealthError: pathErr,
+		}
+	}
+
+	healthErr := healthCheck(context.Background(), baseURL)
 	status := &DaemonStatus{
 		Running:     healthErr == nil,
 		Managed:     state != nil,
 		Listen:      cfg.Listen,
-		ConfigPath:  cfg.SettingsPath(),
+		ConfigPath:  settingsPath,
 		StatePath:   statePath,
 		HealthError: healthErr,
 	}
@@ -167,13 +179,17 @@ func daemonStart(ctx context.Context, statePath, logPath string, cfg *Config, ov
 	if err != nil {
 		return nil, fmt.Errorf("determine executable: %w", err)
 	}
+	settingsPath, err := cfg.ResolveSettingsPath()
+	if err != nil {
+		return nil, err
+	}
 
 	token, err := newShutdownToken()
 	if err != nil {
 		return nil, err
 	}
 	overrides.ShutdownToken = token
-	env := daemonProcessEnv(os.Environ(), cfg.SettingsPath(), overrides)
+	env := daemonProcessEnv(os.Environ(), settingsPath, overrides)
 	pid, err := startBackgroundProcess(exe, nil, env, logPath)
 	if err != nil {
 		return nil, fmt.Errorf("start daemon process: %w", err)
@@ -182,7 +198,7 @@ func daemonStart(ctx context.Context, statePath, logPath string, cfg *Config, ov
 	state := &DaemonState{
 		PID:           pid,
 		Listen:        cfg.Listen,
-		ConfigPath:    cfg.SettingsPath(),
+		ConfigPath:    settingsPath,
 		ShutdownToken: token,
 		StartedAt:     time.Now().UTC(),
 	}
@@ -208,7 +224,7 @@ func daemonStop(ctx context.Context, statePath string) (*DaemonStatus, error) {
 	}
 
 	baseURL := "http://" + state.Listen
-	if err := healthCheck(baseURL); err != nil {
+	if err := healthCheck(ctx, baseURL); err != nil {
 		// Daemon is already dead — clean up stale state.
 		_ = os.Remove(statePath)
 		return stoppedStatus(state, statePath), nil
@@ -255,12 +271,12 @@ func stoppedStatus(state *DaemonState, statePath string) *DaemonStatus {
 	}
 }
 
-func healthCheck(baseURL string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+func healthCheck(ctx context.Context, baseURL string) error {
+	reqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
 	u := baseURL + "/health"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, u, nil)
 	if err != nil {
 		return err
 	}
@@ -287,12 +303,14 @@ func healthCheck(baseURL string) error {
 func waitForHealth(ctx context.Context, baseURL string, timeout time.Duration) error {
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
+	ticker := time.NewTicker(defaultPollInterval)
+	defer ticker.Stop()
 	var lastErr error
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := healthCheck(baseURL); err == nil {
+		if err := healthCheck(ctx, baseURL); err == nil {
 			return nil
 		} else {
 			lastErr = err
@@ -302,7 +320,7 @@ func waitForHealth(ctx context.Context, baseURL string, timeout time.Duration) e
 			return ctx.Err()
 		case <-timer.C:
 			return fmt.Errorf("CAS daemon at %s did not become healthy within %s: %w", baseURL, timeout, lastErr)
-		case <-time.After(defaultPollInterval):
+		case <-ticker.C:
 		}
 	}
 }
@@ -310,11 +328,13 @@ func waitForHealth(ctx context.Context, baseURL string, timeout time.Duration) e
 func waitForStopped(ctx context.Context, baseURL string, timeout time.Duration) error {
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
+	ticker := time.NewTicker(defaultPollInterval)
+	defer ticker.Stop()
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := healthCheck(baseURL); err != nil {
+		if err := healthCheck(ctx, baseURL); err != nil {
 			return nil
 		}
 		select {
@@ -322,7 +342,7 @@ func waitForStopped(ctx context.Context, baseURL string, timeout time.Duration) 
 			return ctx.Err()
 		case <-timer.C:
 			return fmt.Errorf("CAS daemon at %s did not stop within %s", baseURL, timeout)
-		case <-time.After(defaultPollInterval):
+		case <-ticker.C:
 		}
 	}
 }
@@ -331,12 +351,9 @@ func acquireDaemonLock(path string) (func(), error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("create daemon lock dir: %w", err)
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	f, err := createDaemonLockFile(path)
 	if err != nil {
-		if os.IsExist(err) {
-			return nil, fmt.Errorf("CAS daemon start already in progress: %s", path)
-		}
-		return nil, fmt.Errorf("create daemon lock: %w", err)
+		return nil, err
 	}
 	fmt.Fprintf(f, "%d\n", os.Getpid())
 	if err := f.Close(); err != nil {
@@ -344,6 +361,39 @@ func acquireDaemonLock(path string) (func(), error) {
 		return nil, fmt.Errorf("close daemon lock: %w", err)
 	}
 	return func() { _ = os.Remove(path) }, nil
+}
+
+func createDaemonLockFile(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err == nil {
+		return f, nil
+	}
+	if !os.IsExist(err) {
+		return nil, fmt.Errorf("create daemon lock: %w", err)
+	}
+	if !removeStaleDaemonLock(path) {
+		return nil, fmt.Errorf("CAS daemon start already in progress: %s", path)
+	}
+	if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
+		return nil, fmt.Errorf("remove stale daemon lock: %w", removeErr)
+	}
+	f, err = os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create daemon lock: %w", err)
+	}
+	return f, nil
+}
+
+func removeStaleDaemonLock(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return false
+	}
+	return !processExists(pid)
 }
 
 func newShutdownToken() (string, error) {

--- a/cmd/cas/lifecycle_test.go
+++ b/cmd/cas/lifecycle_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWaitForHealthHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := waitForHealth(ctx, "http://127.0.0.1:1", time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForHealth error = %v, want context.Canceled", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("waitForHealth took %s after cancellation", elapsed)
+	}
+}
+
+func TestWriteStateReplacesExistingState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.json")
+
+	first := &DaemonState{PID: 1, Listen: "127.0.0.1:4318", ConfigPath: "first", ShutdownToken: "one"}
+	if err := WriteState(path, first); err != nil {
+		t.Fatalf("WriteState first: %v", err)
+	}
+	second := &DaemonState{PID: 2, Listen: "127.0.0.1:4319", ConfigPath: "second", ShutdownToken: "two"}
+	if err := WriteState(path, second); err != nil {
+		t.Fatalf("WriteState second: %v", err)
+	}
+
+	got, err := LoadState(path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got.PID != 2 || got.ConfigPath != "second" || got.ShutdownToken != "two" {
+		t.Fatalf("state = %#v, want second state", got)
+	}
+}
+
+func TestAcquireDaemonLockExcludesConcurrentStart(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "daemon.json.lock")
+
+	release, err := acquireDaemonLock(lockPath)
+	if err != nil {
+		t.Fatalf("acquire first lock: %v", err)
+	}
+	if _, err := acquireDaemonLock(lockPath); err == nil {
+		t.Fatal("second acquire should fail")
+	}
+	release()
+
+	release, err = acquireDaemonLock(lockPath)
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	release()
+}

--- a/cmd/cas/lifecycle_test.go
+++ b/cmd/cas/lifecycle_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -60,4 +62,42 @@ func TestAcquireDaemonLockExcludesConcurrentStart(t *testing.T) {
 		t.Fatalf("acquire after release: %v", err)
 	}
 	release()
+}
+
+func TestAcquireDaemonLockReplacesStalePID(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "daemon.json.lock")
+	if err := os.WriteFile(lockPath, []byte("-1\n"), 0o600); err != nil {
+		t.Fatalf("write stale lock: %v", err)
+	}
+
+	release, err := acquireDaemonLock(lockPath)
+	if err != nil {
+		t.Fatalf("acquire stale lock: %v", err)
+	}
+	release()
+}
+
+func TestAcquireDaemonLockKeepsLivePID(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "daemon.json.lock")
+	if err := os.WriteFile(lockPath, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600); err != nil {
+		t.Fatalf("write live lock: %v", err)
+	}
+
+	if _, err := acquireDaemonLock(lockPath); err == nil {
+		t.Fatal("acquire live lock should fail")
+	}
+}
+
+func TestWaitForStoppedHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := waitForStopped(ctx, "http://127.0.0.1:1", time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForStopped error = %v, want context.Canceled", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("waitForStopped took %s after cancellation", elapsed)
+	}
 }

--- a/cmd/cas/main.go
+++ b/cmd/cas/main.go
@@ -195,7 +195,11 @@ func runServer(cfg *Config) error {
 	fmt.Fprintf(os.Stderr, "mock-cas listening on %s\n", cfg.Listen)
 	fmt.Fprintf(os.Stderr, "kvstore: type=%s\n", cfg.KVStore.Type)
 	if cfg.KVStore.Type != "memory" {
-		fmt.Fprintf(os.Stderr, "data dir: %s\n", cfg.KVStorePath())
+		kvPath, err := cfg.ResolveKVStorePath()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "data dir: %s\n", kvPath)
 	}
 	if noLatency {
 		fmt.Fprintf(os.Stderr, "latency: disabled\n")
@@ -267,8 +271,12 @@ func newKVStore(cfg *Config) (kvstore.KVStore, func() error, error) {
 	case "memory":
 		return nil, nil, nil
 	case "badger":
+		kvPath, err := cfg.ResolveKVStorePath()
+		if err != nil {
+			return nil, nil, err
+		}
 		kv, err := badger.New(
-			badger.WithPath(cfg.KVStorePath()),
+			badger.WithPath(kvPath),
 			badger.WithInMemory(false),
 		)
 		if err != nil {
@@ -276,7 +284,11 @@ func newKVStore(cfg *Config) (kvstore.KVStore, func() error, error) {
 		}
 		return kv, kv.Close, nil
 	case "fs":
-		kv, err := kvfs.New(cfg.KVStorePath())
+		kvPath, err := cfg.ResolveKVStorePath()
+		if err != nil {
+			return nil, nil, err
+		}
+		kv, err := kvfs.New(kvPath)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/cas/main.go
+++ b/cmd/cas/main.go
@@ -1,0 +1,207 @@
+// Command cas starts a standalone mock CAS HTTP server.
+//
+// Usage:
+//
+//	cas [flags]          Run in foreground
+//	cas init             Create ~/.malt/cas/settings.json
+//	cas start            Start the CAS daemon in the background
+//	cas status           Show the CAS daemon status
+//	cas stop             Stop the managed CAS daemon
+//	cas restart          Restart the managed CAS daemon
+//
+// Examples:
+//
+//	# Initialize settings
+//	cas init
+//
+//	# Start as background daemon
+//	cas start
+//
+//	# No latency (fast local testing)
+//	cas --no-latency
+//
+//	# IPFS-like latency
+//	cas --get-latency 2100ms --put-latency 1400ms --has-latency 100ms
+//
+//	# Custom port
+//	cas --listen 127.0.0.1:9999 --get-latency 50ms
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
+	"github.com/dewebprotocol/malt/storage/kv"
+	"github.com/dewebprotocol/malt/storage/kv/badger"
+	kvfs "github.com/dewebprotocol/malt/storage/kv/fs"
+	"github.com/spf13/cobra"
+)
+
+var (
+	configFile string
+	listen     string
+	getLatency time.Duration
+	putLatency time.Duration
+	hasLatency time.Duration
+	jitter     time.Duration
+	noLatency  bool
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "cas",
+	Short: "Standalone mock CAS HTTP server for MALT",
+	Args:  cobra.NoArgs,
+	RunE:  run,
+}
+
+func init() {
+	rootCmd.Flags().StringVar(&configFile, "config", "", "settings file path (default ~/.malt/cas/settings.json)")
+	rootCmd.Flags().StringVar(&listen, "listen", "", "listen address (overrides settings)")
+	rootCmd.Flags().DurationVar(&getLatency, "get-latency", 0, "simulated Get latency (0 = default IPFS latency)")
+	rootCmd.Flags().DurationVar(&putLatency, "put-latency", 0, "simulated Put latency (0 = default IPFS latency)")
+	rootCmd.Flags().DurationVar(&hasLatency, "has-latency", 0, "simulated Has latency (0 = default IPFS latency)")
+	rootCmd.Flags().DurationVar(&jitter, "jitter", 0, "latency jitter (±)")
+	rootCmd.Flags().BoolVar(&noLatency, "no-latency", false, "disable all latency simulation")
+}
+
+func main() {
+	if os.Getenv(daemonProcessKey) == "1" {
+		if err := runDaemonChild(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// runDaemonChild is the entry point for the forked daemon child process.
+func runDaemonChild() error {
+	configPath := os.Getenv(daemonConfigKey)
+	cfg, err := Load(configPath)
+	if err != nil {
+		return fmt.Errorf("load settings: %w", err)
+	}
+	if listenOverride := os.Getenv(daemonListenKey); listenOverride != "" {
+		cfg.Listen = listenOverride
+	}
+	return runServer(cfg)
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	cfg, err := Load(configFile)
+	if err != nil {
+		return fmt.Errorf("load settings: %w", err)
+	}
+	if listen != "" {
+		cfg.Listen = listen
+	}
+	return runServer(cfg)
+}
+
+// runServer creates the KV store, starts the CAS HTTP server, and blocks
+// until interrupted. Used by both foreground mode and daemon child.
+func runServer(cfg *Config) error {
+	kvStore, kvClose, err := newKVStore(cfg)
+	if err != nil {
+		return fmt.Errorf("init kvstore: %w", err)
+	}
+	if kvClose != nil {
+		defer kvClose()
+	}
+
+	var opts []casmock.Option
+	if kvStore != nil {
+		opts = append(opts, casmock.WithKVStore(kvStore))
+	}
+
+	if noLatency {
+		opts = append(opts, casmock.WithoutLatency())
+	} else {
+		if getLatency > 0 {
+			opts = append(opts, casmock.WithGetLatency(getLatency))
+		}
+		if putLatency > 0 {
+			opts = append(opts, casmock.WithPutLatency(putLatency))
+		}
+		if hasLatency > 0 {
+			opts = append(opts, casmock.WithHasLatency(hasLatency))
+		}
+		if jitter > 0 {
+			opts = append(opts, casmock.WithJitter(jitter))
+		}
+	}
+
+	store := casmock.NewCAS(opts...)
+	srv := casmock.NewHTTPServer(cfg.Listen, store)
+
+	fmt.Fprintf(os.Stderr, "mock-cas listening on %s\n", cfg.Listen)
+	fmt.Fprintf(os.Stderr, "kvstore: type=%s\n", cfg.KVStore.Type)
+	if cfg.KVStore.Type != "memory" {
+		fmt.Fprintf(os.Stderr, "data dir: %s\n", cfg.KVStorePath())
+	}
+	if noLatency {
+		fmt.Fprintf(os.Stderr, "latency: disabled\n")
+	} else if getLatency > 0 || putLatency > 0 || hasLatency > 0 {
+		fmt.Fprintf(os.Stderr, "latency: get=%s put=%s has=%s jitter=%s\n",
+			getLatency, putLatency, hasLatency, jitter)
+	} else {
+		fmt.Fprintf(os.Stderr, "latency: get=%s put=%s has=%s jitter=%s (IPFS defaults)\n",
+			casmock.DefaultGetLatency, casmock.DefaultPutLatency,
+			casmock.DefaultHasLatency, casmock.DefaultJitter)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.Start(); err != nil {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		fmt.Fprintf(os.Stderr, "\nshutting down...\n")
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutCancel()
+		return srv.Shutdown(shutCtx)
+	case err := <-errCh:
+		return fmt.Errorf("server error: %w", err)
+	}
+}
+
+// newKVStore creates a KV store from config. Returns (store, closeFn, error).
+// For memory mode, returns (nil, nil, nil) — casmock defaults to memory.
+func newKVStore(cfg *Config) (kvstore.KVStore, func() error, error) {
+	switch cfg.KVStore.Type {
+	case "memory":
+		return nil, nil, nil
+	case "badger":
+		kv, err := badger.New(
+			badger.WithPath(cfg.KVStorePath()),
+			badger.WithInMemory(false),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		return kv, kv.Close, nil
+	case "fs":
+		kv, err := kvfs.New(cfg.KVStorePath())
+		if err != nil {
+			return nil, nil, err
+		}
+		return kv, kv.Close, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported kvstore type: %s", cfg.KVStore.Type)
+	}
+}

--- a/cmd/cas/main.go
+++ b/cmd/cas/main.go
@@ -30,6 +30,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -60,13 +61,13 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.Flags().StringVar(&configFile, "config", "", "settings file path (default ~/.malt/cas/settings.json)")
-	rootCmd.Flags().StringVar(&listen, "listen", "", "listen address (overrides settings)")
-	rootCmd.Flags().DurationVar(&getLatency, "get-latency", 0, "simulated Get latency (0 = default IPFS latency)")
-	rootCmd.Flags().DurationVar(&putLatency, "put-latency", 0, "simulated Put latency (0 = default IPFS latency)")
-	rootCmd.Flags().DurationVar(&hasLatency, "has-latency", 0, "simulated Has latency (0 = default IPFS latency)")
-	rootCmd.Flags().DurationVar(&jitter, "jitter", 0, "latency jitter (±)")
-	rootCmd.Flags().BoolVar(&noLatency, "no-latency", false, "disable all latency simulation")
+	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "settings file path (default ~/.malt/cas/settings.json)")
+	rootCmd.PersistentFlags().StringVar(&listen, "listen", "", "listen address (overrides settings)")
+	rootCmd.PersistentFlags().DurationVar(&getLatency, "get-latency", 0, "simulated Get latency (0 = default IPFS latency)")
+	rootCmd.PersistentFlags().DurationVar(&putLatency, "put-latency", 0, "simulated Put latency (0 = default IPFS latency)")
+	rootCmd.PersistentFlags().DurationVar(&hasLatency, "has-latency", 0, "simulated Has latency (0 = default IPFS latency)")
+	rootCmd.PersistentFlags().DurationVar(&jitter, "jitter", 0, "latency jitter (±)")
+	rootCmd.PersistentFlags().BoolVar(&noLatency, "no-latency", false, "disable all latency simulation")
 }
 
 func main() {
@@ -93,6 +94,9 @@ func runDaemonChild() error {
 	if listenOverride := os.Getenv(daemonListenKey); listenOverride != "" {
 		cfg.Listen = listenOverride
 	}
+	if err := applyDaemonEnvOverrides(); err != nil {
+		return err
+	}
 	return runServer(cfg)
 }
 
@@ -105,6 +109,49 @@ func run(cmd *cobra.Command, args []string) error {
 		cfg.Listen = listen
 	}
 	return runServer(cfg)
+}
+
+func daemonOverridesFromGlobals() DaemonOverrides {
+	return DaemonOverrides{
+		Listen:     listen,
+		NoLatency:  noLatency,
+		GetLatency: getLatency,
+		PutLatency: putLatency,
+		HasLatency: hasLatency,
+		Jitter:     jitter,
+	}
+}
+
+func applyDaemonEnvOverrides() error {
+	if os.Getenv(daemonNoLatencyKey) == "1" {
+		noLatency = true
+	}
+	var err error
+	if getLatency, err = durationFromEnv(daemonGetLatencyKey, getLatency); err != nil {
+		return err
+	}
+	if putLatency, err = durationFromEnv(daemonPutLatencyKey, putLatency); err != nil {
+		return err
+	}
+	if hasLatency, err = durationFromEnv(daemonHasLatencyKey, hasLatency); err != nil {
+		return err
+	}
+	if jitter, err = durationFromEnv(daemonJitterKey, jitter); err != nil {
+		return err
+	}
+	return nil
+}
+
+func durationFromEnv(key string, current time.Duration) (time.Duration, error) {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return current, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+	return d, nil
 }
 
 // runServer creates the KV store, starts the CAS HTTP server, and blocks
@@ -142,6 +189,8 @@ func runServer(cfg *Config) error {
 
 	store := casmock.NewCAS(opts...)
 	srv := casmock.NewHTTPServer(cfg.Listen, store)
+	shutdownCh := make(chan struct{}, 1)
+	handler := daemonShutdownHandler(srv.Handler(), os.Getenv(daemonShutdownTokenKey), shutdownCh)
 
 	fmt.Fprintf(os.Stderr, "mock-cas listening on %s\n", cfg.Listen)
 	fmt.Fprintf(os.Stderr, "kvstore: type=%s\n", cfg.KVStore.Type)
@@ -163,8 +212,9 @@ func runServer(cfg *Config) error {
 	defer cancel()
 
 	errCh := make(chan error, 1)
+	httpSrv := &http.Server{Addr: cfg.Listen, Handler: handler}
 	go func() {
-		if err := srv.Start(); err != nil {
+		if err := httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			errCh <- err
 		}
 	}()
@@ -174,10 +224,40 @@ func runServer(cfg *Config) error {
 		fmt.Fprintf(os.Stderr, "\nshutting down...\n")
 		shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutCancel()
-		return srv.Shutdown(shutCtx)
+		return httpSrv.Shutdown(shutCtx)
+	case <-shutdownCh:
+		fmt.Fprintf(os.Stderr, "\nshutdown requested...\n")
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutCancel()
+		return httpSrv.Shutdown(shutCtx)
 	case err := <-errCh:
 		return fmt.Errorf("server error: %w", err)
 	}
+}
+
+func daemonShutdownHandler(next http.Handler, token string, shutdownCh chan<- struct{}) http.Handler {
+	if token == "" {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/shutdown" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Header.Get("X-MALT-CAS-Shutdown-Token") != token {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		select {
+		case shutdownCh <- struct{}{}:
+		default:
+		}
+	})
 }
 
 // newKVStore creates a KV store from config. Returns (store, closeFn, error).

--- a/cmd/cas/main_test.go
+++ b/cmd/cas/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDaemonShutdownHandlerRequiresToken(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	shutdownCh := make(chan struct{}, 1)
+	handler := daemonShutdownHandler(next, "secret", shutdownCh)
+
+	req := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status without token = %d, want %d", resp.Code, http.StatusForbidden)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	req.Header.Set("X-MALT-CAS-Shutdown-Token", "secret")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("status with token = %d, want %d", resp.Code, http.StatusAccepted)
+	}
+	select {
+	case <-shutdownCh:
+	default:
+		t.Fatal("shutdown signal was not sent")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/health", nil)
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if !nextCalled || resp.Code != http.StatusNoContent {
+		t.Fatalf("non-shutdown request was not delegated: called=%v status=%d", nextCalled, resp.Code)
+	}
+}

--- a/cmd/cas/process.go
+++ b/cmd/cas/process.go
@@ -17,7 +17,7 @@ type BackgroundProcessSpec struct {
 }
 
 // startBackgroundProcess forks the given executable as a detached background process.
-func startBackgroundProcess(executable string, args []string, env []string, logPath string) (int, error) {
+func startBackgroundProcess(executable string, args []string, env []string, logPath string) (pid int, err error) {
 	if executable == "" {
 		return 0, fmt.Errorf("executable is empty")
 	}
@@ -33,7 +33,11 @@ func startBackgroundProcess(executable string, args []string, env []string, logP
 		if err != nil {
 			return 0, fmt.Errorf("open log: %w", err)
 		}
-		defer log.Close()
+		defer func() {
+			if closeErr := log.Close(); err == nil && closeErr != nil {
+				err = fmt.Errorf("close log: %w", closeErr)
+			}
+		}()
 		cmd.Stdout = log
 		cmd.Stderr = log
 	}
@@ -41,7 +45,7 @@ func startBackgroundProcess(executable string, args []string, env []string, logP
 	if err := cmd.Start(); err != nil {
 		return 0, err
 	}
-	pid := cmd.Process.Pid
+	pid = cmd.Process.Pid
 	if err := cmd.Process.Release(); err != nil {
 		return 0, err
 	}

--- a/cmd/cas/process.go
+++ b/cmd/cas/process.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// BackgroundProcessSpec describes a daemon process to launch.
+type BackgroundProcessSpec struct {
+	Executable string
+	Args       []string
+	Env        []string
+	LogPath    string
+}
+
+// startBackgroundProcess forks the given executable as a detached background process.
+func startBackgroundProcess(executable string, args []string, env []string, logPath string) (int, error) {
+	if executable == "" {
+		return 0, fmt.Errorf("executable is empty")
+	}
+	cmd := exec.Command(executable, args...)
+	if len(env) > 0 {
+		cmd.Env = env
+	}
+	if logPath != "" {
+		if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+			return 0, fmt.Errorf("create log dir: %w", err)
+		}
+		log, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			return 0, fmt.Errorf("open log: %w", err)
+		}
+		defer log.Close()
+		cmd.Stdout = log
+		cmd.Stderr = log
+	}
+	configureBackgroundCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Process.Release(); err != nil {
+		return 0, err
+	}
+	return pid, nil
+}
+
+const (
+	daemonProcessKey = "CAS_DAEMON_PROCESS"
+	daemonConfigKey  = "CAS_DAEMON_CONFIG"
+	daemonListenKey  = "CAS_DAEMON_LISTEN"
+)
+
+// daemonProcessEnv builds the environment for the daemon child process.
+func daemonProcessEnv(env []string, configPath string, listenOverride string) []string {
+	out := withoutEnvKeys(env, daemonProcessKey, daemonConfigKey, daemonListenKey)
+	out = append(out, daemonProcessKey+"=1")
+	if configPath != "" {
+		out = append(out, daemonConfigKey+"="+configPath)
+	}
+	if listenOverride != "" {
+		out = append(out, daemonListenKey+"="+listenOverride)
+	}
+	return out
+}
+
+func withoutEnvKeys(env []string, keys ...string) []string {
+	prefixes := make([]string, 0, len(keys))
+	for _, key := range keys {
+		prefixes = append(prefixes, key+"=")
+	}
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		skip := false
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(entry, prefix) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			out = append(out, entry)
+		}
+	}
+	return out
+}

--- a/cmd/cas/process.go
+++ b/cmd/cas/process.go
@@ -6,14 +6,18 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
-// BackgroundProcessSpec describes a daemon process to launch.
-type BackgroundProcessSpec struct {
-	Executable string
-	Args       []string
-	Env        []string
-	LogPath    string
+// DaemonOverrides are command-line overrides passed to the daemon child.
+type DaemonOverrides struct {
+	Listen        string
+	NoLatency     bool
+	GetLatency    time.Duration
+	PutLatency    time.Duration
+	HasLatency    time.Duration
+	Jitter        time.Duration
+	ShutdownToken string
 }
 
 // startBackgroundProcess forks the given executable as a detached background process.
@@ -53,20 +57,55 @@ func startBackgroundProcess(executable string, args []string, env []string, logP
 }
 
 const (
-	daemonProcessKey = "CAS_DAEMON_PROCESS"
-	daemonConfigKey  = "CAS_DAEMON_CONFIG"
-	daemonListenKey  = "CAS_DAEMON_LISTEN"
+	daemonProcessKey       = "CAS_DAEMON_PROCESS"
+	daemonConfigKey        = "CAS_DAEMON_CONFIG"
+	daemonListenKey        = "CAS_DAEMON_LISTEN"
+	daemonNoLatencyKey     = "CAS_DAEMON_NO_LATENCY"
+	daemonGetLatencyKey    = "CAS_DAEMON_GET_LATENCY"
+	daemonPutLatencyKey    = "CAS_DAEMON_PUT_LATENCY"
+	daemonHasLatencyKey    = "CAS_DAEMON_HAS_LATENCY"
+	daemonJitterKey        = "CAS_DAEMON_JITTER"
+	daemonShutdownTokenKey = "CAS_DAEMON_SHUTDOWN_TOKEN"
 )
 
 // daemonProcessEnv builds the environment for the daemon child process.
-func daemonProcessEnv(env []string, configPath string, listenOverride string) []string {
-	out := withoutEnvKeys(env, daemonProcessKey, daemonConfigKey, daemonListenKey)
+func daemonProcessEnv(env []string, configPath string, overrides DaemonOverrides) []string {
+	out := withoutEnvKeys(
+		env,
+		daemonProcessKey,
+		daemonConfigKey,
+		daemonListenKey,
+		daemonNoLatencyKey,
+		daemonGetLatencyKey,
+		daemonPutLatencyKey,
+		daemonHasLatencyKey,
+		daemonJitterKey,
+		daemonShutdownTokenKey,
+	)
 	out = append(out, daemonProcessKey+"=1")
 	if configPath != "" {
 		out = append(out, daemonConfigKey+"="+configPath)
 	}
-	if listenOverride != "" {
-		out = append(out, daemonListenKey+"="+listenOverride)
+	if overrides.Listen != "" {
+		out = append(out, daemonListenKey+"="+overrides.Listen)
+	}
+	if overrides.NoLatency {
+		out = append(out, daemonNoLatencyKey+"=1")
+	}
+	if overrides.GetLatency > 0 {
+		out = append(out, daemonGetLatencyKey+"="+overrides.GetLatency.String())
+	}
+	if overrides.PutLatency > 0 {
+		out = append(out, daemonPutLatencyKey+"="+overrides.PutLatency.String())
+	}
+	if overrides.HasLatency > 0 {
+		out = append(out, daemonHasLatencyKey+"="+overrides.HasLatency.String())
+	}
+	if overrides.Jitter > 0 {
+		out = append(out, daemonJitterKey+"="+overrides.Jitter.String())
+	}
+	if overrides.ShutdownToken != "" {
+		out = append(out, daemonShutdownTokenKey+"="+overrides.ShutdownToken)
 	}
 	return out
 }

--- a/cmd/cas/process_test.go
+++ b/cmd/cas/process_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDaemonProcessEnvIncludesRuntimeOverrides(t *testing.T) {
+	env := daemonProcessEnv([]string{
+		"KEEP=1",
+		daemonProcessKey + "=0",
+		daemonListenKey + "=old",
+	}, "settings.json", DaemonOverrides{
+		Listen:        "127.0.0.1:4999",
+		NoLatency:     true,
+		GetLatency:    50 * time.Millisecond,
+		PutLatency:    60 * time.Millisecond,
+		HasLatency:    70 * time.Millisecond,
+		Jitter:        5 * time.Millisecond,
+		ShutdownToken: "secret",
+	})
+
+	want := map[string]bool{
+		"KEEP=1":                            true,
+		daemonProcessKey + "=1":             true,
+		daemonConfigKey + "=settings.json":  true,
+		daemonListenKey + "=127.0.0.1:4999": true,
+		daemonNoLatencyKey + "=1":           true,
+		daemonGetLatencyKey + "=50ms":       true,
+		daemonPutLatencyKey + "=60ms":       true,
+		daemonHasLatencyKey + "=70ms":       true,
+		daemonJitterKey + "=5ms":            true,
+		daemonShutdownTokenKey + "=secret":  true,
+	}
+	for _, entry := range env {
+		delete(want, entry)
+		if strings.HasPrefix(entry, daemonListenKey+"=old") {
+			t.Fatalf("old listen override was not removed: %q", entry)
+		}
+	}
+	if len(want) > 0 {
+		t.Fatalf("missing env entries: %#v\nactual: %#v", want, env)
+	}
+}

--- a/cmd/cas/process_unix.go
+++ b/cmd/cas/process_unix.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"syscall"
@@ -20,4 +21,16 @@ func signalProcess(pid int) error {
 		return err
 	}
 	return process.Signal(syscall.SIGTERM)
+}
+
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
 }

--- a/cmd/cas/process_unix.go
+++ b/cmd/cas/process_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureBackgroundCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}
+
+func signalProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Signal(syscall.SIGTERM)
+}

--- a/cmd/cas/process_windows.go
+++ b/cmd/cas/process_windows.go
@@ -24,5 +24,25 @@ func signalProcess(pid int) error {
 	if err != nil {
 		return err
 	}
-	return process.Signal(os.Interrupt)
+	return process.Kill()
+}
+
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	const (
+		processQueryLimitedInformation = 0x1000
+		stillActive                    = 259
+	)
+	handle, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(handle)
+	var exitCode uint32
+	if err := syscall.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return true
+	}
+	return exitCode == stillActive
 }

--- a/cmd/cas/process_windows.go
+++ b/cmd/cas/process_windows.go
@@ -24,5 +24,5 @@ func signalProcess(pid int) error {
 	if err != nil {
 		return err
 	}
-	return process.Kill()
+	return process.Signal(os.Interrupt)
 }

--- a/cmd/cas/process_windows.go
+++ b/cmd/cas/process_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+const (
+	createNewProcessGroup = 0x00000200
+	detachProcess         = 0x00000008
+)
+
+func configureBackgroundCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: createNewProcessGroup | detachProcess,
+	}
+}
+
+func signalProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Kill()
+}

--- a/cmd/cas/process_windows_test.go
+++ b/cmd/cas/process_windows_test.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestSignalProcessTerminatesDetachedProcess(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess")
+	cmd.Env = append(os.Environ(), "MALT_CAS_HELPER_PROCESS=1")
+	configureBackgroundCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Process.Release(); err != nil {
+		t.Fatalf("release helper: %v", err)
+	}
+
+	if err := signalProcess(pid); err != nil {
+		t.Fatalf("signalProcess: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processExists(pid) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("process %d still exists after signalProcess", pid)
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("MALT_CAS_HELPER_PROCESS") != "1" {
+		return
+	}
+	time.Sleep(30 * time.Second)
+	os.Exit(0)
+}

--- a/storage/cas/mock/http.go
+++ b/storage/cas/mock/http.go
@@ -33,12 +33,20 @@ func NewHTTPServer(addr string, c cas.Client) *HTTPServer {
 // Handler returns the configured HTTP handler.
 func (s *HTTPServer) Handler() http.Handler {
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", s.handleHealth)
 	mux.HandleFunc("POST /api/v0/block/get", s.handleBlockGet)
 	mux.HandleFunc("POST /api/v0/block/put", s.handleBlockPut)
 	mux.HandleFunc("POST /api/v0/block/stat", s.handleBlockStat)
 	mux.HandleFunc("POST /api/v0/malt/block/has-batch", s.handleHasBatch)
 	mux.HandleFunc("POST /api/v0/malt/block/put-batch", s.handlePutBatch)
 	return mux
+}
+
+func (s *HTTPServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(struct {
+		Status string `json:"status"`
+	}{Status: "ok"})
 }
 
 // Start starts serving the Kubo-compatible API.


### PR DESCRIPTION
Add start/stop/status/restart lifecycle commands to the CAS CLI. Includes cas init for settings, persistent KV store (badger by default), health endpoint, and platform-specific process handling.