### PR TITLE
Harden IPLD parsing and query paths

### DIFF
--- a/graph/querypath/path.go
+++ b/graph/querypath/path.go
@@ -3,14 +3,36 @@
 // Rules:
 //   - empty or omitted path means current root
 //   - leading "/" is accepted and removed
+//   - ".", "..", empty interior segments, and NUL bytes are rejected
 package querypath
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // CanonicalizeQueryPath normalizes a path from a stat/content query string.
 // The empty string denotes the root. Leading slashes are stripped;
-// internal path semantics are unchanged.
-func CanonicalizeQueryPath(p string) string {
+// internal path semantics are validated but otherwise unchanged.
+func CanonicalizeQueryPath(p string) (string, error) {
 	p = strings.TrimSpace(p)
-	return strings.TrimPrefix(p, "/")
+	p = strings.TrimPrefix(p, "/")
+	if p == "" {
+		return "", nil
+	}
+	if strings.ContainsRune(p, '\x00') {
+		return "", fmt.Errorf("query path contains NUL byte")
+	}
+	parts := strings.Split(p, "/")
+	for _, part := range parts {
+		switch part {
+		case "":
+			return "", fmt.Errorf("query path contains empty segment")
+		case ".":
+			return "", fmt.Errorf("query path contains current-directory segment")
+		case "..":
+			return "", fmt.Errorf("query path contains parent-directory segment")
+		}
+	}
+	return p, nil
 }

--- a/graph/querypath/path.go
+++ b/graph/querypath/path.go
@@ -7,9 +7,13 @@
 package querypath
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
+
+// ErrInvalidQueryPath identifies malformed client query paths.
+var ErrInvalidQueryPath = errors.New("invalid query path")
 
 // CanonicalizeQueryPath normalizes a path from a stat/content query string.
 // The empty string denotes the root. Leading slashes are stripped;
@@ -21,17 +25,17 @@ func CanonicalizeQueryPath(p string) (string, error) {
 		return "", nil
 	}
 	if strings.ContainsRune(p, '\x00') {
-		return "", fmt.Errorf("query path contains NUL byte")
+		return "", fmt.Errorf("%w: contains NUL byte", ErrInvalidQueryPath)
 	}
 	parts := strings.Split(p, "/")
 	for _, part := range parts {
 		switch part {
 		case "":
-			return "", fmt.Errorf("query path contains empty segment")
+			return "", fmt.Errorf("%w: contains empty segment", ErrInvalidQueryPath)
 		case ".":
-			return "", fmt.Errorf("query path contains current-directory segment")
+			return "", fmt.Errorf("%w: contains current-directory segment", ErrInvalidQueryPath)
 		case "..":
-			return "", fmt.Errorf("query path contains parent-directory segment")
+			return "", fmt.Errorf("%w: contains parent-directory segment", ErrInvalidQueryPath)
 		}
 	}
 	return p, nil

--- a/graph/querypath/path_test.go
+++ b/graph/querypath/path_test.go
@@ -17,8 +17,29 @@ func TestCanonicalizeQueryPath(t *testing.T) {
 		{"/docs/readme.md", "docs/readme.md"},
 	}
 	for _, tc := range tests {
-		if got := querypath.CanonicalizeQueryPath(tc.in); got != tc.want {
+		got, err := querypath.CanonicalizeQueryPath(tc.in)
+		if err != nil {
+			t.Fatalf("CanonicalizeQueryPath(%q) returned error: %v", tc.in, err)
+		}
+		if got != tc.want {
 			t.Errorf("CanonicalizeQueryPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCanonicalizeQueryPathRejectsBadInputs(t *testing.T) {
+	tests := []string{
+		".",
+		"..",
+		"docs/./readme.md",
+		"docs/../readme.md",
+		"docs//readme.md",
+		"docs/readme.md/",
+		"docs/\x00/readme.md",
+	}
+	for _, input := range tests {
+		if got, err := querypath.CanonicalizeQueryPath(input); err == nil {
+			t.Errorf("CanonicalizeQueryPath(%q) = %q, want error", input, got)
 		}
 	}
 }

--- a/graph/querypath/path_test.go
+++ b/graph/querypath/path_test.go
@@ -1,6 +1,7 @@
 package querypath_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/dewebprotocol/malt/graph/querypath"
@@ -40,6 +41,8 @@ func TestCanonicalizeQueryPathRejectsBadInputs(t *testing.T) {
 	for _, input := range tests {
 		if got, err := querypath.CanonicalizeQueryPath(input); err == nil {
 			t.Errorf("CanonicalizeQueryPath(%q) = %q, want error", input, got)
+		} else if !errors.Is(err, querypath.ErrInvalidQueryPath) {
+			t.Errorf("CanonicalizeQueryPath(%q) error = %v, want ErrInvalidQueryPath", input, err)
 		}
 	}
 }

--- a/server/routes_content.go
+++ b/server/routes_content.go
@@ -3,14 +3,12 @@ package server
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 
 	"github.com/dewebprotocol/malt/api/http"
-	"github.com/dewebprotocol/malt/graph/resolver"
 	"github.com/dewebprotocol/malt/storage/cas"
 	cid "github.com/ipfs/go-cid"
 )
@@ -37,11 +35,7 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request) {
 	wantProof := r.Method != http.MethodHead && !shouldOmitDefaultProof(r)
 	resolved, err := s.resolvePath(r.Context(), svc, root, path, wantProof)
 	if err != nil {
-		status := http.StatusInternalServerError
-		if errors.Is(err, errPathNotFound) || errors.Is(err, resolver.ErrResolutionFailed) {
-			status = http.StatusNotFound
-		}
-		writeError(w, status, err.Error())
+		writeError(w, resolvePathStatus(err), err.Error())
 		return
 	}
 	stat := resolved.stat

--- a/server/routes_resolve.go
+++ b/server/routes_resolve.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/dewebprotocol/malt/api/http"
+	"github.com/dewebprotocol/malt/graph/querypath"
 	"github.com/dewebprotocol/malt/graph/resolver"
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
@@ -29,11 +30,7 @@ func (s *Server) handleResolve(w http.ResponseWriter, r *http.Request) {
 func (s *Server) serveResolve(w http.ResponseWriter, r *http.Request, svc graphService, root cid.Cid, queryPath string) {
 	resolved, err := s.resolvePath(r.Context(), svc, root, queryPath, !shouldOmitDefaultProof(r))
 	if err != nil {
-		status := http.StatusInternalServerError
-		if errors.Is(err, errPathNotFound) || errors.Is(err, resolver.ErrResolutionFailed) {
-			status = http.StatusNotFound
-		}
-		writeError(w, status, err.Error())
+		writeError(w, resolvePathStatus(err), err.Error())
 		return
 	}
 	addVaryHeader(w, "X-Malt-Proof")
@@ -86,4 +83,15 @@ func (s *Server) resolvePath(ctx context.Context, svc graphService, root cid.Cid
 	}
 	resolved.proofList = pl
 	return resolved, nil
+}
+
+func resolvePathStatus(err error) int {
+	switch {
+	case errors.Is(err, querypath.ErrInvalidQueryPath):
+		return http.StatusBadRequest
+	case errors.Is(err, errPathNotFound) || errors.Is(err, resolver.ErrResolutionFailed):
+		return http.StatusNotFound
+	default:
+		return http.StatusInternalServerError
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/dewebprotocol/malt/api/http"
 	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/graph/querypath"
 	"github.com/dewebprotocol/malt/runtime/node"
 	cid "github.com/ipfs/go-cid"
 )
@@ -139,6 +141,10 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	s.registerRoutes(mux)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := validateRawReadQueryPath(r); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		if isRemovedPublicRoute(r.Method, r.URL.Path) {
 			s.handleRemovedPublicRoute(w, r)
 			return
@@ -238,6 +244,67 @@ func isRemovedPublicRoute(method, rawPath string) bool {
 		return true
 	}
 	return false
+}
+
+func validateRawReadQueryPath(r *http.Request) error {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return nil
+	}
+	rawPath := r.URL.EscapedPath()
+	if rawPath == "" {
+		rawPath = r.URL.Path
+	}
+
+	if strings.HasPrefix(rawPath, "/resolve/") {
+		afterPrefix := strings.TrimPrefix(rawPath, "/resolve/")
+		_, rawQueryPath, ok := strings.Cut(afterPrefix, "/")
+		if !ok {
+			return nil
+		}
+		return validateEscapedQueryPath(rawQueryPath)
+	}
+
+	trimmed := strings.TrimPrefix(rawPath, "/")
+	root, rawQueryPath, ok := strings.Cut(trimmed, "/")
+	if !ok || root == "" || !contentReadRootSegment(root) {
+		return nil
+	}
+	return validateEscapedQueryPath(rawQueryPath)
+}
+
+func contentReadRootSegment(root string) bool {
+	switch root {
+	case "health", "metrics", "metrics:reset", "resolve", "verify", "lineage", "_", "_unixfs":
+		return false
+	default:
+		return true
+	}
+}
+
+func validateEscapedQueryPath(rawPath string) error {
+	if rawPath == "" {
+		return nil
+	}
+	segments := strings.Split(rawPath, "/")
+	for _, segment := range segments {
+		if segment == "" {
+			return fmt.Errorf("%w: contains empty segment", querypath.ErrInvalidQueryPath)
+		}
+		decoded, err := url.PathUnescape(segment)
+		if err != nil {
+			return fmt.Errorf("%w: invalid escape sequence", querypath.ErrInvalidQueryPath)
+		}
+		if strings.ContainsRune(decoded, '\x00') {
+			return fmt.Errorf("%w: contains NUL byte", querypath.ErrInvalidQueryPath)
+		}
+		switch decoded {
+		case ".":
+			return fmt.Errorf("%w: contains current-directory segment", querypath.ErrInvalidQueryPath)
+		case "..":
+			return fmt.Errorf("%w: contains parent-directory segment", querypath.ErrInvalidQueryPath)
+		}
+	}
+	return nil
 }
 
 func (s *Server) handleRemovedPublicRoute(w http.ResponseWriter, r *http.Request) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -745,6 +745,64 @@ func TestServerContentRouteRejectsLegacyFormatModes(t *testing.T) {
 	}
 }
 
+func TestServerInvalidQueryPathsReturnBadRequest(t *testing.T) {
+	node := newTestNode(t)
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	createBody, err := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"name": fakeCIDString("name")}),
+	})
+	if err != nil {
+		t.Fatalf("marshal create request: %v", err)
+	}
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create root status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var createResp httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create root: %v", err)
+	}
+	resp.Body.Close()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "resolve parent", method: http.MethodGet, path: "/resolve/" + createResp.Root + "/.."},
+		{name: "content duplicate slash", method: http.MethodGet, path: "/" + createResp.Root + "/docs//readme.txt"},
+		{name: "content head current dir", method: http.MethodHead, path: "/" + createResp.Root + "/."},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &http.Client{
+				CheckRedirect: func(*http.Request, []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
+			req, err := http.NewRequest(tc.method, ts.URL+tc.path, nil)
+			if err != nil {
+				t.Fatalf("build request: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("%s %s status = %d, want %d", tc.method, tc.path, resp.StatusCode, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
 func TestServerVerifyAcceptsProofList(t *testing.T) {
 	node := newTestNode(t)
 	mockCAS, ok := node.CAS().(*casmock.CAS)

--- a/server/service_graph.go
+++ b/server/service_graph.go
@@ -45,7 +45,10 @@ func (svc graphService) CreateStructure(ctx context.Context, snapshot arcset.Arc
 }
 
 func (svc graphService) ResolveKey(root cid.Cid, rawPath string) (string, *resolver.ResolveResult, error) {
-	cleanPath := querypath.CanonicalizeQueryPath(rawPath)
+	cleanPath, err := querypath.CanonicalizeQueryPath(rawPath)
+	if err != nil {
+		return "", nil, err
+	}
 	result, err := svc.runtime.Resolver().ResolveKey(root, cleanPath)
 	if err != nil {
 		return "", nil, err

--- a/server/service_verify.go
+++ b/server/service_verify.go
@@ -73,7 +73,11 @@ func decodeEvidence(kind string, payload []byte) (evidence.Evidence, error) {
 }
 
 func validateProofListQuery(pl prooflist.ProofList, verifiedPath proofListVerifiedPath) error {
-	want := arcset.CanonicalizePath(querypath.CanonicalizeQueryPath(pl.Query)).String()
+	cleanQuery, err := querypath.CanonicalizeQueryPath(pl.Query)
+	if err != nil {
+		return fmt.Errorf("invalid prooflist query path: %w", err)
+	}
+	want := arcset.CanonicalizePath(cleanQuery).String()
 	if want == "" {
 		return nil
 	}

--- a/storage/cas/ipld.go
+++ b/storage/cas/ipld.go
@@ -3,12 +3,19 @@ package cas
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
 
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
+)
+
+const (
+	maxCBORDepth            = 64
+	maxCBORCollectionLength = 1 << 20
+	maxCBORCopyLength       = 64 << 20
 )
 
 // IPLDCodec identifies the IPLD codec type.
@@ -204,9 +211,13 @@ func (p *IPLDParser) GetAllLinks(node *IPLDNode) []LinkInfo {
 }
 
 // FollowLink fetches a linked block and parses it.
-func (p *IPLDParser) FollowLink(c cid.Cid, linkName string) (*IPLDNode, error) {
+func (p *IPLDParser) FollowLink(ctx context.Context, c cid.Cid, linkName string) (*IPLDNode, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	// Get the block data
-	data, err := p.cas.Get(nil, c)
+	data, err := p.cas.Get(ctx, c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch block: %w", err)
 	}
@@ -224,7 +235,7 @@ func (p *IPLDParser) FollowLink(c cid.Cid, linkName string) (*IPLDNode, error) {
 	}
 
 	// Fetch and parse target
-	targetData, err := p.cas.Get(nil, targetCID)
+	targetData, err := p.cas.Get(ctx, targetCID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch linked block: %w", err)
 	}
@@ -243,6 +254,13 @@ func newCBORDecoder(data []byte) *cborDecoder {
 }
 
 func (d *cborDecoder) decode() (interface{}, error) {
+	return d.decodeValue(0)
+}
+
+func (d *cborDecoder) decodeValue(depth int) (interface{}, error) {
+	if depth > maxCBORDepth {
+		return nil, fmt.Errorf("CBOR nesting exceeds maximum depth %d", maxCBORDepth)
+	}
 	if d.pos >= len(d.data) {
 		return nil, fmt.Errorf("unexpected end of data")
 	}
@@ -261,38 +279,36 @@ func (d *cborDecoder) decode() (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		return -(v.(uint64)) - 1, nil
+		n := v.(uint64)
+		if n > uint64(1<<63-1) {
+			return nil, fmt.Errorf("negative integer is too large")
+		}
+		return int64(-1) - int64(n), nil
 	case 2: // byte string
-		length, err := d.decodeLength(additionalInfo)
+		length, err := d.decodeCopyLength(additionalInfo, "byte string")
 		if err != nil {
 			return nil, err
-		}
-		if d.pos+int(length) > len(d.data) {
-			return nil, fmt.Errorf("byte string length exceeds data")
 		}
 		result := make([]byte, length)
-		copy(result, d.data[d.pos:d.pos+int(length)])
-		d.pos += int(length)
+		copy(result, d.data[d.pos:d.pos+length])
+		d.pos += length
 		return result, nil
 	case 3: // text string
-		length, err := d.decodeLength(additionalInfo)
+		length, err := d.decodeCopyLength(additionalInfo, "text string")
 		if err != nil {
 			return nil, err
 		}
-		if d.pos+int(length) > len(d.data) {
-			return nil, fmt.Errorf("text string length exceeds data")
-		}
-		result := string(d.data[d.pos : d.pos+int(length)])
-		d.pos += int(length)
+		result := string(d.data[d.pos : d.pos+length])
+		d.pos += length
 		return result, nil
 	case 4: // array
-		length, err := d.decodeLength(additionalInfo)
+		length, err := d.decodeCollectionLength(additionalInfo, "array", 1)
 		if err != nil {
 			return nil, err
 		}
 		arr := make([]interface{}, length)
-		for i := uint64(0); i < length; i++ {
-			v, err := d.decode()
+		for i := 0; i < length; i++ {
+			v, err := d.decodeValue(depth + 1)
 			if err != nil {
 				return nil, err
 			}
@@ -300,13 +316,13 @@ func (d *cborDecoder) decode() (interface{}, error) {
 		}
 		return arr, nil
 	case 5: // map
-		length, err := d.decodeLength(additionalInfo)
+		length, err := d.decodeCollectionLength(additionalInfo, "map", 2)
 		if err != nil {
 			return nil, err
 		}
 		m := make(map[string]interface{})
-		for i := uint64(0); i < length; i++ {
-			k, err := d.decode()
+		for i := 0; i < length; i++ {
+			k, err := d.decodeValue(depth + 1)
 			if err != nil {
 				return nil, err
 			}
@@ -314,7 +330,7 @@ func (d *cborDecoder) decode() (interface{}, error) {
 			if !ok {
 				return nil, fmt.Errorf("map key is not a string")
 			}
-			v, err := d.decode()
+			v, err := d.decodeValue(depth + 1)
 			if err != nil {
 				return nil, err
 			}
@@ -328,7 +344,7 @@ func (d *cborDecoder) decode() (interface{}, error) {
 		}
 		// For CID tag (42), decode the following byte string as CID
 		if tag == 42 {
-			v, err := d.decode()
+			v, err := d.decodeValue(depth + 1)
 			if err != nil {
 				return nil, err
 			}
@@ -345,12 +361,44 @@ func (d *cborDecoder) decode() (interface{}, error) {
 			return v, nil
 		}
 		// Skip tag value
-		return d.decode()
+		return d.decodeValue(depth + 1)
 	case 7: // simple/float
 		return d.decodeSimple(additionalInfo)
 	default:
 		return nil, fmt.Errorf("unknown major type: %d", majorType)
 	}
+}
+
+func (d *cborDecoder) remaining() int {
+	return len(d.data) - d.pos
+}
+
+func (d *cborDecoder) decodeCopyLength(additionalInfo byte, kind string) (int, error) {
+	length, err := d.decodeLength(additionalInfo)
+	if err != nil {
+		return 0, err
+	}
+	if length > uint64(maxCBORCopyLength) {
+		return 0, fmt.Errorf("%s length %d exceeds maximum %d", kind, length, maxCBORCopyLength)
+	}
+	if length > uint64(d.remaining()) {
+		return 0, fmt.Errorf("%s length %d exceeds remaining data %d", kind, length, d.remaining())
+	}
+	return int(length), nil
+}
+
+func (d *cborDecoder) decodeCollectionLength(additionalInfo byte, kind string, minItemsPerEntry uint64) (int, error) {
+	length, err := d.decodeLength(additionalInfo)
+	if err != nil {
+		return 0, err
+	}
+	if length > uint64(maxCBORCollectionLength) {
+		return 0, fmt.Errorf("%s length %d exceeds maximum %d", kind, length, maxCBORCollectionLength)
+	}
+	if minItemsPerEntry != 0 && length > uint64(d.remaining())/minItemsPerEntry {
+		return 0, fmt.Errorf("%s length %d exceeds remaining data %d", kind, length, d.remaining())
+	}
+	return int(length), nil
 }
 
 func (d *cborDecoder) decodeUint(additionalInfo byte) (interface{}, error) {

--- a/storage/cas/ipld_test.go
+++ b/storage/cas/ipld_test.go
@@ -1,6 +1,8 @@
 package cas_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/dewebprotocol/malt/storage/cas"
@@ -144,6 +146,99 @@ func TestIPLDParserCBORArray(t *testing.T) {
 	}
 }
 
+func TestIPLDParserCBORRejectsMaliciousInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "array declared length exceeds remaining data",
+			data: []byte{0x9a, 0x00, 0x10, 0x00, 0x01},
+		},
+		{
+			name: "map declared length exceeds remaining data",
+			data: []byte{0xba, 0x00, 0x10, 0x00, 0x01},
+		},
+		{
+			name: "byte string length exceeds remaining data",
+			data: []byte{0x5a, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name: "text string length exceeds remaining data",
+			data: []byte{0x7a, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name: "negative integer overflow",
+			data: []byte{0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name: "nesting exceeds maximum depth",
+			data: nestedCBORArrays(65),
+		},
+	}
+
+	store := mock.NewCAS()
+	parser := cas.NewIPLDParser(store)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mhash, _ := mh.Sum(tc.data, mh.SHA2_256, -1)
+			c := cid.NewCidV1(0x71, mhash)
+			if _, err := parser.ParseBlock(c, tc.data); err == nil {
+				t.Fatal("ParseBlock succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestIPLDParserFollowLinkUsesContext(t *testing.T) {
+	targetData := []byte("target data")
+	targetCID, err := newPayloadCID(targetData)
+	if err != nil {
+		t.Fatalf("newPayloadCID target failed: %v", err)
+	}
+
+	rootData := []byte(fmt.Sprintf(`{"link": {"/": %q}}`, targetCID.String()))
+	rootHash, err := mh.Sum(rootData, mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("root hash failed: %v", err)
+	}
+	rootCID := cid.NewCidV1(0x0201, rootHash)
+
+	store := &recordingReader{
+		blocks: map[string][]byte{
+			rootCID.String():   rootData,
+			targetCID.String(): targetData,
+		},
+	}
+	parser := cas.NewIPLDParser(store)
+	ctx := context.WithValue(context.Background(), contextKey("test"), "marker")
+	node, err := parser.FollowLink(ctx, rootCID, "link")
+	if err != nil {
+		t.Fatalf("FollowLink failed: %v", err)
+	}
+	if string(node.Data) != string(targetData) {
+		t.Fatalf("FollowLink data = %q, want %q", node.Data, targetData)
+	}
+	if store.gets != 2 {
+		t.Fatalf("Get calls = %d, want 2", store.gets)
+	}
+	if store.nilContext {
+		t.Fatal("FollowLink passed nil context to CAS")
+	}
+	if !store.sawMarker {
+		t.Fatal("FollowLink did not pass caller context to CAS")
+	}
+}
+
+func TestIPLDParserFollowLinkNilContextUsesBackground(t *testing.T) {
+	store := &recordingReader{blocks: map[string][]byte{}}
+	parser := cas.NewIPLDParser(store)
+	_, _ = parser.FollowLink(nil, mustDecodeCID("bafkqaaa"), "missing")
+	if store.nilContext {
+		t.Fatal("FollowLink passed nil context to CAS")
+	}
+}
+
 func TestIPLDResolveLink(t *testing.T) {
 	store := mock.NewCAS()
 	parser := cas.NewIPLDParser(store)
@@ -217,4 +312,44 @@ func mustDecodeCID(s string) cid.Cid {
 		panic(err)
 	}
 	return c
+}
+
+func nestedCBORArrays(depth int) []byte {
+	data := make([]byte, 0, depth+1)
+	for i := 0; i < depth; i++ {
+		data = append(data, 0x81)
+	}
+	data = append(data, 0x00)
+	return data
+}
+
+type contextKey string
+
+type recordingReader struct {
+	blocks     map[string][]byte
+	gets       int
+	nilContext bool
+	sawMarker  bool
+}
+
+func (r *recordingReader) Get(ctx context.Context, c cid.Cid) ([]byte, error) {
+	r.gets++
+	if ctx == nil {
+		r.nilContext = true
+	} else if ctx.Value(contextKey("test")) == "marker" {
+		r.sawMarker = true
+	}
+	data, ok := r.blocks[c.String()]
+	if !ok {
+		return nil, fmt.Errorf("missing block %s", c)
+	}
+	return data, nil
+}
+
+func (r *recordingReader) Has(ctx context.Context, c cid.Cid) (bool, error) {
+	if ctx == nil {
+		r.nilContext = true
+	}
+	_, ok := r.blocks[c.String()]
+	return ok, nil
 }


### PR DESCRIPTION
## Summary
- V7: add defensive limits to the hand-written CBOR/IPLD decoder for nesting depth, declared array/map lengths, copy sizes, remaining-data bounds, and negative integer overflow
- V9: make IPLDParser.FollowLink accept context.Context and avoid passing nil contexts to CAS reads
- V13: validate/canonicalize query paths with errors for ., .., empty segments/duplicate slashes, trailing slash, and NUL while preserving empty root paths
- map malformed read/query paths to 400 Bad Request for resolve/content/HEAD, including raw paths that Go ServeMux would otherwise clean or redirect

## Tests
- env GOCACHE=/tmp/go-build-cache go test ./graph/querypath ./server ./storage/cas
- env GOCACHE=/tmp/go-build-cache go test -run '^$' ./...