### PR TITLE
refactor: separate single-step commitment primitives from runtime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -307,6 +307,7 @@ malt/
 
 The current interface exposes:
 
+- `Commitment`
 - `Commit`
 - `Prove`
 - `Verify`
@@ -318,6 +319,8 @@ This already approximates the target map semantic shape:
 - `Verify` validates read proof
 - `Update` is the map write path
 - `Commit` bootstraps a root from a materialized view
+- `Commitment` exposes stateless single-step commitment primitives for
+  storage-free proof and verification
 
 The primary implementation, `mapping/radix`, uses a digest-keyed radix layout.
 It owns:
@@ -343,6 +346,7 @@ operations.
 
 The current interface exposes:
 
+- `Commitment`
 - `Commit`
 - `Prove`
 - `Verify`
@@ -357,6 +361,8 @@ This already approximates the target list semantic shape:
   byte-addressable fixed-chunk lists
 - `Verify` validates read proof
 - `Append`, `Replace`, and `Truncate` are list write operations
+- `Commitment` exposes stateless single-step commitment primitives for
+  storage-free proof and verification
 
 The primary implementation, `list/tree`, uses a tree-shaped fixed-slot layout.
 It owns:

--- a/auth/semantic/list/commitment_test.go
+++ b/auth/semantic/list/commitment_test.go
@@ -2,15 +2,34 @@ package list
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/binary"
 	"fmt"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
+
+func TestCommitmentCommitReturnsListTypedRoot(t *testing.T) {
+	handler, err := NewCommitment(testScheme{})
+	if err != nil {
+		t.Fatalf("NewCommitment failed: %v", err)
+	}
+
+	root, err := handler.Commit(context.Background(), NewViewFromSlice([]cid.Cid{
+		testCID(t, "value-a"),
+		testCID(t, "value-b"),
+	}))
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	if got := maltcid.SemanticKindOf(root); got != maltcid.SemanticKindList {
+		t.Fatalf("root semantic kind = %s, want %s", got, maltcid.SemanticKindList)
+	}
+}
 
 func TestCommitmentCommitRejectsUndefinedValues(t *testing.T) {
 	handler, err := NewCommitment(testScheme{})
@@ -31,18 +50,15 @@ type testScheme struct{}
 func (testScheme) MaxValues() int { return 1024 }
 
 func (testScheme) Commit(values []commitment.Cell) (cid.Cid, error) {
-	h := sha256.New()
+	h := sha512.New()
 	var lenBuf [8]byte
 	for _, value := range values {
 		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(value)))
 		_, _ = h.Write(lenBuf[:])
 		_, _ = h.Write(value)
 	}
