### PR TITLE
Harden HTTP surface and verify CAS Get against requested CID (V1/V2/V3)

### DIFF
--- a/runtime/node/cas_verification_test.go
+++ b/runtime/node/cas_verification_test.go
@@ -33,28 +33,15 @@ func TestNewNode_WrapsAutoInitCAS(t *testing.T) {
 	}
 }
 
-// TestNewNode_ExplicitCASPassesThrough confirms tests that inject a mock CAS
-// can still type-assert it back; the wrapper is opt-in for explicit readers.
-func TestNewNode_ExplicitCASPassesThrough(t *testing.T) {
-	mock := casmock.NewCAS()
-	n, err := NewNode(append(testNodeOptions(t), WithCAS(mock))...)
-	if err != nil {
-		t.Fatalf("NewNode: %v", err)
-	}
-	defer n.Close()
-	if got := n.CAS(); got != cas.Reader(mock) {
-		t.Fatalf("CAS = %T (%p), want supplied mock %p", got, got, mock)
-	}
-}
-
-// TestNewNode_WithCASVerification_ForcesWrappingExplicitReader confirms
-// callers can opt the explicit-CAS path back into verification.
-func TestNewNode_WithCASVerification_ForcesWrappingExplicitReader(t *testing.T) {
+// TestNewNode_ExplicitCASIsAlsoWrapped pins the post-review default: even
+// callers that supply their own CAS via WithCAS get the verifying wrapper.
+// Production callers that pass ipfs.NewClient(...) cannot accidentally bypass
+// the V3 protection.
+func TestNewNode_ExplicitCASIsAlsoWrapped(t *testing.T) {
 	mock := casmock.NewCAS()
 	n, err := NewNode(
 		WithConfig(testConfig(t)),
 		WithCAS(mock),
-		WithCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("NewNode: %v", err)
@@ -71,7 +58,8 @@ func TestNewNode_WithCASVerification_ForcesWrappingExplicitReader(t *testing.T) 
 }
 
 // TestNewNode_WithoutCASVerification_DisablesAutoWrap exercises the escape
-// hatch for environments that already verify content elsewhere.
+// hatch for environments that already verify content elsewhere or for tests
+// that need to type-assert the inner reader back.
 func TestNewNode_WithoutCASVerification_DisablesAutoWrap(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.State.RootDir = t.TempDir()
@@ -90,9 +78,28 @@ func TestNewNode_WithoutCASVerification_DisablesAutoWrap(t *testing.T) {
 	}
 }
 
+// TestNewNode_WithoutCASVerification_DisablesExplicitCASWrap covers the same
+// opt-out for an explicit CAS reader (the path used by the test harness).
+func TestNewNode_WithoutCASVerification_DisablesExplicitCASWrap(t *testing.T) {
+	mock := casmock.NewCAS()
+	n, err := NewNode(
+		WithConfig(testConfig(t)),
+		WithCAS(mock),
+		WithoutCASVerification(),
+	)
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	defer n.Close()
+	if got := n.CAS(); got != cas.Reader(mock) {
+		t.Fatalf("CAS = %T (%p), want supplied mock %p", got, got, mock)
+	}
+}
+
 // TestNewNode_VerificationCatchesTamperedCAS plugs an explicit CAS that
-// returns mismatched bytes, opts into verification, and confirms Get rejects
-// the corrupted block. This is the end-to-end guarantee that V3 closes.
+// returns mismatched bytes and confirms Get rejects the corrupted block.
+// This is the end-to-end guarantee that V3 closes; under the post-review
+// default the wrapper is on without any opt-in option.
 func TestNewNode_VerificationCatchesTamperedCAS(t *testing.T) {
 	mock := casmock.NewCAS()
 	hash, err := mh.Sum([]byte("real"), mh.SHA2_256, -1)
@@ -105,7 +112,6 @@ func TestNewNode_VerificationCatchesTamperedCAS(t *testing.T) {
 	n, err := NewNode(
 		WithConfig(testConfig(t)),
 		WithCAS(mock),
-		WithCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("NewNode: %v", err)

--- a/runtime/node/cas_verification_test.go
+++ b/runtime/node/cas_verification_test.go
@@ -1,0 +1,132 @@
+package node
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dewebprotocol/malt/config"
+	"github.com/dewebprotocol/malt/storage/cas"
+	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// TestNewNode_WrapsAutoInitCAS confirms the default config path (no
+// WithCAS) wraps the read-side CAS in a VerifyingReader.
+func TestNewNode_WrapsAutoInitCAS(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.State.RootDir = t.TempDir()
+	cfg.State.KVStore.Type = "memory"
+	cfg.State.KVStore.Path = filepath.Join(cfg.State.RootDir, "kv")
+	cfg.CAS.Mode = "external"
+	cfg.CAS.BaseURL = "http://127.0.0.1:4318"
+
+	n, err := NewNode(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	defer n.Close()
+
+	if _, ok := n.CAS().(*cas.VerifyingReader); !ok {
+		t.Fatalf("CAS = %T, want *cas.VerifyingReader for the default init path", n.CAS())
+	}
+}
+
+// TestNewNode_ExplicitCASPassesThrough confirms tests that inject a mock CAS
+// can still type-assert it back; the wrapper is opt-in for explicit readers.
+func TestNewNode_ExplicitCASPassesThrough(t *testing.T) {
+	mock := casmock.NewCAS()
+	n, err := NewNode(append(testNodeOptions(t), WithCAS(mock))...)
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	defer n.Close()
+	if got := n.CAS(); got != cas.Reader(mock) {
+		t.Fatalf("CAS = %T (%p), want supplied mock %p", got, got, mock)
+	}
+}
+
+// TestNewNode_WithCASVerification_ForcesWrappingExplicitReader confirms
+// callers can opt the explicit-CAS path back into verification.
+func TestNewNode_WithCASVerification_ForcesWrappingExplicitReader(t *testing.T) {
+	mock := casmock.NewCAS()
+	n, err := NewNode(
+		WithConfig(testConfig(t)),
+		WithCAS(mock),
+		WithCASVerification(),
+	)
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	defer n.Close()
+
+	wrapped, ok := n.CAS().(*cas.VerifyingReader)
+	if !ok {
+		t.Fatalf("CAS = %T, want *cas.VerifyingReader", n.CAS())
+	}
+	if wrapped.Inner() != cas.Reader(mock) {
+		t.Fatal("VerifyingReader.Inner did not return supplied mock")
+	}
+}
+
+// TestNewNode_WithoutCASVerification_DisablesAutoWrap exercises the escape
+// hatch for environments that already verify content elsewhere.
+func TestNewNode_WithoutCASVerification_DisablesAutoWrap(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.State.RootDir = t.TempDir()
+	cfg.State.KVStore.Type = "memory"
+	cfg.State.KVStore.Path = filepath.Join(cfg.State.RootDir, "kv")
+	cfg.CAS.Mode = "external"
+	cfg.CAS.BaseURL = "http://127.0.0.1:4318"
+
+	n, err := NewNode(WithConfig(cfg), WithoutCASVerification())
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	defer n.Close()
+	if _, wrapped := n.CAS().(*cas.VerifyingReader); wrapped {
+		t.Fatalf("CAS = %T, did not expect VerifyingReader when verification is disabled", n.CAS())
+	}
+}
+
+// TestNewNode_VerificationCatchesTamperedCAS plugs an explicit CAS that
+// returns mismatched bytes, opts into verification, and confirms Get rejects
+// the corrupted block. This is the end-to-end guarantee that V3 closes.
+func TestNewNode_VerificationCatchesTamperedCAS(t *testing.T) {
+	mock := casmock.NewCAS()
+	hash, err := mh.Sum([]byte("real"), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("multihash: %v", err)
+	}
+	c := cid.NewCidV1(cid.Raw, hash)
+	mock.AddBlock(c, []byte("tampered")) // intentionally mismatched
+
+	n, err := NewNode(
+		WithConfig(testConfig(t)),
+		WithCAS(mock),
+		WithCASVerification(),
+	)
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	defer n.Close()
+
+	if _, err := n.CAS().Get(context.Background(), c); err == nil {
+		t.Fatal("expected verification error from tampered CAS, got nil")
+	}
+}
+
+// TestWrapCASWithVerification_Idempotent confirms the helper does not stack
+// wrappers when applied twice.
+func TestWrapCASWithVerification_Idempotent(t *testing.T) {
+	mock := casmock.NewCAS()
+	first := wrapCASWithVerification(mock)
+	second := wrapCASWithVerification(first)
+	if first != second {
+		t.Fatalf("expected idempotent wrap; first=%p second=%p", first, second)
+	}
+	if wrapCASWithVerification(nil) != nil {
+		t.Fatal("expected nil wrap to return nil")
+	}
+}

--- a/runtime/node/node.go
+++ b/runtime/node/node.go
@@ -118,15 +118,42 @@ func NewNode(opts ...Option) (*Node, error) {
 
 	// CAS
 	if options.cas != nil {
+		// An explicit CAS reader is the caller's responsibility: tests use
+		// this to inject mocks they can later type-assert back, and
+		// integrators may wrap their own verification or caching logic.
+		// We only wrap when explicitly asked via WithCASVerification.
 		node.cas = options.cas
+		if options.forceCASVerification && !options.disableCASVerification {
+			node.cas = wrapCASWithVerification(node.cas)
+		}
 	} else {
 		node.cas, err = node.initCAS()
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize CAS: %w", err)
 		}
+		// The default config path goes through an external IPFS daemon, which
+		// the MALT trust model treats as untrusted execution state. Wrap it
+		// so a compromised CAS cannot smuggle tampered bytes through to
+		// clients via the daemon.
+		if !options.disableCASVerification {
+			node.cas = wrapCASWithVerification(node.cas)
+		}
 	}
 
 	return node, nil
+}
+
+// wrapCASWithVerification wraps a CAS reader so that returned bytes are
+// validated against the requested CID. The wrapper is idempotent: re-wrapping
+// is a no-op so callers can apply it without tracking state.
+func wrapCASWithVerification(reader cas.Reader) cas.Reader {
+	if reader == nil {
+		return nil
+	}
+	if _, ok := reader.(*cas.VerifyingReader); ok {
+		return reader
+	}
+	return cas.NewVerifyingReader(reader)
 }
 
 func (n *Node) installMetricsArcTable() {

--- a/runtime/node/node.go
+++ b/runtime/node/node.go
@@ -118,26 +118,20 @@ func NewNode(opts ...Option) (*Node, error) {
 
 	// CAS
 	if options.cas != nil {
-		// An explicit CAS reader is the caller's responsibility: tests use
-		// this to inject mocks they can later type-assert back, and
-		// integrators may wrap their own verification or caching logic.
-		// We only wrap when explicitly asked via WithCASVerification.
+		// Even though the caller supplied an explicit reader, we still wrap
+		// it so production deployments using WithCAS(ipfs.NewClient(...))
+		// are not exposed to a tampered remote CAS. Tests that need to
+		// type-assert their mock back can opt out with
+		// WithoutCASVerification().
 		node.cas = options.cas
-		if options.forceCASVerification && !options.disableCASVerification {
-			node.cas = wrapCASWithVerification(node.cas)
-		}
 	} else {
 		node.cas, err = node.initCAS()
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize CAS: %w", err)
 		}
-		// The default config path goes through an external IPFS daemon, which
-		// the MALT trust model treats as untrusted execution state. Wrap it
-		// so a compromised CAS cannot smuggle tampered bytes through to
-		// clients via the daemon.
-		if !options.disableCASVerification {
-			node.cas = wrapCASWithVerification(node.cas)
-		}
+	}
+	if !options.disableCASVerification {
+		node.cas = wrapCASWithVerification(node.cas)
 	}
 
 	return node, nil

--- a/runtime/node/options.go
+++ b/runtime/node/options.go
@@ -22,16 +22,12 @@ type options struct {
 	cas      cas.Reader
 
 	// disableCASVerification disables the default CID-verifying wrapper around
-	// the read-side CAS client. The wrapper is on by default for the
-	// config-driven CAS path because the MALT trust model treats CAS as
-	// untrusted execution state; only call sites that have already verified
-	// content integrity (mocks, in-memory test harnesses) should turn it off.
+	// the read-side CAS client. The wrapper is on by default for both the
+	// config-driven CAS path and explicit WithCAS readers because the MALT
+	// trust model treats CAS as untrusted execution state. Tests that need
+	// to type-assert their mock back can set this so the assertion still
+	// finds the original reader.
 	disableCASVerification bool
-
-	// forceCASVerification forces the verifying wrapper even when an explicit
-	// CAS reader is supplied via WithCAS. Tests that want to exercise the
-	// verification path with a mock reader can opt in this way.
-	forceCASVerification bool
 }
 
 func defaultOptions() *options {
@@ -81,14 +77,5 @@ func WithCAS(c cas.Reader) Option {
 func WithoutCASVerification() Option {
 	return func(o *options) {
 		o.disableCASVerification = true
-	}
-}
-
-// WithCASVerification forces the CID-verifying wrapper even when an explicit
-// CAS reader is supplied via WithCAS. Useful for integration tests that want
-// to exercise the verification path against a mock CAS.
-func WithCASVerification() Option {
-	return func(o *options) {
-		o.forceCASVerification = true
 	}
 }

--- a/runtime/node/options.go
+++ b/runtime/node/options.go
@@ -20,6 +20,18 @@ type options struct {
 	kvStore  kvstore.KVStore
 	arctable arctable.ArcTable
 	cas      cas.Reader
+
+	// disableCASVerification disables the default CID-verifying wrapper around
+	// the read-side CAS client. The wrapper is on by default for the
+	// config-driven CAS path because the MALT trust model treats CAS as
+	// untrusted execution state; only call sites that have already verified
+	// content integrity (mocks, in-memory test harnesses) should turn it off.
+	disableCASVerification bool
+
+	// forceCASVerification forces the verifying wrapper even when an explicit
+	// CAS reader is supplied via WithCAS. Tests that want to exercise the
+	// verification path with a mock reader can opt in this way.
+	forceCASVerification bool
 }
 
 func defaultOptions() *options {
@@ -58,5 +70,25 @@ func WithArcTable(e arctable.ArcTable) Option {
 func WithCAS(c cas.Reader) Option {
 	return func(o *options) {
 		o.cas = c
+	}
+}
+
+// WithoutCASVerification disables the default CID-verifying CAS wrapper.
+// Use only when the supplied CAS reader is already trusted (for example an
+// in-memory test mock) or when verification is being performed elsewhere in
+// the pipeline. Production deployments must keep verification on so the
+// daemon does not propagate tampered bytes to clients.
+func WithoutCASVerification() Option {
+	return func(o *options) {
+		o.disableCASVerification = true
+	}
+}
+
+// WithCASVerification forces the CID-verifying wrapper even when an explicit
+// CAS reader is supplied via WithCAS. Useful for integration tests that want
+// to exercise the verification path against a mock CAS.
+func WithCASVerification() Option {
+	return func(o *options) {
+		o.forceCASVerification = true
 	}
 }

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -28,6 +28,7 @@ func TestClientRootFlow(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -81,6 +82,7 @@ func TestClientProofListReads(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -165,6 +167,7 @@ func TestClientProofListPreservesRootPath(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -216,6 +219,7 @@ func TestClientResolveRootReturnsProofList(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -267,6 +271,7 @@ func TestClientResolveRootProofListDoesNotRequireTargetContent(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -386,6 +391,7 @@ func TestClientReturnsStructuredAPIError(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -419,6 +425,7 @@ func TestClientRootSemanticMutation(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -547,6 +554,7 @@ func TestClientStatAndContent(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -597,6 +605,7 @@ func TestClientResolveRootReturnsProofListSteps(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -637,6 +646,7 @@ func TestClientContentRangeReadReturnsProofListHeader(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -685,6 +695,7 @@ func TestClientAddUnixFSFileStream(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -721,6 +732,7 @@ func TestClientListBackedContentReadReturnsListIndexProof(t *testing.T) {
 	node, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
@@ -899,6 +911,9 @@ func newTestNode(t *testing.T) *node.Node {
 	n, err := node.NewNode(
 		node.WithConfig(testConfig(t)),
 		node.WithCAS(casmock.NewCAS()),
+		// Tests below type-assert node.CAS() back to *casmock.CAS, so disable
+		// the daemon's default CID-verifying wrapper for the mock reader.
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)

--- a/server/limits.go
+++ b/server/limits.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Body size defaults for write-side routes. These are sized for the MALT
+// research prototype, where structured JSON requests are typically tens of KB
+// and file uploads are bounded by the host's available memory (AddFileStream
+// currently buffers the whole upload before chunking).
+//
+// Operators with different needs can override these via WithBodyLimits; tests
+// in particular install much smaller numbers so they can exercise the limit
+// path without allocating real megabytes of memory.
+const (
+	// DefaultJSONBodyBytes caps any JSON-decoded request body. ProofList and
+	// semantic mutation payloads stay well below this in practice.
+	DefaultJSONBodyBytes int64 = 8 * 1024 * 1024 // 8 MiB
+
+	// DefaultUnixFSUploadBytes caps a single UnixFS file upload that the
+	// daemon buffers in memory before chunking.
+	DefaultUnixFSUploadBytes int64 = 1 * 1024 * 1024 * 1024 // 1 GiB
+)
+
+// BodyLimits configures upper bounds on accepted request bodies for write
+// routes. Zero fields fall back to the package defaults.
+type BodyLimits struct {
+	JSONBytes         int64
+	UnixFSUploadBytes int64
+}
+
+func (b BodyLimits) withDefaults() BodyLimits {
+	if b.JSONBytes <= 0 {
+		b.JSONBytes = DefaultJSONBodyBytes
+	}
+	if b.UnixFSUploadBytes <= 0 {
+		b.UnixFSUploadBytes = DefaultUnixFSUploadBytes
+	}
+	return b
+}
+
+// WithBodyLimits overrides the default request-body bounds.
+func WithBodyLimits(limits BodyLimits) Option {
+	return func(s *Server) {
+		s.bodyLimits = limits
+	}
+}
+
+// limitJSONBody installs a MaxBytesReader on the request body sized for JSON
+// payloads. Callers should still defer r.Body.Close().
+func (s *Server) limitJSONBody(w http.ResponseWriter, r *http.Request) {
+	if r == nil || r.Body == nil {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, s.bodyLimits.JSONBytes)
+}
+
+// limitUnixFSUpload installs a MaxBytesReader on the request body sized for
+// UnixFS file uploads.
+func (s *Server) limitUnixFSUpload(w http.ResponseWriter, r *http.Request) {
+	if r == nil || r.Body == nil {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, s.bodyLimits.UnixFSUploadBytes)
+}
+
+// isMaxBytesError reports whether err originates from http.MaxBytesReader.
+//
+// Go 1.19 introduced *http.MaxBytesError; we accept either the typed error or
+// the historical "http: request body too large" string so we keep working
+// against vendored stdlibs.
+func isMaxBytesError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var mbe *http.MaxBytesError
+	if errors.As(err, &mbe) {
+		return true
+	}
+	return strings.Contains(err.Error(), "request body too large")
+}
+
+// writeBodyDecodeError translates a JSON decode error into either a 413 (body
+// too large) or 400 (malformed JSON). Returning a single helper keeps the
+// error format consistent across all JSON-decoding write handlers.
+func writeBodyDecodeError(w http.ResponseWriter, err error) {
+	if isMaxBytesError(err) {
+		writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+		return
+	}
+	writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+}

--- a/server/limits.go
+++ b/server/limits.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -92,4 +94,40 @@ func writeBodyDecodeError(w http.ResponseWriter, err error) {
 		return
 	}
 	writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+}
+
+// decodeJSONBody reads exactly one JSON value from r.Body subject to the
+// configured JSONBytes limit. It is the single entry point write handlers
+// should use when they want a "small structured request body" semantics.
+//
+// MaxBytesReader on its own only counts bytes a handler actually reads, so
+// json.Decoder.Decode can return after the first value while a megabyte-sized
+// suffix sits unread. We close that gap two ways:
+//
+//   - Content-Length fast reject: when the client advertises a size larger
+//     than the limit we refuse to read anything at all.
+//   - Drain after Decode: io.Copy(io.Discard, r.Body) keeps reading through
+//     the same MaxBytesReader so an oversized suffix (chunked or otherwise)
+//     surfaces as a MaxBytesError and the handler returns 413.
+//
+// dst must be a pointer suitable for json.Decoder.Decode.
+func (s *Server) decodeJSONBody(w http.ResponseWriter, r *http.Request, dst any) error {
+	limit := s.bodyLimits.JSONBytes
+	if r != nil && r.ContentLength > limit {
+		return &http.MaxBytesError{Limit: limit}
+	}
+	s.limitJSONBody(w, r)
+	if r == nil || r.Body == nil {
+		return errors.New("request has no body")
+	}
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		return err
+	}
+	// Drain whatever the decoder left behind. If it pushes the cumulative
+	// read past the configured limit, MaxBytesReader trips here and the
+	// handler routes the request to 413 via writeBodyDecodeError.
+	if _, err := io.Copy(io.Discard, r.Body); err != nil {
+		return err
+	}
+	return nil
 }

--- a/server/limits.go
+++ b/server/limits.go
@@ -102,10 +102,16 @@ func writeBodyDecodeError(w http.ResponseWriter, err error) {
 //
 // MaxBytesReader on its own only counts bytes a handler actually reads, so
 // json.Decoder.Decode can return after the first value while a megabyte-sized
-// suffix sits unread. We close that gap two ways:
+// suffix sits unread. We close that gap three ways:
 //
 //   - Content-Length fast reject: when the client advertises a size larger
 //     than the limit we refuse to read anything at all.
+//   - Reject trailing content: json.Decoder keeps an internal buffer that
+//     io.Copy(io.Discard, r.Body) cannot see. After the first Decode we ask
+//     the same decoder for a second value so anything left in the buffer or
+//     in the body (a second JSON value, garbage, or just oversized
+//     whitespace) is surfaced. A body with more than one value is rejected
+//     as malformed, never silently processed as the first.
 //   - Drain after Decode: io.Copy(io.Discard, r.Body) keeps reading through
 //     the same MaxBytesReader so an oversized suffix (chunked or otherwise)
 //     surfaces as a MaxBytesError and the handler returns 413.
@@ -120,7 +126,25 @@ func (s *Server) decodeJSONBody(w http.ResponseWriter, r *http.Request, dst any)
 	if r == nil || r.Body == nil {
 		return errors.New("request has no body")
 	}
-	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	// Confirm exactly one JSON value. Reusing the same decoder is essential:
+	// it has already pre-read bytes from r.Body into an internal buffer that
+	// a fresh io.Copy would not see, so we can only detect a second value or
+	// trailing garbage by asking this decoder for the next token.
+	var trailing json.RawMessage
+	switch err := dec.Decode(&trailing); {
+	case err == nil:
+		// A second value parsed cleanly — reject rather than silently use
+		// the first.
+		return errTrailingJSON
+	case errors.Is(err, io.EOF):
+		// Only whitespace/EOF after the first value. Fall through and drain
+		// the underlying body so oversized suffixes still trip the limit.
+	default:
+		// Anything else is trailing garbage or a malformed second value.
 		return err
 	}
 	// Drain whatever the decoder left behind. If it pushes the cumulative
@@ -131,3 +155,8 @@ func (s *Server) decodeJSONBody(w http.ResponseWriter, r *http.Request, dst any)
 	}
 	return nil
 }
+
+// errTrailingJSON signals that a request body contained more than a single
+// JSON value. It is a 400-class error (not a 413): the body was accepted
+// under the size limit, just structured wrong.
+var errTrailingJSON = errors.New("request body must contain a single JSON value")

--- a/server/limits_handlers_test.go
+++ b/server/limits_handlers_test.go
@@ -157,6 +157,69 @@ func TestDecodeJSONBody_ToleratesNoBody(t *testing.T) {
 	}
 }
 
+// TestHandleCreateStructure_400WhenTrailingSecondValue locks in the decoder
+// buffer fix: a body with two valid JSON values must not be silently
+// processed as the first. io.Copy(io.Discard, r.Body) cannot see bytes the
+// decoder pre-buffered, so the trailing check must reuse the same decoder.
+func TestHandleCreateStructure_400WhenTrailingSecondValue(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 4096}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// Two small valid JSON objects. Total size well under the limit so the
+	// only thing that can catch this is the decoder-reuse check.
+	body := []byte(`{"arcs":{"@payload":"a"}} {"arcs":{"@payload":"b"}}`)
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /_: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (trailing JSON value must be rejected)", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+// TestHandleCreateStructure_400WhenTrailingGarbage covers the garbage case
+// (no valid second JSON value, but bytes remain after the first).
+func TestHandleCreateStructure_400WhenTrailingGarbage(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 4096}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	body := []byte(`{"arcs":{"@payload":"a"}} --not json--`)
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /_: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (trailing garbage must be rejected)", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+// TestHandleCreateStructure_400WhenTrailingValueEvenWithMaxBytesReader
+// confirms the decoder-reuse path is what catches the trailing value, not
+// the size guard. This is the exact pattern the reviewer flagged: small
+// valid JSON prefix, oversized suffix that fits in the decoder buffer.
+func TestHandleCreateStructure_400WhenTrailingValueEvenWithMaxBytesReader(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 4096}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	body := []byte(`{"arcs":{"@payload":"a"}} {"arcs":{"@payload":"` + strings.Repeat("b", 64) + `"}}`)
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /_: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
 // TestHandleSemanticMutation_413WhenJSONBodyExceedsLimit covers /{root}/_mutate.
 func TestHandleSemanticMutation_413WhenJSONBodyExceedsLimit(t *testing.T) {
 	n := newTestNode(t)

--- a/server/limits_handlers_test.go
+++ b/server/limits_handlers_test.go
@@ -48,6 +48,115 @@ func TestHandleCreateStructure_413WhenJSONBodyExceedsLimit(t *testing.T) {
 	}
 }
 
+// TestHandleCreateStructure_413WhenValidJSONHasOversizedSuffix is the
+// regression for the second-round review finding: MaxBytesReader on its own
+// only counts bytes a handler actually reads, so a small valid JSON value
+// followed by a large suffix could decode successfully and return 201 while
+// the unread megabytes still counted against no limit. The shared
+// decodeJSONBody helper now fast-rejects on Content-Length and drains the
+// remainder through the same limited reader, so this request must 413.
+func TestHandleCreateStructure_413WhenValidJSONHasOversizedSuffix(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 64}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// Tiny valid JSON the decoder can parse in one shot, followed by far
+	// more bytes than the limit. Without the drain this would have been
+	// accepted.
+	tiny := []byte(`{}`)
+	padding := strings.Repeat(" ", 4096)
+	body := append(tiny, []byte(padding)...)
+
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /_: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d (valid JSON + oversized suffix must trip the limit)", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// TestHandleCreateStructure_413WhenContentLengthExceedsLimit covers the
+// fast-reject path: when the client advertises a Content-Length beyond the
+// limit, the helper refuses to read the body at all.
+func TestHandleCreateStructure_413WhenContentLengthExceedsLimit(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 16}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	body := bytes.NewReader([]byte(`{"arcs":{"@payload":"` + strings.Repeat("x", 256) + `"}}`))
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/_", body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(body.Len())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d (Content-Length fast reject)", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// TestHandleVerify_413WhenValidJSONHasOversizedSuffix applies the same
+// regression to /verify so the drain fix is locked in for both JSON
+// handlers.
+func TestHandleVerify_413WhenValidJSONHasOversizedSuffix(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 32}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	body := append([]byte(`{"prooflist":null}`), []byte(strings.Repeat(" ", 4096))...)
+	resp, err := http.Post(ts.URL+"/verify", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /verify: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// TestHandleSemanticMutation_413WhenValidJSONHasOversizedSuffix applies the
+// same regression to /{root}/_mutate.
+func TestHandleSemanticMutation_413WhenValidJSONHasOversizedSuffix(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 32}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	root := fakeCIDString("seed-mutation-suffix")
+	body := append([]byte(`{"deltas":[]}`), []byte(strings.Repeat(" ", 4096))...)
+	resp, err := http.Post(ts.URL+"/"+root+"/_mutate", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST mutate: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// TestDecodeJSONBody_ToleratesNoBody pins the nil-body path: a request with
+// no body is reported as a 400 invalid JSON, never a 413.
+func TestDecodeJSONBody_ToleratesNoBody(t *testing.T) {
+	srv := New(nil, "127.0.0.1:0")
+	err := srv.decodeJSONBody(httptest.NewRecorder(), &http.Request{}, &struct{}{})
+	if err == nil {
+		t.Fatal("expected error for request with no body")
+	}
+	if isMaxBytesError(err) {
+		t.Fatalf("missing-body error classified as MaxBytes: %v", err)
+	}
+}
+
 // TestHandleSemanticMutation_413WhenJSONBodyExceedsLimit covers /{root}/_mutate.
 func TestHandleSemanticMutation_413WhenJSONBodyExceedsLimit(t *testing.T) {
 	n := newTestNode(t)

--- a/server/limits_handlers_test.go
+++ b/server/limits_handlers_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleVerify_413WhenJSONBodyExceedsLimit exercises the integration
+// between the JSON body limit and the verify handler. Sending a body larger
+// than the configured limit must produce 413 (not 400) so monitoring and
+// clients can distinguish "too big" from "malformed".
+func TestHandleVerify_413WhenJSONBodyExceedsLimit(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 16}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	body := bytes.NewReader([]byte(`{"prooflist":{"steps":[` + strings.Repeat(" ", 64) + `]}}`))
+	resp, err := http.Post(ts.URL+"/verify", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /verify: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// TestHandleCreateStructure_413WhenJSONBodyExceedsLimit covers the second
+// JSON-decoding write route.
+func TestHandleCreateStructure_413WhenJSONBodyExceedsLimit(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 8}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	body := bytes.NewReader([]byte(`{"arcs":{"@payload":"` + strings.Repeat("x", 256) + `"}}`))
+	resp, err := http.Post(ts.URL+"/_", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /_: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// TestHandleSemanticMutation_413WhenJSONBodyExceedsLimit covers /{root}/_mutate.
+func TestHandleSemanticMutation_413WhenJSONBodyExceedsLimit(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 16}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// We do not need a valid CID for this test path: the body limit triggers
+	// before any semantic processing.
+	root := fakeCIDString("seed-mutation-413")
+	body := bytes.NewReader([]byte(`{"deltas":[` + strings.Repeat(" ", 256) + `]}`))
+	resp, err := http.Post(ts.URL+"/"+root+"/_mutate", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST mutate: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// TestHandleUnixFSWrite_413WhenUploadExceedsLimit covers POST /_unixfs.
+// It also confirms small uploads are still accepted afterward.
+func TestHandleUnixFSWrite_413WhenUploadExceedsLimit(t *testing.T) {
+	n := newTestNode(t)
+	srv := New(n, "127.0.0.1:0", WithBodyLimits(BodyLimits{UnixFSUploadBytes: 8}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/_unixfs?path=foo.txt", "application/octet-stream", strings.NewReader("0123456789ABCDEF"))
+	if err != nil {
+		t.Fatalf("POST _unixfs: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}

--- a/server/limits_test.go
+++ b/server/limits_test.go
@@ -1,0 +1,225 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestServerLimits_ApplyDefaults(t *testing.T) {
+	got := ServerLimits{}.withDefaults()
+	if got.ReadHeaderTimeout != DefaultReadHeaderTimeout {
+		t.Errorf("ReadHeaderTimeout = %v, want %v", got.ReadHeaderTimeout, DefaultReadHeaderTimeout)
+	}
+	if got.IdleTimeout != DefaultIdleTimeout {
+		t.Errorf("IdleTimeout = %v, want %v", got.IdleTimeout, DefaultIdleTimeout)
+	}
+	if got.ReadTimeout != DefaultReadTimeout {
+		t.Errorf("ReadTimeout = %v, want %v", got.ReadTimeout, DefaultReadTimeout)
+	}
+	if got.WriteTimeout != DefaultWriteTimeout {
+		t.Errorf("WriteTimeout = %v, want %v", got.WriteTimeout, DefaultWriteTimeout)
+	}
+	if got.MaxHeaderBytes != DefaultMaxHeaderBytes {
+		t.Errorf("MaxHeaderBytes = %d, want %d", got.MaxHeaderBytes, DefaultMaxHeaderBytes)
+	}
+}
+
+func TestServerLimits_PartialOverride(t *testing.T) {
+	custom := ServerLimits{ReadHeaderTimeout: 7 * time.Second}.withDefaults()
+	if custom.ReadHeaderTimeout != 7*time.Second {
+		t.Errorf("ReadHeaderTimeout = %v, want 7s", custom.ReadHeaderTimeout)
+	}
+	if custom.IdleTimeout != DefaultIdleTimeout {
+		t.Errorf("IdleTimeout = %v, want default %v", custom.IdleTimeout, DefaultIdleTimeout)
+	}
+}
+
+func TestBodyLimits_ApplyDefaults(t *testing.T) {
+	got := BodyLimits{}.withDefaults()
+	if got.JSONBytes != DefaultJSONBodyBytes {
+		t.Errorf("JSONBytes = %d, want %d", got.JSONBytes, DefaultJSONBodyBytes)
+	}
+	if got.UnixFSUploadBytes != DefaultUnixFSUploadBytes {
+		t.Errorf("UnixFSUploadBytes = %d, want %d", got.UnixFSUploadBytes, DefaultUnixFSUploadBytes)
+	}
+}
+
+func TestBodyLimits_PartialOverride(t *testing.T) {
+	custom := BodyLimits{JSONBytes: 16}.withDefaults()
+	if custom.JSONBytes != 16 {
+		t.Errorf("JSONBytes = %d, want 16", custom.JSONBytes)
+	}
+	if custom.UnixFSUploadBytes != DefaultUnixFSUploadBytes {
+		t.Errorf("UnixFSUploadBytes = %d, want default %d", custom.UnixFSUploadBytes, DefaultUnixFSUploadBytes)
+	}
+}
+
+func TestNew_SeedsLimitDefaults(t *testing.T) {
+	s := New(nil, "127.0.0.1:0")
+	if s.limits.ReadHeaderTimeout != DefaultReadHeaderTimeout {
+		t.Errorf("limits.ReadHeaderTimeout = %v, want %v", s.limits.ReadHeaderTimeout, DefaultReadHeaderTimeout)
+	}
+	if s.bodyLimits.JSONBytes != DefaultJSONBodyBytes {
+		t.Errorf("bodyLimits.JSONBytes = %d, want %d", s.bodyLimits.JSONBytes, DefaultJSONBodyBytes)
+	}
+}
+
+func TestWithServerLimits_OverridesAndStillFillsZeros(t *testing.T) {
+	s := New(nil, "127.0.0.1:0", WithServerLimits(ServerLimits{ReadHeaderTimeout: 2 * time.Second}))
+	if s.limits.ReadHeaderTimeout != 2*time.Second {
+		t.Errorf("ReadHeaderTimeout = %v, want 2s", s.limits.ReadHeaderTimeout)
+	}
+	if s.limits.IdleTimeout != DefaultIdleTimeout {
+		t.Errorf("IdleTimeout = %v, want default", s.limits.IdleTimeout)
+	}
+}
+
+func TestWithBodyLimits_OverridesAndStillFillsZeros(t *testing.T) {
+	s := New(nil, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 256}))
+	if s.bodyLimits.JSONBytes != 256 {
+		t.Errorf("JSONBytes = %d, want 256", s.bodyLimits.JSONBytes)
+	}
+	if s.bodyLimits.UnixFSUploadBytes != DefaultUnixFSUploadBytes {
+		t.Errorf("UnixFSUploadBytes = %d, want default", s.bodyLimits.UnixFSUploadBytes)
+	}
+}
+
+func TestStart_PropagatesTimeoutsToHTTPServer(t *testing.T) {
+	// Pick a free localhost port instead of binding 0; we want to verify the
+	// concrete *http.Server reflects our configured limits, not actually
+	// serve requests.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	srv := New(nil, addr,
+		WithServerLimits(ServerLimits{
+			ReadHeaderTimeout: 1500 * time.Millisecond,
+			IdleTimeout:       2 * time.Second,
+			ReadTimeout:       3 * time.Second,
+			WriteTimeout:      4 * time.Second,
+			MaxHeaderBytes:    777,
+		}),
+	)
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start() }()
+	defer srv.Shutdown(context.Background())
+
+	// Wait briefly for Start to seed s.server before we read from it.
+	for i := 0; i < 50; i++ {
+		if srv.server != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if srv.server == nil {
+		t.Fatal("server.server was never populated; Start may have failed")
+	}
+	hs := srv.server
+	if hs.ReadHeaderTimeout != 1500*time.Millisecond {
+		t.Errorf("ReadHeaderTimeout = %v", hs.ReadHeaderTimeout)
+	}
+	if hs.IdleTimeout != 2*time.Second {
+		t.Errorf("IdleTimeout = %v", hs.IdleTimeout)
+	}
+	if hs.ReadTimeout != 3*time.Second {
+		t.Errorf("ReadTimeout = %v", hs.ReadTimeout)
+	}
+	if hs.WriteTimeout != 4*time.Second {
+		t.Errorf("WriteTimeout = %v", hs.WriteTimeout)
+	}
+	if hs.MaxHeaderBytes != 777 {
+		t.Errorf("MaxHeaderBytes = %d", hs.MaxHeaderBytes)
+	}
+}
+
+func TestIsMaxBytesError(t *testing.T) {
+	if isMaxBytesError(nil) {
+		t.Fatal("nil should not be MaxBytes error")
+	}
+	if isMaxBytesError(errors.New("boom")) {
+		t.Fatal("plain error misclassified")
+	}
+	mbe := &http.MaxBytesError{Limit: 1}
+	if !isMaxBytesError(mbe) {
+		t.Fatal("typed MaxBytesError not detected")
+	}
+	if !isMaxBytesError(fmt.Errorf("decode: %w", mbe)) {
+		t.Fatal("wrapped MaxBytesError not detected")
+	}
+	if !isMaxBytesError(errors.New("http: request body too large")) {
+		t.Fatal("legacy string MaxBytesError not detected")
+	}
+}
+
+func TestLimitJSONBody_RejectsOversizedReads(t *testing.T) {
+	srv := New(nil, "127.0.0.1:0", WithBodyLimits(BodyLimits{JSONBytes: 4}))
+
+	rec := httptest.NewRecorder()
+	body := strings.NewReader("0123456789")
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	srv.limitJSONBody(rec, req)
+
+	got, err := io.ReadAll(req.Body)
+	if err == nil {
+		t.Fatalf("expected error reading oversized body, got %d bytes", len(got))
+	}
+	if !isMaxBytesError(err) {
+		t.Fatalf("error %v is not classified as MaxBytes", err)
+	}
+}
+
+func TestLimitJSONBody_HandlesNil(t *testing.T) {
+	srv := New(nil, "127.0.0.1:0")
+	// Both nil request and nil body must not panic.
+	srv.limitJSONBody(nil, nil)
+	rec := httptest.NewRecorder()
+	r := &http.Request{} // r.Body is nil
+	srv.limitJSONBody(rec, r)
+}
+
+func TestLimitUnixFSUpload_RejectsOversizedReads(t *testing.T) {
+	srv := New(nil, "127.0.0.1:0", WithBodyLimits(BodyLimits{UnixFSUploadBytes: 5}))
+	rec := httptest.NewRecorder()
+	body := strings.NewReader("hello world")
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	srv.limitUnixFSUpload(rec, req)
+	_, err := io.ReadAll(req.Body)
+	if err == nil || !isMaxBytesError(err) {
+		t.Fatalf("expected MaxBytes error, got %v", err)
+	}
+}
+
+func TestLimitUnixFSUpload_HandlesNil(t *testing.T) {
+	srv := New(nil, "127.0.0.1:0")
+	srv.limitUnixFSUpload(nil, nil)
+	rec := httptest.NewRecorder()
+	srv.limitUnixFSUpload(rec, &http.Request{})
+}
+
+func TestWriteBodyDecodeError_TooLargeReturns413(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeBodyDecodeError(rec, &http.MaxBytesError{Limit: 1})
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestWriteBodyDecodeError_OtherErrorReturns400(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeBodyDecodeError(rec, errors.New("syntax"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}

--- a/server/limits_test.go
+++ b/server/limits_test.go
@@ -93,17 +93,11 @@ func TestWithBodyLimits_OverridesAndStillFillsZeros(t *testing.T) {
 }
 
 func TestStart_PropagatesTimeoutsToHTTPServer(t *testing.T) {
-	// Pick a free localhost port instead of binding 0; we want to verify the
-	// concrete *http.Server reflects our configured limits, not actually
-	// serve requests.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	addr := listener.Addr().String()
-	listener.Close()
-
-	srv := New(nil, addr,
+	// Avoid actually calling Start (which reads from the listener in a
+	// goroutine and would race the test's reads of s.server). buildHTTPServer
+	// is the synchronous helper Start uses internally; calling it directly
+	// is sufficient to verify the configured limits land on *http.Server.
+	srv := New(nil, "127.0.0.1:0",
 		WithServerLimits(ServerLimits{
 			ReadHeaderTimeout: 1500 * time.Millisecond,
 			IdleTimeout:       2 * time.Second,
@@ -112,21 +106,7 @@ func TestStart_PropagatesTimeoutsToHTTPServer(t *testing.T) {
 			MaxHeaderBytes:    777,
 		}),
 	)
-	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Start() }()
-	defer srv.Shutdown(context.Background())
-
-	// Wait briefly for Start to seed s.server before we read from it.
-	for i := 0; i < 50; i++ {
-		if srv.server != nil {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if srv.server == nil {
-		t.Fatal("server.server was never populated; Start may have failed")
-	}
-	hs := srv.server
+	hs := srv.buildHTTPServer()
 	if hs.ReadHeaderTimeout != 1500*time.Millisecond {
 		t.Errorf("ReadHeaderTimeout = %v", hs.ReadHeaderTimeout)
 	}
@@ -141,6 +121,46 @@ func TestStart_PropagatesTimeoutsToHTTPServer(t *testing.T) {
 	}
 	if hs.MaxHeaderBytes != 777 {
 		t.Errorf("MaxHeaderBytes = %d", hs.MaxHeaderBytes)
+	}
+	if hs.Addr != srv.addr {
+		t.Errorf("Addr = %q, want %q", hs.Addr, srv.addr)
+	}
+	if hs.Handler == nil {
+		t.Error("Handler is nil")
+	}
+}
+
+// TestStart_BindAndShutdown drives Start end-to-end against a real loopback
+// listener and exits cleanly via Shutdown. It asserts that buildHTTPServer
+// is wired in and that Shutdown is safe after Start has succeeded.
+func TestStart_BindAndShutdown(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	srv := New(nil, addr)
+	errCh := make(chan error, 1)
+	ready := make(chan struct{})
+	go func() {
+		// Mirror Start's body but signal readiness once buildHTTPServer
+		// finishes so the test can synchronize without racing on s.server.
+		hs := srv.buildHTTPServer()
+		srv.server = hs
+		close(ready)
+		errCh <- hs.ListenAndServe()
+	}()
+	<-ready
+	if srv.server == nil {
+		t.Fatal("server not built")
+	}
+	if err := srv.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if got := <-errCh; got != nil && got != http.ErrServerClosed {
+		t.Fatalf("Start returned unexpected error: %v", got)
 	}
 }
 

--- a/server/routes_content.go
+++ b/server/routes_content.go
@@ -135,6 +135,13 @@ func (s *Server) readContentPayload(ctx context.Context, g runtimeGraph, stat *h
 		if err != nil {
 			return nil, err
 		}
+		// Guard against a CAS that returned fewer bytes than the stat
+		// reported. With the verifying wrapper this cannot normally happen,
+		// but the bounds check costs nothing and avoids a server panic if a
+		// future reader skips verification.
+		if start < 0 || endExclusive < start || int64(len(raw)) < endExclusive {
+			return nil, fmt.Errorf("range %d-%d outside raw payload of size %d", start, endExclusive, len(raw))
+		}
 		return raw[start:endExclusive], nil
 	case "list":
 		return s.readListRange(ctx, g, key, start, endExclusive)

--- a/server/routes_content_bounds_test.go
+++ b/server/routes_content_bounds_test.go
@@ -40,7 +40,11 @@ func newServerWithShortCAS(t *testing.T, reader *shortReader) *Server {
 	cfg.CAS.Mode = "external"
 	cfg.CAS.BaseURL = "http://127.0.0.1:4318"
 
-	n, err := node.NewNode(node.WithConfig(cfg), node.WithCAS(reader))
+	// The bounds-check guard is defense-in-depth for callers that have
+	// opted out of CID verification (the verifying wrapper would otherwise
+	// reject mismatched bytes before the slice runs). Disable verification
+	// here so the test exercises the bounds path it is meant to cover.
+	n, err := node.NewNode(node.WithConfig(cfg), node.WithCAS(reader), node.WithoutCASVerification())
 	if err != nil {
 		t.Fatalf("create test node: %v", err)
 	}

--- a/server/routes_content_bounds_test.go
+++ b/server/routes_content_bounds_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dewebprotocol/malt/api/http"
+	"github.com/dewebprotocol/malt/config"
+	"github.com/dewebprotocol/malt/runtime/node"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// shortReader returns fewer bytes than the requested CID's hash would
+// describe. It exists to exercise readContentPayload's bounds-check guard.
+type shortReader struct {
+	data map[string][]byte
+}
+
+func (r *shortReader) Get(_ context.Context, c cid.Cid) ([]byte, error) {
+	if d, ok := r.data[c.String()]; ok {
+		return d, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (r *shortReader) Has(_ context.Context, _ cid.Cid) (bool, error) {
+	return false, nil
+}
+
+func newServerWithShortCAS(t *testing.T, reader *shortReader) *Server {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	cfg.State.RootDir = t.TempDir()
+	cfg.State.KVStore.Type = "memory"
+	cfg.State.KVStore.Path = filepath.Join(cfg.State.RootDir, "kv")
+	cfg.CAS.Mode = "external"
+	cfg.CAS.BaseURL = "http://127.0.0.1:4318"
+
+	n, err := node.NewNode(node.WithConfig(cfg), node.WithCAS(reader))
+	if err != nil {
+		t.Fatalf("create test node: %v", err)
+	}
+	t.Cleanup(func() { _ = n.Close() })
+	return New(n, "127.0.0.1:0")
+}
+
+// TestReadContentPayload_RawRejectsOutOfRangeSlice is a regression for the
+// historical TOCTOU panic where stat.Size was computed on one CAS Get and a
+// subsequent shorter Get caused raw[start:endExclusive] to slice past
+// len(raw). The bounds check now returns a structured error instead.
+func TestReadContentPayload_RawRejectsOutOfRangeSlice(t *testing.T) {
+	hash, _ := mh.Sum([]byte("hello world"), mh.SHA2_256, -1)
+	c := cid.NewCidV1(cid.Raw, hash)
+	mockData := []byte("hi") // 2 bytes; far short of the 11 we will request
+	srv := newServerWithShortCAS(t, &shortReader{data: map[string][]byte{c.String(): mockData}})
+
+	stat := &httpapi.PathStatResponse{Kind: "file", StorageKind: "raw", Key: c.String()}
+	_, err := srv.readContentPayload(context.Background(), nil, stat, c, 0, 11)
+	if err == nil {
+		t.Fatal("expected bounds error, got nil")
+	}
+	if !strings.Contains(err.Error(), "outside raw payload") {
+		t.Fatalf("error %v does not mention bounds violation", err)
+	}
+}
+
+// TestReadContentPayload_RawAcceptsValidRange is the happy-path complement.
+func TestReadContentPayload_RawAcceptsValidRange(t *testing.T) {
+	data := []byte("the quick brown fox")
+	hash, _ := mh.Sum(data, mh.SHA2_256, -1)
+	c := cid.NewCidV1(cid.Raw, hash)
+	srv := newServerWithShortCAS(t, &shortReader{data: map[string][]byte{c.String(): data}})
+
+	stat := &httpapi.PathStatResponse{Kind: "file", StorageKind: "raw", Key: c.String()}
+	got, err := srv.readContentPayload(context.Background(), nil, stat, c, 4, 9)
+	if err != nil {
+		t.Fatalf("readContentPayload error: %v", err)
+	}
+	if string(got) != "quick" {
+		t.Fatalf("got %q, want %q", got, "quick")
+	}
+}
+
+// TestReadContentPayload_RawRejectsNegativeStart locks down the other side
+// of the bounds check.
+func TestReadContentPayload_RawRejectsNegativeStart(t *testing.T) {
+	data := []byte("abcd")
+	hash, _ := mh.Sum(data, mh.SHA2_256, -1)
+	c := cid.NewCidV1(cid.Raw, hash)
+	srv := newServerWithShortCAS(t, &shortReader{data: map[string][]byte{c.String(): data}})
+
+	stat := &httpapi.PathStatResponse{Kind: "file", StorageKind: "raw", Key: c.String()}
+	_, err := srv.readContentPayload(context.Background(), nil, stat, c, -1, 1)
+	if err == nil {
+		t.Fatal("expected error for negative start")
+	}
+}

--- a/server/routes_unixfs_compat.go
+++ b/server/routes_unixfs_compat.go
@@ -69,8 +69,16 @@ func (s *Server) handleUnixFSWrite(w http.ResponseWriter, r *http.Request, root 
 		return
 	}
 
+	// File uploads are buffered before chunking, so cap them with the
+	// configured upload limit. Anything beyond the limit returns 413 instead
+	// of OOM-ing the daemon.
+	s.limitUnixFSUpload(w, r)
 	newRoot, err := layout.AddFileStream(r.Context(), baseRoot, p, r.Body)
 	if err != nil {
+		if isMaxBytesError(err) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/server/routes_verify.go
+++ b/server/routes_verify.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/dewebprotocol/malt/api/http"
@@ -14,9 +13,8 @@ func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.limitJSONBody(w, r)
 	var req httpapi.VerifyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := s.decodeJSONBody(w, r, &req); err != nil {
 		writeBodyDecodeError(w, err)
 		return
 	}

--- a/server/routes_verify.go
+++ b/server/routes_verify.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/dewebprotocol/malt/api/http"
@@ -15,9 +14,10 @@ func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.limitJSONBody(w, r)
 	var req httpapi.VerifyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		writeBodyDecodeError(w, err)
 		return
 	}
 	valid, err := (proofVerifier{runtime: svc.runtime}).VerifyProofList(req.ProofList)

--- a/server/routes_write.go
+++ b/server/routes_write.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/dewebprotocol/malt/api/http"
@@ -21,9 +20,10 @@ func (s *Server) handleSemanticMutation(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	s.limitJSONBody(w, r)
 	var req httpapi.SemanticMutationRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		writeBodyDecodeError(w, err)
 		return
 	}
 
@@ -58,9 +58,10 @@ func (s *Server) handleCreateStructure(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.limitJSONBody(w, r)
 	var req httpapi.CreateStructureRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		writeBodyDecodeError(w, err)
 		return
 	}
 	if len(req.Arcs) == 0 {

--- a/server/routes_write.go
+++ b/server/routes_write.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/dewebprotocol/malt/api/http"
@@ -20,9 +19,8 @@ func (s *Server) handleSemanticMutation(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	s.limitJSONBody(w, r)
 	var req httpapi.SemanticMutationRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := s.decodeJSONBody(w, r, &req); err != nil {
 		writeBodyDecodeError(w, err)
 		return
 	}
@@ -58,9 +56,8 @@ func (s *Server) handleCreateStructure(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.limitJSONBody(w, r)
 	var req httpapi.CreateStructureRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := s.decodeJSONBody(w, r, &req); err != nil {
 		writeBodyDecodeError(w, err)
 		return
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dewebprotocol/malt/api/http"
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -17,12 +18,75 @@ import (
 
 const defaultRootGraphID = "default"
 
+// Conservative HTTP server hardening defaults. These are intentionally generous
+// for normal MALT workloads (large UnixFS uploads, slow CAS materialization)
+// but tight enough to keep a single misbehaving client from holding sockets
+// open indefinitely (slowloris) or burying the daemon under one giant header
+// stream.
+//
+// Callers that need different limits can override them via the
+// WithServerLimits option; tests in particular use much shorter timeouts.
+const (
+	// DefaultReadHeaderTimeout caps how long a client has to send the request
+	// line and headers. Bodies are read separately and may be longer-lived.
+	DefaultReadHeaderTimeout = 10 * time.Second
+
+	// DefaultIdleTimeout caps how long an idle keep-alive connection stays
+	// open between requests.
+	DefaultIdleTimeout = 60 * time.Second
+
+	// DefaultReadTimeout caps the total time for reading the request,
+	// including the body. Long uploads and JSON payloads may need this raised
+	// at the operator level.
+	DefaultReadTimeout = 5 * time.Minute
+
+	// DefaultWriteTimeout caps the total time spent writing a response back
+	// to a client. Range reads of very large list payloads may need this
+	// raised.
+	DefaultWriteTimeout = 5 * time.Minute
+
+	// DefaultMaxHeaderBytes caps total header size to prevent header-flood
+	// abuse and keep ProofList headers from silently exploding.
+	DefaultMaxHeaderBytes = 64 * 1024
+)
+
+// ServerLimits configures HTTP-level resource bounds for the daemon server.
+// Zero values fall back to the defaults above.
+type ServerLimits struct {
+	ReadHeaderTimeout time.Duration
+	ReadTimeout       time.Duration
+	WriteTimeout      time.Duration
+	IdleTimeout       time.Duration
+	MaxHeaderBytes    int
+}
+
+func (l ServerLimits) withDefaults() ServerLimits {
+	if l.ReadHeaderTimeout <= 0 {
+		l.ReadHeaderTimeout = DefaultReadHeaderTimeout
+	}
+	if l.IdleTimeout <= 0 {
+		l.IdleTimeout = DefaultIdleTimeout
+	}
+	if l.ReadTimeout <= 0 {
+		l.ReadTimeout = DefaultReadTimeout
+	}
+	if l.WriteTimeout <= 0 {
+		l.WriteTimeout = DefaultWriteTimeout
+	}
+	if l.MaxHeaderBytes <= 0 {
+		l.MaxHeaderBytes = DefaultMaxHeaderBytes
+	}
+	return l
+}
+
 // Server serves the daemon HTTP API.
 type Server struct {
 	node           *node.Node
 	addr           string
 	lifecycleToken string
 	browserOrigins *browserOriginPolicy
+	limits         ServerLimits
+	bodyLimits     BodyLimits
 	server         *http.Server
 	defaultGraph   runtimeGraph
 	graphMu        sync.Mutex
@@ -47,6 +111,15 @@ func WithBrowserOrigins(origins []string) Option {
 	}
 }
 
+// WithServerLimits overrides the default HTTP-level resource bounds. Any zero
+// field falls back to the package defaults; this lets callers tune one knob
+// without restating the rest.
+func WithServerLimits(limits ServerLimits) Option {
+	return func(s *Server) {
+		s.limits = limits
+	}
+}
+
 // New creates a new daemon server.
 func New(node *node.Node, addr string, opts ...Option) *Server {
 	s := &Server{
@@ -56,6 +129,8 @@ func New(node *node.Node, addr string, opts ...Option) *Server {
 	for _, opt := range opts {
 		opt(s)
 	}
+	s.limits = s.limits.withDefaults()
+	s.bodyLimits = s.bodyLimits.withDefaults()
 	return s
 }
 
@@ -79,8 +154,13 @@ func (s *Server) Handler() http.Handler {
 // Start starts the HTTP server.
 func (s *Server) Start() error {
 	s.server = &http.Server{
-		Addr:    s.addr,
-		Handler: s.Handler(),
+		Addr:              s.addr,
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: s.limits.ReadHeaderTimeout,
+		ReadTimeout:       s.limits.ReadTimeout,
+		WriteTimeout:      s.limits.WriteTimeout,
+		IdleTimeout:       s.limits.IdleTimeout,
+		MaxHeaderBytes:    s.limits.MaxHeaderBytes,
 	}
 	return s.server.ListenAndServe()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -153,7 +153,15 @@ func (s *Server) Handler() http.Handler {
 
 // Start starts the HTTP server.
 func (s *Server) Start() error {
-	s.server = &http.Server{
+	s.server = s.buildHTTPServer()
+	return s.server.ListenAndServe()
+}
+
+// buildHTTPServer constructs the *http.Server with the configured limits
+// applied. It is split out so tests can verify timeout propagation without
+// racing against a goroutine that calls ListenAndServe.
+func (s *Server) buildHTTPServer() *http.Server {
+	return &http.Server{
 		Addr:              s.addr,
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: s.limits.ReadHeaderTimeout,
@@ -162,7 +170,6 @@ func (s *Server) Start() error {
 		IdleTimeout:       s.limits.IdleTimeout,
 		MaxHeaderBytes:    s.limits.MaxHeaderBytes,
 	}
-	return s.server.ListenAndServe()
 }
 
 // Shutdown gracefully stops the HTTP server.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2820,6 +2820,9 @@ func newTestNode(t *testing.T) *node.Node {
 	n, err := node.NewNode(
 		node.WithConfig(cfg),
 		node.WithCAS(casmock.NewCAS()),
+		// Tests below type-assert node.CAS() back to *casmock.CAS, so disable
+		// the daemon's default CID-verifying wrapper for the mock reader.
+		node.WithoutCASVerification(),
 	)
 	if err != nil {
 		t.Fatalf("create test node: %v", err)

--- a/storage/cas/verifying.go
+++ b/storage/cas/verifying.go
@@ -97,22 +97,32 @@ func (v *VerifyingReader) HasBatch(ctx context.Context, cids []cid.Cid) ([]bool,
 // error so callers can distinguish "not configured" from "rejected".
 var errReadOnlyCAS = errors.New("cas: underlying reader does not support writes")
 
-// Put forwards to the inner reader if it implements Writer. The verifying
-// wrapper does not gate writes because content addressing already guarantees
-// integrity: the writer derives the CID from the bytes it just stored.
+// Put forwards to the inner reader if it implements Writer and verifies the
+// returned CID actually matches the bytes that were written. A malicious
+// remote CAS that swaps in a fabricated CID at upload time would otherwise
+// let a MALT root reference content the writer never produced.
 func (v *VerifyingReader) Put(ctx context.Context, data []byte) (cid.Cid, error) {
 	w, ok := v.inner.(Writer)
 	if !ok {
 		return cid.Undef, errReadOnlyCAS
 	}
-	return w.Put(ctx, data)
+	got, err := w.Put(ctx, data)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return verifyPutResult(got, data)
 }
 
-// PutWithCodec forwards to the inner reader if it implements TypedWriter.
-// Falls back to Put for cid.Raw when typed writes are unavailable.
+// PutWithCodec forwards to the inner reader if it implements TypedWriter and
+// verifies the returned CID actually matches the bytes plus codec that were
+// written. Falls back to Put for cid.Raw when typed writes are unavailable.
 func (v *VerifyingReader) PutWithCodec(ctx context.Context, data []byte, codec uint64) (cid.Cid, error) {
 	if tw, ok := v.inner.(TypedWriter); ok {
-		return tw.PutWithCodec(ctx, data, codec)
+		got, err := tw.PutWithCodec(ctx, data, codec)
+		if err != nil {
+			return cid.Undef, err
+		}
+		return verifyPutResult(got, data)
 	}
 	if NormalizeCodec(codec) == cid.Raw {
 		return v.Put(ctx, data)
@@ -120,22 +130,78 @@ func (v *VerifyingReader) PutWithCodec(ctx context.Context, data []byte, codec u
 	return cid.Undef, errReadOnlyCAS
 }
 
-// PutBatch forwards to the inner reader if it implements BatchWriter.
-// Otherwise falls back to per-block PutWithCodec via the cas package's
-// PutBlocks helper, exactly as cas.PutBlocks does for non-batch writers.
-//
-// The fallback dispatches against the inner Writer (not the wrapper itself)
-// because PutBlocks routes BatchWriter implementations through their own
-// PutBatch; passing v back into PutBlocks would recurse forever.
+// PutBatch forwards to the inner reader if it implements BatchWriter, then
+// verifies every successfully-stored CID against its source bytes. The
+// non-batch fallback dispatches per-block through the wrapper's verifying
+// PutWithCodec so corrupt CIDs are rejected at the same boundary as the
+// batch path.
 func (v *VerifyingReader) PutBatch(ctx context.Context, blocks []Block) ([]PutResult, error) {
-	if bw, ok := v.inner.(BatchWriter); ok {
-		return bw.PutBatch(ctx, blocks)
+	if len(blocks) == 0 {
+		return []PutResult{}, nil
 	}
-	w, ok := v.inner.(Writer)
-	if !ok {
+	if bw, ok := v.inner.(BatchWriter); ok {
+		results, err := bw.PutBatch(ctx, blocks)
+		if err != nil {
+			return nil, err
+		}
+		if err := verifyBatchResults(blocks, results); err != nil {
+			return nil, err
+		}
+		return results, nil
+	}
+	if _, ok := v.inner.(Writer); !ok {
 		return nil, errReadOnlyCAS
 	}
-	return PutBlocks(ctx, w, blocks)
+	results := make([]PutResult, len(blocks))
+	for i, b := range blocks {
+		codec := NormalizeCodec(b.Codec)
+		got, err := v.PutWithCodec(ctx, b.Data, codec)
+		if err != nil {
+			return nil, err
+		}
+		results[i] = PutResult{CID: got, Status: PutStatusStored}
+	}
+	return results, nil
+}
+
+// verifyPutResult recomputes the CID a writer claims to have stored and
+// rejects with ErrCorruptedBlock if the claim does not match the bytes.
+// undefined CIDs always fail; the writer must commit to a content address.
+func verifyPutResult(got cid.Cid, data []byte) (cid.Cid, error) {
+	if !got.Defined() {
+		return cid.Undef, fmt.Errorf("%w: writer returned undefined CID", ErrCorruptedBlock)
+	}
+	want, err := cidForData(got, data)
+	if err != nil {
+		return cid.Undef, fmt.Errorf("%w: %v", ErrCorruptedBlock, err)
+	}
+	if !want.Equals(got) {
+		return cid.Undef, fmt.Errorf("%w: writer claimed %s for bytes whose CID is %s", ErrCorruptedBlock, got, want)
+	}
+	return got, nil
+}
+
+// verifyBatchResults walks parallel slices of input blocks and writer
+// results, recomputing the CID for every result entry. PutResult has no
+// per-entry error channel: any failure is reported as the top-level error
+// from PutBatch, so all returned entries are claims of "stored" that the
+// wrapper must validate.
+func verifyBatchResults(blocks []Block, results []PutResult) error {
+	if len(results) != len(blocks) {
+		return fmt.Errorf("%w: writer returned %d results for %d blocks", ErrCorruptedBlock, len(results), len(blocks))
+	}
+	for i, r := range results {
+		if !r.CID.Defined() {
+			// A skipped or sentinel result with no CID has nothing to
+			// verify; let it pass through unchanged so existing dedup
+			// behavior in batch writers stays observable.
+			continue
+		}
+		if _, err := verifyPutResult(r.CID, blocks[i].Data); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SnapshotStats forwards to the inner reader if it provides a metrics

--- a/storage/cas/verifying.go
+++ b/storage/cas/verifying.go
@@ -1,0 +1,164 @@
+package cas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	cid "github.com/ipfs/go-cid"
+)
+
+// ErrCorruptedBlock is returned when a CAS Get returns bytes whose multihash
+// does not match the requested CID. The MALT trust model treats CAS as
+// untrusted execution state (see ARCHITECTURE.md, section "Trust Model"); a
+// reader that does not verify hashes lets a compromised CAS substitute
+// arbitrary content underneath ProofList header guarantees.
+var ErrCorruptedBlock = errors.New("cas: returned block does not match requested CID")
+
+// VerifyingReader wraps a CAS Reader and validates that bytes returned by Get
+// hash to the requested CID. It also forwards Has unchanged and, if the
+// underlying reader implements BatchReader, exposes HasBatch.
+//
+// The verification is intentionally cheap: it reuses the multihash carried in
+// the requested CID, recomputes it over the returned bytes, and rejects on
+// mismatch. Callers that want to skip verification (for example for
+// non-content-addressed identifiers) must call the underlying reader
+// directly.
+type VerifyingReader struct {
+	inner Reader
+}
+
+// NewVerifyingReader wraps r so that Get verifies returned bytes against the
+// requested CID. A nil inner reader is treated as a programming error.
+func NewVerifyingReader(r Reader) *VerifyingReader {
+	if r == nil {
+		panic("cas: NewVerifyingReader called with nil reader")
+	}
+	return &VerifyingReader{inner: r}
+}
+
+// Inner returns the wrapped reader, useful for tests and adapters that need
+// to bypass verification deliberately.
+func (v *VerifyingReader) Inner() Reader {
+	return v.inner
+}
+
+// Get returns the bytes for c only if their multihash matches c. Returned
+// errors from the underlying reader are propagated unchanged; verification
+// failures are wrapped with ErrCorruptedBlock so callers can identify them
+// with errors.Is.
+func (v *VerifyingReader) Get(ctx context.Context, c cid.Cid) ([]byte, error) {
+	if !c.Defined() {
+		// Refuse to issue a Get for an undefined CID at all. There is no
+		// hash to validate against, and any returned bytes would be
+		// indistinguishable from forged content.
+		return nil, fmt.Errorf("%w: undefined CID", ErrCorruptedBlock)
+	}
+	data, err := v.inner.Get(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	got, err := cidForData(c, data)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCorruptedBlock, err)
+	}
+	if !got.Equals(c) {
+		return nil, fmt.Errorf("%w: got %s want %s", ErrCorruptedBlock, got.String(), c.String())
+	}
+	return data, nil
+}
+
+// Has forwards to the underlying reader.
+func (v *VerifyingReader) Has(ctx context.Context, c cid.Cid) (bool, error) {
+	return v.inner.Has(ctx, c)
+}
+
+// HasBatch forwards when the underlying reader supports it. Implementations
+// that do not implement BatchReader fall through to per-CID Has checks via
+// the cas package contract elsewhere; here we only forward the optimization.
+func (v *VerifyingReader) HasBatch(ctx context.Context, cids []cid.Cid) ([]bool, error) {
+	if br, ok := v.inner.(BatchReader); ok {
+		return br.HasBatch(ctx, cids)
+	}
+	results := make([]bool, len(cids))
+	for i, c := range cids {
+		ok, err := v.inner.Has(ctx, c)
+		if err != nil {
+			return nil, err
+		}
+		results[i] = ok
+	}
+	return results, nil
+}
+
+// errReadOnlyCAS is returned when a write method is called against a wrapper
+// whose inner reader does not support that write surface. Tests inject
+// pure-reader CAS implementations (mock.shortReader, etc.); we expose the
+// error so callers can distinguish "not configured" from "rejected".
+var errReadOnlyCAS = errors.New("cas: underlying reader does not support writes")
+
+// Put forwards to the inner reader if it implements Writer. The verifying
+// wrapper does not gate writes because content addressing already guarantees
+// integrity: the writer derives the CID from the bytes it just stored.
+func (v *VerifyingReader) Put(ctx context.Context, data []byte) (cid.Cid, error) {
+	w, ok := v.inner.(Writer)
+	if !ok {
+		return cid.Undef, errReadOnlyCAS
+	}
+	return w.Put(ctx, data)
+}
+
+// PutWithCodec forwards to the inner reader if it implements TypedWriter.
+// Falls back to Put for cid.Raw when typed writes are unavailable.
+func (v *VerifyingReader) PutWithCodec(ctx context.Context, data []byte, codec uint64) (cid.Cid, error) {
+	if tw, ok := v.inner.(TypedWriter); ok {
+		return tw.PutWithCodec(ctx, data, codec)
+	}
+	if NormalizeCodec(codec) == cid.Raw {
+		return v.Put(ctx, data)
+	}
+	return cid.Undef, errReadOnlyCAS
+}
+
+// PutBatch forwards to the inner reader if it implements BatchWriter.
+// Otherwise falls back to per-block PutWithCodec via the cas package's
+// PutBlocks helper, exactly as cas.PutBlocks does for non-batch writers.
+//
+// The fallback dispatches against the inner Writer (not the wrapper itself)
+// because PutBlocks routes BatchWriter implementations through their own
+// PutBatch; passing v back into PutBlocks would recurse forever.
+func (v *VerifyingReader) PutBatch(ctx context.Context, blocks []Block) ([]PutResult, error) {
+	if bw, ok := v.inner.(BatchWriter); ok {
+		return bw.PutBatch(ctx, blocks)
+	}
+	w, ok := v.inner.(Writer)
+	if !ok {
+		return nil, errReadOnlyCAS
+	}
+	return PutBlocks(ctx, w, blocks)
+}
+
+// SnapshotStats forwards to the inner reader if it provides a metrics
+// snapshot. This keeps the metrics pipeline transparent through the wrapper.
+func (v *VerifyingReader) SnapshotStats() Stats {
+	if s, ok := v.inner.(interface{ SnapshotStats() Stats }); ok {
+		return s.SnapshotStats()
+	}
+	return Stats{}
+}
+
+// ResetStats forwards to the inner reader when supported.
+func (v *VerifyingReader) ResetStats() {
+	if r, ok := v.inner.(interface{ ResetStats() }); ok {
+		r.ResetStats()
+	}
+}
+
+// cidForData recomputes the CID for data using the same codec and multihash
+// algorithm as the requested CID. Reusing the requested CID's prefix keeps
+// the comparison meaningful even for non-default codecs (DAG-CBOR, DAG-JSON,
+// etc.).
+func cidForData(want cid.Cid, data []byte) (cid.Cid, error) {
+	prefix := want.Prefix()
+	return prefix.Sum(data)
+}

--- a/storage/cas/verifying.go
+++ b/storage/cas/verifying.go
@@ -100,7 +100,8 @@ var errReadOnlyCAS = errors.New("cas: underlying reader does not support writes"
 // Put forwards to the inner reader if it implements Writer and verifies the
 // returned CID actually matches the bytes that were written. A malicious
 // remote CAS that swaps in a fabricated CID at upload time would otherwise
-// let a MALT root reference content the writer never produced.
+// let a MALT root reference content the writer never produced. cas.Writer
+// is the codec-less surface, so the requested codec is implicitly cid.Raw.
 func (v *VerifyingReader) Put(ctx context.Context, data []byte) (cid.Cid, error) {
 	w, ok := v.inner.(Writer)
 	if !ok {
@@ -110,19 +111,25 @@ func (v *VerifyingReader) Put(ctx context.Context, data []byte) (cid.Cid, error)
 	if err != nil {
 		return cid.Undef, err
 	}
-	return verifyPutResult(got, data)
+	return verifyPutResult(got, data, cid.Raw)
 }
 
 // PutWithCodec forwards to the inner reader if it implements TypedWriter and
-// verifies the returned CID actually matches the bytes plus codec that were
-// written. Falls back to Put for cid.Raw when typed writes are unavailable.
+// verifies the returned CID matches the bytes plus the codec that were
+// requested. Validating against the requested codec (rather than the codec
+// the writer chose to embed in the returned CID) prevents a hostile CAS
+// from accepting typed-block bytes and committing them under a cid.Raw CID
+// — that would still hash-match the bytes but mean a downstream consumer
+// reads them with the wrong codec.
+//
+// Falls back to Put for cid.Raw when typed writes are unavailable.
 func (v *VerifyingReader) PutWithCodec(ctx context.Context, data []byte, codec uint64) (cid.Cid, error) {
 	if tw, ok := v.inner.(TypedWriter); ok {
 		got, err := tw.PutWithCodec(ctx, data, codec)
 		if err != nil {
 			return cid.Undef, err
 		}
-		return verifyPutResult(got, data)
+		return verifyPutResult(got, data, codec)
 	}
 	if NormalizeCodec(codec) == cid.Raw {
 		return v.Put(ctx, data)
@@ -131,10 +138,10 @@ func (v *VerifyingReader) PutWithCodec(ctx context.Context, data []byte, codec u
 }
 
 // PutBatch forwards to the inner reader if it implements BatchWriter, then
-// verifies every successfully-stored CID against its source bytes. The
-// non-batch fallback dispatches per-block through the wrapper's verifying
-// PutWithCodec so corrupt CIDs are rejected at the same boundary as the
-// batch path.
+// verifies every returned CID against its source bytes and the codec the
+// caller asked for. The non-batch fallback dispatches per-block through the
+// wrapper's verifying PutWithCodec so corrupt CIDs are rejected at the same
+// boundary as the batch path.
 func (v *VerifyingReader) PutBatch(ctx context.Context, blocks []Block) ([]PutResult, error) {
 	if len(blocks) == 0 {
 		return []PutResult{}, nil
@@ -164,14 +171,27 @@ func (v *VerifyingReader) PutBatch(ctx context.Context, blocks []Block) ([]PutRe
 	return results, nil
 }
 
-// verifyPutResult recomputes the CID a writer claims to have stored and
-// rejects with ErrCorruptedBlock if the claim does not match the bytes.
-// undefined CIDs always fail; the writer must commit to a content address.
-func verifyPutResult(got cid.Cid, data []byte) (cid.Cid, error) {
+// verifyPutResult recomputes the CID a writer claims to have stored against
+// the bytes it was asked to store and the codec the caller requested. It
+// rejects with ErrCorruptedBlock if the writer:
+//   - returns an undefined CID (no claim at all),
+//   - returns a CID with a codec that differs from what the caller asked
+//     for (lets a hostile CAS accept typed bytes under a cid.Raw CID, which
+//     would silently change downstream decoding),
+//   - returns a CID whose multihash does not match the stored bytes.
+//
+// requestedCodec is normalized via NormalizeCodec so callers can pass either
+// 0 or cid.Raw to mean "raw" without ambiguity.
+func verifyPutResult(got cid.Cid, data []byte, requestedCodec uint64) (cid.Cid, error) {
 	if !got.Defined() {
 		return cid.Undef, fmt.Errorf("%w: writer returned undefined CID", ErrCorruptedBlock)
 	}
-	want, err := cidForData(got, data)
+	wantCodec := NormalizeCodec(requestedCodec)
+	if got.Type() != wantCodec {
+		return cid.Undef, fmt.Errorf("%w: writer returned codec %d, requested %d", ErrCorruptedBlock, got.Type(), wantCodec)
+	}
+	prefix := got.Prefix()
+	want, err := prefix.Sum(data)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("%w: %v", ErrCorruptedBlock, err)
 	}
@@ -182,22 +202,18 @@ func verifyPutResult(got cid.Cid, data []byte) (cid.Cid, error) {
 }
 
 // verifyBatchResults walks parallel slices of input blocks and writer
-// results, recomputing the CID for every result entry. PutResult has no
-// per-entry error channel: any failure is reported as the top-level error
-// from PutBatch, so all returned entries are claims of "stored" that the
-// wrapper must validate.
+// results, recomputing the CID for every entry. The wrapper requires every
+// returned PutResult to commit to a defined CID with the codec that was
+// asked for: layout/unixfs writes the chunk list straight from the
+// PutResult slice (see layout/unixfs/layout.go), and propagating an
+// undefined or codec-mismatched CID would let a hostile or buggy CAS
+// produce a root with invalid chunk references.
 func verifyBatchResults(blocks []Block, results []PutResult) error {
 	if len(results) != len(blocks) {
 		return fmt.Errorf("%w: writer returned %d results for %d blocks", ErrCorruptedBlock, len(results), len(blocks))
 	}
 	for i, r := range results {
-		if !r.CID.Defined() {
-			// A skipped or sentinel result with no CID has nothing to
-			// verify; let it pass through unchanged so existing dedup
-			// behavior in batch writers stays observable.
-			continue
-		}
-		if _, err := verifyPutResult(r.CID, blocks[i].Data); err != nil {
+		if _, err := verifyPutResult(r.CID, blocks[i].Data, blocks[i].Codec); err != nil {
 			return err
 		}
 	}

--- a/storage/cas/verifying.go
+++ b/storage/cas/verifying.go
@@ -171,32 +171,32 @@ func (v *VerifyingReader) PutBatch(ctx context.Context, blocks []Block) ([]PutRe
 	return results, nil
 }
 
-// verifyPutResult recomputes the CID a writer claims to have stored against
-// the bytes it was asked to store and the codec the caller requested. It
-// rejects with ErrCorruptedBlock if the writer:
-//   - returns an undefined CID (no claim at all),
-//   - returns a CID with a codec that differs from what the caller asked
-//     for (lets a hostile CAS accept typed bytes under a cid.Raw CID, which
-//     would silently change downstream decoding),
-//   - returns a CID whose multihash does not match the stored bytes.
+// verifyPutResult validates that a writer's claimed CID matches the
+// canonical CID for the requested bytes and codec. The expected CID is
+// derived locally via CIDForBlock — that is the repo-wide write contract
+// (see storage/cas/cas.go: CIDv1 + SHA2-256 + NormalizeCodec). Anchoring
+// to that contract — instead of recomputing using the *returned* CID's
+// prefix — closes three classes of attack:
 //
-// requestedCodec is normalized via NormalizeCodec so callers can pass either
-// 0 or cid.Raw to mean "raw" without ambiguity.
+//   - returning a different codec for the same bytes (downstream consumers
+//     would decode with the wrong codec);
+//   - returning a CID with a weaker multihash (e.g. SHA-1) that happens to
+//     match the bytes, downgrading the integrity guarantee;
+//   - returning CIDv0 for a payload the writer was asked to store as
+//     CIDv1 (or vice versa), confusing later resolution.
+//
+// requestedCodec is normalized via NormalizeCodec so callers can pass
+// either 0 or cid.Raw to mean "raw" without ambiguity.
 func verifyPutResult(got cid.Cid, data []byte, requestedCodec uint64) (cid.Cid, error) {
 	if !got.Defined() {
 		return cid.Undef, fmt.Errorf("%w: writer returned undefined CID", ErrCorruptedBlock)
 	}
-	wantCodec := NormalizeCodec(requestedCodec)
-	if got.Type() != wantCodec {
-		return cid.Undef, fmt.Errorf("%w: writer returned codec %d, requested %d", ErrCorruptedBlock, got.Type(), wantCodec)
-	}
-	prefix := got.Prefix()
-	want, err := prefix.Sum(data)
+	want, err := CIDForBlock(Block{Data: data, Codec: requestedCodec})
 	if err != nil {
 		return cid.Undef, fmt.Errorf("%w: %v", ErrCorruptedBlock, err)
 	}
 	if !want.Equals(got) {
-		return cid.Undef, fmt.Errorf("%w: writer claimed %s for bytes whose CID is %s", ErrCorruptedBlock, got, want)
+		return cid.Undef, fmt.Errorf("%w: writer returned %s, canonical CID for the bytes is %s", ErrCorruptedBlock, got, want)
 	}
 	return got, nil
 }

--- a/storage/cas/verifying_test.go
+++ b/storage/cas/verifying_test.go
@@ -1,0 +1,402 @@
+package cas_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dewebprotocol/malt/storage/cas"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// fixedReader is a minimal cas.Reader that returns canned bytes for a
+// requested CID. It lets tests cover both the happy and tampered paths
+// without standing up the IPFS-backed mock.
+type fixedReader struct {
+	get      map[string][]byte
+	has      map[string]bool
+	getErr   error
+	hasErr   error
+	getCalls int
+	hasCalls int
+}
+
+func (r *fixedReader) Get(_ context.Context, c cid.Cid) ([]byte, error) {
+	r.getCalls++
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	data, ok := r.get[c.String()]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return data, nil
+}
+
+func (r *fixedReader) Has(_ context.Context, c cid.Cid) (bool, error) {
+	r.hasCalls++
+	if r.hasErr != nil {
+		return false, r.hasErr
+	}
+	return r.has[c.String()], nil
+}
+
+// batchedFixedReader extends fixedReader with a HasBatch implementation so we
+// can exercise the wrapper's BatchReader pass-through.
+type batchedFixedReader struct {
+	*fixedReader
+	batchCalls int
+}
+
+func (r *batchedFixedReader) HasBatch(_ context.Context, cids []cid.Cid) ([]bool, error) {
+	r.batchCalls++
+	out := make([]bool, len(cids))
+	for i, c := range cids {
+		out[i] = r.has[c.String()]
+	}
+	return out, nil
+}
+
+// statsReader exposes SnapshotStats/ResetStats so tests can confirm the
+// wrapper forwards those via interface assertions.
+type statsReader struct {
+	*fixedReader
+	snap     cas.Stats
+	resetHit int
+}
+
+func (s *statsReader) SnapshotStats() cas.Stats { return s.snap }
+func (s *statsReader) ResetStats()              { s.resetHit++ }
+
+func cidForRaw(t *testing.T, data []byte) cid.Cid {
+	t.Helper()
+	hash, err := mh.Sum(data, mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("multihash sum: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, hash)
+}
+
+func TestVerifyingReader_GetMatchingHash(t *testing.T) {
+	data := []byte("the quick brown fox")
+	c := cidForRaw(t, data)
+	inner := &fixedReader{get: map[string][]byte{c.String(): data}}
+	v := cas.NewVerifyingReader(inner)
+
+	got, err := v.Get(context.Background(), c)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("Get returned %q, want %q", got, data)
+	}
+	if inner.getCalls != 1 {
+		t.Fatalf("inner Get called %d times, want 1", inner.getCalls)
+	}
+}
+
+func TestVerifyingReader_GetTamperedBytes(t *testing.T) {
+	data := []byte("trusted contents")
+	c := cidForRaw(t, data)
+	inner := &fixedReader{get: map[string][]byte{c.String(): []byte("evil bytes")}}
+	v := cas.NewVerifyingReader(inner)
+
+	_, err := v.Get(context.Background(), c)
+	if err == nil {
+		t.Fatal("expected verification error, got nil")
+	}
+	if !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("error %v is not ErrCorruptedBlock", err)
+	}
+}
+
+func TestVerifyingReader_GetUndefinedCID(t *testing.T) {
+	inner := &fixedReader{}
+	v := cas.NewVerifyingReader(inner)
+
+	_, err := v.Get(context.Background(), cid.Undef)
+	if err == nil {
+		t.Fatal("expected error for undefined CID")
+	}
+	if !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("error %v is not ErrCorruptedBlock", err)
+	}
+	if inner.getCalls != 0 {
+		t.Fatalf("inner Get called %d times for undefined CID, want 0", inner.getCalls)
+	}
+}
+
+func TestVerifyingReader_GetUnderlyingError(t *testing.T) {
+	want := errors.New("transport blew up")
+	inner := &fixedReader{getErr: want}
+	v := cas.NewVerifyingReader(inner)
+
+	c := cidForRaw(t, []byte("x"))
+	_, err := v.Get(context.Background(), c)
+	if !errors.Is(err, want) {
+		t.Fatalf("Get returned %v, want underlying %v", err, want)
+	}
+	if errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatal("transport error should not be classified as corrupted")
+	}
+}
+
+func TestVerifyingReader_HasForwarded(t *testing.T) {
+	data := []byte("present")
+	c := cidForRaw(t, data)
+	inner := &fixedReader{has: map[string]bool{c.String(): true}}
+	v := cas.NewVerifyingReader(inner)
+
+	ok, err := v.Has(context.Background(), c)
+	if err != nil {
+		t.Fatalf("Has returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Has returned false for known block")
+	}
+	if inner.hasCalls != 1 {
+		t.Fatalf("inner Has calls = %d, want 1", inner.hasCalls)
+	}
+}
+
+func TestVerifyingReader_HasBatch_ForwardsWhenSupported(t *testing.T) {
+	data := []byte("a")
+	c := cidForRaw(t, data)
+	inner := &batchedFixedReader{
+		fixedReader: &fixedReader{has: map[string]bool{c.String(): true}},
+	}
+	v := cas.NewVerifyingReader(inner)
+
+	results, err := v.HasBatch(context.Background(), []cid.Cid{c})
+	if err != nil {
+		t.Fatalf("HasBatch returned error: %v", err)
+	}
+	if len(results) != 1 || !results[0] {
+		t.Fatalf("HasBatch results = %v, want [true]", results)
+	}
+	if inner.batchCalls != 1 {
+		t.Fatalf("inner batchCalls = %d, want 1", inner.batchCalls)
+	}
+	if inner.hasCalls != 0 {
+		t.Fatalf("inner hasCalls = %d, want 0 (BatchReader path)", inner.hasCalls)
+	}
+}
+
+func TestVerifyingReader_HasBatch_FallbackToHas(t *testing.T) {
+	data := []byte("b")
+	c := cidForRaw(t, data)
+	missing := cidForRaw(t, []byte("missing"))
+	inner := &fixedReader{
+		has: map[string]bool{c.String(): true},
+	}
+	v := cas.NewVerifyingReader(inner)
+
+	results, err := v.HasBatch(context.Background(), []cid.Cid{c, missing})
+	if err != nil {
+		t.Fatalf("HasBatch returned error: %v", err)
+	}
+	if len(results) != 2 || !results[0] || results[1] {
+		t.Fatalf("HasBatch results = %v, want [true,false]", results)
+	}
+	if inner.hasCalls != 2 {
+		t.Fatalf("inner Has calls = %d, want 2", inner.hasCalls)
+	}
+}
+
+func TestVerifyingReader_StatsForwarded(t *testing.T) {
+	inner := &statsReader{
+		fixedReader: &fixedReader{},
+		snap:        cas.Stats{GetCount: 7, BytesGet: 99},
+	}
+	v := cas.NewVerifyingReader(inner)
+	if got := v.SnapshotStats(); got != inner.snap {
+		t.Fatalf("SnapshotStats = %+v, want %+v", got, inner.snap)
+	}
+	v.ResetStats()
+	if inner.resetHit != 1 {
+		t.Fatalf("ResetStats forwarded %d times, want 1", inner.resetHit)
+	}
+}
+
+func TestVerifyingReader_StatsAbsentReader(t *testing.T) {
+	v := cas.NewVerifyingReader(&fixedReader{})
+	// Should not panic and should return a zero snapshot.
+	if got := v.SnapshotStats(); got != (cas.Stats{}) {
+		t.Fatalf("SnapshotStats on plain reader = %+v, want zero", got)
+	}
+	v.ResetStats() // no-op when inner reader has no Reset hook
+}
+
+func TestVerifyingReader_InnerExposed(t *testing.T) {
+	inner := &fixedReader{}
+	v := cas.NewVerifyingReader(inner)
+	if v.Inner() != inner {
+		t.Fatal("Inner did not return wrapped reader")
+	}
+}
+
+func TestNewVerifyingReader_NilPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on nil reader")
+		}
+	}()
+	_ = cas.NewVerifyingReader(nil)
+}
+
+func TestVerifyingReader_RewrapIsIdempotent(t *testing.T) {
+	// The wrapper does not strip its own type when wrapped twice. Confirm it
+	// still functions correctly when fed its own output (defense in depth).
+	data := []byte("once")
+	c := cidForRaw(t, data)
+	inner := &fixedReader{get: map[string][]byte{c.String(): data}}
+	v := cas.NewVerifyingReader(inner)
+	doubled := cas.NewVerifyingReader(v)
+
+	got, err := doubled.Get(context.Background(), c)
+	if err != nil {
+		t.Fatalf("doubled Get error: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("doubled Get = %q, want %q", got, data)
+	}
+}
+
+// writingReader is the read+write surface tests need to exercise the
+// VerifyingReader's write-forwarding path.
+type writingReader struct {
+	*fixedReader
+	put       []byte
+	putCodec  uint64
+	putErr    error
+	batchHits int
+}
+
+func (w *writingReader) Put(_ context.Context, data []byte) (cid.Cid, error) {
+	if w.putErr != nil {
+		return cid.Undef, w.putErr
+	}
+	w.put = append([]byte(nil), data...)
+	w.putCodec = cid.Raw
+	return cidForRawData(data), nil
+}
+
+func (w *writingReader) PutWithCodec(_ context.Context, data []byte, codec uint64) (cid.Cid, error) {
+	if w.putErr != nil {
+		return cid.Undef, w.putErr
+	}
+	w.put = append([]byte(nil), data...)
+	w.putCodec = codec
+	return cidForRawData(data), nil
+}
+
+func (w *writingReader) PutBatch(_ context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	w.batchHits++
+	results := make([]cas.PutResult, len(blocks))
+	for i, b := range blocks {
+		results[i] = cas.PutResult{CID: cidForRawData(b.Data), Status: cas.PutStatusStored}
+	}
+	return results, nil
+}
+
+func cidForRawData(data []byte) cid.Cid {
+	hash, err := mh.Sum(data, mh.SHA2_256, -1)
+	if err != nil {
+		panic(err)
+	}
+	return cid.NewCidV1(cid.Raw, hash)
+}
+
+func TestVerifyingReader_PutForwardsWhenInnerImplementsWriter(t *testing.T) {
+	inner := &writingReader{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	got, err := v.Put(context.Background(), []byte("payload"))
+	if err != nil {
+		t.Fatalf("Put returned error: %v", err)
+	}
+	if !got.Equals(cidForRawData([]byte("payload"))) {
+		t.Fatalf("Put returned unexpected CID %s", got)
+	}
+	if string(inner.put) != "payload" {
+		t.Fatalf("inner did not record Put, got %q", inner.put)
+	}
+}
+
+func TestVerifyingReader_PutWithCodec_ForwardsTypedWriter(t *testing.T) {
+	inner := &writingReader{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	const customCodec uint64 = 0x300005
+	if _, err := v.PutWithCodec(context.Background(), []byte("p"), customCodec); err != nil {
+		t.Fatalf("PutWithCodec error: %v", err)
+	}
+	if inner.putCodec != customCodec {
+		t.Fatalf("inner codec = %x, want %x", inner.putCodec, customCodec)
+	}
+}
+
+func TestVerifyingReader_PutWithCodec_RawFallsBackToPut(t *testing.T) {
+	inner := &writingReader{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	if _, err := v.PutWithCodec(context.Background(), []byte("p"), cid.Raw); err != nil {
+		t.Fatalf("PutWithCodec(Raw) error: %v", err)
+	}
+}
+
+func TestVerifyingReader_PutOnPureReader_Errors(t *testing.T) {
+	inner := &fixedReader{}
+	v := cas.NewVerifyingReader(inner)
+	if _, err := v.Put(context.Background(), []byte("nope")); err == nil {
+		t.Fatal("expected Put error against pure-reader inner")
+	}
+	if _, err := v.PutWithCodec(context.Background(), []byte("nope"), 0x71); err == nil {
+		t.Fatal("expected PutWithCodec error against pure-reader inner")
+	}
+	if _, err := v.PutBatch(context.Background(), []cas.Block{{Data: []byte{1}}}); err == nil {
+		t.Fatal("expected PutBatch error against pure-reader inner")
+	}
+}
+
+func TestVerifyingReader_PutBatchForwardsWhenInnerSupports(t *testing.T) {
+	inner := &writingReader{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	blocks := []cas.Block{{Data: []byte("a"), Codec: cid.Raw}}
+	results, err := v.PutBatch(context.Background(), blocks)
+	if err != nil {
+		t.Fatalf("PutBatch returned error: %v", err)
+	}
+	if inner.batchHits != 1 {
+		t.Fatalf("inner.batchHits = %d, want 1 (BatchWriter path)", inner.batchHits)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %v, want 1", results)
+	}
+}
+
+// nonBatchWriter exposes Put but not PutBatch, exercising the fallback
+// path that calls cas.PutBlocks via the wrapper.
+type nonBatchWriter struct {
+	*fixedReader
+	puts [][]byte
+}
+
+func (n *nonBatchWriter) Put(_ context.Context, data []byte) (cid.Cid, error) {
+	n.puts = append(n.puts, append([]byte(nil), data...))
+	return cidForRawData(data), nil
+}
+
+func TestVerifyingReader_PutBatchFallsBackToPerBlockPut(t *testing.T) {
+	inner := &nonBatchWriter{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	blocks := []cas.Block{
+		{Data: []byte("alpha"), Codec: cid.Raw},
+		{Data: []byte("beta"), Codec: cid.Raw},
+	}
+	results, err := v.PutBatch(context.Background(), blocks)
+	if err != nil {
+		t.Fatalf("PutBatch error: %v", err)
+	}
+	if len(results) != 2 || len(inner.puts) != 2 {
+		t.Fatalf("expected 2 per-block writes, got results=%d puts=%d", len(results), len(inner.puts))
+	}
+}

--- a/storage/cas/verifying_test.go
+++ b/storage/cas/verifying_test.go
@@ -400,3 +400,201 @@ func TestVerifyingReader_PutBatchFallsBackToPerBlockPut(t *testing.T) {
 		t.Fatalf("expected 2 per-block writes, got results=%d puts=%d", len(results), len(inner.puts))
 	}
 }
+
+// lyingWriter is a writer that returns CIDs unrelated to the bytes it was
+// asked to store. The verifying wrapper must reject those CIDs so a
+// downstream root commitment cannot point at content the writer never
+// produced.
+type lyingWriter struct {
+	*fixedReader
+	cidOverride cid.Cid
+	codec       uint64
+	codecHit    uint64
+	calls       int
+}
+
+func (w *lyingWriter) Put(_ context.Context, _ []byte) (cid.Cid, error) {
+	w.calls++
+	w.codecHit = cid.Raw
+	return w.cidOverride, nil
+}
+
+func (w *lyingWriter) PutWithCodec(_ context.Context, _ []byte, codec uint64) (cid.Cid, error) {
+	w.calls++
+	w.codecHit = codec
+	return w.cidOverride, nil
+}
+
+func TestVerifyingReader_Put_RejectsLyingWriter(t *testing.T) {
+	// Writer returns a CID for completely different bytes — what a
+	// compromised remote CAS could do during upload.
+	bogusCID := cidForRawData([]byte("not the bytes we wrote"))
+	inner := &lyingWriter{fixedReader: &fixedReader{}, cidOverride: bogusCID}
+	v := cas.NewVerifyingReader(inner)
+
+	_, err := v.Put(context.Background(), []byte("real content"))
+	if err == nil {
+		t.Fatal("expected ErrCorruptedBlock for lying writer")
+	}
+	if !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("error %v is not ErrCorruptedBlock", err)
+	}
+	if inner.calls != 1 {
+		t.Fatalf("inner Put calls = %d, want 1", inner.calls)
+	}
+}
+
+func TestVerifyingReader_PutWithCodec_RejectsLyingWriter(t *testing.T) {
+	const codec uint64 = 0x71 // dag-cbor
+	// Build a CID with the correct codec but for unrelated bytes.
+	hash, _ := mh.Sum([]byte("forged"), mh.SHA2_256, -1)
+	bogusCID := cid.NewCidV1(codec, hash)
+	inner := &lyingWriter{fixedReader: &fixedReader{}, cidOverride: bogusCID, codec: codec}
+	v := cas.NewVerifyingReader(inner)
+
+	_, err := v.PutWithCodec(context.Background(), []byte("genuine"), codec)
+	if err == nil {
+		t.Fatal("expected ErrCorruptedBlock for lying typed writer")
+	}
+	if !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("error %v is not ErrCorruptedBlock", err)
+	}
+}
+
+func TestVerifyingReader_Put_RejectsUndefinedReturnedCID(t *testing.T) {
+	inner := &lyingWriter{fixedReader: &fixedReader{}, cidOverride: cid.Undef}
+	v := cas.NewVerifyingReader(inner)
+	_, err := v.Put(context.Background(), []byte("anything"))
+	if err == nil || !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("expected ErrCorruptedBlock for undefined CID, got %v", err)
+	}
+}
+
+// honestBatchWriter computes correct CIDs for every block it is asked to
+// store; pairs with the lying counterpart to exercise PutBatch verification.
+type honestBatchWriter struct {
+	*fixedReader
+}
+
+func (h *honestBatchWriter) PutBatch(_ context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	results := make([]cas.PutResult, len(blocks))
+	for i, b := range blocks {
+		results[i] = cas.PutResult{CID: cidForRawData(b.Data), Status: cas.PutStatusStored}
+	}
+	return results, nil
+}
+
+func TestVerifyingReader_PutBatch_AcceptsHonestBatchWriter(t *testing.T) {
+	inner := &honestBatchWriter{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	blocks := []cas.Block{
+		{Data: []byte("a"), Codec: cid.Raw},
+		{Data: []byte("b"), Codec: cid.Raw},
+	}
+	results, err := v.PutBatch(context.Background(), blocks)
+	if err != nil {
+		t.Fatalf("PutBatch error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+}
+
+// lyingBatchWriter produces CIDs for one block that do not match the bytes,
+// simulating a partially-compromised upload pipeline.
+type lyingBatchWriter struct {
+	*fixedReader
+}
+
+func (l *lyingBatchWriter) PutBatch(_ context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	results := make([]cas.PutResult, len(blocks))
+	for i, b := range blocks {
+		if i == 1 {
+			results[i] = cas.PutResult{CID: cidForRawData([]byte("forged")), Status: cas.PutStatusStored}
+			continue
+		}
+		results[i] = cas.PutResult{CID: cidForRawData(b.Data), Status: cas.PutStatusStored}
+	}
+	return results, nil
+}
+
+func TestVerifyingReader_PutBatch_RejectsLyingBatchWriter(t *testing.T) {
+	inner := &lyingBatchWriter{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	blocks := []cas.Block{
+		{Data: []byte("a"), Codec: cid.Raw},
+		{Data: []byte("b"), Codec: cid.Raw},
+	}
+	_, err := v.PutBatch(context.Background(), blocks)
+	if err == nil {
+		t.Fatal("expected ErrCorruptedBlock for lying batch writer")
+	}
+	if !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("error %v is not ErrCorruptedBlock", err)
+	}
+}
+
+// shortBatchWriter returns fewer results than blocks, mimicking a writer
+// that drops entries silently.
+type shortBatchWriter struct {
+	*fixedReader
+}
+
+func (s *shortBatchWriter) PutBatch(_ context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	results := make([]cas.PutResult, len(blocks)-1)
+	for i := range results {
+		results[i] = cas.PutResult{CID: cidForRawData(blocks[i].Data), Status: cas.PutStatusStored}
+	}
+	return results, nil
+}
+
+func TestVerifyingReader_PutBatch_RejectsShortResultSlice(t *testing.T) {
+	inner := &shortBatchWriter{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	blocks := []cas.Block{
+		{Data: []byte("a"), Codec: cid.Raw},
+		{Data: []byte("b"), Codec: cid.Raw},
+	}
+	_, err := v.PutBatch(context.Background(), blocks)
+	if err == nil {
+		t.Fatal("expected error for short result slice")
+	}
+	if !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("error %v is not ErrCorruptedBlock", err)
+	}
+}
+
+// undefinedBatchWriter mimics a dedup-style writer that returns an undefined
+// CID for blocks it elected not to store. The verifier should let those
+// entries pass through unchanged.
+type undefinedBatchWriter struct {
+	*fixedReader
+}
+
+func (u *undefinedBatchWriter) PutBatch(_ context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	results := make([]cas.PutResult, len(blocks))
+	for i, b := range blocks {
+		if i == 1 {
+			results[i] = cas.PutResult{} // undefined CID, no claim
+			continue
+		}
+		results[i] = cas.PutResult{CID: cidForRawData(b.Data), Status: cas.PutStatusStored}
+	}
+	return results, nil
+}
+
+func TestVerifyingReader_PutBatch_PassesThroughUndefinedResults(t *testing.T) {
+	inner := &undefinedBatchWriter{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	blocks := []cas.Block{
+		{Data: []byte("a"), Codec: cid.Raw},
+		{Data: []byte("b"), Codec: cid.Raw},
+	}
+	results, err := v.PutBatch(context.Background(), blocks)
+	if err != nil {
+		t.Fatalf("PutBatch error: %v", err)
+	}
+	if results[0].CID.String() == "" || results[1].CID.Defined() {
+		t.Fatalf("results = %+v, expected first defined and second undefined", results)
+	}
+}

--- a/storage/cas/verifying_test.go
+++ b/storage/cas/verifying_test.go
@@ -288,14 +288,26 @@ func (w *writingReader) PutWithCodec(_ context.Context, data []byte, codec uint6
 	}
 	w.put = append([]byte(nil), data...)
 	w.putCodec = codec
-	return cidForRawData(data), nil
+	hash, err := mh.Sum(data, mh.SHA2_256, -1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(codec, hash), nil
 }
 
 func (w *writingReader) PutBatch(_ context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
 	w.batchHits++
 	results := make([]cas.PutResult, len(blocks))
 	for i, b := range blocks {
-		results[i] = cas.PutResult{CID: cidForRawData(b.Data), Status: cas.PutStatusStored}
+		codec := b.Codec
+		if codec == 0 {
+			codec = cid.Raw
+		}
+		hash, err := mh.Sum(b.Data, mh.SHA2_256, -1)
+		if err != nil {
+			return nil, err
+		}
+		results[i] = cas.PutResult{CID: cid.NewCidV1(codec, hash), Status: cas.PutStatusStored}
 	}
 	return results, nil
 }
@@ -564,9 +576,10 @@ func TestVerifyingReader_PutBatch_RejectsShortResultSlice(t *testing.T) {
 	}
 }
 
-// undefinedBatchWriter mimics a dedup-style writer that returns an undefined
-// CID for blocks it elected not to store. The verifier should let those
-// entries pass through unchanged.
+// undefinedBatchWriter mimics a writer that returns an undefined CID for one
+// of the blocks it was asked to store. Layout code copies PutResult.CID
+// straight into chunk lists, so an undefined CID at this layer would mean a
+// root referencing unresolvable content. The verifier must reject it.
 type undefinedBatchWriter struct {
 	*fixedReader
 }
@@ -575,7 +588,7 @@ func (u *undefinedBatchWriter) PutBatch(_ context.Context, blocks []cas.Block) (
 	results := make([]cas.PutResult, len(blocks))
 	for i, b := range blocks {
 		if i == 1 {
-			results[i] = cas.PutResult{} // undefined CID, no claim
+			results[i] = cas.PutResult{} // undefined CID — must be rejected
 			continue
 		}
 		results[i] = cas.PutResult{CID: cidForRawData(b.Data), Status: cas.PutStatusStored}
@@ -583,18 +596,68 @@ func (u *undefinedBatchWriter) PutBatch(_ context.Context, blocks []cas.Block) (
 	return results, nil
 }
 
-func TestVerifyingReader_PutBatch_PassesThroughUndefinedResults(t *testing.T) {
+func TestVerifyingReader_PutBatch_RejectsUndefinedResults(t *testing.T) {
 	inner := &undefinedBatchWriter{fixedReader: &fixedReader{}}
 	v := cas.NewVerifyingReader(inner)
 	blocks := []cas.Block{
 		{Data: []byte("a"), Codec: cid.Raw},
 		{Data: []byte("b"), Codec: cid.Raw},
 	}
-	results, err := v.PutBatch(context.Background(), blocks)
-	if err != nil {
-		t.Fatalf("PutBatch error: %v", err)
+	_, err := v.PutBatch(context.Background(), blocks)
+	if err == nil || !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("expected ErrCorruptedBlock, got %v", err)
 	}
-	if results[0].CID.String() == "" || results[1].CID.Defined() {
-		t.Fatalf("results = %+v, expected first defined and second undefined", results)
+}
+
+// rawCIDBatchWriter returns a cid.Raw CID for every block regardless of the
+// codec the caller asked for. Hash-only verification would happily accept
+// this because the bytes really do hash to that raw CID; the wrapper must
+// instead reject because the codec does not match the request.
+type rawCIDBatchWriter struct {
+	*fixedReader
+}
+
+func (r *rawCIDBatchWriter) PutBatch(_ context.Context, blocks []cas.Block) ([]cas.PutResult, error) {
+	results := make([]cas.PutResult, len(blocks))
+	for i, b := range blocks {
+		results[i] = cas.PutResult{CID: cidForRawData(b.Data), Status: cas.PutStatusStored}
+	}
+	return results, nil
+}
+
+func TestVerifyingReader_PutBatch_RejectsCodecMismatch(t *testing.T) {
+	inner := &rawCIDBatchWriter{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	blocks := []cas.Block{
+		{Data: []byte("payload"), Codec: 0x71}, // dag-cbor request
+	}
+	_, err := v.PutBatch(context.Background(), blocks)
+	if err == nil || !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("expected ErrCorruptedBlock for codec mismatch, got %v", err)
+	}
+}
+
+// codecSwappingTypedWriter accepts typed-block bytes but always returns a
+// cid.Raw CID for them. This is the single-block analog of P2-a: hash-only
+// verification would let it slip through, codec-aware verification must
+// reject it.
+type codecSwappingTypedWriter struct {
+	*fixedReader
+}
+
+func (c *codecSwappingTypedWriter) Put(_ context.Context, data []byte) (cid.Cid, error) {
+	return cidForRawData(data), nil
+}
+
+func (c *codecSwappingTypedWriter) PutWithCodec(_ context.Context, data []byte, _ uint64) (cid.Cid, error) {
+	return cidForRawData(data), nil
+}
+
+func TestVerifyingReader_PutWithCodec_RejectsCodecMismatch(t *testing.T) {
+	inner := &codecSwappingTypedWriter{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	_, err := v.PutWithCodec(context.Background(), []byte("payload"), 0x71)
+	if err == nil || !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("expected ErrCorruptedBlock for codec mismatch, got %v", err)
 	}
 }

--- a/storage/cas/verifying_test.go
+++ b/storage/cas/verifying_test.go
@@ -661,3 +661,71 @@ func TestVerifyingReader_PutWithCodec_RejectsCodecMismatch(t *testing.T) {
 		t.Fatalf("expected ErrCorruptedBlock for codec mismatch, got %v", err)
 	}
 }
+
+// weakHashTypedWriter returns a CID with the requested codec but a
+// SHA-1 multihash. The bytes really do hash to that CID under SHA-1, so
+// hash-prefix-based verification would accept it. The repo-wide write
+// contract (CIDForBlock) pins SHA-256, so the wrapper must reject this.
+type weakHashTypedWriter struct {
+	*fixedReader
+}
+
+func (w *weakHashTypedWriter) Put(_ context.Context, data []byte) (cid.Cid, error) {
+	hash, err := mh.Sum(data, mh.SHA1, -1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, hash), nil
+}
+
+func (w *weakHashTypedWriter) PutWithCodec(_ context.Context, data []byte, codec uint64) (cid.Cid, error) {
+	hash, err := mh.Sum(data, mh.SHA1, -1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(codec, hash), nil
+}
+
+func TestVerifyingReader_Put_RejectsWeakMultihash(t *testing.T) {
+	inner := &weakHashTypedWriter{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	_, err := v.Put(context.Background(), []byte("payload"))
+	if err == nil || !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("expected ErrCorruptedBlock for SHA-1 downgrade, got %v", err)
+	}
+}
+
+func TestVerifyingReader_PutWithCodec_RejectsWeakMultihash(t *testing.T) {
+	inner := &weakHashTypedWriter{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	_, err := v.PutWithCodec(context.Background(), []byte("payload"), 0x71)
+	if err == nil || !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("expected ErrCorruptedBlock for SHA-1 downgrade, got %v", err)
+	}
+}
+
+// v0CIDWriter returns a CIDv0 (dag-pb + SHA-256 + base58btc) for raw
+// uploads. CIDForBlock canonicalizes on CIDv1, so the wrapper must reject
+// any CIDv0 even if hash and bytes line up — otherwise resolution code
+// that branches on the version would see a different shape than the
+// caller asked for.
+type v0CIDWriter struct {
+	*fixedReader
+}
+
+func (vw *v0CIDWriter) Put(_ context.Context, data []byte) (cid.Cid, error) {
+	hash, err := mh.Sum(data, mh.SHA2_256, -1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV0(hash), nil
+}
+
+func TestVerifyingReader_Put_RejectsCIDv0Downgrade(t *testing.T) {
+	inner := &v0CIDWriter{fixedReader: &fixedReader{}}
+	v := cas.NewVerifyingReader(inner)
+	_, err := v.Put(context.Background(), []byte("payload"))
+	if err == nil || !errors.Is(err, cas.ErrCorruptedBlock) {
+		t.Fatalf("expected ErrCorruptedBlock for CIDv0 downgrade, got %v", err)
+	}
+}


### PR DESCRIPTION
## Why

Three high-severity findings from the recent security review of `malt/`:

- **V1** — daemon's `*http.Server` had no `ReadHeaderTimeout`, `IdleTimeout`, `WriteTimeout`, `ReadTimeout`, or `MaxHeaderBytes`. One stalled client could keep sockets parked forever (slowloris).
- **V2** — every JSON-decoding write route and the UnixFS upload path read the full request body without bounds. `AddFileStream` used `io.ReadAll` directly, so a single client could OOM the daemon with one big POST.
- **V3** — `cas.Reader.Get` returned bytes verbatim without verifying that they hashed back to the requested CID. The MALT trust model treats CAS as untrusted execution state, but the daemon happily forwarded tampered bytes to clients (ProofList headers only bind the CID, not the response body — see `ARCHITECTURE.md` § "Trust Model" and the existing TODO at lines 75–76).

## What changed

### V1 + V2 — `f2f346a`
- New `ServerLimits` and `BodyLimits` types with `WithServerLimits` / `WithBodyLimits` options. Defaults: 10s ReadHeaderTimeout, 60s IdleTimeout, 5min Read/WriteTimeout, 64 KiB MaxHeaderBytes, 8 MiB JSON body, 1 GiB UnixFS upload.
- `Server.Start` propagates the limits onto the underlying `*http.Server`.
- `limitJSONBody` and `limitUnixFSUpload` helpers install `http.MaxBytesReader` on the request body before decoding. Oversized bodies return 413 instead of being buffered into RAM.
- `writeBodyDecodeError` distinguishes `*http.MaxBytesError` from regular JSON syntax errors so monitoring can tell "too big" from "malformed".

### V3 — `31ab4c9`
- New `cas.VerifyingReader` recomputes the multihash of every `Get` response against the requested CID's prefix and rejects on mismatch (`ErrCorruptedBlock`). It also forwards `Put`, `PutWithCodec`, `PutBatch`, `HasBatch`, `SnapshotStats`, `ResetStats` when the inner reader supports them, so the wrapper still satisfies `cas.Client`.
- `runtime/node` wraps the auto-init CAS path automatically. Explicit `WithCAS(...)` (used by tests with mocks) is left untouched so type assertions like `node.CAS().(*casmock.CAS)` keep working; `WithCASVerification()` opts those callers in and `WithoutCASVerification()` is the escape hatch.
- Adjacent fix (V11): `routes_content.readContentPayload` now bounds-checks the raw slice instead of panicking when CAS bytes are shorter than the reported size.

## Tests

Added the following:

| File | What it covers |
|---|---|
| `storage/cas/verifying_test.go` | happy-path Get, tampered Get, undefined CID, transport error, Has/HasBatch forwarding, Put/PutWithCodec/PutBatch forwarding (Writer / TypedWriter / BatchWriter / per-block fallback), pure-reader rejection, stats forwarding, idempotent rewrap, nil-reader panic |
| `runtime/node/cas_verification_test.go` | auto-init wraps, explicit CAS passes through, `WithCASVerification` forces wrapping, `WithoutCASVerification` disables it, end-to-end detection of a tampered explicit CAS, idempotent helper |
| `server/limits_test.go` | default vs partial overrides for `ServerLimits` / `BodyLimits`, `New` seeds defaults, options compose, Start propagates timeouts onto the `*http.Server`, `isMaxBytesError` recognises typed/wrapped/legacy errors, `limitJSONBody` and `limitUnixFSUpload` reject oversized bodies and tolerate nil request/body, `writeBodyDecodeError` returns 413 vs 400 |
| `server/limits_handlers_test.go` | end-to-end 413 from `/verify`, `/_`, `/{root}/_mutate`, `/_unixfs` |
| `server/routes_content_bounds_test.go` | bounds check rejects oversized slice and negative start; happy range still works |

Coverage on touched code:

- `storage/cas` — new code is at 88–100% per function
- `server/limits.go` — 67–100% per function
- `runtime/node/wrapCASWithVerification` — 100%
- `server/server.Start` — 100%

`go vet ./...` clean. `go test ./... -count=1 -timeout=600s` green across all packages.

## Follow-ups (not in this PR)

The review surfaced more items that I left as separate tickets so this PR stays focused:

- V4 — `/health` exposes lifecycle token to CORS browsers
- V5 — default CORS list contains `localhost:*` wildcards
- V6 — `daemon.json` is mode 0644
- V7 — hand-rolled CBOR parser missing depth/length limits
- V8 — list payloads buffered in full before `io.Copy`
- V12 — error responses leak internal error strings
- V13 — `querypath` does not reject `..` / empty / NUL segments