### PR TITLE
refactor: remove embedded mock CAS from daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-.PHONY: all build build-malt build-malt-eval test vet clean
+.PHONY: all build build-malt build-cas build-malt-eval test vet clean
 
 all: build
 
-build: build-malt build-malt-eval
+build: build-malt build-cas build-malt-eval
 
 build-malt:
 	go build -buildvcs=false -o bin/malt ./cmd/malt
+
+build-cas:
+	go build -buildvcs=false -o bin/cas ./cmd/cas
 
 build-malt-eval:
 	go build -buildvcs=false -o bin/malt-eval ./cmd/eval/malt-eval

--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ Prerequisites:
 - Go 1.25.7 or newer
 - Git
 
-Build the two local binaries:
+Build the three local binaries:
 
 ```bash
 mkdir -p bin
 go build -buildvcs=false -o bin/malt ./cmd/malt
+go build -buildvcs=false -o bin/cas ./cmd/cas
 go build -buildvcs=false -o bin/malt-eval ./cmd/eval/malt-eval
 ```
 
@@ -75,7 +76,7 @@ at `127.0.0.1:4318` and a daemon API at `127.0.0.1:4317`. For local development
 without a real IPFS node, start the standalone mock CAS server first:
 
 ```bash
-bin/malt cas &
+bin/cas start
 ```
 
 Then initialize and start the daemon:

--- a/README.md
+++ b/README.md
@@ -70,8 +70,15 @@ go build -buildvcs=false -o bin/malt ./cmd/malt
 go build -buildvcs=false -o bin/malt-eval ./cmd/eval/malt-eval
 ```
 
-Initialize the local runtime. The default configuration uses a local embedded
-mock CAS at `127.0.0.1:4318` and a daemon API at `127.0.0.1:4317`.
+Initialize the local runtime. The default configuration expects an external CAS
+at `127.0.0.1:4318` and a daemon API at `127.0.0.1:4317`. For local development
+without a real IPFS node, start the standalone mock CAS server first:
+
+```bash
+bin/malt cas &
+```
+
+Then initialize and start the daemon:
 
 ```bash
 bin/malt init --non-interactive

