### PR TITLE
cleanup: remove daemon-side CAS latency configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ go.work.sum
 # Logs and local state
 *.log
 *.db
+/cas

--- a/cmd/cas/main.go
+++ b/cmd/cas/main.go
@@ -17,14 +17,8 @@
 //	# Start as background daemon
 //	cas start
 //
-//	# No latency (fast local testing)
-//	cas --no-latency
-//
-//	# IPFS-like latency
-//	cas --get-latency 2100ms --put-latency 1400ms --has-latency 100ms
-//
 //	# Custom port
-//	cas --listen 127.0.0.1:9999 --get-latency 50ms
+//	cas --listen 127.0.0.1:9999
 package main
 
 import (
@@ -46,11 +40,6 @@ import (
 var (
 	configFile string
 	listen     string
-	getLatency time.Duration
-	putLatency time.Duration
-	hasLatency time.Duration
-	jitter     time.Duration
-	noLatency  bool
 )
 
 var rootCmd = &cobra.Command{
@@ -63,11 +52,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "settings file path (default ~/.malt/cas/settings.json)")
 	rootCmd.PersistentFlags().StringVar(&listen, "listen", "", "listen address (overrides settings)")
-	rootCmd.PersistentFlags().DurationVar(&getLatency, "get-latency", 0, "simulated Get latency (0 = default IPFS latency)")
-	rootCmd.PersistentFlags().DurationVar(&putLatency, "put-latency", 0, "simulated Put latency (0 = default IPFS latency)")
-	rootCmd.PersistentFlags().DurationVar(&hasLatency, "has-latency", 0, "simulated Has latency (0 = default IPFS latency)")
-	rootCmd.PersistentFlags().DurationVar(&jitter, "jitter", 0, "latency jitter (±)")
-	rootCmd.PersistentFlags().BoolVar(&noLatency, "no-latency", false, "disable all latency simulation")
+	
 }
 
 func main() {
@@ -94,9 +79,6 @@ func runDaemonChild() error {
 	if listenOverride := os.Getenv(daemonListenKey); listenOverride != "" {
 		cfg.Listen = listenOverride
 	}
-	if err := applyDaemonEnvOverrides(); err != nil {
-		return err
-	}
 	return runServer(cfg)
 }
 
@@ -112,47 +94,10 @@ func run(cmd *cobra.Command, args []string) error {
 }
 
 func daemonOverridesFromGlobals() DaemonOverrides {
-	return DaemonOverrides{
-		Listen:     listen,
-		NoLatency:  noLatency,
-		GetLatency: getLatency,
-		PutLatency: putLatency,
-		HasLatency: hasLatency,
-		Jitter:     jitter,
-	}
+	return DaemonOverrides{Listen: listen}
 }
 
-func applyDaemonEnvOverrides() error {
-	if os.Getenv(daemonNoLatencyKey) == "1" {
-		noLatency = true
-	}
-	var err error
-	if getLatency, err = durationFromEnv(daemonGetLatencyKey, getLatency); err != nil {
-		return err
-	}
-	if putLatency, err = durationFromEnv(daemonPutLatencyKey, putLatency); err != nil {
-		return err
-	}
-	if hasLatency, err = durationFromEnv(daemonHasLatencyKey, hasLatency); err != nil {
-		return err
-	}
-	if jitter, err = durationFromEnv(daemonJitterKey, jitter); err != nil {
-		return err
-	}
-	return nil
-}
 
-func durationFromEnv(key string, current time.Duration) (time.Duration, error) {
-	raw := os.Getenv(key)
-	if raw == "" {
-		return current, nil
-	}
-	d, err := time.ParseDuration(raw)
-	if err != nil {
-		return 0, fmt.Errorf("parse %s: %w", key, err)
-	}
-	return d, nil
-}
 
 // runServer creates the KV store, starts the CAS HTTP server, and blocks
 // until interrupted. Used by both foreground mode and daemon child.
@@ -170,22 +115,7 @@ func runServer(cfg *Config) error {
 		opts = append(opts, casmock.WithKVStore(kvStore))
 	}
 
-	if noLatency {
-		opts = append(opts, casmock.WithoutLatency())
-	} else {
-		if getLatency > 0 {
-			opts = append(opts, casmock.WithGetLatency(getLatency))
-		}
-		if putLatency > 0 {
-			opts = append(opts, casmock.WithPutLatency(putLatency))
-		}
-		if hasLatency > 0 {
-			opts = append(opts, casmock.WithHasLatency(hasLatency))
-		}
-		if jitter > 0 {
-			opts = append(opts, casmock.WithJitter(jitter))
-		}
-	}
+
 
 	store := casmock.NewCAS(opts...)
 	srv := casmock.NewHTTPServer(cfg.Listen, store)
@@ -201,16 +131,7 @@ func runServer(cfg *Config) error {
 		}
 		fmt.Fprintf(os.Stderr, "data dir: %s\n", kvPath)
 	}
-	if noLatency {
-		fmt.Fprintf(os.Stderr, "latency: disabled\n")
-	} else if getLatency > 0 || putLatency > 0 || hasLatency > 0 {
-		fmt.Fprintf(os.Stderr, "latency: get=%s put=%s has=%s jitter=%s\n",
-			getLatency, putLatency, hasLatency, jitter)
-	} else {
-		fmt.Fprintf(os.Stderr, "latency: get=%s put=%s has=%s jitter=%s (IPFS defaults)\n",
-			casmock.DefaultGetLatency, casmock.DefaultPutLatency,
-			casmock.DefaultHasLatency, casmock.DefaultJitter)
-	}
+
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/cmd/cas/main.go
+++ b/cmd/cas/main.go
@@ -52,7 +52,6 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "settings file path (default ~/.malt/cas/settings.json)")
 	rootCmd.PersistentFlags().StringVar(&listen, "listen", "", "listen address (overrides settings)")
