### PR TITLE
Unify list tree slot metadata layout

### DIFF
--- a/cmd/eval/internal/eval/suites/proofoverhead/suite.go
+++ b/cmd/eval/internal/eval/suites/proofoverhead/suite.go
@@ -357,8 +357,8 @@ func evidenceCount(structureName string, proof []byte) int {
 		return 1
 	}
 	var envelope struct {
-		LengthProof []byte `json:"length_proof"`
-		Steps       []struct {
+		MetadataProof []byte `json:"metadata_proof"`
+		Steps         []struct {
 			Proof []byte `json:"proof"`
 		} `json:"steps"`
 	}
@@ -366,7 +366,7 @@ func evidenceCount(structureName string, proof []byte) int {
 		return 1
 	}
 	count := 0
-	if len(envelope.LengthProof) > 0 {
+	if len(envelope.MetadataProof) > 0 {
 		count++
 	}
 	for _, step := range envelope.Steps {

--- a/runtime/semantic/list/tree/internal/layout.go
+++ b/runtime/semantic/list/tree/internal/layout.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	// DefaultFanout is the v1 default commitment width for list nodes.
-	// The current KZG backend supports 256 slots per commitment, so v1 fixes
-	// this value to 256.
+	// DefaultFanout is the default commitment width for list nodes.
+	// The current KZG backend supports 256 slots per commitment, so this
+	// value is fixed to 256.
 	DefaultFanout = 256
 
 	// BranchingFactor is the number of content slots per committed list node.
@@ -25,8 +25,7 @@ const (
 	// Slot 0 in every list node is reserved for authenticated node metadata, so
 	// all nodes expose (DefaultFanout-1) content slots.
 	//
-	// For simplicity, v2 uses the same branching factor for root and non-root
-	// nodes.
+	// Root and non-root nodes share the same branching factor.
 	BranchingFactor = DefaultFanout - 1
 
 	// RootWidth is the fixed slot width for the committed root node.
@@ -36,10 +35,10 @@ const (
 	// NodeWidth is the fixed slot width for all committed non-root nodes.
 	NodeWidth = DefaultFanout
 
-	nodeMetaPrefix = "malt:list:node-meta:v2:"
+	nodeMetaPrefix = "malt:list:node-meta:"
 )
 
-// NodeMetadata is the authenticated metadata stored in slot 0 of every v2 list
+// NodeMetadata is the authenticated metadata stored in slot 0 of every list
 // tree node. ChunkSize == 0 identifies a plain list node; ChunkSize > 0
 // identifies a fixed-width measured node whose TotalSize is the byte span
 // covered by that subtree.
@@ -51,7 +50,7 @@ type NodeMetadata struct {
 }
 
 // ValidateCommitment checks whether the supplied index commitment can support
-// the v2 list layout.
+// the list layout.
 func ValidateCommitment(scheme commitment.IndexCommitment) error {
 	if scheme == nil {
 		return fmt.Errorf("index commitment is nil")
@@ -206,7 +205,7 @@ func VerifySlot(scheme commitment.IndexCommitment, root cid.Cid, slot uint64, va
 	return scheme.VerifyIndex(root, slot, value, proof)
 }
 
-// EncodeNodeMetadata encodes authenticated v2 list node metadata as a
+// EncodeNodeMetadata encodes authenticated list node metadata as a
 // self-describing identity CID.
 func EncodeNodeMetadata(meta NodeMetadata) (cid.Cid, error) {
 	if meta.ChunkSize == 0 && meta.TotalSize != 0 {
@@ -229,7 +228,7 @@ func EncodeNodeMetadata(meta NodeMetadata) (cid.Cid, error) {
 	return cid.NewCidV1(cid.Raw, sum), nil
 }
 
-// DecodeNodeMetadata parses authenticated v2 list node metadata.
+// DecodeNodeMetadata parses authenticated list node metadata.
 func DecodeNodeMetadata(marker cid.Cid) (NodeMetadata, error) {
 	if !marker.Defined() {
 		return NodeMetadata{}, fmt.Errorf("node metadata marker is undefined")

--- a/runtime/semantic/list/tree/internal/layout.go
+++ b/runtime/semantic/list/tree/internal/layout.go
@@ -36,22 +36,8 @@ const (
 	// NodeWidth is the fixed slot width for all committed non-root nodes.
 	NodeWidth = DefaultFanout
 
-	// LegacyNodeWidth is the v1 non-root width. Legacy children do not reserve
-	// slot 0 for metadata; all slots are content slots.
-	LegacyNodeWidth = BranchingFactor
-
-	lengthMarkerPrefix = "malt:list:length:v1:"
-	fixedMetaPrefix    = "malt:list:fixed-meta:v1:"
-	nodeMetaPrefix     = "malt:list:node-meta:v2:"
+	nodeMetaPrefix = "malt:list:node-meta:v2:"
 )
-
-// FixedMetadata is the authenticated root metadata for fixed-width measured
-// lists.
-type FixedMetadata struct {
-	ChildCount uint64
-	TotalSize  uint64
-	ChunkSize  uint64
-}
 
 // NodeMetadata is the authenticated metadata stored in slot 0 of every v2 list
 // tree node. ChunkSize == 0 identifies a plain list node; ChunkSize > 0
@@ -91,9 +77,6 @@ func ContentSlots(slots []cid.Cid, isRoot bool) []cid.Cid {
 	if len(slots) == 0 {
 		return nil
 	}
-	if !isRoot && len(slots) == LegacyNodeWidth {
-		return slots
-	}
 	return slots[1:]
 }
 
@@ -105,9 +88,6 @@ func ContentSlotIndex(slots []cid.Cid, isRoot bool, digit int) (uint64, error) {
 	content := ContentSlots(slots, isRoot)
 	if digit >= len(content) {
 		return 0, fmt.Errorf("content digit %d exceeds content width %d", digit, len(content))
-	}
-	if !isRoot && len(slots) == LegacyNodeWidth {
-		return uint64(digit), nil
 	}
 	return uint64(digit) + 1, nil
 }
@@ -226,101 +206,6 @@ func VerifySlot(scheme commitment.IndexCommitment, root cid.Cid, slot uint64, va
 	return scheme.VerifyIndex(root, slot, value, proof)
 }
 
-// EncodeLengthMarker encodes list length as a self-describing identity CID so
-// it can be parsed after restart without any external side state.
-func EncodeLengthMarker(length uint64) (cid.Cid, error) {
-	payload := make([]byte, len(lengthMarkerPrefix)+8)
-	copy(payload, []byte(lengthMarkerPrefix))
-	binary.BigEndian.PutUint64(payload[len(lengthMarkerPrefix):], length)
-
-	sum, err := mh.Sum(payload, mh.IDENTITY, len(payload))
-	if err != nil {
-		return cid.Undef, err
-	}
-	return cid.NewCidV1(cid.Raw, sum), nil
-}
-
-// DecodeLengthMarker parses the authenticated list length from an identity CID.
-func DecodeLengthMarker(marker cid.Cid) (uint64, error) {
-	if !marker.Defined() {
-		return 0, fmt.Errorf("length marker is undefined")
-	}
-
-	decoded, err := mh.Decode(marker.Hash())
-	if err != nil {
-		return 0, err
-	}
-	if decoded.Code != mh.IDENTITY {
-		return 0, fmt.Errorf("length marker is not identity-encoded")
-	}
-	if len(decoded.Digest) != len(lengthMarkerPrefix)+8 {
-		return 0, fmt.Errorf("length marker payload has unexpected size %d", len(decoded.Digest))
-	}
-	if string(decoded.Digest[:len(lengthMarkerPrefix)]) != lengthMarkerPrefix {
-		return 0, fmt.Errorf("length marker prefix mismatch")
-	}
-	return binary.BigEndian.Uint64(decoded.Digest[len(lengthMarkerPrefix):]), nil
-}
-
-// EncodeFixedMetadata encodes fixed-width measured list metadata as a
-// self-describing identity CID.
-func EncodeFixedMetadata(meta FixedMetadata) (cid.Cid, error) {
-	payload := make([]byte, len(fixedMetaPrefix)+24)
-	copy(payload, []byte(fixedMetaPrefix))
-	binary.BigEndian.PutUint64(payload[len(fixedMetaPrefix):], meta.ChildCount)
-	binary.BigEndian.PutUint64(payload[len(fixedMetaPrefix)+8:], meta.TotalSize)
-	binary.BigEndian.PutUint64(payload[len(fixedMetaPrefix)+16:], meta.ChunkSize)
-
-	sum, err := mh.Sum(payload, mh.IDENTITY, len(payload))
-	if err != nil {
-		return cid.Undef, err
-	}
-	return cid.NewCidV1(cid.Raw, sum), nil
-}
-
-// DecodeFixedMetadata parses fixed-width measured list metadata from an
-// identity CID.
-func DecodeFixedMetadata(marker cid.Cid) (FixedMetadata, error) {
-	if !marker.Defined() {
-		return FixedMetadata{}, fmt.Errorf("fixed metadata marker is undefined")
-	}
-
-	decoded, err := mh.Decode(marker.Hash())
-	if err != nil {
-		return FixedMetadata{}, err
-	}
-	if decoded.Code != mh.IDENTITY {
-		return FixedMetadata{}, fmt.Errorf("fixed metadata marker is not identity-encoded")
-	}
-	if len(decoded.Digest) != len(fixedMetaPrefix)+24 {
-		nodeMeta, nodeErr := DecodeNodeMetadata(marker)
-		if nodeErr == nil && nodeMeta.ChunkSize > 0 {
-			return FixedMetadata{
-				ChildCount: nodeMeta.ChildCount,
-				TotalSize:  nodeMeta.TotalSize,
-				ChunkSize:  nodeMeta.ChunkSize,
-			}, nil
-		}
-		return FixedMetadata{}, fmt.Errorf("fixed metadata marker payload has unexpected size %d", len(decoded.Digest))
-	}
-	if string(decoded.Digest[:len(fixedMetaPrefix)]) != fixedMetaPrefix {
-		nodeMeta, nodeErr := DecodeNodeMetadata(marker)
-		if nodeErr == nil && nodeMeta.ChunkSize > 0 {
-			return FixedMetadata{
-				ChildCount: nodeMeta.ChildCount,
-				TotalSize:  nodeMeta.TotalSize,
-				ChunkSize:  nodeMeta.ChunkSize,
-			}, nil
-		}
-		return FixedMetadata{}, fmt.Errorf("fixed metadata marker prefix mismatch")
-	}
-	return FixedMetadata{
-		ChildCount: binary.BigEndian.Uint64(decoded.Digest[len(fixedMetaPrefix):]),
-		TotalSize:  binary.BigEndian.Uint64(decoded.Digest[len(fixedMetaPrefix)+8:]),
-		ChunkSize:  binary.BigEndian.Uint64(decoded.Digest[len(fixedMetaPrefix)+16:]),
-	}, nil
-}
-
 // EncodeNodeMetadata encodes authenticated v2 list node metadata as a
 // self-describing identity CID.
 func EncodeNodeMetadata(meta NodeMetadata) (cid.Cid, error) {
@@ -376,25 +261,6 @@ func DecodeNodeMetadata(marker cid.Cid) (NodeMetadata, error) {
 		return NodeMetadata{}, fmt.Errorf("measured empty node carries total size %d", meta.TotalSize)
 	}
 	return meta, nil
-}
-
-// DecodeRootLength parses the child count authenticated in a root metadata
-// marker. Plain lists encode only length; fixed measured lists encode length as
-// ChildCount inside their metadata marker.
-func DecodeRootLength(marker cid.Cid) (uint64, error) {
-	length, err := DecodeLengthMarker(marker)
-	if err == nil {
-		return length, nil
-	}
-	meta, metaErr := DecodeFixedMetadata(marker)
-	if metaErr == nil {
-		return meta.ChildCount, nil
-	}
-	nodeMeta, nodeMetaErr := DecodeNodeMetadata(marker)
-	if nodeMetaErr == nil {
-		return nodeMeta.ChildCount, nil
-	}
-	return 0, err
 }
 
 // RequiredHeight returns the minimal non-root height required for length values.

--- a/runtime/semantic/list/tree/tree.go
+++ b/runtime/semantic/list/tree/tree.go
@@ -27,9 +27,9 @@ type TreeList struct {
 }
 
 type proofEnvelope struct {
-	LengthProof  []byte      `json:"length_proof"`
-	LengthTarget []byte      `json:"length_target,omitempty"`
-	Steps        []proofStep `json:"steps,omitempty"`
+	MetadataProof  []byte      `json:"metadata_proof"`
+	MetadataTarget []byte      `json:"metadata_target,omitempty"`
+	Steps          []proofStep `json:"steps,omitempty"`
 }
 
 type proofStep struct {
@@ -106,15 +106,15 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 	}
 
 	query := list.Query{Length: length}
-	lengthTarget, lengthProof, err := s.commitment.ProveSlot(root, rootSlots, 0)
+	metadataTarget, metadataProof, err := s.commitment.ProveSlot(root, rootSlots, 0)
 	if err != nil {
 		return list.Query{}, nil, err
 	}
-	envelope := proofEnvelope{LengthProof: lengthProof}
-	if target, err := lengthTarget.AsCID(); err != nil {
+	envelope := proofEnvelope{MetadataProof: metadataProof}
+	if target, err := metadataTarget.AsCID(); err != nil {
 		return list.Query{}, nil, err
-	} else if needsExplicitLengthTarget(target, length) {
-		envelope.LengthTarget = lengthTarget.Bytes()
+	} else if needsExplicitMetadataTarget(target, length) {
+		envelope.MetadataTarget = metadataTarget.Bytes()
 	}
 
 	if index >= length {
@@ -171,15 +171,15 @@ func (s *TreeList) Verify(root cid.Cid, index uint64, expected list.Query, proof
 	if err := json.Unmarshal(proof, &envelope); err != nil {
 		return false, err
 	}
-	if len(envelope.LengthProof) == 0 {
-		return false, fmt.Errorf("missing length proof")
+	if len(envelope.MetadataProof) == 0 {
+		return false, fmt.Errorf("missing metadata proof")
 	}
 
-	lengthTarget, err := lengthTargetForVerify(expected.Length, envelope.LengthTarget)
+	metadataTarget, err := metadataTargetForVerify(expected.Length, envelope.MetadataTarget)
 	if err != nil {
 		return false, err
 	}
-	ok, err := s.commitment.VerifySlot(root, 0, lengthTarget, envelope.LengthProof)
+	ok, err := s.commitment.VerifySlot(root, 0, metadataTarget, envelope.MetadataProof)
 	if err != nil || !ok {
 		return ok, err
 	}
@@ -296,7 +296,7 @@ func (s *TreeList) VerifyRange(root cid.Cid, start uint64, end *uint64, expected
 	if len(envelope.MetadataProof) == 0 {
 		return false, fmt.Errorf("missing metadata proof")
 	}
-	meta := layout.FixedMetadata{
+	meta := layout.NodeMetadata{
 		ChildCount: expected.Metadata.ChildCount,
 		TotalSize:  expected.Metadata.TotalSize,
 		ChunkSize:  expected.Metadata.ChunkSize,
@@ -304,7 +304,7 @@ func (s *TreeList) VerifyRange(root cid.Cid, start uint64, end *uint64, expected
 	if err := validateFixedMetadata(meta); err != nil {
 		return false, err
 	}
-	ok, err := s.verifyFixedMetadataSlot(root, meta, envelope.MetadataProof)
+	ok, err := s.verifyMetadataSlot(root, meta, envelope.MetadataProof)
 	if err != nil || !ok {
 		return ok, err
 	}
@@ -963,11 +963,11 @@ func (s *TreeList) loadRoot(ctx context.Context, namespace string, root cid.Cid)
 	if err != nil {
 		return nil, 0, err
 	}
-	length, err := layout.DecodeRootLength(slots[0])
+	meta, err := layout.DecodeNodeMetadata(slots[0])
 	if err != nil {
 		return nil, 0, err
 	}
-	return slots, length, nil
+	return slots, meta.ChildCount, nil
 }
 
 func (s *TreeList) loadNode(ctx context.Context, namespace string, root cid.Cid, isRoot bool) ([]cid.Cid, error) {
@@ -982,16 +982,6 @@ func (s *TreeList) loadNode(ctx context.Context, namespace string, root cid.Cid,
 	validateErr := s.validateSlots(root, slots)
 	if validateErr == nil {
 		return slots, nil
-	}
-	if !isRoot && width != layout.LegacyNodeWidth {
-		legacySlots, err := layout.LoadSlots(ctx, s.arctable, namespace, root, layout.LegacyNodeWidth)
-		if err != nil {
-			return nil, validateErr
-		}
-		if err := s.validateSlots(root, legacySlots); err == nil {
-			return legacySlots, nil
-		}
-		return nil, validateErr
 	}
 	return nil, validateErr
 }
@@ -1034,8 +1024,8 @@ func (s *TreeList) commitSlots(ctx context.Context, namespace string, slots []ci
 	return listRoot, nil
 }
 
-func (s *TreeList) verifyFixedMetadataSlot(root cid.Cid, meta layout.FixedMetadata, proof []byte) (bool, error) {
-	nodeMarker, err := layout.EncodeNodeMetadata(layout.NodeMetadata{
+func (s *TreeList) verifyMetadataSlot(root cid.Cid, meta layout.NodeMetadata, proof []byte) (bool, error) {
+	target, err := nodeMetadataCell(layout.NodeMetadata{
 		Height:     uint64(layout.RequiredHeight(meta.ChildCount)),
 		ChildCount: meta.ChildCount,
 		TotalSize:  meta.TotalSize,
@@ -1044,16 +1034,7 @@ func (s *TreeList) verifyFixedMetadataSlot(root cid.Cid, meta layout.FixedMetada
 	if err != nil {
 		return false, err
 	}
-	ok, err := s.commitment.VerifySlot(root, 0, commitment.CellFromCID(nodeMarker), proof)
-	if err != nil || ok {
-		return ok, err
-	}
-
-	legacyMarker, err := layout.EncodeFixedMetadata(meta)
-	if err != nil {
-		return false, err
-	}
-	return s.commitment.VerifySlot(root, 0, commitment.CellFromCID(legacyMarker), proof)
+	return s.commitment.VerifySlot(root, 0, target, proof)
 }
 
 func encodeProof(query list.Query, envelope proofEnvelope) (list.Query, structure.Proof, error) {
@@ -1131,66 +1112,62 @@ func (s *TreeList) verifyAnyContentSlot(root cid.Cid, slots []uint64, target com
 }
 
 func contentSlotsForVerify(step proofStep, isRoot bool, digit int) ([]uint64, error) {
-	v2Slot := uint64(digit) + 1
+	slot := uint64(digit) + 1
 	if step.Slot == nil {
-		if isRoot {
-			return []uint64{v2Slot}, nil
-		}
-		return []uint64{v2Slot, uint64(digit)}, nil
-	}
-	slot := *step.Slot
-	if isRoot {
-		if slot != v2Slot {
-			return nil, fmt.Errorf("root content digit %d proved slot %d, want %d", digit, slot, v2Slot)
-		}
 		return []uint64{slot}, nil
 	}
-	if slot != uint64(digit) && slot != v2Slot {
-		return nil, fmt.Errorf("content digit %d proved unsupported slot %d", digit, slot)
+	provedSlot := *step.Slot
+	if provedSlot != slot {
+		return nil, fmt.Errorf("content digit %d proved slot %d, want %d", digit, provedSlot, slot)
 	}
-	return []uint64{slot}, nil
+	return []uint64{provedSlot}, nil
 }
 
-func needsExplicitLengthTarget(marker cid.Cid, length uint64) bool {
-	legacy, err := layout.EncodeLengthMarker(length)
+func needsExplicitMetadataTarget(marker cid.Cid, length uint64) bool {
+	plainMarker, err := layout.EncodeNodeMetadata(layout.NodeMetadata{
+		Height:     uint64(layout.RequiredHeight(length)),
+		ChildCount: length,
+	})
 	if err != nil {
 		return true
 	}
-	return !marker.Equals(legacy)
+	return !marker.Equals(plainMarker)
 }
 
-func lengthTargetForVerify(expectedLength uint64, explicit []byte) (commitment.Cell, error) {
+func metadataTargetForVerify(expectedLength uint64, explicit []byte) (commitment.Cell, error) {
 	if len(explicit) == 0 {
-		lengthMarker, err := layout.EncodeLengthMarker(expectedLength)
-		if err != nil {
-			return nil, err
-		}
-		return commitment.CellFromCID(lengthMarker), nil
+		return nodeMetadataCell(layout.NodeMetadata{
+			Height:     uint64(layout.RequiredHeight(expectedLength)),
+			ChildCount: expectedLength,
+		})
 	}
 	cell := commitment.NewCell(explicit)
 	marker, err := cell.AsCID()
 	if err != nil {
 		return nil, err
 	}
-	length, err := layout.DecodeRootLength(marker)
+	meta, err := layout.DecodeNodeMetadata(marker)
 	if err != nil {
 		return nil, err
 	}
-	if length != expectedLength {
-		return nil, fmt.Errorf("length target commits child count %d, expected %d", length, expectedLength)
+	if meta.ChildCount != expectedLength {
+		return nil, fmt.Errorf("metadata target commits child count %d, expected %d", meta.ChildCount, expectedLength)
 	}
 	return cell, nil
 }
 
-func fixedRangeMetadata(marker cid.Cid) (layout.FixedMetadata, error) {
-	meta, err := layout.DecodeFixedMetadata(marker)
+func fixedRangeMetadata(marker cid.Cid) (layout.NodeMetadata, error) {
+	meta, err := layout.DecodeNodeMetadata(marker)
 	if err != nil {
-		return layout.FixedMetadata{}, fmt.Errorf("root does not carry fixed range metadata: %w", err)
+		return layout.NodeMetadata{}, fmt.Errorf("root does not carry node metadata: %w", err)
+	}
+	if meta.ChunkSize == 0 {
+		return layout.NodeMetadata{}, fmt.Errorf("root does not carry fixed range metadata")
 	}
 	return meta, nil
 }
 
-func validateFixedMetadata(meta layout.FixedMetadata) error {
+func validateFixedMetadata(meta layout.NodeMetadata) error {
 	if meta.ChunkSize == 0 {
 		return fmt.Errorf("chunk size is zero")
 	}
@@ -1198,6 +1175,14 @@ func validateFixedMetadata(meta layout.FixedMetadata) error {
 		return fmt.Errorf("child count %d does not match total size %d and chunk size %d", meta.ChildCount, meta.TotalSize, meta.ChunkSize)
 	}
 	return nil
+}
+
+func nodeMetadataCell(meta layout.NodeMetadata) (commitment.Cell, error) {
+	marker, err := layout.EncodeNodeMetadata(meta)
+	if err != nil {
+		return nil, err
+	}
+	return commitment.CellFromCID(marker), nil
 }
 
 func plainNodeMetadata(height int, childCount uint64) (cid.Cid, error) {
@@ -1287,12 +1272,7 @@ func cloneSlots(slots []cid.Cid) []cid.Cid {
 }
 
 func cloneSlotsForMetadataMutation(slots []cid.Cid) []cid.Cid {
-	if len(slots) != layout.LegacyNodeWidth {
-		return cloneSlots(slots)
-	}
-	nextSlots := layout.EmptyNodeSlots()
-	copy(layout.ContentSlots(nextSlots, false), slots)
-	return nextSlots
+	return cloneSlots(slots)
 }
 
 var _ list.Semantics = (*TreeList)(nil)

--- a/runtime/semantic/list/tree/tree_test.go
+++ b/runtime/semantic/list/tree/tree_test.go
@@ -107,9 +107,9 @@ func stripProofStepSlots(t *testing.T, proof []byte) []byte {
 	t.Helper()
 
 	var envelope struct {
-		LengthProof  []byte                       `json:"length_proof"`
-		LengthTarget []byte                       `json:"length_target,omitempty"`
-		Steps        []map[string]json.RawMessage `json:"steps,omitempty"`
+		MetadataProof  []byte                       `json:"metadata_proof"`
+		MetadataTarget []byte                       `json:"metadata_target,omitempty"`
+		Steps          []map[string]json.RawMessage `json:"steps,omitempty"`
 	}
 	if err := json.Unmarshal(proof, &envelope); err != nil {
 		t.Fatalf("decode proof envelope: %v", err)
@@ -124,67 +124,34 @@ func stripProofStepSlots(t *testing.T, proof []byte) []byte {
 	return stripped
 }
 
-func commitLegacyPlainListRoot(t *testing.T, ctx context.Context, scheme commitment.IndexCommitment, e *overwrite.ArcTable, namespace string, values []cid.Cid) cid.Cid {
-	t.Helper()
-	return commitLegacyPlainListNode(t, ctx, scheme, e, namespace, values, layout.RequiredHeight(uint64(len(values))), true)
-}
-
-func commitLegacyPlainListNode(t *testing.T, ctx context.Context, scheme commitment.IndexCommitment, e *overwrite.ArcTable, namespace string, values []cid.Cid, height int, isRoot bool) cid.Cid {
+func commitLegacyWidthNode(t *testing.T, ctx context.Context, scheme commitment.IndexCommitment, e *overwrite.ArcTable, namespace string, values []cid.Cid) cid.Cid {
 	t.Helper()
 
-	var slots []cid.Cid
-	if isRoot {
-		slots = layout.EmptyRootSlots()
-		marker, err := layout.EncodeLengthMarker(uint64(len(values)))
-		if err != nil {
-			t.Fatalf("encode legacy length marker: %v", err)
-		}
-		slots[0] = marker
-	} else {
-		slots = make([]cid.Cid, layout.BranchingFactor)
+	if len(values) > layout.BranchingFactor {
+		t.Fatalf("legacy width helper supports at most %d values", layout.BranchingFactor)
 	}
-	content := slots
-	if isRoot {
-		content = slots[1:]
-	}
-
-	if height == 0 {
-		copy(content, values)
-		return commitLegacySlots(t, ctx, scheme, e, namespace, slots)
-	}
-
-	childSpan, err := layout.SubtreeCapacity(height - 1)
-	if err != nil {
-		t.Fatalf("legacy child span: %v", err)
-	}
-	for childIdx, start := 0, 0; start < len(values); childIdx++ {
-		end := start + int(childSpan)
-		if end > len(values) {
-			end = len(values)
-		}
-		content[childIdx] = commitLegacyPlainListNode(t, ctx, scheme, e, namespace, values[start:end], height-1, false)
-		start = end
-	}
-	return commitLegacySlots(t, ctx, scheme, e, namespace, slots)
+	slots := make([]cid.Cid, layout.BranchingFactor)
+	copy(slots, values)
+	return commitTestSlots(t, ctx, scheme, e, namespace, slots)
 }
 
-func commitLegacySlots(t *testing.T, ctx context.Context, scheme commitment.IndexCommitment, e *overwrite.ArcTable, namespace string, slots []cid.Cid) cid.Cid {
+func commitTestSlots(t *testing.T, ctx context.Context, scheme commitment.IndexCommitment, e *overwrite.ArcTable, namespace string, slots []cid.Cid) cid.Cid {
 	t.Helper()
 
 	root, err := layout.CommitSlots(scheme, slots)
 	if err != nil {
-		t.Fatalf("commit legacy slots: %v", err)
+		t.Fatalf("commit slots: %v", err)
 	}
 	commBytes, err := maltcid.ExtractCommitment(root)
 	if err != nil {
-		t.Fatalf("extract legacy commitment: %v", err)
+		t.Fatalf("extract commitment: %v", err)
 	}
 	listRoot, err := maltcid.NewTypedCID(maltcid.SemanticKindList, maltcid.BackendKindOf(root), commBytes)
 	if err != nil {
-		t.Fatalf("wrap legacy list root: %v", err)
+		t.Fatalf("wrap list root: %v", err)
 	}
 	if err := layout.StoreSlots(ctx, e, namespace, listRoot, slots); err != nil {
-		t.Fatalf("store legacy slots: %v", err)
+		t.Fatalf("store slots: %v", err)
 	}
 	return listRoot
 }
@@ -234,34 +201,33 @@ func TestTreeListSemanticProofsAndRestart(t *testing.T) {
 	}
 }
 
-func TestTreeListProvesLegacyMultiLevelRootsAfterRestart(t *testing.T) {
+func TestTreeListRejectsLegacyWidthMaterialization(t *testing.T) {
 	ctx := context.Background()
-	values := makeValues(300)
+	values := makeValues(layout.BranchingFactor)
 
 	for name, factory := range listSchemes() {
 		t.Run(name, func(t *testing.T) {
 			kv := kvmemory.New()
-			namespace := "tree-legacy-multilevel-" + name
+			namespace := "tree-legacy-width-" + name
 			scheme := factory(t)
 			_, e, err := newListWithArcTable(scheme, kv)
 			if err != nil {
 				t.Fatalf("newListWithArcTable failed: %v", err)
 			}
-			root := commitLegacyPlainListRoot(t, ctx, scheme, e, namespace, values)
+			root := commitLegacyWidthNode(t, ctx, scheme, e, namespace, values)
 
 			restarted, err := tree.NewList(scheme, e)
 			if err != nil {
 				t.Fatalf("NewList after restart failed: %v", err)
 			}
-			assertVerifiedQuery(t, restarted, namespace, root, 256, list.Query{
-				Key:    values[256],
-				Length: uint64(len(values)),
-			})
+			if _, _, err := restarted.Prove(ctx, namespace, root, 0); err == nil {
+				t.Fatal("Prove should reject legacy-width materialization")
+			}
 		})
 	}
 }
 
-func TestTreeListVerifiesLegacyMultiLevelProofWithoutStepSlots(t *testing.T) {
+func TestTreeListVerifiesProofWithoutStepSlots(t *testing.T) {
 	ctx := context.Background()
 	values := makeValues(300)
 	index := uint64(layout.BranchingFactor)
@@ -269,51 +235,7 @@ func TestTreeListVerifiesLegacyMultiLevelProofWithoutStepSlots(t *testing.T) {
 	for name, factory := range listSchemes() {
 		t.Run(name, func(t *testing.T) {
 			kv := kvmemory.New()
-			namespace := "tree-legacy-proof-without-slots-" + name
-			scheme := factory(t)
-			_, e, err := newListWithArcTable(scheme, kv)
-			if err != nil {
-				t.Fatalf("newListWithArcTable failed: %v", err)
-			}
-			root := commitLegacyPlainListRoot(t, ctx, scheme, e, namespace, values)
-
-			restarted, err := tree.NewList(scheme, e)
-			if err != nil {
-				t.Fatalf("NewList after restart failed: %v", err)
-			}
-			query, proof, err := restarted.Prove(ctx, namespace, root, index)
-			if err != nil {
-				t.Fatalf("Prove(%d) failed: %v", index, err)
-			}
-			ok, err := restarted.Verify(root, index, query, proof)
-			if err != nil {
-				t.Fatalf("Verify(%d) with explicit slots failed: %v", index, err)
-			}
-			if !ok {
-				t.Fatalf("Verify(%d) with explicit slots returned false", index)
-			}
-			legacyProof := stripProofStepSlots(t, proof)
-
-			ok, err = restarted.Verify(root, index, query, legacyProof)
-			if err != nil {
-				t.Fatalf("Verify(%d) failed: %v", index, err)
-			}
-			if !ok {
-				t.Fatalf("Verify(%d) returned false", index)
-			}
-		})
-	}
-}
-
-func TestTreeListVerifiesModernMultiLevelProofWithoutStepSlots(t *testing.T) {
-	ctx := context.Background()
-	values := makeValues(300)
-	index := uint64(layout.BranchingFactor)
-
-	for name, factory := range listSchemes() {
-		t.Run(name, func(t *testing.T) {
-			kv := kvmemory.New()
-			namespace := "tree-modern-proof-without-slots-" + name
+			namespace := "tree-proof-without-slots-" + name
 
 			semantic := newList(t, factory, kv)
 			root, err := semantic.Commit(ctx, namespace, list.NewViewFromSlice(values))
@@ -324,9 +246,9 @@ func TestTreeListVerifiesModernMultiLevelProofWithoutStepSlots(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Prove(%d) failed: %v", index, err)
 			}
-			legacyProof := stripProofStepSlots(t, proof)
+			strippedProof := stripProofStepSlots(t, proof)
 
-			ok, err := semantic.Verify(root, index, query, legacyProof)
+			ok, err := semantic.Verify(root, index, query, strippedProof)
 			if err != nil {
 				t.Fatalf("Verify(%d) failed: %v", index, err)
 			}
@@ -337,29 +259,27 @@ func TestTreeListVerifiesModernMultiLevelProofWithoutStepSlots(t *testing.T) {
 	}
 }
 
-func TestTreeListAppendIntoLegacyChildPreservesSlotZero(t *testing.T) {
+func TestTreeListAppendIntoChildUpdatesSlotZeroMetadata(t *testing.T) {
 	ctx := context.Background()
 	values := makeValues(300)
 
 	for name, factory := range listSchemes() {
 		t.Run(name, func(t *testing.T) {
 			kv := kvmemory.New()
-			namespace := "tree-legacy-append-" + name
+			namespace := "tree-child-append-" + name
 			scheme := factory(t)
-			_, e, err := newListWithArcTable(scheme, kv)
+			restarted, e, err := newListWithArcTable(scheme, kv)
 			if err != nil {
 				t.Fatalf("newListWithArcTable failed: %v", err)
 			}
-			root := commitLegacyPlainListRoot(t, ctx, scheme, e, namespace, values)
-
-			restarted, err := tree.NewList(scheme, e)
+			root, err := restarted.Commit(ctx, namespace, list.NewViewFromSlice(values))
 			if err != nil {
-				t.Fatalf("NewList after restart failed: %v", err)
+				t.Fatalf("Commit failed: %v", err)
 			}
-			appended := newPayloadCID([]byte("appended to legacy child"))
+			appended := newPayloadCID([]byte("appended to child"))
 			appendedRoot, appendedIndex, err := restarted.Append(ctx, namespace, root, appended)
 			if err != nil {
-				t.Fatalf("Append into legacy child failed: %v", err)
+				t.Fatalf("Append into child failed: %v", err)
 			}
 			if appendedIndex != uint64(len(values)) {
 				t.Fatalf("append index = %d, want %d", appendedIndex, len(values))
@@ -377,6 +297,22 @@ func TestTreeListAppendIntoLegacyChildPreservesSlotZero(t *testing.T) {
 				Key:    appended,
 				Length: uint64(len(values) + 1),
 			})
+
+			secondChildRoot, err := e.Get(ctx, namespace, cid.Undef, layout.NodeSlotPath(appendedRoot, 2))
+			if err != nil {
+				t.Fatalf("fetch second child root: %v", err)
+			}
+			secondChildSlots, err := layout.LoadSlots(ctx, e, namespace, secondChildRoot, layout.NodeWidth)
+			if err != nil {
+				t.Fatalf("load second child slots: %v", err)
+			}
+			meta, err := layout.DecodeNodeMetadata(secondChildSlots[0])
+			if err != nil {
+				t.Fatalf("decode second child metadata: %v", err)
+			}
+			if meta.ChildCount != uint64(len(values)+1-layout.BranchingFactor) {
+				t.Fatalf("second child count = %d, want %d", meta.ChildCount, len(values)+1-layout.BranchingFactor)
+			}
 		})
 	}
 }
@@ -408,12 +344,12 @@ func TestTreeListChildNodesCarryAuthenticatedMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("load child slots: %v", err)
 			}
-			childLen, err := layout.DecodeRootLength(childSlots[0])
+			childMeta, err := layout.DecodeNodeMetadata(childSlots[0])
 			if err != nil {
 				t.Fatalf("decode child metadata: %v", err)
 			}
-			if childLen != uint64(layout.BranchingFactor) {
-				t.Fatalf("child length = %d, want %d", childLen, layout.BranchingFactor)
+			if childMeta.ChildCount != uint64(layout.BranchingFactor) {
+				t.Fatalf("child length = %d, want %d", childMeta.ChildCount, layout.BranchingFactor)
 			}
 			if !childSlots[1].Equals(values[0]) {
 				t.Fatalf("child logical index 0 stored at slot 1 = %s, want %s", childSlots[1], values[0])
@@ -451,7 +387,7 @@ func TestTreeListMeasuredChildNodesCarryRangeMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("load first child slots: %v", err)
 			}
-			firstMeta, err := layout.DecodeFixedMetadata(firstChildSlots[0])
+			firstMeta, err := layout.DecodeNodeMetadata(firstChildSlots[0])
 			if err != nil {
 				t.Fatalf("decode first child fixed metadata: %v", err)
 			}
@@ -467,7 +403,7 @@ func TestTreeListMeasuredChildNodesCarryRangeMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("load second child slots: %v", err)
 			}
-			secondMeta, err := layout.DecodeFixedMetadata(secondChildSlots[0])
+			secondMeta, err := layout.DecodeNodeMetadata(secondChildSlots[0])
 			if err != nil {
 				t.Fatalf("decode second child fixed metadata: %v", err)
 			}


### PR DESCRIPTION
Unifies list tree nodes around the 256-slot layout with slot 0 storing NodeMetadata for both root and non-root nodes. Removes legacy 255-slot fallback and old length/fixed metadata markers, updates proof metadata fields, and refreshes list/tree tests.