--- a/config/config.go
+++ b/config/config.go
@@ -63,21 +63,9 @@ type StructureConfig struct {
 
 // CASConfig configures the immutable content backend.
 type CASConfig struct {
-	Mode         string             `json:"mode"`
-	BaseURL      string             `json:"base_url,omitempty"`
-	Timeout      string             `json:"timeout"`
-	EmbeddedMock EmbeddedMockConfig `json:"embedded_mock,omitempty"`
-}
-
-// EmbeddedMockConfig is deprecated and ignored. Kept for backward-compatible
-// JSON deserialization of old config files.
-type EmbeddedMockConfig struct {
-	// Deprecated: embedded mock CAS was removed; this field is ignored.
-	Enabled bool `json:"enabled,omitempty"`
-	// Deprecated: embedded mock CAS was removed; this field is ignored.
-	Listen string `json:"listen,omitempty"`
-	// Deprecated: embedded mock CAS was removed; this field is ignored.
-	Latency string `json:"latency,omitempty"`
+	Mode    string `json:"mode"`
+	BaseURL string `json:"base_url,omitempty"`
+	Timeout string `json:"timeout"`
 }
 
 // LoggingConfig configures runtime logging.
@@ -232,7 +220,6 @@ func WriteToFile(path string, cfg *Config) error {
 func (c *Config) applyDefaults() {
 	defaults := DefaultConfig()
 	casModeWasEmpty := c.CAS.Mode == ""
-	legacyEmbeddedMock := c.CAS.Mode == "embedded-mock"
 	if c.RPC.Listen == "" {
 		c.RPC.Listen = defaults.RPC.Listen
 	}
@@ -255,13 +242,7 @@ func (c *Config) applyDefaults() {
 	if c.CAS.Mode == "" {
 		c.CAS.Mode = defaults.CAS.Mode
 	}
-	if legacyEmbeddedMock {
-		c.CAS.Mode = "external"
-		if c.CAS.EmbeddedMock.Listen != "" {
-			c.CAS.BaseURL = urlFromListen(c.CAS.EmbeddedMock.Listen)
-		}
-	}
-	if c.CAS.BaseURL == "" && (casModeWasEmpty || legacyEmbeddedMock) {
+	if c.CAS.BaseURL == "" && casModeWasEmpty {
 		c.CAS.BaseURL = defaults.CAS.BaseURL
 	}
 	if c.CAS.Timeout == "" {
@@ -307,16 +288,16 @@ func (c *Config) Validate() error {
 	}
 
 	switch c.CAS.Mode {
-	case "external", "mock":
+	case "external":
 	default:
-		return fmt.Errorf("unsupported cas.mode %q (use external or mock)", c.CAS.Mode)
+		return fmt.Errorf("unsupported cas.mode %q (use external)", c.CAS.Mode)
 	}
 
 	if _, err := c.CASTimeout(); err != nil {
 		return fmt.Errorf("invalid cas.timeout: %w", err)
 	}
 
-	if c.CAS.Mode == "external" && c.CAS.BaseURL == "" {
+	if c.CAS.BaseURL == "" {
 		return fmt.Errorf("cas.base_url is required")
 	}
 
@@ -336,13 +317,6 @@ func cleanStringList(values []string) []string {
 		out = append(out, trimmed)
 	}
 	return out
-}
-
-func urlFromListen(listen string) string {
-	if strings.HasPrefix(listen, "http://") || strings.HasPrefix(listen, "https://") {
-		return strings.TrimRight(listen, "/")
-	}
-	return "http://" + strings.TrimRight(listen, "/")
 }
 
 // ConfigDir returns the parent directory of the config file.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,11 +100,7 @@ func TestLoadFromFile_NewSchema(t *testing.T) {
   "cas": {
     "mode": "external",
     "base_url": "http://127.0.0.1:5001",
-    "timeout": "45s",
-    "embedded_mock": {
-      "enabled": false,
-      "listen": "127.0.0.1:4318"
-    }
+    "timeout": "45s"
   },
   "logging": {
     "level": "debug",
@@ -144,52 +140,10 @@ func TestLoadFromFile_NewSchema(t *testing.T) {
 	}
 }
 
-func TestLoadFromFileMigratesLegacyEmbeddedMockCAS(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "malt.json")
-	content := `{
-  "rpc": {
-    "listen": "127.0.0.1:9999"
-  },
-  "cas": {
-    "mode": "embedded-mock",
-    "timeout": "30s",
-    "embedded_mock": {
-      "enabled": true,
-      "listen": "127.0.0.1:4321"
-    }
-  }
-}`
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-
-	cfg, err := LoadFromFile(path)
-	if err != nil {
-		t.Fatalf("LoadFromFile() error = %v", err)
-	}
-	if cfg.CAS.Mode != "external" {
-		t.Fatalf("CAS.Mode = %q, want external", cfg.CAS.Mode)
-	}
-	if got := cfg.CASBaseURL(); got != "http://127.0.0.1:4321" {
-		t.Fatalf("CASBaseURL() = %q, want http://127.0.0.1:4321", got)
-	}
-}
-
 func TestValidateAllowsFsAndIpa(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.State.KVStore.Type = "fs"
 	cfg.Structure.DefaultBackend = "ipa"
-
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("Validate() error = %v", err)
-	}
-}
-
-func TestValidateAllowsMockCASMode(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.CAS.Mode = "mock"
-	cfg.CAS.BaseURL = ""
 
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v", err)

--- a/runtime/node/e2e_test.go
+++ b/runtime/node/e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/config"
 	"github.com/dewebprotocol/malt/graph"
+	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -23,7 +24,10 @@ func fakeCID(seed string) cid.Cid {
 
 func newTestGraph(t *testing.T) (*Node, graph.Runtime) {
 	t.Helper()
-	node, err := NewNode(WithConfig(testRuntimeConfig(t)))
+	node, err := NewNode(
+		WithConfig(testRuntimeConfig(t)),
+		WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
 	}
@@ -286,6 +290,7 @@ func testRuntimeConfig(t *testing.T) *config.Config {
 	cfg.State.RootDir = t.TempDir()
 	cfg.State.KVStore.Type = "badger"
 	cfg.State.KVStore.Path = filepath.Join(cfg.State.RootDir, "kv")
-	cfg.CAS.Mode = "mock"
+	cfg.CAS.Mode = "external"
+	cfg.CAS.BaseURL = "http://127.0.0.1:4318"
 	return cfg
 }

--- a/runtime/node/metrics_test.go
+++ b/runtime/node/metrics_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNodeMetricsSnapshotAndReset(t *testing.T) {
-	node, err := NewNode(WithConfig(testConfig(t)))
+	node, err := NewNode(testNodeOptions(t)...)
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
 	}

--- a/runtime/node/node.go
+++ b/runtime/node/node.go
@@ -20,15 +20,11 @@ import (
 	"github.com/dewebprotocol/malt/runtime/metrics"
 	"github.com/dewebprotocol/malt/storage/cas"
 	"github.com/dewebprotocol/malt/storage/cas/ipfs"
-	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
 	"github.com/dewebprotocol/malt/storage/kv"
 	"github.com/dewebprotocol/malt/storage/kv/badger"
 	"github.com/dewebprotocol/malt/storage/kv/fs"
 	kvmemory "github.com/dewebprotocol/malt/storage/kv/memory"
-	kvprefix "github.com/dewebprotocol/malt/storage/kv/prefix"
 )
-
-const mockCASKeyPrefix = "cas/"
 
 func canonicalArcTableType(t string) string {
 	switch t {
@@ -207,11 +203,8 @@ func (n *Node) initCAS() (cas.Reader, error) {
 			n.cfg.CASBaseURL(),
 			ipfs.WithTimeout(timeout),
 		), nil
-	case "mock":
-		// Keep this mode only for tests or direct in-process injection paths.
-		return casmock.NewCAS(casmock.WithoutLatency(), casmock.WithKVStore(kvprefix.New(n.kv, []byte(mockCASKeyPrefix)))), nil
 	default:
-		return nil, fmt.Errorf("unknown cas mode: %s", n.cfg.CAS.Mode)
+		return nil, fmt.Errorf("unsupported cas mode: %s (use external)", n.cfg.CAS.Mode)
 	}
 }
 

--- a/runtime/node/node_test.go
+++ b/runtime/node/node_test.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,8 +10,7 @@ import (
 	"github.com/dewebprotocol/malt/config"
 	"github.com/dewebprotocol/malt/graph"
 	runtimegraph "github.com/dewebprotocol/malt/runtime/graph"
-	"github.com/dewebprotocol/malt/storage/cas"
-	kvstore "github.com/dewebprotocol/malt/storage/kv"
+	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -27,7 +25,7 @@ func newTestCID(seed string) cid.Cid {
 }
 
 func TestCreateManagedGraphUsesNodeRuntimeProfile(t *testing.T) {
-	node, err := NewNode(WithConfig(testConfig(t)))
+	node, err := NewNode(testNodeOptions(t)...)
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
 	}
@@ -47,7 +45,7 @@ func TestCreateManagedGraphUsesNodeRuntimeProfile(t *testing.T) {
 }
 
 func TestOpenGraphUsesStoredBackend(t *testing.T) {
-	node, err := NewNode(WithConfig(testConfig(t)))
+	node, err := NewNode(testNodeOptions(t)...)
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
 	}
@@ -79,7 +77,7 @@ func TestOpenGraphUsesStoredIPABackend(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.Structure.DefaultBackend = "ipa"
 
-	node, err := NewNode(WithConfig(cfg))
+	node, err := NewNode(WithConfig(cfg), WithCAS(casmock.NewCAS(casmock.WithoutLatency())))
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
 	}
@@ -108,7 +106,7 @@ func TestOpenGraphUsesStoredIPABackend(t *testing.T) {
 }
 
 func TestNewGraphReturnsRuntimeContractWithNamespaceOption(t *testing.T) {
-	node, err := NewNode(WithConfig(testConfig(t)))
+	node, err := NewNode(testNodeOptions(t)...)
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
 	}
@@ -135,7 +133,7 @@ func TestNewNodeWithFsKVStore(t *testing.T) {
 	cfg.State.KVStore.Type = "fs"
 	cfg.State.KVStore.Path = filepath.Join(cfg.State.RootDir, "kvfs")
 
-	node, err := NewNode(WithConfig(cfg))
+	node, err := NewNode(WithConfig(cfg), WithCAS(casmock.NewCAS(casmock.WithoutLatency())))
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
 	}
@@ -146,77 +144,8 @@ func TestNewNodeWithFsKVStore(t *testing.T) {
 	}
 }
 
-func TestMockCASPersistsBlocksAcrossNodeRestart(t *testing.T) {
-	cfg := testConfig(t)
-	ctx := context.Background()
-
-	first, err := NewNode(WithConfig(cfg))
-	if err != nil {
-		t.Fatalf("NewNode first failed: %v", err)
-	}
-	firstCAS, ok := first.CAS().(cas.Client)
-	if !ok {
-		t.Fatalf("first CAS = %T, want cas.Client", first.CAS())
-	}
-	block, err := firstCAS.Put(ctx, []byte("persistent mock block"))
-	if err != nil {
-		t.Fatalf("first Put: %v", err)
-	}
-	if err := first.Close(); err != nil {
-		t.Fatalf("close first node: %v", err)
-	}
-
-	second, err := NewNode(WithConfig(cfg))
-	if err != nil {
-		t.Fatalf("NewNode second failed: %v", err)
-	}
-	defer second.Close()
-	secondCAS, ok := second.CAS().(cas.Client)
-	if !ok {
-		t.Fatalf("second CAS = %T, want cas.Client", second.CAS())
-	}
-	got, err := secondCAS.Get(ctx, block)
-	if err != nil {
-		t.Fatalf("second Get: %v", err)
-	}
-	if string(got) != "persistent mock block" {
-		t.Fatalf("block payload = %q, want persistent mock block", got)
-	}
-}
-
-func TestMockCASUsesSeparateKVNamespace(t *testing.T) {
-	cfg := testConfig(t)
-	ctx := context.Background()
-
-	node, err := NewNode(WithConfig(cfg))
-	if err != nil {
-		t.Fatalf("NewNode failed: %v", err)
-	}
-	defer node.Close()
-	mockCAS, ok := node.CAS().(cas.Client)
-	if !ok {
-		t.Fatalf("CAS = %T, want cas.Client", node.CAS())
-	}
-	block, err := mockCAS.Put(ctx, []byte("namespaced mock block"))
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
-
-	if _, err := node.KVStore().Get(ctx, []byte("block/"+block.String())); !errors.Is(err, kvstore.ErrNotFound) {
-		t.Fatalf("unprefixed block key error = %v, want ErrNotFound", err)
-	}
-	got, err := node.KVStore().Get(ctx, []byte("cas/block/"+block.String()))
-	if err != nil {
-		t.Fatalf("prefixed block key Get: %v", err)
-	}
-	if string(got) != "namespaced mock block" {
-		t.Fatalf("prefixed block payload = %q, want namespaced mock block", got)
-	}
-}
-
 func TestOpenGraphRejectsArcTableMismatch(t *testing.T) {
-	cfg := testConfig(t)
-	node, err := NewNode(WithConfig(cfg))
+	node, err := NewNode(testNodeOptions(t)...)
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
 	}
@@ -242,6 +171,15 @@ func testConfig(t *testing.T) *config.Config {
 	cfg.State.RootDir = t.TempDir()
 	cfg.State.KVStore.Type = "badger"
 	cfg.State.KVStore.Path = filepath.Join(cfg.State.RootDir, "kv")
-	cfg.CAS.Mode = "mock"
+	cfg.CAS.Mode = "external"
+	cfg.CAS.BaseURL = "http://127.0.0.1:4318"
 	return cfg
+}
+
+func testNodeOptions(t *testing.T) []Option {
+	t.Helper()
+	return []Option{
+		WithConfig(testConfig(t)),
+		WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	}
 }

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -25,7 +25,10 @@ import (
 
 func TestClientRootFlow(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -75,7 +78,10 @@ func TestClientRootFlow(t *testing.T) {
 
 func TestClientProofListReads(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -156,7 +162,10 @@ func TestClientProofListReads(t *testing.T) {
 
 func TestClientProofListPreservesRootPath(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -204,7 +213,10 @@ func TestClientProofListPreservesRootPath(t *testing.T) {
 
 func TestClientResolveRootReturnsProofList(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -252,7 +264,10 @@ func TestClientResolveRootReturnsProofList(t *testing.T) {
 
 func TestClientResolveRootProofListDoesNotRequireTargetContent(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -368,7 +383,10 @@ func TestClientMetricsSnapshotAndReset(t *testing.T) {
 
 func TestClientReturnsStructuredAPIError(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -398,7 +416,10 @@ func TestClientReturnsStructuredAPIError(t *testing.T) {
 
 func TestClientRootSemanticMutation(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -523,7 +544,10 @@ func TestUnixFSClientAppliesPlanThroughWriterEndpoint(t *testing.T) {
 
 func TestClientStatAndContent(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -570,7 +594,10 @@ func TestClientStatAndContent(t *testing.T) {
 
 func TestClientResolveRootReturnsProofListSteps(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -607,7 +634,10 @@ func TestClientResolveRootReturnsProofListSteps(t *testing.T) {
 
 func TestClientContentRangeReadReturnsProofListHeader(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -652,7 +682,10 @@ func TestClientContentRangeReadReturnsProofListHeader(t *testing.T) {
 
 func TestClientAddUnixFSFileStream(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -685,7 +718,10 @@ func TestClientAddUnixFSFileStream(t *testing.T) {
 
 func TestClientListBackedContentReadReturnsListIndexProof(t *testing.T) {
 	cfg := testConfig(t)
-	node, err := node.NewNode(node.WithConfig(cfg))
+	node, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
@@ -852,8 +888,25 @@ func testConfig(t *testing.T) *config.Config {
 	cfg.State.RootDir = t.TempDir()
 	cfg.State.KVStore.Type = "memory"
 	cfg.State.KVStore.Path = filepath.Join(cfg.State.RootDir, "kv")
-	cfg.CAS.Mode = "mock"
+	cfg.CAS.Mode = "external"
+	cfg.CAS.BaseURL = "http://127.0.0.1:4318"
 	return cfg
+}
+
+func newTestNode(t *testing.T) *node.Node {
+	t.Helper()
+
+	n, err := node.NewNode(
+		node.WithConfig(testConfig(t)),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = n.Close()
+	})
+	return n
 }
 
 func persistentTestConfig(t *testing.T) (*config.Config, *ipfs.Client) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2814,16 +2814,20 @@ func newTestNode(t *testing.T) *node.Node {
 	cfg.State.RootDir = t.TempDir()
 	cfg.State.KVStore.Type = "badger"
 	cfg.State.KVStore.Path = filepath.Join(cfg.State.RootDir, "kv")
-	cfg.CAS.Mode = "mock"
+	cfg.CAS.Mode = "external"
+	cfg.CAS.BaseURL = "http://127.0.0.1:4318"
 
-	node, err := node.NewNode(node.WithConfig(cfg))
+	n, err := node.NewNode(
+		node.WithConfig(cfg),
+		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = node.Close()
+		_ = n.Close()
 	})
-	return node
+	return n
 }
 
 func fakeCIDString(seed string) string {


### PR DESCRIPTION
## Summary

- Remove the in-process mock CAS mode from the MALT daemon — `cas.mode` now only supports `"external"`
- Remove `EmbeddedMockConfig` struct and legacy `"embedded-mock"` migration logic from config
- Remove mock CAS init path from `runtime/node` (`casmock` import, `mockCASKeyPrefix`, `"mock"` case)
- Update all tests to inject mock CAS via `node.WithCAS()` option instead of config mode
- Update `malt/README.md` quick start to use standalone `malt cas` server

## Motivation

The daemon should not embed a mock CAS. If users want a mocked CAS for local development, they can run `malt cas` as a standalone server. If they want IPFS, they configure the external endpoint. This simplifies the daemon and makes the CAS a deployment concern, not a code path.

## Test plan

- `go test ./config/...` — config validation and loading
- `go test ./runtime/node/...` — node creation, graph operations, e2e, metrics
- `go test ./server/...` — all server handler tests
- `go test ./sdk/client/...` — client flow tests
- `go test ./...` — full suite passes (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)