-	
 }
 
 func main() {
@@ -97,8 +96,6 @@ func daemonOverridesFromGlobals() DaemonOverrides {
 	return DaemonOverrides{Listen: listen}
 }
 
-
-
 // runServer creates the KV store, starts the CAS HTTP server, and blocks
 // until interrupted. Used by both foreground mode and daemon child.
 func runServer(cfg *Config) error {
@@ -115,8 +112,6 @@ func runServer(cfg *Config) error {
 		opts = append(opts, casmock.WithKVStore(kvStore))
 	}
 
-
-
 	store := casmock.NewCAS(opts...)
 	srv := casmock.NewHTTPServer(cfg.Listen, store)
 	shutdownCh := make(chan struct{}, 1)
@@ -131,7 +126,6 @@ func runServer(cfg *Config) error {
 		}
 		fmt.Fprintf(os.Stderr, "data dir: %s\n", kvPath)
 	}
-
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/cmd/cas/process.go
+++ b/cmd/cas/process.go
@@ -6,17 +6,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 )
 
 // DaemonOverrides are command-line overrides passed to the daemon child.
 type DaemonOverrides struct {
 	Listen        string
-	NoLatency     bool
-	GetLatency    time.Duration
-	PutLatency    time.Duration
-	HasLatency    time.Duration
-	Jitter        time.Duration
 	ShutdownToken string
 }
 
@@ -60,11 +54,6 @@ const (
 	daemonProcessKey       = "CAS_DAEMON_PROCESS"
 	daemonConfigKey        = "CAS_DAEMON_CONFIG"
 	daemonListenKey        = "CAS_DAEMON_LISTEN"
-	daemonNoLatencyKey     = "CAS_DAEMON_NO_LATENCY"
-	daemonGetLatencyKey    = "CAS_DAEMON_GET_LATENCY"
-	daemonPutLatencyKey    = "CAS_DAEMON_PUT_LATENCY"
-	daemonHasLatencyKey    = "CAS_DAEMON_HAS_LATENCY"
-	daemonJitterKey        = "CAS_DAEMON_JITTER"
 	daemonShutdownTokenKey = "CAS_DAEMON_SHUTDOWN_TOKEN"
 )
 
