### PR TITLE
Seed init config with browser CORS origins

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -605,12 +605,15 @@ Allowed runtime values:
 - `state.kvstore.type`: `badger`, `memory`, or `fs`
 - `structure.default_backend`: `kzg` or `ipa`
 - `rpc.cors_allowed_origins`: browser origins allowed to call local read/proof
-  routes and `POST /verify`. Empty or omitted disables browser CORS. Exact
-  origins are matched literally. Port wildcards are only supported for loopback
-  origins such as `http://localhost:*`, `http://127.0.0.1:*`, and
-  `http://[::1]:*`; the daemon still replies with the concrete request origin.
-  The daemon reads this policy at startup. Change the file and restart the
-  managed daemon to apply browser-access changes.
+  routes, `POST /verify`, and UnixFS browser write routes such as
+  `POST /_unixfs?path=...` and `POST /{root}/{path...}`. Empty or omitted
+  disables browser CORS. Exact origins are matched literally. Port wildcards
+  are only supported for loopback origins such as `http://localhost:*`,
+  `http://127.0.0.1:*`, and `http://[::1]:*`; the daemon still replies with the
+  concrete request origin. Admin and semantic-mutation routes are not exposed
+  through the browser CORS surface. The daemon reads this policy at startup.
+  Change the file and restart the managed daemon to apply browser-access
+  changes.
 
 This config is a packaging and runtime decision. It does not define the core
 MALT semantic abstraction.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -572,11 +572,11 @@ Current config shape:
   "rpc": {
     "listen": "127.0.0.1:4317",
     "cors_allowed_origins": [
-      "http://127.0.0.1:*",
-      "http://localhost:*",
-      "http://[::1]:*",
       "https://dewebprotocol.dev",
-      "https://dewebprotocol.github.io"
+      "https://dewebprotocol.github.io",
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+      "http://[::1]:*"
     ]
   },
   "state": {

--- a/cmd/malt/initcmd.go
+++ b/cmd/malt/initcmd.go
@@ -19,6 +19,14 @@ var (
 	initKVStoreType    string
 )
 
+var initBrowserCORSAllowedOrigins = []string{
+	"https://dewebprotocol.dev",
+	"https://dewebprotocol.github.io",
+	"http://localhost:*",
+	"http://127.0.0.1:*",
+	"http://[::1]:*",
+}
+
 func init() {
 	rootCmd.AddCommand(initCmd)
 	initCmd.Flags().BoolVar(&initForce, "force", false, "overwrite an existing config file")
@@ -37,6 +45,7 @@ var initCmd = &cobra.Command{
 
 func runInit(cmd *cobra.Command, args []string) error {
 	cfg := config.DefaultConfig()
+	cfg.RPC.CORSAllowedOrigins = defaultInitBrowserCORSAllowedOrigins()
 
 	configPath, err := config.ResolveConfigPath(cfgFile)
 	if err != nil {
@@ -64,6 +73,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "daemon API: %s\n", cfg.APIBaseURL())
 	fmt.Fprintf(os.Stdout, "CAS: %s\n", cfg.CASBaseURL())
 	return nil
+}
+
+func defaultInitBrowserCORSAllowedOrigins() []string {
+	return append([]string(nil), initBrowserCORSAllowedOrigins...)
 }
 
 func promptString(reader *bufio.Reader, label string, explicit string, fallback string, nonInteractive bool) string {

--- a/cmd/malt/initcmd_test.go
+++ b/cmd/malt/initcmd_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/dewebprotocol/malt/config"
+)
+
+func TestInitWritesRecommendedBrowserCORSOrigins(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOME", home)
+
+	oldCfgFile := cfgFile
+	oldInitForce := initForce
+	oldInitNonInteractive := initNonInteractive
+	oldInitStateRoot := initStateRoot
+	oldInitRPCListen := initRPCListen
+	oldInitCASBaseURL := initCASBaseURL
+	oldInitKVStoreType := initKVStoreType
+	t.Cleanup(func() {
+		cfgFile = oldCfgFile
+		initForce = oldInitForce
+		initNonInteractive = oldInitNonInteractive
+		initStateRoot = oldInitStateRoot
+		initRPCListen = oldInitRPCListen
+		initCASBaseURL = oldInitCASBaseURL
+		initKVStoreType = oldInitKVStoreType
+	})
+
+	cfgFile = filepath.Join(home, "malt.json")
+	initForce = false
+	initNonInteractive = true
+	initStateRoot = ""
+	initRPCListen = ""
+	initCASBaseURL = ""
+	initKVStoreType = ""
+
+	if err := runInit(testCommandWithContext(context.Background()), nil); err != nil {
+		t.Fatalf("runInit() error = %v", err)
+	}
+
+	cfg, err := config.LoadFromFile(cfgFile)
+	if err != nil {
+		t.Fatalf("LoadFromFile() error = %v", err)
+	}
+
+	want := []string{
+		"https://dewebprotocol.dev",
+		"https://dewebprotocol.github.io",
+		"http://localhost:*",
+		"http://127.0.0.1:*",
+		"http://[::1]:*",
+	}
+	if !slices.Equal(cfg.RPC.CORSAllowedOrigins, want) {
+		t.Fatalf("RPC.CORSAllowedOrigins = %#v, want %#v", cfg.RPC.CORSAllowedOrigins, want)
+	}
+}

--- a/config.example.json
+++ b/config.example.json
@@ -2,11 +2,11 @@
   "rpc": {
     "listen": "127.0.0.1:4317",
     "cors_allowed_origins": [
-      "http://127.0.0.1:*",
-      "http://localhost:*",
-      "http://[::1]:*",
       "https://dewebprotocol.dev",
-      "https://dewebprotocol.github.io"
+      "https://dewebprotocol.github.io",
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+      "http://[::1]:*"
     ]
   },
   "state": {


### PR DESCRIPTION
## Summary
- Seed the recommended browser CORS allowlist into the config generated by malt init
- Keep runtime defaults disabled unless the config file opts in explicitly
- Keep loopback-only port wildcards for local docs/dev use

## Test Plan
- go test ./config ./server ./cmd/malt ./daemon