-	sum, err := mh.Sum(h.Sum(nil), mh.SHA2_256, -1)
-	if err != nil {
-		return cid.Undef, err
-	}
-	return cid.NewCidV1(cid.Raw, sum), nil
+	sum := h.Sum(nil)
+	return maltcid.NewMapKZGCid(sum[:maltcid.KZGCommitmentSize])
 }
 
 func (testScheme) Prove([]commitment.Cell, uint64) (cid.Cid, commitment.Cell, []byte, error) {

--- a/auth/semantic/list/commitment_test.go
+++ b/auth/semantic/list/commitment_test.go
@@ -1,0 +1,79 @@
+package list
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/commitment"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestCommitmentCommitRejectsUndefinedValues(t *testing.T) {
+	handler, err := NewCommitment(testScheme{})
+	if err != nil {
+		t.Fatalf("NewCommitment failed: %v", err)
+	}
+
+	if _, err := handler.Commit(context.Background(), NewViewFromSlice([]cid.Cid{
+		testCID(t, "value"),
+		cid.Undef,
+	})); err == nil {
+		t.Fatal("Commit should reject undefined values")
+	}
+}
+
+type testScheme struct{}
+
+func (testScheme) MaxValues() int { return 1024 }
+
+func (testScheme) Commit(values []commitment.Cell) (cid.Cid, error) {
+	h := sha256.New()
+	var lenBuf [8]byte
+	for _, value := range values {
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(value)))
+		_, _ = h.Write(lenBuf[:])
+		_, _ = h.Write(value)
+	}
+	sum, err := mh.Sum(h.Sum(nil), mh.SHA2_256, -1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, sum), nil
+}
+
+func (testScheme) Prove([]commitment.Cell, uint64) (cid.Cid, commitment.Cell, []byte, error) {
+	return cid.Undef, nil, nil, fmt.Errorf("not implemented")
+}
+
+func (testScheme) BatchProve([]commitment.Cell, []uint64) (cid.Cid, []commitment.Cell, []byte, error) {
+	return cid.Undef, nil, nil, fmt.Errorf("not implemented")
+}
+
+func (testScheme) VerifyIndex(cid.Cid, uint64, commitment.Cell, []byte) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
+func (testScheme) BatchVerify(cid.Cid, []uint64, []commitment.Cell, []byte) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
+func (testScheme) VerifyProof(cid.Cid, commitment.Cell, []byte) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
+func (testScheme) Replace([]commitment.Cell, uint64, commitment.Cell, commitment.Cell) (cid.Cid, error) {
+	return cid.Undef, fmt.Errorf("not implemented")
+}
+
+func testCID(t *testing.T, payload string) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum([]byte(payload), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("mh.Sum failed: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}

--- a/auth/semantic/list/list.go
+++ b/auth/semantic/list/list.go
@@ -1,10 +1,21 @@
 // Package list defines the public stable-indexed list semantic for MALT.
+//
+// This package provides two layers of abstraction:
+//   - Commitment: stateless single-step primitives (Commit, ProveSlot, VerifySlot)
+//   - Semantics: stateful multi-step operations that combine primitives
+//
+// The Commitment layer is designed for use by any runtime (gateway, decentralized
+// node, light client) without storage dependencies. The Semantics layer combines
+// these primitives with storage access for complete operations.
 package list
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/dewebprotocol/malt/auth/commitment"
 	"github.com/dewebprotocol/malt/auth/semantic"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -47,12 +58,98 @@ type RangeResult struct {
 	Segments []cid.Cid
 }
 
+// Commitment provides stateless single-step commitment primitives for list semantics.
+//
+// This component handles the cryptographic commitment operations without any
+// storage dependencies. It can be used by gateway runtimes, decentralized nodes,
+// and light clients alike.
+type Commitment struct {
+	scheme commitment.IndexCommitment
+}
+
+// NewCommitment creates a new list commitment handler.
+func NewCommitment(scheme commitment.IndexCommitment) (*Commitment, error) {
+	if scheme == nil {
+		return nil, fmt.Errorf("index commitment scheme is nil")
+	}
+	return &Commitment{scheme: scheme}, nil
+}
+
+// Scheme returns the underlying commitment scheme.
+func (c *Commitment) Scheme() commitment.IndexCommitment {
+	return c.scheme
+}
+
+// Commit commits a list view to a root using the commitment scheme.
+func (c *Commitment) Commit(ctx context.Context, view View) (cid.Cid, error) {
+	if view == nil {
+		return cid.Undef, fmt.Errorf("view is nil")
+	}
+
+	cells := make([]commitment.Cell, view.Len())
+	for i := uint64(0); i < view.Len(); i++ {
+		value, ok := view.Get(i)
+		if !ok {
+			return cid.Undef, fmt.Errorf("missing value at index %d", i)
+		}
+		cells[i] = commitment.CellFromCID(value)
+	}
+
+	return c.scheme.Commit(cells)
+}
+
+// ProveSlot proves one slot in a committed node.
+//
+// Given the slots of a committed node, this function generates a proof for the
+// specified slot index. The caller must ensure that slots correspond to the root.
+func (c *Commitment) ProveSlot(root cid.Cid, slots []cid.Cid, slot uint64) (commitment.Cell, []byte, error) {
+	if !root.Defined() {
+		return nil, nil, fmt.Errorf("root is undefined")
+	}
+
+	cells := cellsFromCIDs(slots)
+	provedRoot, value, proof, err := c.scheme.Prove(cells, slot)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ok, err := maltcid.EqualCommitment(provedRoot, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !ok {
+		return nil, nil, fmt.Errorf("proved root does not match requested root")
+	}
+
+	return value, proof, nil
+}
+
+// VerifySlot verifies a single slot proof against a committed root.
+//
+// This function does not require access to the actual slot values - it only
+// needs the root commitment, slot index, expected value, and proof bytes.
+func (c *Commitment) VerifySlot(root cid.Cid, slot uint64, value commitment.Cell, proof []byte) (bool, error) {
+	return c.scheme.VerifyIndex(root, slot, value, proof)
+}
+
+// CellsFromCIDs converts a CID slice to commitment cells.
+func cellsFromCIDs(values []cid.Cid) []commitment.Cell {
+	cells := make([]commitment.Cell, len(values))
+	for i, value := range values {
+		cells[i] = commitment.CellFromCID(value)
+	}
+	return cells
+}
+
 // Semantics defines the public stable-indexed list semantics.
 //
-// Commit is the bootstrap path from a materialized list view. All other
-// runtime operations execute directly against the committed list root using the
-// supplied graph scope rather than caller-managed materialized views.
+// This interface combines the single-step commitment primitives with storage
+// access to provide complete list operations. Implementations use the
+// Commitment primitives internally and add multi-step tree traversal logic.
 type Semantics interface {
+	// Commitment returns the underlying commitment primitives.
+	Commitment() *Commitment
+
 	// Commit commits the supplied list view into the provided graph scope and
 	// returns a structure root.
 	Commit(ctx context.Context, namespace string, view View) (cid.Cid, error)

--- a/auth/semantic/list/list.go
+++ b/auth/semantic/list/list.go
@@ -98,7 +98,11 @@ func (c *Commitment) Commit(ctx context.Context, view View) (cid.Cid, error) {
 		cells[i] = commitment.CellFromCID(value)
 	}
 
-	return c.scheme.Commit(cells)
+	root, err := c.scheme.Commit(cells)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return listTypedRoot(root)
 }
 
 // ProveSlot proves one slot in a committed node.
@@ -142,6 +146,14 @@ func cellsFromCIDs(values []cid.Cid) []commitment.Cell {
 		cells[i] = commitment.CellFromCID(value)
 	}
 	return cells
+}
+
+func listTypedRoot(root cid.Cid) (cid.Cid, error) {
+	commBytes, err := maltcid.ExtractCommitment(root)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return maltcid.NewTypedCID(maltcid.SemanticKindList, maltcid.BackendKindOf(root), commBytes)
 }
 
 // Semantics defines the public stable-indexed list semantics.

--- a/auth/semantic/list/list.go
+++ b/auth/semantic/list/list.go
@@ -92,6 +92,9 @@ func (c *Commitment) Commit(ctx context.Context, view View) (cid.Cid, error) {
 		if !ok {
 			return cid.Undef, fmt.Errorf("missing value at index %d", i)
 		}
+		if !value.Defined() {
+			return cid.Undef, fmt.Errorf("value at index %d is undefined", i)
+		}
 		cells[i] = commitment.CellFromCID(value)
 	}
 

--- a/auth/semantic/mapping/commitment_test.go
+++ b/auth/semantic/mapping/commitment_test.go
@@ -1,0 +1,167 @@
+package mapping
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestCommitmentCommitAuthenticatesKeys(t *testing.T) {
+	handler, err := NewCommitment(testScheme{})
+	if err != nil {
+		t.Fatalf("NewCommitment failed: %v", err)
+	}
+
+	valueA := testCID(t, "value-a")
+	valueB := testCID(t, "value-b")
+	first, err := handler.Commit(context.Background(), NewViewFrom(map[string]cid.Cid{
+		"a": valueA,
+		"b": valueB,
+	}))
+	if err != nil {
+		t.Fatalf("Commit(first) failed: %v", err)
+	}
+	second, err := handler.Commit(context.Background(), NewViewFrom(map[string]cid.Cid{
+		"c": valueA,
+		"d": valueB,
+	}))
+	if err != nil {
+		t.Fatalf("Commit(second) failed: %v", err)
+	}
+	if first.Equals(second) {
+		t.Fatal("different keys with the same ordered values produced the same root")
+	}
+}
+
+func TestCommitmentCommitRejectsInvalidBindings(t *testing.T) {
+	handler, err := NewCommitment(testScheme{})
+	if err != nil {
+		t.Fatalf("NewCommitment failed: %v", err)
+	}
+
+	if _, err := handler.Commit(context.Background(), NewViewFromPaths(map[arcset.Path]cid.Cid{
+		"": testCID(t, "value"),
+	})); err == nil {
+		t.Fatal("Commit should reject empty keys")
+	}
+	if _, err := handler.Commit(context.Background(), NewViewFromPaths(map[arcset.Path]cid.Cid{
+		arcset.CanonicalizePath("a"): cid.Undef,
+	})); err == nil {
+		t.Fatal("Commit should reject undefined values")
+	}
+}
+
+func TestCommitmentCommitRejectsNonCanonicalIterationOrder(t *testing.T) {
+	handler, err := NewCommitment(testScheme{})
+	if err != nil {
+		t.Fatalf("NewCommitment failed: %v", err)
+	}
+
+	if _, err := handler.Commit(context.Background(), orderedView{
+		{key: arcset.CanonicalizePath("b"), value: testCID(t, "value-b")},
+		{key: arcset.CanonicalizePath("a"), value: testCID(t, "value-a")},
+	}); err == nil {
+		t.Fatal("Commit should reject non-canonical iteration order")
+	}
+}
+
+type orderedView []orderedBinding
+
+type orderedBinding struct {
+	key   arcset.Path
+	value cid.Cid
+}
+
+func (v orderedView) Len() int {
+	return len(v)
+}
+
+func (v orderedView) Get(key arcset.Path) (cid.Cid, bool) {
+	for _, binding := range v {
+		if binding.key == key {
+			return binding.value, true
+		}
+	}
+	return cid.Undef, false
+}
+
+func (v orderedView) Iterate() Iterator {
+	return &orderedIterator{bindings: v}
+}
+
+type orderedIterator struct {
+	bindings orderedView
+	index    int
+}
+
+func (it *orderedIterator) Next() (arcset.Path, cid.Cid, bool) {
+	if it.index >= len(it.bindings) {
+		return "", cid.Undef, false
+	}
+	binding := it.bindings[it.index]
+	it.index++
+	return binding.key, binding.value, true
+}
+
+func (it *orderedIterator) Err() error {
+	return nil
+}
+
+type testScheme struct{}
+
+func (testScheme) MaxValues() int { return 1024 }
+
+func (testScheme) Commit(values []commitment.Cell) (cid.Cid, error) {
+	h := sha256.New()
+	var lenBuf [8]byte
+	for _, value := range values {
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(value)))
+		_, _ = h.Write(lenBuf[:])
+		_, _ = h.Write(value)
+	}
+	sum, err := mh.Sum(h.Sum(nil), mh.SHA2_256, -1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, sum), nil
+}
+
+func (testScheme) Prove([]commitment.Cell, uint64) (cid.Cid, commitment.Cell, []byte, error) {
+	return cid.Undef, nil, nil, fmt.Errorf("not implemented")
+}
+
+func (testScheme) BatchProve([]commitment.Cell, []uint64) (cid.Cid, []commitment.Cell, []byte, error) {
+	return cid.Undef, nil, nil, fmt.Errorf("not implemented")
+}
+
+func (testScheme) VerifyIndex(cid.Cid, uint64, commitment.Cell, []byte) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
+func (testScheme) BatchVerify(cid.Cid, []uint64, []commitment.Cell, []byte) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
+func (testScheme) VerifyProof(cid.Cid, commitment.Cell, []byte) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
+func (testScheme) Replace([]commitment.Cell, uint64, commitment.Cell, commitment.Cell) (cid.Cid, error) {
+	return cid.Undef, fmt.Errorf("not implemented")
+}
+
+func testCID(t *testing.T, payload string) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum([]byte(payload), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("mh.Sum failed: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}

--- a/auth/semantic/mapping/commitment_test.go
+++ b/auth/semantic/mapping/commitment_test.go
@@ -2,13 +2,14 @@ package mapping
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/binary"
 	"fmt"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -37,6 +38,48 @@ func TestCommitmentCommitAuthenticatesKeys(t *testing.T) {
 	}
 	if first.Equals(second) {
 		t.Fatal("different keys with the same ordered values produced the same root")
+	}
+}
+
+func TestCommitmentCommitProveSlotRoundTrip(t *testing.T) {
+	handler, err := NewCommitment(testScheme{})
+	if err != nil {
+		t.Fatalf("NewCommitment failed: %v", err)
+	}
+
+	keyA := arcset.CanonicalizePath("a")
+	keyB := arcset.CanonicalizePath("b")
+	valueA := testCID(t, "value-a")
+	valueB := testCID(t, "value-b")
+	root, err := handler.Commit(context.Background(), NewViewFromPaths(map[arcset.Path]cid.Cid{
+		keyA: valueA,
+		keyB: valueB,
+	}))
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	slotA, err := BindingCID(keyA, valueA)
+	if err != nil {
+		t.Fatalf("BindingCID(a) failed: %v", err)
+	}
+	slotB, err := BindingCID(keyB, valueB)
+	if err != nil {
+		t.Fatalf("BindingCID(b) failed: %v", err)
+	}
+	proved, proof, err := handler.ProveSlot(root, []cid.Cid{slotA, slotB}, 1)
+	if err != nil {
+		t.Fatalf("ProveSlot failed: %v", err)
+	}
+	if !proved.Equal(commitment.CellFromCID(slotB)) {
+		t.Fatal("ProveSlot returned the wrong binding slot")
+	}
+	ok, err := handler.VerifySlot(root, 1, proved, proof)
+	if err != nil {
+		t.Fatalf("VerifySlot failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("VerifySlot returned false")
 	}
 }
 
@@ -119,30 +162,39 @@ type testScheme struct{}
 func (testScheme) MaxValues() int { return 1024 }
 
 func (testScheme) Commit(values []commitment.Cell) (cid.Cid, error) {
-	h := sha256.New()
+	h := sha512.New()
 	var lenBuf [8]byte
 	for _, value := range values {
 		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(value)))
 		_, _ = h.Write(lenBuf[:])
 		_, _ = h.Write(value)
 	}
-	sum, err := mh.Sum(h.Sum(nil), mh.SHA2_256, -1)
-	if err != nil {
-		return cid.Undef, err
-	}
-	return cid.NewCidV1(cid.Raw, sum), nil
+	sum := h.Sum(nil)
+	return maltcid.NewMapKZGCid(sum[:maltcid.KZGCommitmentSize])
 }
 
