### PR TITLE
refactor: shrink graph runtime ports

### DIFF
--- a/cmd/eval/internal/eval/readbench/local_malt.go
+++ b/cmd/eval/internal/eval/readbench/local_malt.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/config"
-	"github.com/dewebprotocol/malt/graph"
+	runtimegraph "github.com/dewebprotocol/malt/runtime/graph"
 	"github.com/dewebprotocol/malt/runtime/node"
 	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
 	cid "github.com/ipfs/go-cid"
@@ -18,7 +18,7 @@ import (
 type LocalMALTSystem struct {
 	store *casmock.CAS
 	node  *node.Node
-	g     graph.Runtime
+	g     *runtimegraph.RuntimeGraph
 	root  cid.Cid
 }
 

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -4,27 +4,10 @@ import (
 	"context"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
-	"github.com/dewebprotocol/malt/auth/semantic/list"
-	"github.com/dewebprotocol/malt/auth/semantic/mapping"
 	"github.com/dewebprotocol/malt/graph/resolver"
 	"github.com/dewebprotocol/malt/graph/writer"
 	cid "github.com/ipfs/go-cid"
 )
-
-// Graph is the authenticated graph contract exposed to runtime callers.
-type Graph interface {
-	ID() string
-	Namespace() string
-	Resolver() Resolver
-	Writer() Writer
-}
-
-// Runtime is the current server-side graph runtime contract.
-type Runtime interface {
-	Graph
-	Semantic() mapping.Semantics
-	ListSemantic() list.Semantics
-}
 
 // Resolver is the graph read/proof port.
 type Resolver interface {

--- a/graph/interfaces_test.go
+++ b/graph/interfaces_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/dewebprotocol/malt/graph/writer"
 )
 
-func TestRuntimeGraphImplementsGraphContracts(t *testing.T) {
+func TestResolverAndWriterImplementGraphPorts(t *testing.T) {
 	var _ Resolver = (*resolver.Resolver)(nil)
 	var _ Writer = (*writer.Writer)(nil)
 }

--- a/runtime/graph/graph.go
+++ b/runtime/graph/graph.go
@@ -18,8 +18,9 @@ import (
 	"github.com/dewebprotocol/malt/storage/cas"
 )
 
-// RuntimeGraph is a per-graph unit combining resolver (read) and writer (write).
-// It is stateless: the root CID is always passed as a parameter, never held internally.
+// RuntimeGraph is a per-graph runtime composition of semantic implementations,
+// resolver, and writer. It does not own authoritative heads or freshness policy.
+// The root CID is always supplied by callers.
 type RuntimeGraph struct {
 	id           string
 	namespace    string

--- a/runtime/graph/graph_test.go
+++ b/runtime/graph/graph_test.go
@@ -5,11 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dewebprotocol/malt/graph"
+	"github.com/dewebprotocol/malt/runtime/arctable/overwrite"
 	"github.com/dewebprotocol/malt/storage/kv/memory"
 )
-
-var _ graph.Runtime = (*RuntimeGraph)(nil)
 
 func newTestStore() *Store {
 	return NewStore(memory.New())
@@ -17,6 +15,32 @@ func newTestStore() *Store {
 
 func newTestManager() *Manager {
 	return NewManager(newTestStore())
+}
+
+func TestNewGraphInitializesRuntimeComposition(t *testing.T) {
+	kv := memory.New()
+	table, err := overwrite.NewArcTable(overwrite.WithKVStore(kv))
+	if err != nil {
+		t.Fatalf("NewArcTable failed: %v", err)
+	}
+
+	g, err := NewGraph("composition", table, nil, WithNamespace("ns"))
+	if err != nil {
+		t.Fatalf("NewGraph failed: %v", err)
+	}
+
+	if g.ID() != "composition" {
+		t.Fatalf("ID = %q, want composition", g.ID())
+	}
+	if g.Namespace() != "ns" {
+		t.Fatalf("Namespace = %q, want ns", g.Namespace())
+	}
+	if g.Resolver() == nil || g.Writer() == nil {
+		t.Fatal("resolver and writer must be initialized")
+	}
+	if g.Semantic() == nil || g.ListSemantic() == nil {
+		t.Fatal("semantic implementations must be initialized")
+	}
 }
 
 func TestStoreCreateAndGet(t *testing.T) {

--- a/runtime/node/e2e_test.go
+++ b/runtime/node/e2e_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/config"
-	"github.com/dewebprotocol/malt/graph"
+	runtimegraph "github.com/dewebprotocol/malt/runtime/graph"
 	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -22,7 +22,7 @@ func fakeCID(seed string) cid.Cid {
 	return cid.NewCidV1(cid.Raw, mhash)
 }
 
-func newTestGraph(t *testing.T) (*Node, graph.Runtime) {
+func newTestGraph(t *testing.T) (*Node, *runtimegraph.RuntimeGraph) {
 	t.Helper()
 	node, err := NewNode(
 		WithConfig(testRuntimeConfig(t)),

--- a/runtime/node/node.go
+++ b/runtime/node/node.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dewebprotocol/malt/auth/commitment/kzg"
 	"github.com/dewebprotocol/malt/auth/proof/prooflist"
 	"github.com/dewebprotocol/malt/config"
-	"github.com/dewebprotocol/malt/graph"
 	"github.com/dewebprotocol/malt/runtime/arctable"
 	"github.com/dewebprotocol/malt/runtime/arctable/overwrite"
 	"github.com/dewebprotocol/malt/runtime/arctable/versioned"
@@ -225,7 +224,7 @@ func (n *Node) CreateManagedGraph(ctx context.Context, id string, backend string
 // OpenGraph opens a managed graph using the runtime profile stored in GraphMeta.
 // The persisted backend selects the commitment scheme; the persisted ArcTable type
 // must match the node's shared ArcTable implementation.
-func (n *Node) OpenGraph(ctx context.Context, id string) (graph.Runtime, error) {
+func (n *Node) OpenGraph(ctx context.Context, id string) (*runtimegraph.RuntimeGraph, error) {
 	meta, err := n.graphManager.GetGraph(ctx, id)
 	if err != nil {
 		return nil, err
@@ -258,7 +257,7 @@ func (n *Node) OpenGraph(ctx context.Context, id string) (graph.Runtime, error) 
 //   - opts: functional options (runtimegraph.WithCommitmentScheme, runtimegraph.WithNamespace, etc.)
 //
 // The Node auto-injects shared infrastructure (ArcTable, CAS).
-func (n *Node) NewGraph(id string, opts ...runtimegraph.Option) (graph.Runtime, error) {
+func (n *Node) NewGraph(id string, opts ...runtimegraph.Option) (*runtimegraph.RuntimeGraph, error) {
 	o := &runtimegraph.Options{}
 	for _, opt := range opts {
 		opt(o)

--- a/runtime/node/node_test.go
+++ b/runtime/node/node_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/config"
-	"github.com/dewebprotocol/malt/graph"
 	runtimegraph "github.com/dewebprotocol/malt/runtime/graph"
 	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
 	"github.com/dewebprotocol/malt/wire/maltcid"
@@ -105,7 +104,7 @@ func TestOpenGraphUsesStoredIPABackend(t *testing.T) {
 	}
 }
 
-func TestNewGraphReturnsRuntimeContractWithNamespaceOption(t *testing.T) {
+func TestNewGraphReturnsRuntimeCompositionWithNamespaceOption(t *testing.T) {
 	node, err := NewNode(testNodeOptions(t)...)
 	if err != nil {
 		t.Fatalf("NewNode failed: %v", err)
@@ -116,7 +115,6 @@ func TestNewGraphReturnsRuntimeContractWithNamespaceOption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewGraph failed: %v", err)
 	}
-	var _ graph.Runtime = g
 	if g.ID() != "default-id" {
 		t.Fatalf("graph ID = %q, want default-id", g.ID())
 	}
@@ -125,6 +123,9 @@ func TestNewGraphReturnsRuntimeContractWithNamespaceOption(t *testing.T) {
 	}
 	if g.Resolver() == nil || g.Writer() == nil {
 		t.Fatalf("runtime graph must provide resolver and writer ports")
+	}
+	if g.Semantic() == nil || g.ListSemantic() == nil {
+		t.Fatalf("runtime graph semantic implementations must be initialized")
 	}
 }
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/dewebprotocol/malt/api/http"
 	"github.com/dewebprotocol/malt/auth/proof/prooflist"
-	"github.com/dewebprotocol/malt/graph"
 	"github.com/dewebprotocol/malt/graph/resolver"
 	"github.com/dewebprotocol/malt/graph/resolver/step/explicit"
 	"github.com/dewebprotocol/malt/graph/writer"
@@ -40,7 +39,7 @@ var (
 	errLegacyRootRequiresMigrationOptIn = errors.New("root is not a UnixFS root; pass migrate=1 to opt into legacy tree migration")
 )
 
-func (s *Server) statForResolvedKey(ctx context.Context, g graph.Runtime, key cid.Cid) (*httpapi.PathStatResponse, cid.Cid, error) {
+func (s *Server) statForResolvedKey(ctx context.Context, g runtimeGraph, key cid.Cid) (*httpapi.PathStatResponse, cid.Cid, error) {
 	stat, err := s.pathStatForTarget(ctx, g, key, false)
 	if err != nil {
 		return nil, cid.Undef, err
@@ -66,7 +65,7 @@ func statReadTarget(stat *httpapi.PathStatResponse) (cid.Cid, error) {
 	return decodeCID(target)
 }
 
-func (s *Server) pathStatForTarget(ctx context.Context, g graph.Runtime, target cid.Cid, rawMustExist bool) (*httpapi.PathStatResponse, error) {
+func (s *Server) pathStatForTarget(ctx context.Context, g runtimeGraph, target cid.Cid, rawMustExist bool) (*httpapi.PathStatResponse, error) {
 	if entries, ok, err := unixfs.ManifestDirectoryEntries(ctx, s.node.CAS(), target); ok || err != nil {
 		if err != nil {
 			return nil, err
@@ -126,7 +125,7 @@ func (s *Server) pathStatForTarget(ctx context.Context, g graph.Runtime, target 
 	}
 }
 
-func (s *Server) readProofList(ctx context.Context, g graph.Runtime, resolved *pathResolution, start, endExclusive int64) (*prooflist.ProofList, error) {
+func (s *Server) readProofList(ctx context.Context, g runtimeGraph, resolved *pathResolution, start, endExclusive int64) (*prooflist.ProofList, error) {
 	if resolved == nil || resolved.proofList == nil {
 		return nil, fmt.Errorf("resolution prooflist is missing")
 	}
@@ -151,11 +150,11 @@ func (s *Server) readProofList(ctx context.Context, g graph.Runtime, resolved *p
 	return &pl, nil
 }
 
-func (s *Server) statFromFlatTarget(ctx context.Context, g graph.Runtime, target cid.Cid) (*httpapi.PathStatResponse, error) {
+func (s *Server) statFromFlatTarget(ctx context.Context, g runtimeGraph, target cid.Cid) (*httpapi.PathStatResponse, error) {
 	return s.pathStatForTarget(ctx, g, target, true)
 }
 
-func (s *Server) legacyPathStat(ctx context.Context, g graph.Runtime, root cid.Cid, path string) (*httpapi.PathStatResponse, error) {
+func (s *Server) legacyPathStat(ctx context.Context, g runtimeGraph, root cid.Cid, path string) (*httpapi.PathStatResponse, error) {
 	keyResult, err := g.Resolver().ResolveKey(root, path)
 	if err != nil {
 		return nil, err
@@ -173,7 +172,7 @@ func (s *Server) legacyPathStat(ctx context.Context, g graph.Runtime, root cid.C
 	return s.pathStatForTarget(ctx, g, key, false)
 }
 
-func (s *Server) unixFSLayout(g graph.Runtime) (*unixfs.Layout, error) {
+func (s *Server) unixFSLayout(g runtimeGraph) (*unixfs.Layout, error) {
 	blocks, ok := s.node.CAS().(cas.Client)
 	if !ok {
 		return nil, fmt.Errorf("configured CAS does not support writes")
@@ -186,7 +185,7 @@ func (s *Server) unixFSLayout(g graph.Runtime) (*unixfs.Layout, error) {
 	})
 }
 
-func (s *Server) prepareUnixFSRoot(ctx context.Context, g graph.Runtime, layout *unixfs.Layout, root cid.Cid, allowLegacyMigration bool) (cid.Cid, error) {
+func (s *Server) prepareUnixFSRoot(ctx context.Context, g runtimeGraph, layout *unixfs.Layout, root cid.Cid, allowLegacyMigration bool) (cid.Cid, error) {
 	if !root.Defined() {
 		return cid.Undef, nil
 	}
@@ -204,7 +203,7 @@ func (s *Server) prepareUnixFSRoot(ctx context.Context, g graph.Runtime, layout 
 	return cid.Undef, nil
 }
 
-func (s *Server) applyUnixFSLayoutMutation(ctx context.Context, g graph.Runtime, layout *unixfs.Layout, oldRoot cid.Cid, newRoot cid.Cid) (writer.WriteReceipt, error) {
+func (s *Server) applyUnixFSLayoutMutation(ctx context.Context, g runtimeGraph, layout *unixfs.Layout, oldRoot cid.Cid, newRoot cid.Cid) (writer.WriteReceipt, error) {
 	if oldRoot.Defined() && oldRoot.Equals(newRoot) {
 		if maltcid.SemanticKindOf(newRoot) != maltcid.SemanticKindMap {
 			return writer.WriteReceipt{}, fmt.Errorf("unixfs mutation result must be a map current root")
@@ -230,15 +229,15 @@ func (s *Server) applyUnixFSLayoutMutation(ctx context.Context, g graph.Runtime,
 	return receipt, nil
 }
 
-func (s *Server) applyWriterMutation(ctx context.Context, g graph.Runtime, mut writer.SemanticMutation) (writer.WriteReceipt, error) {
+func (s *Server) applyWriterMutation(ctx context.Context, g runtimeGraph, mut writer.SemanticMutation) (writer.WriteReceipt, error) {
 	return graphService{runtime: g}.ApplyMutation(ctx, mut)
 }
 
-func (s *Server) migrateLegacyTreeToUnixFS(ctx context.Context, g graph.Runtime, layout *unixfs.Layout, legacyRoot cid.Cid) (cid.Cid, error) {
+func (s *Server) migrateLegacyTreeToUnixFS(ctx context.Context, g runtimeGraph, layout *unixfs.Layout, legacyRoot cid.Cid) (cid.Cid, error) {
 	return s.copyLegacyPathToUnixFS(ctx, g, layout, legacyRoot, "", cid.Undef, "")
 }
 
-func (s *Server) copyLegacyPathToUnixFS(ctx context.Context, g graph.Runtime, layout *unixfs.Layout, legacyRoot cid.Cid, legacyPath string, unixRoot cid.Cid, unixPath string) (cid.Cid, error) {
+func (s *Server) copyLegacyPathToUnixFS(ctx context.Context, g runtimeGraph, layout *unixfs.Layout, legacyRoot cid.Cid, legacyPath string, unixRoot cid.Cid, unixPath string) (cid.Cid, error) {
 	stat, err := s.legacyPathStat(ctx, g, legacyRoot, legacyPath)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("migrate legacy path %q: %w", legacyPath, err)
@@ -300,7 +299,7 @@ func (s *Server) directoryEntriesFromStat(ctx context.Context, stat *httpapi.Pat
 	return unixfs.DirectoryManifestPayloadEntries(ctx, s.node.CAS(), payloadCID)
 }
 
-func (s *Server) readStatFile(ctx context.Context, g graph.Runtime, stat *httpapi.PathStatResponse) ([]byte, error) {
+func (s *Server) readStatFile(ctx context.Context, g runtimeGraph, stat *httpapi.PathStatResponse) ([]byte, error) {
 	if stat == nil || stat.Kind != "file" {
 		return nil, fmt.Errorf("file stat is required")
 	}
@@ -327,7 +326,7 @@ func (s *Server) readStatFile(ctx context.Context, g graph.Runtime, stat *httpap
 	}
 }
 
-func (s *Server) unixFSPathStat(ctx context.Context, g graph.Runtime, root cid.Cid, p string) (*httpapi.PathStatResponse, error) {
+func (s *Server) unixFSPathStat(ctx context.Context, g runtimeGraph, root cid.Cid, p string) (*httpapi.PathStatResponse, error) {
 	layout, err := s.unixFSLayout(g)
 	if err != nil {
 		return nil, err
@@ -363,7 +362,7 @@ func (s *Server) unixFSPathStat(ctx context.Context, g graph.Runtime, root cid.C
 	}
 }
 
-func (s *Server) listFileSize(ctx context.Context, g graph.Runtime, listRoot cid.Cid) (int64, uint64, error) {
+func (s *Server) listFileSize(ctx context.Context, g runtimeGraph, listRoot cid.Cid) (int64, uint64, error) {
 	layout, err := s.unixFSLayout(g)
 	if err != nil {
 		return 0, 0, err
@@ -372,7 +371,7 @@ func (s *Server) listFileSize(ctx context.Context, g graph.Runtime, listRoot cid
 	return int64(size), count, err
 }
 
-func (s *Server) readListRange(ctx context.Context, g graph.Runtime, listRoot cid.Cid, start, endExclusive int64) ([]byte, error) {
+func (s *Server) readListRange(ctx context.Context, g runtimeGraph, listRoot cid.Cid, start, endExclusive int64) ([]byte, error) {
 	if endExclusive <= start {
 		return []byte{}, nil
 	}
@@ -447,7 +446,7 @@ func resolveMiss(_ cid.Cid, _ string, result *resolver.ResolveResult) bool {
 	return !result.RemainingPath.IsEmpty()
 }
 
-func mandatoryMapPayload(ctx context.Context, g graph.Runtime, root cid.Cid) (cid.Cid, error) {
+func mandatoryMapPayload(ctx context.Context, g runtimeGraph, root cid.Cid) (cid.Cid, error) {
 	payload, err := g.Writer().GetArc(ctx, g.Namespace(), root, explicit.PayloadArc.String())
 	if err != nil {
 		return cid.Undef, err

--- a/server/routes_content.go
+++ b/server/routes_content.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/dewebprotocol/malt/api/http"
-	"github.com/dewebprotocol/malt/graph"
 	"github.com/dewebprotocol/malt/graph/resolver"
 	"github.com/dewebprotocol/malt/storage/cas"
 	cid "github.com/ipfs/go-cid"
@@ -129,7 +128,7 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.Copy(w, bytes.NewReader(payload))
 }
 
-func (s *Server) readContentPayload(ctx context.Context, g graph.Runtime, stat *httpapi.PathStatResponse, key cid.Cid, start, endExclusive int64) ([]byte, error) {
+func (s *Server) readContentPayload(ctx context.Context, g runtimeGraph, stat *httpapi.PathStatResponse, key cid.Cid, start, endExclusive int64) ([]byte, error) {
 	switch stat.StorageKind {
 	case "raw":
 		raw, err := s.node.CAS().Get(ctx, key)

--- a/server/server.go
+++ b/server/server.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/dewebprotocol/malt/api/http"
 	"github.com/dewebprotocol/malt/auth/arcset"
-	"github.com/dewebprotocol/malt/graph"
 	"github.com/dewebprotocol/malt/runtime/node"
 	cid "github.com/ipfs/go-cid"
 )
@@ -25,7 +24,7 @@ type Server struct {
 	lifecycleToken string
 	browserOrigins *browserOriginPolicy
 	server         *http.Server
-	defaultGraph   graph.Runtime
+	defaultGraph   runtimeGraph
 	graphMu        sync.Mutex
 }
 
@@ -158,7 +157,7 @@ func (s *Server) handleRemovedPublicRoute(w http.ResponseWriter, r *http.Request
 	writeError(w, http.StatusNotFound, "not found")
 }
 
-func (s *Server) getOrCreateGraph(ctx context.Context) (graph.Runtime, error) {
+func (s *Server) getOrCreateGraph(ctx context.Context) (runtimeGraph, error) {
 	s.graphMu.Lock()
 	defer s.graphMu.Unlock()
 	if s.defaultGraph != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -280,7 +280,7 @@ func TestServerGraphServiceUsesInjectedRuntime(t *testing.T) {
 	}
 }
 
-var _ graph.Runtime = (*stubGraphRuntime)(nil)
+var _ runtimeGraph = (*stubGraphRuntime)(nil)
 
 type stubGraphRuntime struct {
 	id        string

--- a/server/service_graph.go
+++ b/server/service_graph.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	listsemantic "github.com/dewebprotocol/malt/auth/semantic/list"
+	mappingsemantic "github.com/dewebprotocol/malt/auth/semantic/mapping"
 	"github.com/dewebprotocol/malt/graph"
 	"github.com/dewebprotocol/malt/graph/querypath"
 	"github.com/dewebprotocol/malt/graph/resolver"
@@ -13,8 +15,17 @@ import (
 	cid "github.com/ipfs/go-cid"
 )
 
+type runtimeGraph interface {
+	ID() string
+	Namespace() string
+	Resolver() graph.Resolver
+	Writer() graph.Writer
+	Semantic() mappingsemantic.Semantics
+	ListSemantic() listsemantic.Semantics
+}
+
 type graphService struct {
-	runtime graph.Runtime
+	runtime runtimeGraph
 }
 
 func (s *Server) graphService(ctx context.Context) (graphService, error) {

--- a/server/service_verify.go
+++ b/server/service_verify.go
@@ -9,14 +9,13 @@ import (
 	"github.com/dewebprotocol/malt/auth/proof/prooflist"
 	"github.com/dewebprotocol/malt/auth/semantic"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
-	"github.com/dewebprotocol/malt/graph"
 	"github.com/dewebprotocol/malt/graph/querypath"
 	"github.com/dewebprotocol/malt/graph/resolver"
 	"github.com/dewebprotocol/malt/layout/unixfs"
 )
 
 type proofVerifier struct {
-	runtime graph.Runtime
+	runtime runtimeGraph
 }
 
 type proofListVerifiedPath struct {


### PR DESCRIPTION
## Summary
- remove the broad root graph.Graph / graph.Runtime interfaces
- keep root graph as resolver/writer port definitions only
- make runtime/node return the concrete runtimegraph.RuntimeGraph
- move server runtime capability requirements into a local consumer interface

## Why
auth/semantic/list and auth/semantic/mapping own list/map semantic interfaces and authenticated operation capabilities. The root graph package should not duplicate those semantics or make itself look like a graph-node hierarchy. Resolver traversal belongs to graph/resolver; mutation application belongs to graph/writer; concrete wiring belongs to runtime/graph.

## Validation
- git diff --check
- go vet ./...
- go test -run '^$' ./...
- go test ./... (run by maintainer outside sandbox)