@@ -75,11 +64,6 @@ func daemonProcessEnv(env []string, configPath string, overrides DaemonOverrides
 		daemonProcessKey,
 		daemonConfigKey,
 		daemonListenKey,
-		daemonNoLatencyKey,
-		daemonGetLatencyKey,
-		daemonPutLatencyKey,
-		daemonHasLatencyKey,
-		daemonJitterKey,
 		daemonShutdownTokenKey,
 	)
 	out = append(out, daemonProcessKey+"=1")
@@ -88,21 +72,6 @@ func daemonProcessEnv(env []string, configPath string, overrides DaemonOverrides
 	}
 	if overrides.Listen != "" {
 		out = append(out, daemonListenKey+"="+overrides.Listen)
-	}
-	if overrides.NoLatency {
-		out = append(out, daemonNoLatencyKey+"=1")
-	}
-	if overrides.GetLatency > 0 {
-		out = append(out, daemonGetLatencyKey+"="+overrides.GetLatency.String())
-	}
-	if overrides.PutLatency > 0 {
-		out = append(out, daemonPutLatencyKey+"="+overrides.PutLatency.String())
-	}
-	if overrides.HasLatency > 0 {
-		out = append(out, daemonHasLatencyKey+"="+overrides.HasLatency.String())
-	}
-	if overrides.Jitter > 0 {
-		out = append(out, daemonJitterKey+"="+overrides.Jitter.String())
 	}
 	if overrides.ShutdownToken != "" {
 		out = append(out, daemonShutdownTokenKey+"="+overrides.ShutdownToken)

--- a/cmd/cas/process_test.go
+++ b/cmd/cas/process_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestDaemonProcessEnvIncludesRuntimeOverrides(t *testing.T) {
@@ -13,11 +12,6 @@ func TestDaemonProcessEnvIncludesRuntimeOverrides(t *testing.T) {
 		daemonListenKey + "=old",
 	}, "settings.json", DaemonOverrides{
 		Listen:        "127.0.0.1:4999",
-		NoLatency:     true,
-		GetLatency:    50 * time.Millisecond,
-		PutLatency:    60 * time.Millisecond,
-		HasLatency:    70 * time.Millisecond,
-		Jitter:        5 * time.Millisecond,
 		ShutdownToken: "secret",
 	})
 
@@ -26,11 +20,6 @@ func TestDaemonProcessEnvIncludesRuntimeOverrides(t *testing.T) {
 		daemonProcessKey + "=1":             true,
 		daemonConfigKey + "=settings.json":  true,
 		daemonListenKey + "=127.0.0.1:4999": true,
-		daemonNoLatencyKey + "=1":           true,
-		daemonGetLatencyKey + "=50ms":       true,
-		daemonPutLatencyKey + "=60ms":       true,
-		daemonHasLatencyKey + "=70ms":       true,
-		daemonJitterKey + "=5ms":            true,
 		daemonShutdownTokenKey + "=secret":  true,
 	}
 	for _, entry := range env {

--- a/cmd/eval/helper/evalcas/factory.go
+++ b/cmd/eval/helper/evalcas/factory.go
@@ -23,5 +23,5 @@ func NewWithLatency(d time.Duration) *casmock.CAS {
 
 // NewNoLatency creates a mock CAS with zero latency.
 func NewNoLatency() *casmock.CAS {
-	return casmock.NewCAS(casmock.WithoutLatency())
+	return casmock.NewCAS()
 }

--- a/cmd/eval/helper/evalcas/factory.go
+++ b/cmd/eval/helper/evalcas/factory.go
@@ -1,7 +1,6 @@
 // Package evalcas provides eval-specific CAS instances with precise, jitter-free
-// latency. The main mock CAS (storage/cas/mock) uses realistic IPFS latency
-// defaults with random jitter; this package provides deterministic latency for
-// benchmark measurements.
+// latency. The main mock CAS (storage/cas/mock) now defaults to zero latency;
+// this package provides explicit helpers for deterministic benchmark latency.
 package evalcas
 
 import (

--- a/cmd/eval/internal/eval/readbench/baseline.go
+++ b/cmd/eval/internal/eval/readbench/baseline.go
@@ -44,7 +44,7 @@ func newFixtureData(cfg FixtureConfig) fixtureData {
 }
 
 func newBaselineSystem(ctx context.Context, system SystemName, fixture fixtureData) (*BaselineSystem, error) {
-	store := casmock.NewCAS(casmock.WithoutLatency())
+	store := casmock.NewCAS()
 	return newBaselineSystemWithStore(ctx, system, fixture, store)
 }
 

--- a/cmd/eval/internal/eval/readbench/runner_test.go
+++ b/cmd/eval/internal/eval/readbench/runner_test.go
@@ -521,7 +521,7 @@ func newTestDaemon(t *testing.T) string {
 func newTestDaemonWithCAS(t *testing.T) (string, *casmock.CAS) {
 	t.Helper()
 
-	mockCAS := casmock.NewCAS(casmock.WithoutLatency())
+	mockCAS := casmock.NewCAS()
 
 	cfg := config.DefaultConfig()
 	cfg.State.RootDir = t.TempDir()

--- a/cmd/internal/merkledagimport/import_test.go
+++ b/cmd/internal/merkledagimport/import_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestImportFileStoresUnixFSDAG(t *testing.T) {
 	ctx := context.Background()
-	casClient := casmock.NewCAS(casmock.WithoutLatency())
+	casClient := casmock.NewCAS()
 	file := filepath.Join(t.TempDir(), "hello.txt")
 	if err := os.WriteFile(file, []byte("hello merkle dag"), 0o644); err != nil {
 		t.Fatalf("write file: %v", err)
@@ -47,7 +47,7 @@ func TestImportFileStoresUnixFSDAG(t *testing.T) {
 
 func TestImportDirectoryStoresHAMTUnixFSDAG(t *testing.T) {
 	ctx := context.Background()
-	casClient := casmock.NewCAS(casmock.WithoutLatency())
+	casClient := casmock.NewCAS()
 	root := filepath.Join(t.TempDir(), "repo")
 	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
 		t.Fatalf("mkdir docs: %v", err)
@@ -88,7 +88,7 @@ func TestImportDirectoryStoresHAMTUnixFSDAG(t *testing.T) {
 
 func TestImportFilesStoresVirtualHAMTUnixFSDAG(t *testing.T) {
 	ctx := context.Background()
-	casClient := casmock.NewCAS(casmock.WithoutLatency())
+	casClient := casmock.NewCAS()
 
 	result, err := ImportFiles(ctx, casClient, []File{
 		{Path: "README.md", Data: []byte("readme"), Mode: 0o644},
@@ -122,7 +122,7 @@ func TestImportFilesStoresVirtualHAMTUnixFSDAG(t *testing.T) {
 
 func TestImportRejectsTopLevelLayout(t *testing.T) {
 	ctx := context.Background()
-	casClient := casmock.NewCAS(casmock.WithoutLatency())
+	casClient := casmock.NewCAS()
 	file := filepath.Join(t.TempDir(), "hello.txt")
 	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
 		t.Fatalf("write file: %v", err)

--- a/cmd/malt/add_ignore_test.go
+++ b/cmd/malt/add_ignore_test.go
@@ -157,7 +157,7 @@ func TestStageFlatUnixFSDirectoryAppliesMaltignore(t *testing.T) {
 
 func TestAddInputsMerkleDAGAppliesIgnoreFilter(t *testing.T) {
 	ctx := context.Background()
-	casClient := casmock.NewCAS(casmock.WithoutLatency())
+	casClient := casmock.NewCAS()
 	root := t.TempDir()
 	repo := filepath.Join(root, "repo")
 	writeAddIgnoreTestFile(t, repo, ".gitignore", "ignored/\n")

--- a/cmd/malt/add_test.go
+++ b/cmd/malt/add_test.go
@@ -453,7 +453,7 @@ func TestFormatAddSummaryUsesHumanReadableObjectCounts(t *testing.T) {
 
 func TestAddInputsWithUnixFSMerkleDAGTarget(t *testing.T) {
 	ctx := context.Background()
-	casClient := casmock.NewCAS(casmock.WithoutLatency())
+	casClient := casmock.NewCAS()
 	file := filepath.Join(t.TempDir(), "hello.txt")
 	if err := os.WriteFile(file, []byte("hello merkle target"), 0o644); err != nil {
 		t.Fatalf("write file: %v", err)
@@ -613,7 +613,7 @@ func TestAddWorkflowMaterializesSmallLargeAndEmptyDir(t *testing.T) {
 
 func TestAddCASBatcherDeduplicatesBlocks(t *testing.T) {
 	ctx := context.Background()
-	recorder := newRecordingAddCAS(casmock.NewCAS(casmock.WithoutLatency()))
+	recorder := newRecordingAddCAS(casmock.NewCAS())
 	batcher := newAddCASBatcher(recorder)
 
 	first, err := batcher.Put(ctx, []byte("same"))
@@ -1191,7 +1191,7 @@ func TestAddInputsWithUnixFSRootReplacesExistingDirWithSymlinkDirBoundary(t *tes
 func newAddTestClients(t *testing.T) (*daemonclient.Client, *ipfs.Client) {
 	t.Helper()
 
-	mockCAS := casmock.NewCAS(casmock.WithoutLatency())
+	mockCAS := casmock.NewCAS()
 	mockHTTP := casmock.NewHTTPServer("127.0.0.1:0", mockCAS)
 	casTS := httptest.NewServer(mockHTTP.Handler())
 	t.Cleanup(casTS.Close)

--- a/daemon/run_test.go
+++ b/daemon/run_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestStartUsesExternalCASConfig(t *testing.T) {
-	mockCAS := casmock.NewCAS(casmock.WithoutLatency())
+	mockCAS := casmock.NewCAS()
 	casServer := httptest.NewServer(casmock.NewHTTPServer("", mockCAS).Handler())
 	defer casServer.Close()
 

--- a/layout/unixfs/layout_test.go
+++ b/layout/unixfs/layout_test.go
@@ -21,7 +21,7 @@ import (
 
 func newLayout(t *testing.T, chunkSize int) *unixfs.Layout {
 	t.Helper()
-	return newLayoutWithBlocks(t, chunkSize, casmock.NewCAS(casmock.WithoutLatency()))
+	return newLayoutWithBlocks(t, chunkSize, casmock.NewCAS())
 }
 
 func newLayoutWithBlocks(t *testing.T, chunkSize int, blocks cas.Client) *unixfs.Layout {
@@ -73,7 +73,7 @@ type spyBatchCAS struct {
 }
 
 func newSpyBatchCAS() *spyBatchCAS {
-	return &spyBatchCAS{inner: casmock.NewCAS(casmock.WithoutLatency())}
+	return &spyBatchCAS{inner: casmock.NewCAS()}
 }
 
 func (s *spyBatchCAS) Get(ctx context.Context, c cid.Cid) ([]byte, error) {

--- a/runtime/node/e2e_test.go
+++ b/runtime/node/e2e_test.go
@@ -26,7 +26,7 @@ func newTestGraph(t *testing.T) (*Node, graph.Runtime) {
 	t.Helper()
 	node, err := NewNode(
 		WithConfig(testRuntimeConfig(t)),
-		WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)

--- a/runtime/node/node_test.go
+++ b/runtime/node/node_test.go
@@ -77,7 +77,7 @@ func TestOpenGraphUsesStoredIPABackend(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.Structure.DefaultBackend = "ipa"
 
-	node, err := NewNode(WithConfig(cfg), WithCAS(casmock.NewCAS(casmock.WithoutLatency())))
+	node, err := NewNode(WithConfig(cfg), WithCAS(casmock.NewCAS()))
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestNewNodeWithFsKVStore(t *testing.T) {
 	cfg.State.KVStore.Type = "fs"
 	cfg.State.KVStore.Path = filepath.Join(cfg.State.RootDir, "kvfs")
 
-	node, err := NewNode(WithConfig(cfg), WithCAS(casmock.NewCAS(casmock.WithoutLatency())))
+	node, err := NewNode(WithConfig(cfg), WithCAS(casmock.NewCAS()))
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
 	}
@@ -180,6 +180,6 @@ func testNodeOptions(t *testing.T) []Option {
 	t.Helper()
 	return []Option{
 		WithConfig(testConfig(t)),
-		WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		WithCAS(casmock.NewCAS()),
 	}
 }

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -27,7 +27,7 @@ func TestClientRootFlow(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -80,7 +80,7 @@ func TestClientProofListReads(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -164,7 +164,7 @@ func TestClientProofListPreservesRootPath(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -215,7 +215,7 @@ func TestClientResolveRootReturnsProofList(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -266,7 +266,7 @@ func TestClientResolveRootProofListDoesNotRequireTargetContent(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -385,7 +385,7 @@ func TestClientReturnsStructuredAPIError(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -418,7 +418,7 @@ func TestClientRootSemanticMutation(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -546,7 +546,7 @@ func TestClientStatAndContent(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -596,7 +596,7 @@ func TestClientResolveRootReturnsProofListSteps(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -636,7 +636,7 @@ func TestClientContentRangeReadReturnsProofListHeader(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -684,7 +684,7 @@ func TestClientAddUnixFSFileStream(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -720,7 +720,7 @@ func TestClientListBackedContentReadReturnsListIndexProof(t *testing.T) {
 	cfg := testConfig(t)
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -898,7 +898,7 @@ func newTestNode(t *testing.T) *node.Node {
 
 	n, err := node.NewNode(
 		node.WithConfig(testConfig(t)),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2819,7 +2819,7 @@ func newTestNode(t *testing.T) *node.Node {
 
 	n, err := node.NewNode(
 		node.WithConfig(cfg),
-		node.WithCAS(casmock.NewCAS(casmock.WithoutLatency())),
+		node.WithCAS(casmock.NewCAS()),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)

--- a/storage/cas/mock/batch_test.go
+++ b/storage/cas/mock/batch_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCASPutBatchStoresBlocks(t *testing.T) {
 	ctx := context.Background()
-	store := NewCAS(WithoutLatency())
+	store := NewCAS()
 	blocks := []cas.Block{
 		{Data: []byte("first")},
 		{Data: []byte("second")},
@@ -40,7 +40,7 @@ func TestCASPutBatchStoresBlocks(t *testing.T) {
 
 func TestCASPutBatchReportsAlreadyPresent(t *testing.T) {
 	ctx := context.Background()
-	store := NewCAS(WithoutLatency())
+	store := NewCAS()
 	block := cas.Block{Data: []byte("same")}
 	if _, err := store.PutBatch(ctx, []cas.Block{block}); err != nil {
 		t.Fatalf("initial PutBatch: %v", err)
@@ -57,7 +57,7 @@ func TestCASPutBatchReportsAlreadyPresent(t *testing.T) {
 
 func TestCASHasBatchPreservesOrder(t *testing.T) {
 	ctx := context.Background()
-	store := NewCAS(WithoutLatency())
+	store := NewCAS()
 	present, err := cas.CIDForBlock(cas.Block{Data: []byte("present")})
 	if err != nil {
 		t.Fatalf("CIDForBlock present: %v", err)
@@ -88,7 +88,7 @@ func TestCASHasBatchPreservesOrder(t *testing.T) {
 
 func TestCASPutBatchSupportsTypedCodecs(t *testing.T) {
 	ctx := context.Background()
-	store := NewCAS(WithoutLatency())
+	store := NewCAS()
 	payload := []byte(`{"entries":["a.txt"]}`)
 
 	results, err := store.PutBatch(ctx, []cas.Block{{Data: payload, Codec: testTypedCodec}})

--- a/storage/cas/mock/http_test.go
+++ b/storage/cas/mock/http_test.go
@@ -19,7 +19,7 @@ import (
 const testTypedCodec = 0x300005
 
 func TestHTTPServerKuboCompatibleBlockAPI(t *testing.T) {
-	mockCAS := NewCAS(WithoutLatency())
+	mockCAS := NewCAS()
 	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
 	defer ts.Close()
 
@@ -49,7 +49,7 @@ func TestHTTPServerKuboCompatibleBlockAPI(t *testing.T) {
 }
 
 func TestHTTPServerHealthEndpoint(t *testing.T) {
-	mockCAS := NewCAS(WithoutLatency())
+	mockCAS := NewCAS()
 	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
 	defer ts.Close()
 
@@ -64,7 +64,7 @@ func TestHTTPServerHealthEndpoint(t *testing.T) {
 }
 
 func TestHTTPServerSupportsTypedBlockPut(t *testing.T) {
-	mockCAS := NewCAS(WithoutLatency())
+	mockCAS := NewCAS()
 	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
 	defer ts.Close()
 
@@ -89,7 +89,7 @@ func TestHTTPServerSupportsTypedBlockPut(t *testing.T) {
 }
 
 func TestHTTPServerSupportsHasBatch(t *testing.T) {
-	mockCAS := NewCAS(WithoutLatency())
+	mockCAS := NewCAS()
 	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
 	defer ts.Close()
 
@@ -115,7 +115,7 @@ func TestHTTPServerSupportsHasBatch(t *testing.T) {
 }
 
 func TestHTTPServerSupportsPutBatch(t *testing.T) {
-	mockCAS := NewCAS(WithoutLatency())
+	mockCAS := NewCAS()
 	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
 	defer ts.Close()
 
@@ -141,7 +141,7 @@ func TestHTTPServerSupportsPutBatch(t *testing.T) {
 }
 
 func TestHTTPServerPutBatchRejectsInvalidBase64(t *testing.T) {
-	mockCAS := NewCAS(WithoutLatency())
+	mockCAS := NewCAS()
 	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
 	defer ts.Close()
 
@@ -150,7 +150,7 @@ func TestHTTPServerPutBatchRejectsInvalidBase64(t *testing.T) {
 }
 
 func TestHTTPServerPutBatchPreservesResultOrder(t *testing.T) {
-	mockCAS := NewCAS(WithoutLatency())
+	mockCAS := NewCAS()
 	ts := httptest.NewServer(NewHTTPServer("", mockCAS).Handler())
 	defer ts.Close()
 

--- a/storage/cas/mock/mock.go
+++ b/storage/cas/mock/mock.go
@@ -1,13 +1,7 @@
 // Package mock provides a mock CAS implementation for testing.
 // It uses a KVStore-backed block service with configurable latency
-// to simulate IPFS Kubo behavior.
-//
-// Default latencies are based on ProbeLab Kubo v0.39.0 e2e measurements
-// (Europe Frankfurt, DHT):
-//
-//	Get: ~2.1s total (TTFB + provider discovery + broadcast)
-//	Put: ~1.4s Add Duration (merkle-izing + block storage)
-//	Has: ~100ms (index lookup, no data transfer)
+// for controlled evaluation scenarios. Use WithGetLatency, WithPutLatency,
+// and WithHasLatency to set latency values explicitly.
 package mock
 
 import (
@@ -55,12 +49,7 @@ type options struct {
 }
 
 func defaultOptions() *options {
-	return &options{
-		getLatency: DefaultGetLatency,
-		putLatency: DefaultPutLatency,
-		hasLatency: DefaultHasLatency,
-		jitter:     DefaultJitter,
-	}
+	return &options{}
 }
 
 // WithGetLatency sets the simulated Get operation latency.
@@ -91,16 +80,6 @@ func WithJitter(d time.Duration) Option {
 	}
 }
 
-// WithoutLatency disables latency simulation entirely.
-func WithoutLatency() Option {
-	return func(o *options) {
-		o.getLatency = 0
-		o.putLatency = 0
-		o.hasLatency = 0
-		o.jitter = 0
-	}
-}
-
 // WithKVStore stores mock CAS blocks in the supplied KVStore.
 func WithKVStore(kv kvstore.KVStore) Option {
 	return func(o *options) {
@@ -109,8 +88,8 @@ func WithKVStore(kv kvstore.KVStore) Option {
 }
 
 // NewCAS creates a mock CAS backed by an in-memory KVStore.
-// By default, operations simulate ProbeLab Kubo v0.39.0 e2e latency.
-// Use WithoutLatency for fast unit tests, or individual WithXLatency to tune.
+// Latency defaults to zero. Use WithGetLatency, WithPutLatency, WithHasLatency
+// and WithJitter to simulate network conditions for evaluation scenarios.
 func NewCAS(opts ...Option) *CAS {
 	options := defaultOptions()
 	for _, opt := range opts {

--- a/storage/cas/mock/stats_test.go
+++ b/storage/cas/mock/stats_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCASStatsCountOperationsAndBytes(t *testing.T) {
 	ctx := context.Background()
-	cas := NewCAS(WithoutLatency())
+	cas := NewCAS()
 
 	payload := []byte("instrumented block")
 	blockCID, err := cas.Put(ctx, payload)
@@ -43,7 +43,7 @@ func TestCASStatsCountOperationsAndBytes(t *testing.T) {
 
 func TestCASStatsResetClearsCounters(t *testing.T) {
 	ctx := context.Background()
-	cas := NewCAS(WithoutLatency())
+	cas := NewCAS()
 
 	blockCID, err := cas.Put(ctx, []byte("reset me"))
 	if err != nil {


### PR DESCRIPTION
## Summary

Remove all latency simulation configuration from the CAS daemon side. The daemon itself should not configure latency manually; only CAS clients in evaluation scenarios need latency settings.

### Core changes

1. **Mock CAS now defaults to zero latency** — `defaultOptions()` no longer sets the IPFS-like default values (2.1s / 1.4s / 100ms), and the `WithoutLatency()` option is removed because zero latency is now the default.
2. **Daemon CLI cleanup** — Remove the five latency-related flags and their wiring: `--get-latency`, `--put-latency`, `--has-latency`, `--jitter`, and `--no-latency`.
3. **Daemon child-process env cleanup** — Reduce `DaemonOverrides` to `Listen` and `ShutdownToken` only, and stop propagating any latency-related configuration.
4. **45+ callsite cleanup** — Replace all `casmock.NewCAS(casmock.WithoutLatency())` calls with `casmock.NewCAS()`.

### Kept intentionally

- `WithGetLatency`, `WithPutLatency`, `WithHasLatency`, and `WithJitter` remain available in mock CAS for evaluation scenarios.
- `DefaultGetLatency` and related constants remain available for eval code references.

### Validation

- `go build ./...` ✅
- `go test ./cmd/cas/ ./daemon/ ./storage/cas/mock/ ./server/` ✅