-func (testScheme) Prove([]commitment.Cell, uint64) (cid.Cid, commitment.Cell, []byte, error) {
-	return cid.Undef, nil, nil, fmt.Errorf("not implemented")
+func (s testScheme) Prove(values []commitment.Cell, index uint64) (cid.Cid, commitment.Cell, []byte, error) {
+	root, err := s.Commit(values)
+	if err != nil {
+		return cid.Undef, nil, nil, err
+	}
+	if index >= uint64(len(values)) {
+		return cid.Undef, nil, nil, fmt.Errorf("index %d out of range", index)
+	}
+	proof := make([]byte, 8)
+	binary.BigEndian.PutUint64(proof, index)
+	return root, commitment.NewCell(values[index]), proof, nil
 }
 
 func (testScheme) BatchProve([]commitment.Cell, []uint64) (cid.Cid, []commitment.Cell, []byte, error) {
 	return cid.Undef, nil, nil, fmt.Errorf("not implemented")
 }
 
-func (testScheme) VerifyIndex(cid.Cid, uint64, commitment.Cell, []byte) (bool, error) {
-	return false, fmt.Errorf("not implemented")
+func (testScheme) VerifyIndex(_ cid.Cid, index uint64, _ commitment.Cell, proof []byte) (bool, error) {
+	if len(proof) != 8 {
+		return false, fmt.Errorf("proof length = %d, want 8", len(proof))
+	}
+	return binary.BigEndian.Uint64(proof) == index, nil
 }
 
 func (testScheme) BatchVerify(cid.Cid, []uint64, []commitment.Cell, []byte) (bool, error) {

--- a/auth/semantic/mapping/mapping.go
+++ b/auth/semantic/mapping/mapping.go
@@ -1,11 +1,22 @@
 // Package mapping defines the public keyed-map semantic for MALT.
+//
+// This package provides two layers of abstraction:
+//   - Commitment: stateless single-step primitives (Commit, ProveSlot, VerifySlot)
+//   - Semantics: stateful multi-step operations that combine primitives
+//
+// The Commitment layer is designed for use by any runtime (gateway, decentralized
+// node, light client) without storage dependencies. The Semantics layer combines
+// these primitives with storage access for complete operations.
 package mapping
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/auth/commitment"
 	"github.com/dewebprotocol/malt/auth/semantic"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -33,8 +44,104 @@ type Binding struct {
 	Present bool
 }
 
+// Commitment provides stateless single-step commitment primitives for map semantics.
+//
+// This component handles the cryptographic commitment operations without any
+// storage dependencies. It can be used by gateway runtimes, decentralized nodes,
+// and light clients alike.
+type Commitment struct {
+	scheme commitment.IndexCommitment
+}
+
+// NewCommitment creates a new map commitment handler.
+func NewCommitment(scheme commitment.IndexCommitment) (*Commitment, error) {
+	if scheme == nil {
+		return nil, fmt.Errorf("index commitment scheme is nil")
+	}
+	return &Commitment{scheme: scheme}, nil
+}
+
+// Scheme returns the underlying commitment scheme.
+func (c *Commitment) Scheme() commitment.IndexCommitment {
+	return c.scheme
+}
+
+// Commit commits a map view to a root using the commitment scheme.
+func (c *Commitment) Commit(ctx context.Context, view View) (cid.Cid, error) {
+	if view == nil {
+		return cid.Undef, fmt.Errorf("view is nil")
+	}
+
+	cells := make([]commitment.Cell, view.Len())
+	iter := view.Iterate()
+	i := 0
+	for {
+		_, value, ok := iter.Next()
+		if !ok {
+			break
+		}
+		cells[i] = commitment.CellFromCID(value)
+		i++
+	}
+	if err := iter.Err(); err != nil {
+		return cid.Undef, err
+	}
+
+	return c.scheme.Commit(cells)
+}
+
+// ProveSlot proves one slot in a committed node.
+//
+// Given the slots of a committed node, this function generates a proof for the
+// specified slot index. The caller must ensure that slots correspond to the root.
+func (c *Commitment) ProveSlot(root cid.Cid, slots []cid.Cid, slot uint64) (commitment.Cell, []byte, error) {
+	if !root.Defined() {
+		return nil, nil, fmt.Errorf("root is undefined")
+	}
+
+	cells := cellsFromCIDs(slots)
+	provedRoot, value, proof, err := c.scheme.Prove(cells, slot)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ok, err := maltcid.EqualCommitment(provedRoot, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !ok {
+		return nil, nil, fmt.Errorf("proved root does not match requested root")
+	}
+
+	return value, proof, nil
+}
+
+// VerifySlot verifies a single slot proof against a committed root.
+//
+// This function does not require access to the actual slot values - it only
+// needs the root commitment, slot index, expected value, and proof bytes.
+func (c *Commitment) VerifySlot(root cid.Cid, slot uint64, value commitment.Cell, proof []byte) (bool, error) {
+	return c.scheme.VerifyIndex(root, slot, value, proof)
+}
+
+// CellsFromCIDs converts a CID slice to commitment cells.
+func cellsFromCIDs(values []cid.Cid) []commitment.Cell {
+	cells := make([]commitment.Cell, len(values))
+	for i, value := range values {
+		cells[i] = commitment.CellFromCID(value)
+	}
+	return cells
+}
+
 // Semantics defines the public keyed-map semantics.
+//
+// This interface combines the single-step commitment primitives with storage
+// access to provide complete map operations. Implementations use the
+// Commitment primitives internally and add multi-step tree traversal logic.
 type Semantics interface {
+	// Commitment returns the underlying commitment primitives.
+	Commitment() *Commitment
+
 	// Commit commits the supplied map view and returns a structure root.
 	Commit(ctx context.Context, namespace string, view View) (cid.Cid, error)
 

--- a/auth/semantic/mapping/mapping.go
+++ b/auth/semantic/mapping/mapping.go
@@ -11,6 +11,7 @@ package mapping
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -66,7 +67,7 @@ func (c *Commitment) Scheme() commitment.IndexCommitment {
 	return c.scheme
 }
 
-// Commit commits a map view to a root using the commitment scheme.
+// Commit commits a map view to a root using keyed binding cells.
 func (c *Commitment) Commit(ctx context.Context, view View) (cid.Cid, error) {
 	if view == nil {
 		return cid.Undef, fmt.Errorf("view is nil")
@@ -75,16 +76,33 @@ func (c *Commitment) Commit(ctx context.Context, view View) (cid.Cid, error) {
 	cells := make([]commitment.Cell, view.Len())
 	iter := view.Iterate()
 	i := 0
+	var previous arcset.Path
+	hasPrevious := false
 	for {
-		_, value, ok := iter.Next()
+		key, value, ok := iter.Next()
 		if !ok {
 			break
 		}
-		cells[i] = commitment.CellFromCID(value)
+		if i >= len(cells) {
+			return cid.Undef, fmt.Errorf("view iterator yielded more bindings than Len")
+		}
+		cell, err := bindingCell(key, value)
+		if err != nil {
+			return cid.Undef, err
+		}
+		if hasPrevious && key <= previous {
+			return cid.Undef, fmt.Errorf("view iteration is not in canonical key order")
+		}
+		cells[i] = cell
+		previous = key
+		hasPrevious = true
 		i++
 	}
 	if err := iter.Err(); err != nil {
 		return cid.Undef, err
+	}
+	if i != len(cells) {
+		return cid.Undef, fmt.Errorf("view iterator yielded %d bindings, expected %d", i, len(cells))
 	}
 
 	return c.scheme.Commit(cells)
@@ -131,6 +149,28 @@ func cellsFromCIDs(values []cid.Cid) []commitment.Cell {
 		cells[i] = commitment.CellFromCID(value)
 	}
 	return cells
+}
+
+func bindingCell(key arcset.Path, value cid.Cid) (commitment.Cell, error) {
+	if key.IsEmpty() {
+		return nil, fmt.Errorf("key is empty")
+	}
+	if !value.Defined() {
+		return nil, fmt.Errorf("value is undefined")
+	}
+
+	keyBytes := []byte(key.String())
+	valueBytes := value.Bytes()
+	if len(keyBytes) > 0xffff {
+		return nil, fmt.Errorf("key %q is too long", key.String())
+	}
+
+	out := make([]byte, 0, 1+2+len(keyBytes)+len(valueBytes))
+	out = append(out, 1)
+	out = binary.BigEndian.AppendUint16(out, uint16(len(keyBytes)))
+	out = append(out, keyBytes...)
+	out = append(out, valueBytes...)
+	return commitment.NewCell(out), nil
 }
 
 // Semantics defines the public keyed-map semantics.

--- a/auth/semantic/mapping/mapping.go
+++ b/auth/semantic/mapping/mapping.go
@@ -19,7 +19,10 @@ import (
 	"github.com/dewebprotocol/malt/auth/semantic"
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
 )
+
+const bindingPrefix = "malt:map:binding:v1:"
 
 // Iterator iterates over a map view in canonical key order.
 type Iterator interface {
@@ -67,7 +70,7 @@ func (c *Commitment) Scheme() commitment.IndexCommitment {
 	return c.scheme
 }
 
-// Commit commits a map view to a root using keyed binding cells.
+// Commit commits a map view to a root using keyed binding CID slots.
 func (c *Commitment) Commit(ctx context.Context, view View) (cid.Cid, error) {
 	if view == nil {
 		return cid.Undef, fmt.Errorf("view is nil")
@@ -112,6 +115,8 @@ func (c *Commitment) Commit(ctx context.Context, view View) (cid.Cid, error) {
 //
 // Given the slots of a committed node, this function generates a proof for the
 // specified slot index. The caller must ensure that slots correspond to the root.
+// For roots produced by Commit, slots are canonical BindingCID values in view
+// iteration order rather than bare map target CIDs.
 func (c *Commitment) ProveSlot(root cid.Cid, slots []cid.Cid, slot uint64) (commitment.Cell, []byte, error) {
 	if !root.Defined() {
 		return nil, nil, fmt.Errorf("root is undefined")
@@ -151,26 +156,39 @@ func cellsFromCIDs(values []cid.Cid) []commitment.Cell {
 	return cells
 }
 
-func bindingCell(key arcset.Path, value cid.Cid) (commitment.Cell, error) {
+// BindingCID encodes one keyed map binding as the CID slot committed by Commit.
+func BindingCID(key arcset.Path, value cid.Cid) (cid.Cid, error) {
 	if key.IsEmpty() {
-		return nil, fmt.Errorf("key is empty")
+		return cid.Undef, fmt.Errorf("key is empty")
 	}
 	if !value.Defined() {
-		return nil, fmt.Errorf("value is undefined")
+		return cid.Undef, fmt.Errorf("value is undefined")
 	}
 
 	keyBytes := []byte(key.String())
 	valueBytes := value.Bytes()
 	if len(keyBytes) > 0xffff {
-		return nil, fmt.Errorf("key %q is too long", key.String())
+		return cid.Undef, fmt.Errorf("key %q is too long", key.String())
 	}
 
-	out := make([]byte, 0, 1+2+len(keyBytes)+len(valueBytes))
-	out = append(out, 1)
+	out := make([]byte, 0, len(bindingPrefix)+2+len(keyBytes)+len(valueBytes))
+	out = append(out, []byte(bindingPrefix)...)
 	out = binary.BigEndian.AppendUint16(out, uint16(len(keyBytes)))
 	out = append(out, keyBytes...)
 	out = append(out, valueBytes...)
-	return commitment.NewCell(out), nil
+	sum, err := mh.Sum(out, mh.IDENTITY, len(out))
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, sum), nil
+}
+
+func bindingCell(key arcset.Path, value cid.Cid) (commitment.Cell, error) {
+	binding, err := BindingCID(key, value)
+	if err != nil {
+		return nil, err
+	}
+	return commitment.CellFromCID(binding), nil
 }
 
 // Semantics defines the public keyed-map semantics.

--- a/cmd/eval/internal/baseline/indexedmap/indexed.go
+++ b/cmd/eval/internal/baseline/indexedmap/indexed.go
@@ -26,8 +26,8 @@ const (
 // Map materializes a keyed runtime view into a canonical-path ordered binding
 // vector and delegates authentication to a primitive index commitment backend.
 type Map struct {
-	scheme   commitment.IndexCommitment
-	arctable arctable.ArcTable
+	commitment *mapping.Commitment
+	arctable   arctable.ArcTable
 }
 
 type entry struct {
@@ -45,7 +45,18 @@ func NewMap(scheme commitment.IndexCommitment, e arctable.ArcTable) (*Map, error
 	if e == nil {
 		return nil, fmt.Errorf("arctable is nil")
 	}
-	return &Map{scheme: scheme, arctable: e}, nil
+
+	commitmentHandler, err := mapping.NewCommitment(scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create map commitment: %w", err)
+	}
+
+	return &Map{commitment: commitmentHandler, arctable: e}, nil
+}
+
+// Commitment returns the underlying commitment primitives.
+func (m *Map) Commitment() *mapping.Commitment {
+	return m.commitment
 }
 
 // Commit commits the supplied keyed view and materializes the runtime state in ArcTable.
@@ -54,7 +65,7 @@ func (s *Map) Commit(ctx context.Context, namespace string, view mapping.View) (
 	if err != nil {
 		return cid.Undef, err
 	}
-	root, err := s.scheme.Commit(cells)
+	root, err := s.commitment.Scheme().Commit(cells)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -76,7 +87,7 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 		return mapping.Binding{}, nil, fmt.Errorf("path %s not found", key.String())
 	}
 
-	recomputedRoot, err := s.scheme.Commit(cells)
+	recomputedRoot, err := s.commitment.Scheme().Commit(cells)
 	if err != nil {
 		return mapping.Binding{}, nil, err
 	}
@@ -84,7 +95,7 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 		return mapping.Binding{}, nil, fmt.Errorf("recomputed root does not match requested root")
 	}
 
-	provedRoot, proved, proof, err := s.scheme.Prove(cells, uint64(index))
+	provedRoot, proved, proof, err := s.commitment.Scheme().Prove(cells, uint64(index))
 	if err != nil {
 		return mapping.Binding{}, nil, err
 	}
@@ -108,7 +119,7 @@ func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, pr
 	if err != nil {
 		return false, err
 	}
-	return s.scheme.VerifyProof(root, cell, proof)
+	return s.commitment.Scheme().VerifyProof(root, cell, proof)
 }
 
 // Update applies insert, replace, or delete semantics over the committed runtime state.
@@ -118,7 +129,7 @@ func (s *Map) Update(ctx context.Context, namespace string, root cid.Cid, key ar
 		return cid.Undef, err
 	}
 
-	recomputedRoot, err := s.scheme.Commit(cells)
+	recomputedRoot, err := s.commitment.Scheme().Commit(cells)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -155,7 +166,7 @@ func (s *Map) Update(ctx context.Context, namespace string, root cid.Cid, key ar
 		if err != nil {
 			return cid.Undef, err
 		}
-		newRoot, err := s.scheme.Replace(cells, uint64(index), oldCell, newCell)
+		newRoot, err := s.commitment.Scheme().Replace(cells, uint64(index), oldCell, newCell)
 		if err != nil {
 			return cid.Undef, err
 		}
@@ -185,7 +196,7 @@ func (s *Map) commitEntries(ctx context.Context, namespace string, entries []ent
 	if err != nil {
 		return cid.Undef, err
 	}
-	root, err := s.scheme.Commit(cells)
+	root, err := s.commitment.Scheme().Commit(cells)
 	if err != nil {
 		return cid.Undef, err
 	}

--- a/runtime/semantic/list/tree/tree.go
+++ b/runtime/semantic/list/tree/tree.go
@@ -1,6 +1,10 @@
 // Package tree implements the stable-indexed list semantic using a tree-shaped
 // fixed-slot layout. Runtime operations execute against node materialization
 // stored in ArcTable, so proofs and updates do not require a caller-supplied view.
+//
+// This implementation uses the single-step commitment primitives from
+// auth/semantic/list and combines them with storage access for multi-step
+// tree traversal operations.
 package tree
 
 import (
@@ -18,8 +22,8 @@ import (
 )
 
 type TreeList struct {
-	scheme   commitment.IndexCommitment
-	arctable arctable.ArcTable
+	commitment *list.Commitment
+	arctable   arctable.ArcTable
 }
 
 type proofEnvelope struct {
@@ -51,10 +55,21 @@ func NewList(scheme commitment.IndexCommitment, arctable arctable.ArcTable) (*Tr
 	if arctable == nil {
 		return nil, fmt.Errorf("arctable is nil")
 	}
+
+	commitmentHandler, err := list.NewCommitment(scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create list commitment: %w", err)
+	}
+
 	return &TreeList{
-		scheme:   scheme,
-		arctable: arctable,
+		commitment: commitmentHandler,
+		arctable:   arctable,
 	}, nil
+}
+
+// Commitment returns the underlying commitment primitives.
+func (s *TreeList) Commitment() *list.Commitment {
+	return s.commitment
 }
 
 func (s *TreeList) Commit(ctx context.Context, namespace string, view list.View) (cid.Cid, error) {
@@ -91,7 +106,7 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 	}
 
 	query := list.Query{Length: length}
-	lengthTarget, lengthProof, err := layout.ProveSlot(s.scheme, root, rootSlots, 0)
+	lengthTarget, lengthProof, err := s.commitment.ProveSlot(root, rootSlots, 0)
 	if err != nil {
 		return list.Query{}, nil, err
 	}
@@ -121,7 +136,7 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 			return list.Query{}, nil, err
 		}
 
-		target, proof, err := layout.ProveSlot(s.scheme, currentRoot, currentSlots, slot)
+		target, proof, err := s.commitment.ProveSlot(currentRoot, currentSlots, slot)
 		if err != nil {
 			return list.Query{}, nil, err
 		}
@@ -164,7 +179,7 @@ func (s *TreeList) Verify(root cid.Cid, index uint64, expected list.Query, proof
 	if err != nil {
 		return false, err
 	}
-	ok, err := layout.VerifySlot(s.scheme, root, 0, lengthTarget, envelope.LengthProof)
+	ok, err := s.commitment.VerifySlot(root, 0, lengthTarget, envelope.LengthProof)
 	if err != nil || !ok {
 		return ok, err
 	}
@@ -231,7 +246,7 @@ func (s *TreeList) ProveRange(ctx context.Context, namespace string, root cid.Ci
 		return list.RangeResult{}, nil, err
 	}
 
-	_, metadataProof, err := layout.ProveSlot(s.scheme, root, rootSlots, 0)
+	_, metadataProof, err := s.commitment.ProveSlot(root, rootSlots, 0)
 	if err != nil {
 		return list.RangeResult{}, nil, err
 	}
@@ -964,7 +979,7 @@ func (s *TreeList) loadNode(ctx context.Context, namespace string, root cid.Cid,
 	if err != nil {
 		return nil, err
 	}
-	validateErr := layout.ValidateSlots(s.scheme, root, slots)
+	validateErr := s.validateSlots(root, slots)
 	if validateErr == nil {
 		return slots, nil
 	}
@@ -973,7 +988,7 @@ func (s *TreeList) loadNode(ctx context.Context, namespace string, root cid.Cid,
 		if err != nil {
 			return nil, validateErr
 		}
-		if err := layout.ValidateSlots(s.scheme, root, legacySlots); err == nil {
+		if err := s.validateSlots(root, legacySlots); err == nil {
 			return legacySlots, nil
 		}
 		return nil, validateErr
@@ -981,8 +996,24 @@ func (s *TreeList) loadNode(ctx context.Context, namespace string, root cid.Cid,
 	return nil, validateErr
 }
 
+// validateSlots checks that the materialized slot vector recomputes to root.
+func (s *TreeList) validateSlots(root cid.Cid, slots []cid.Cid) error {
+	recomputed, err := s.commitment.Scheme().Commit(cellsFromCIDs(slots))
+	if err != nil {
+		return err
+	}
+	ok, err := maltcid.EqualCommitment(recomputed, root)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("materialized node state does not match root %s", root.String())
+	}
+	return nil
+}
+
 func (s *TreeList) commitSlots(ctx context.Context, namespace string, slots []cid.Cid) (cid.Cid, error) {
-	root, err := layout.CommitSlots(s.scheme, slots)
+	root, err := s.commitment.Scheme().Commit(cellsFromCIDs(slots))
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -1013,7 +1044,7 @@ func (s *TreeList) verifyFixedMetadataSlot(root cid.Cid, meta layout.FixedMetada
 	if err != nil {
 		return false, err
 	}
-	ok, err := layout.VerifySlot(s.scheme, root, 0, commitment.CellFromCID(nodeMarker), proof)
+	ok, err := s.commitment.VerifySlot(root, 0, commitment.CellFromCID(nodeMarker), proof)
 	if err != nil || ok {
 		return ok, err
 	}
@@ -1022,7 +1053,7 @@ func (s *TreeList) verifyFixedMetadataSlot(root cid.Cid, meta layout.FixedMetada
 	if err != nil {
 		return false, err
 	}
-	return layout.VerifySlot(s.scheme, root, 0, commitment.CellFromCID(legacyMarker), proof)
+	return s.commitment.VerifySlot(root, 0, commitment.CellFromCID(legacyMarker), proof)
 }
 
 func encodeProof(query list.Query, envelope proofEnvelope) (list.Query, structure.Proof, error) {
@@ -1084,7 +1115,7 @@ func (s *TreeList) verifyAnyContentSlot(root cid.Cid, slots []uint64, target com
 	for _, slot := range slots {
 		// Backends may mutate proof buffers while decoding; keep retries isolated.
 		proofCopy := append([]byte(nil), proof...)
-		ok, err := layout.VerifySlot(s.scheme, root, slot, target, proofCopy)
+		ok, err := s.commitment.VerifySlot(root, slot, target, proofCopy)
 		if err != nil {
 			verifyErr = err
 			continue
@@ -1266,3 +1297,12 @@ func cloneSlotsForMetadataMutation(slots []cid.Cid) []cid.Cid {
 
 var _ list.Semantics = (*TreeList)(nil)
 var _ list.MeasuredSemantics = (*TreeList)(nil)
+
+// cellsFromCIDs converts a CID slice to commitment cells.
+func cellsFromCIDs(values []cid.Cid) []commitment.Cell {
+	cells := make([]commitment.Cell, len(values))
+	for i, value := range values {
+		cells[i] = commitment.CellFromCID(value)
+	}
+	return cells
+}

--- a/runtime/semantic/mapping/radix/radix.go
+++ b/runtime/semantic/mapping/radix/radix.go
@@ -1,5 +1,9 @@
 // Package radix implements a digest-keyed radix-map semantic above the
 // primitive index commitment backends.
+//
+// This implementation uses the single-step commitment primitives from
+// auth/semantic/mapping and combines them with storage access for multi-step
+// radix tree traversal operations.
 package radix
 
 import (
@@ -28,8 +32,8 @@ const (
 )
 
 type Map struct {
-	scheme   commitment.IndexCommitment
-	arctable arctable.ArcTable
+	commitment *mapping.Commitment
+	arctable   arctable.ArcTable
 }
 
 type leafBinding struct {
@@ -62,7 +66,18 @@ func NewMap(scheme commitment.IndexCommitment, e arctable.ArcTable) (*Map, error
 	if scheme.MaxValues() < fanout {
 		return nil, fmt.Errorf("index commitment capacity %d is smaller than radix fanout %d", scheme.MaxValues(), fanout)
 	}
-	return &Map{scheme: scheme, arctable: e}, nil
+
+	commitmentHandler, err := mapping.NewCommitment(scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create map commitment: %w", err)
+	}
+
+	return &Map{commitment: commitmentHandler, arctable: e}, nil
+}
+
+// Commitment returns the underlying commitment primitives.
+func (s *Map) Commitment() *mapping.Commitment {
+	return s.commitment
 }
 
 func (s *Map) Commit(ctx context.Context, namespace string, view mapping.View) (cid.Cid, error) {
@@ -92,12 +107,9 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 		}
 
 		slotIndex := digest[depth]
-		provedRoot, value, proof, err := s.scheme.Prove(cellsFromCIDs(slots), uint64(slotIndex))
+		value, proof, err := s.commitment.ProveSlot(currentRoot, slots, uint64(slotIndex))
 		if err != nil {
 			return mapping.Binding{}, nil, err
-		}
-		if !provedRoot.Equals(currentRoot) {
-			return mapping.Binding{}, nil, fmt.Errorf("proved root does not match requested node root")
 		}
 
 		slotCID, err := value.AsCID()
@@ -148,12 +160,9 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 				return mapping.Binding{}, nil, fmt.Errorf("path %s not found", key.String())
 			}
 
-			provedRoot, value, proof, err := s.scheme.Prove(cellsFromCIDs(markers), uint64(index))
+			value, proof, err := s.commitment.ProveSlot(bucketRoot, markers, uint64(index))
 			if err != nil {
 				return mapping.Binding{}, nil, err
-			}
-			if !provedRoot.Equals(bucketRoot) {
-				return mapping.Binding{}, nil, fmt.Errorf("bucket proof root mismatch")
 			}
 			_, leafValue, err := decodeLeafMarkerCID(value)
 			if err != nil {
@@ -211,7 +220,7 @@ func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, pr
 			}
 		}
 
-		ok, err := s.scheme.VerifyIndex(currentRoot, uint64(digest[depth]), commitment.CellFromCID(slotCID), step.Proof)
+		ok, err := s.commitment.VerifySlot(currentRoot, uint64(digest[depth]), commitment.CellFromCID(slotCID), step.Proof)
 		if err != nil || !ok {
 			return ok, err
 		}
@@ -234,7 +243,7 @@ func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, pr
 			if depth != len(envelope.Steps)-1 || envelope.Bucket == nil {
 				return false, nil
 			}
-			return s.scheme.VerifyProof(bucketRoot, commitment.CellFromCID(expectedLeaf), envelope.Bucket.Proof)
+			return s.commitment.Scheme().VerifyProof(bucketRoot, commitment.CellFromCID(expectedLeaf), envelope.Bucket.Proof)
 		}
 
 		if depth == len(envelope.Steps)-1 {
@@ -391,7 +400,7 @@ func (s *Map) updateBucket(ctx context.Context, namespace string, bucketRoot cid
 		if len(markers) == 1 {
 			return nextMarker, nil
 		}
-		root, err := s.scheme.Replace(cellsFromCIDs(markers), uint64(index), commitment.CellFromCID(markers[index]), commitment.CellFromCID(nextMarker))
+		root, err := s.commitment.Scheme().Replace(cellsFromCIDs(markers), uint64(index), commitment.CellFromCID(markers[index]), commitment.CellFromCID(nextMarker))
 		if err != nil {
 			return cid.Undef, err
 		}
@@ -481,7 +490,7 @@ func (s *Map) buildSubtree(ctx context.Context, namespace string, bindings []lea
 }
 
 func (s *Map) commitNode(ctx context.Context, namespace string, slots []cid.Cid) (cid.Cid, error) {
-	root, err := s.scheme.Commit(cellsFromCIDs(slots))
+	root, err := s.commitment.Scheme().Commit(cellsFromCIDs(slots))
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -529,11 +538,11 @@ func (s *Map) commitBucketMarkers(ctx context.Context, namespace string, markers
 	case 1:
 		return markers[0], nil
 	}
-	if len(markers) > s.scheme.MaxValues() {
-		return cid.Undef, fmt.Errorf("bucket size %d exceeds commitment capacity %d", len(markers), s.scheme.MaxValues())
+	if len(markers) > s.commitment.Scheme().MaxValues() {
+		return cid.Undef, fmt.Errorf("bucket size %d exceeds commitment capacity %d", len(markers), s.commitment.Scheme().MaxValues())
 	}
 
-	root, err := s.scheme.Commit(cellsFromCIDs(markers))
+	root, err := s.commitment.Scheme().Commit(cellsFromCIDs(markers))
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -609,7 +618,7 @@ func (s *Map) loadValidatedNode(ctx context.Context, namespace string, root cid.
 	if err != nil {
 		return nil, err
 	}
-	recomputed, err := s.scheme.Commit(cellsFromCIDs(slots))
+	recomputed, err := s.commitment.Scheme().Commit(cellsFromCIDs(slots))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Restructure semantic layer to clearly separate:
- **auth/semantic**: stateless single-step commitment primitives
- **runtime/semantic**: multi-step tree traversal with storage access

### Changes

1. **auth/semantic/list/list.go**: Add `Commitment` struct with `Commit`, `ProveSlot`, `VerifySlot` primitives
2. **auth/semantic/mapping/mapping.go**: Add `Commitment` struct with `Commit`, `ProveSlot`, `VerifySlot` primitives
3. **runtime/semantic/list/tree/tree.go**: Refactor `TreeList` to use auth commitment primitives
4. **runtime/semantic/mapping/radix/radix.go**: Refactor `RadixMap` to use auth commitment primitives
5. **cmd/eval/internal/baseline/indexedmap/indexed.go**: Update to implement new interface

### Architecture

```
┌─────────────────────────────────────────────────────┐
│                    auth Layer                  │
│                                                     │
│  List Commitment:                                   │
│    Commit(view) → root                               │
│    ProveSlot(root, slots, index) → single step proof │
│    VerifySlot(root, index, value, proof) → bool      │
│                                                     │
│  Map Commitment:                                    │
│    Commit(view) → root                               │
│    ProveSlot(root, slots, slot) → single step proof  │
│    VerifySlot(root, slot, value, proof) → bool       │
│                                                     │
│  → stateless, without storage dependent                       │
└─────────────────────────────────────────────────────┘
                          ▲
                          │ use
┌─────────────────────────┴───────────────────────────┐
│                  runtime layer                                        │
│                                                                            │

│    Multi-level traversal → Combine N single-step proofs                    │
│    Storage Interaction → ArcTable Read/Write                          │
│                                                     │
│  → stateful                                                      │
└─────────────────────────────────────────────────────┘
```

### Benefits

- **Light clients**: Can import only auth package to verify single-step proofs
- **Gateway runtime**: Uses runtime layer to compose complete proof paths
- **Decentralized nodes**: Same primitives, different storage backends

## Test plan

- [x] `go test ./auth/semantic/...` passes
- [x] `go test ./runtime/semantic/...` passes
- [x] `go test ./...` passes (all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)