### PR TITLE
Harden lifecycle identity and default CORS

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -587,13 +587,7 @@ Current config shape:
 {
   "rpc": {
     "listen": "127.0.0.1:4317",
-    "cors_allowed_origins": [
-      "https://dewebprotocol.dev",
-      "https://dewebprotocol.github.io",
-      "http://localhost:*",
-      "http://127.0.0.1:*",
-      "http://[::1]:*"
-    ]
+    "cors_allowed_origins": []
   },
   "state": {
     "root_dir": "D:/malt-state",
@@ -623,13 +617,13 @@ Allowed runtime values:
 - `rpc.cors_allowed_origins`: browser origins allowed to call local read/proof
   routes, `POST /verify`, and UnixFS browser write routes such as
   `POST /_unixfs?path=...` and `POST /{root}/{path...}`. Empty or omitted
-  disables browser CORS. Exact origins are matched literally. Port wildcards
-  are only supported for loopback origins such as `http://localhost:*`,
-  `http://127.0.0.1:*`, and `http://[::1]:*`; the daemon still replies with the
-  concrete request origin. Admin and semantic-mutation routes are not exposed
-  through the browser CORS surface. The daemon reads this policy at startup.
-  Change the file and restart the managed daemon to apply browser-access
-  changes.
+  disables browser CORS, which is the default written by `malt init`. Exact
+  origins are matched literally. Port wildcards are only supported for loopback
+  origins such as `http://localhost:*`, `http://127.0.0.1:*`, and
+  `http://[::1]:*`; the daemon still replies with the concrete request origin.
+  Admin and semantic-mutation routes are not exposed through the browser CORS
+  surface. The daemon reads this policy at startup. Change the file and restart
+  the managed daemon to apply browser-access changes.
 
 This config is a packaging and runtime decision. It does not define the core
 MALT semantic abstraction.

--- a/api/http/types.go
+++ b/api/http/types.go
@@ -12,8 +12,13 @@ type ErrorResponse struct {
 
 // HealthResponse is returned by the daemon health endpoint.
 type HealthResponse struct {
-	Status         string `json:"status"`
-	LifecycleToken string `json:"lifecycle_token,omitempty"`
+	Status string `json:"status"`
+}
+
+// LifecycleIdentityResponse is returned by the local managed-daemon identity
+// endpoint.
+type LifecycleIdentityResponse struct {
+	Status string `json:"status"`
 }
 
 // MetricsResponse wraps a node-local metrics snapshot.

--- a/cmd/malt/initcmd.go
+++ b/cmd/malt/initcmd.go
@@ -19,14 +19,6 @@ var (
 	initKVStoreType    string
 )
 
-var initBrowserCORSAllowedOrigins = []string{
-	"https://dewebprotocol.dev",
-	"https://dewebprotocol.github.io",
-	"http://localhost:*",
-	"http://127.0.0.1:*",
-	"http://[::1]:*",
-}
-
 func init() {
 	rootCmd.AddCommand(initCmd)
 	initCmd.Flags().BoolVar(&initForce, "force", false, "overwrite an existing config file")
@@ -45,7 +37,6 @@ var initCmd = &cobra.Command{
 
 func runInit(cmd *cobra.Command, args []string) error {
 	cfg := config.DefaultConfig()
-	cfg.RPC.CORSAllowedOrigins = defaultInitBrowserCORSAllowedOrigins()
 
 	configPath, err := config.ResolveConfigPath(cfgFile)
 	if err != nil {
@@ -73,10 +64,6 @@ func runInit(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "daemon API: %s\n", cfg.APIBaseURL())
 	fmt.Fprintf(os.Stdout, "CAS: %s\n", cfg.CASBaseURL())
 	return nil
-}
-
-func defaultInitBrowserCORSAllowedOrigins() []string {
-	return append([]string(nil), initBrowserCORSAllowedOrigins...)
 }
 
 func promptString(reader *bufio.Reader, label string, explicit string, fallback string, nonInteractive bool) string {

--- a/cmd/malt/initcmd_test.go
+++ b/cmd/malt/initcmd_test.go
@@ -3,13 +3,12 @@ package main
 import (
 	"context"
 	"path/filepath"
-	"slices"
 	"testing"
 
 	"github.com/dewebprotocol/malt/config"
 )
 
-func TestInitWritesRecommendedBrowserCORSOrigins(t *testing.T) {
+func TestInitDisablesBrowserCORSByDefault(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("HOME", home)
@@ -48,14 +47,7 @@ func TestInitWritesRecommendedBrowserCORSOrigins(t *testing.T) {
 		t.Fatalf("LoadFromFile() error = %v", err)
 	}
 
-	want := []string{
-		"https://dewebprotocol.dev",
-		"https://dewebprotocol.github.io",
-		"http://localhost:*",
-		"http://127.0.0.1:*",
-		"http://[::1]:*",
-	}
-	if !slices.Equal(cfg.RPC.CORSAllowedOrigins, want) {
-		t.Fatalf("RPC.CORSAllowedOrigins = %#v, want %#v", cfg.RPC.CORSAllowedOrigins, want)
+	if len(cfg.RPC.CORSAllowedOrigins) != 0 {
+		t.Fatalf("RPC.CORSAllowedOrigins = %#v, want disabled by default", cfg.RPC.CORSAllowedOrigins)
 	}
 }

--- a/config.example.json
+++ b/config.example.json
@@ -1,13 +1,7 @@
 {
   "rpc": {
     "listen": "127.0.0.1:4317",
-    "cors_allowed_origins": [
-      "https://dewebprotocol.dev",
-      "https://dewebprotocol.github.io",
-      "http://localhost:*",
-      "http://127.0.0.1:*",
-      "http://[::1]:*"
-    ]
+    "cors_allowed_origins": []
   },
   "state": {
     "root_dir": "~/.malt/state",

--- a/daemon/lifecycle.go
+++ b/daemon/lifecycle.go
@@ -23,6 +23,7 @@ const (
 	defaultLifecycleStopTimeout  = 10 * time.Second
 	defaultLifecyclePollInterval = 100 * time.Millisecond
 	LifecycleTokenEnv            = "MALT_DAEMON_LIFECYCLE_TOKEN"
+	lifecycleTokenHeader         = "X-Malt-Lifecycle-Token"
 )
 
 // ErrDaemonStateNotFound is returned when no managed daemon state file exists.
@@ -204,7 +205,19 @@ func WriteDaemonState(path string, state *DaemonState) error {
 		return fmt.Errorf("encode daemon state: %w", err)
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("write daemon state: %w", err)
+	}
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("secure daemon state permissions: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write daemon state: %w", err)
+	}
+	if err := f.Close(); err != nil {
 		return fmt.Errorf("write daemon state: %w", err)
 	}
 	return nil
@@ -437,7 +450,13 @@ func sleepWithContext(ctx context.Context, sleep func(time.Duration), d time.Dur
 }
 
 func defaultHealthCheck(ctx context.Context, baseURL string) error {
-	_, err := fetchHealth(ctx, baseURL)
+	health, err := fetchHealth(ctx, baseURL)
+	if err != nil {
+		return err
+	}
+	if health.Status != "ok" {
+		return fmt.Errorf("health status %q", health.Status)
+	}
 	return err
 }
 
@@ -445,14 +464,7 @@ func defaultIdentityCheck(ctx context.Context, baseURL string, token string) err
 	if token == "" {
 		return errors.New("missing expected lifecycle token")
 	}
-	health, err := fetchHealth(ctx, baseURL)
-	if err != nil {
-		return err
-	}
-	if health.LifecycleToken != token {
-		return fmt.Errorf("daemon lifecycle token mismatch")
-	}
-	return nil
+	return fetchLifecycleIdentity(ctx, baseURL, token)
 }
 
 func fetchHealth(ctx context.Context, baseURL string) (*httpapi.HealthResponse, error) {
@@ -475,6 +487,32 @@ func fetchHealth(ctx context.Context, baseURL string) (*httpapi.HealthResponse, 
 		return nil, fmt.Errorf("decode health response: %w", err)
 	}
 	return &health, nil
+}
+
+func fetchLifecycleIdentity(ctx context.Context, baseURL string, token string) error {
+	u := strings.TrimRight(baseURL, "/") + "/_lifecycle/identity"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set(lifecycleTokenHeader, token)
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("lifecycle identity status %d", resp.StatusCode)
+	}
+	var identity httpapi.LifecycleIdentityResponse
+	if err := json.NewDecoder(resp.Body).Decode(&identity); err != nil && err != io.EOF {
+		return fmt.Errorf("decode lifecycle identity response: %w", err)
+	}
+	if identity.Status != "ok" {
+		return fmt.Errorf("lifecycle identity status %q", identity.Status)
+	}
+	return nil
 }
 
 func generateLifecycleToken() (string, error) {

--- a/daemon/lifecycle.go
+++ b/daemon/lifecycle.go
@@ -209,9 +209,9 @@ func WriteDaemonState(path string, state *DaemonState) error {
 	if err != nil {
 		return fmt.Errorf("write daemon state: %w", err)
 	}
-	if err := f.Chmod(0o600); err != nil {
+	if err := secureDaemonStatePermissions(path); err != nil {
 		_ = f.Close()
-		return fmt.Errorf("secure daemon state permissions: %w", err)
+		return err
 	}
 	if _, err := f.Write(data); err != nil {
 		_ = f.Close()
@@ -219,6 +219,13 @@ func WriteDaemonState(path string, state *DaemonState) error {
 	}
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("write daemon state: %w", err)
+	}
+	return nil
+}
+
+func secureDaemonStatePermissions(path string) error {
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("secure daemon state permissions: %w", err)
 	}
 	return nil
 }
@@ -241,6 +248,11 @@ func (m *LifecycleManager) Status(ctx context.Context, cfg *config.Config) (*Dae
 	healthErr := m.healthCheck(ctx, baseURL)
 	if state != nil {
 		healthErr = m.daemonIdentityError(ctx, state)
+		if healthErr == nil {
+			if err := secureDaemonStatePermissions(m.statePath); err != nil {
+				return nil, err
+			}
+		}
 	}
 	status := &DaemonStatus{
 		Running:     healthErr == nil,

--- a/daemon/lifecycle.go
+++ b/daemon/lifecycle.go
@@ -464,7 +464,13 @@ func defaultIdentityCheck(ctx context.Context, baseURL string, token string) err
 	if token == "" {
 		return errors.New("missing expected lifecycle token")
 	}
-	return fetchLifecycleIdentity(ctx, baseURL, token)
+	if err := fetchLifecycleIdentity(ctx, baseURL, token); err != nil {
+		if legacyErr := fetchLegacyHealthIdentity(ctx, baseURL, token); legacyErr == nil {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func fetchHealth(ctx context.Context, baseURL string) (*httpapi.HealthResponse, error) {
@@ -487,6 +493,40 @@ func fetchHealth(ctx context.Context, baseURL string) (*httpapi.HealthResponse, 
 		return nil, fmt.Errorf("decode health response: %w", err)
 	}
 	return &health, nil
+}
+
+func fetchLegacyHealthIdentity(ctx context.Context, baseURL string, token string) error {
+	u := strings.TrimRight(baseURL, "/") + "/health"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("legacy health status %d", resp.StatusCode)
+	}
+	var health struct {
+		Status         string `json:"status"`
+		LifecycleToken string `json:"lifecycle_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil && err != io.EOF {
+		return fmt.Errorf("decode legacy health response: %w", err)
+	}
+	if health.Status != "ok" {
+		return fmt.Errorf("legacy health status %q", health.Status)
+	}
+	if health.LifecycleToken == "" {
+		return errors.New("legacy health response missing lifecycle token")
+	}
+	if health.LifecycleToken != token {
+		return errors.New("legacy health lifecycle token mismatch")
+	}
+	return nil
 }
 
 func fetchLifecycleIdentity(ctx context.Context, baseURL string, token string) error {

--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 	"time"
@@ -87,6 +89,42 @@ func TestLifecycleStartWritesManagedState(t *testing.T) {
 	if state.LifecycleToken != "managed-token" {
 		t.Fatalf("state lifecycle token = %q, want managed-token", state.LifecycleToken)
 	}
+	assertDaemonStateMode(t, statePath)
+}
+
+func TestWriteDaemonStateSecuresTokenFileMode(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "daemon.json")
+
+	if err := WriteDaemonState(statePath, &DaemonState{
+		PID:            4242,
+		Listen:         "127.0.0.1:54321",
+		BaseURL:        "http://127.0.0.1:54321",
+		ConfigPath:     "config.json",
+		LifecycleToken: "managed-token",
+		StartedAt:      time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteDaemonState: %v", err)
+	}
+	assertDaemonStateMode(t, statePath)
+}
+
+func TestWriteDaemonStateTightensExistingFileMode(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "daemon.json")
+	if err := os.WriteFile(statePath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("seed daemon state: %v", err)
+	}
+
+	if err := WriteDaemonState(statePath, &DaemonState{
+		PID:            4242,
+		Listen:         "127.0.0.1:54321",
+		BaseURL:        "http://127.0.0.1:54321",
+		ConfigPath:     "config.json",
+		LifecycleToken: "managed-token",
+		StartedAt:      time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteDaemonState: %v", err)
+	}
+	assertDaemonStateMode(t, statePath)
 }
 
 func TestLifecycleStartDoesNotLaunchWhenDaemonIsHealthy(t *testing.T) {
@@ -309,5 +347,16 @@ func TestLifecycleRestartStopsThenStarts(t *testing.T) {
 	}
 	if !status.Running || status.PID != 5678 {
 		t.Fatalf("status = %+v, want restarted pid 5678", status)
+	}
+}
+
+func assertDaemonStateMode(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat daemon state: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("daemon state mode = %v, want 0600", got)
 	}
 }

--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -163,6 +163,69 @@ func TestLifecycleStartDoesNotLaunchWhenDaemonIsHealthy(t *testing.T) {
 	}
 }
 
+func TestLifecycleStatusTightensLoadedStateFileMode(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RPC.Listen = "127.0.0.1:54327"
+	statePath := t.TempDir() + "/daemon.json"
+	seedInsecureDaemonState(t, statePath, &DaemonState{
+		PID:            1111,
+		Listen:         cfg.RPC.Listen,
+		BaseURL:        cfg.APIBaseURL(),
+		ConfigPath:     "config.json",
+		LifecycleToken: "managed-token",
+		StartedAt:      time.Now(),
+	})
+
+	manager := NewLifecycleManager(LifecycleOptions{
+		StatePath:     statePath,
+		HealthCheck:   func(context.Context, string) error { return nil },
+		IdentityCheck: func(context.Context, string, string) error { return nil },
+		SignalProcess: func(int) error { return nil },
+	})
+
+	status, err := manager.Status(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !status.Running || !status.Managed {
+		t.Fatalf("status = %+v, want running managed daemon", status)
+	}
+	assertDaemonStateMode(t, statePath)
+}
+
+func TestLifecycleStartTightensHealthyLoadedStateFileMode(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RPC.Listen = "127.0.0.1:54328"
+	statePath := t.TempDir() + "/daemon.json"
+	seedInsecureDaemonState(t, statePath, &DaemonState{
+		PID:            1111,
+		Listen:         cfg.RPC.Listen,
+		BaseURL:        cfg.APIBaseURL(),
+		ConfigPath:     "config.json",
+		LifecycleToken: "managed-token",
+		StartedAt:      time.Now(),
+	})
+
+	manager := NewLifecycleManager(LifecycleOptions{
+		StatePath: statePath,
+		StartProcess: func(BackgroundProcessSpec) (int, error) {
+			t.Fatal("StartProcess should not be called for a healthy daemon")
+			return 0, nil
+		},
+		HealthCheck:   func(context.Context, string) error { return nil },
+		IdentityCheck: func(context.Context, string, string) error { return nil },
+	})
+
+	status, err := manager.Start(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !status.Running || !status.Managed || status.PID != 1111 {
+		t.Fatalf("status = %+v, want existing managed daemon", status)
+	}
+	assertDaemonStateMode(t, statePath)
+}
+
 func TestLifecycleStopSignalsManagedDaemonAndRemovesState(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.RPC.Listen = "127.0.0.1:54323"
@@ -398,5 +461,15 @@ func assertDaemonStateMode(t *testing.T, path string) {
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Fatalf("daemon state mode = %v, want 0600", got)
+	}
+}
+
+func seedInsecureDaemonState(t *testing.T, path string, state *DaemonState) {
+	t.Helper()
+	if err := WriteDaemonState(path, state); err != nil {
+		t.Fatalf("WriteDaemonState: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod insecure daemon state: %v", err)
 	}
 }

--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -347,6 +349,44 @@ func TestLifecycleRestartStopsThenStarts(t *testing.T) {
 	}
 	if !status.Running || status.PID != 5678 {
 		t.Fatalf("status = %+v, want restarted pid 5678", status)
+	}
+}
+
+func TestDefaultIdentityCheckFallsBackToLegacyHealthToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_lifecycle/identity":
+			http.NotFound(w, r)
+		case "/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","lifecycle_token":"managed-token"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	if err := defaultIdentityCheck(context.Background(), ts.URL, "managed-token"); err != nil {
+		t.Fatalf("defaultIdentityCheck legacy fallback: %v", err)
+	}
+}
+
+func TestDefaultIdentityCheckRejectsMismatchedLegacyHealthToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_lifecycle/identity":
+			http.NotFound(w, r)
+		case "/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","lifecycle_token":"other-token"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	if err := defaultIdentityCheck(context.Background(), ts.URL, "managed-token"); err == nil {
+		t.Fatal("defaultIdentityCheck succeeded with mismatched legacy health token")
 	}
 }
 

--- a/daemon/run_test.go
+++ b/daemon/run_test.go
@@ -46,8 +46,8 @@ func TestStartUsesExternalCASConfig(t *testing.T) {
 	if health.Status != "ok" {
 		t.Fatalf("health status = %q, want ok", health.Status)
 	}
-	if health.LifecycleToken != "managed-token" {
-		t.Fatalf("health lifecycle token = %q, want managed-token", health.LifecycleToken)
+	if err := fetchLifecycleIdentity(context.Background(), baseURL, "managed-token"); err != nil {
+		t.Fatalf("fetchLifecycleIdentity: %v", err)
 	}
 }
 

--- a/server/cors.go
+++ b/server/cors.go
@@ -175,7 +175,7 @@ func browserCORSUnixFSWritePathAllowed(rawPath string) bool {
 		return false
 	}
 	switch root {
-	case "health", "metrics", "metrics:reset", "resolve", "verify", "lineage", "_", "_unixfs":
+	case "health", "metrics", "metrics:reset", "resolve", "verify", "lineage", "_", "_unixfs", "_lifecycle":
 		return false
 	}
 	return rest != "_mutate"
@@ -194,7 +194,7 @@ func browserCORSReadPathAllowed(rawPath string) bool {
 	}
 	first, _, _ := strings.Cut(trimmed, "/")
 	switch first {
-	case "health", "metrics", "metrics:reset", "resolve", "verify", "lineage", "_", "_unixfs":
+	case "health", "metrics", "metrics:reset", "resolve", "verify", "lineage", "_", "_unixfs", "_lifecycle":
 		return false
 	default:
 		return true

--- a/server/cors_test.go
+++ b/server/cors_test.go
@@ -196,6 +196,22 @@ func TestBrowserCORSDeniesUnconfiguredOriginsAndAdminWrites(t *testing.T) {
 			t.Fatalf("Access-Control-Allow-Origin = %q, want empty", got)
 		}
 	})
+
+	t.Run("lifecycle identity preflight", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/_lifecycle/identity", nil)
+		req.Header.Set("Origin", "https://docs.example")
+		req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("lifecycle identity preflight status = %d, want %d", rec.Code, http.StatusForbidden)
+		}
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Fatalf("Access-Control-Allow-Origin = %q, want empty", got)
+		}
+	})
 }
 
 func containsHeaderValue(values []string, want string) bool {

--- a/server/routes_admin.go
+++ b/server/routes_admin.go
@@ -7,10 +7,25 @@ import (
 	"github.com/dewebprotocol/malt/runtime/metrics"
 )
 
+const lifecycleIdentityTokenHeader = "X-Malt-Lifecycle-Token"
+
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, &httpapi.HealthResponse{
-		Status:         "ok",
-		LifecycleToken: s.lifecycleToken,
+		Status: "ok",
+	})
+}
+
+func (s *Server) handleLifecycleIdentity(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Origin") != "" {
+		http.Error(w, "browser origin is not allowed", http.StatusForbidden)
+		return
+	}
+	if s.lifecycleToken == "" || r.Header.Get(lifecycleIdentityTokenHeader) != s.lifecycleToken {
+		http.Error(w, "lifecycle identity token mismatch", http.StatusUnauthorized)
+		return
+	}
+	writeJSON(w, http.StatusOK, &httpapi.LifecycleIdentityResponse{
+		Status: "ok",
 	})
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -95,8 +95,8 @@ type Server struct {
 // Option configures the daemon server.
 type Option func(*Server)
 
-// WithLifecycleToken exposes the managed-process identity token through
-// /health for local lifecycle commands.
+// WithLifecycleToken configures the local managed-process identity token used
+// by lifecycle commands.
 func WithLifecycleToken(token string) Option {
 	return func(s *Server) {
 		s.lifecycleToken = token
@@ -183,6 +183,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// Admin (specific routes, matched first by Go ServeMux)
 	mux.HandleFunc("GET /health", s.handleHealth)
+	mux.HandleFunc("GET /_lifecycle/identity", s.handleLifecycleIdentity)
 	mux.HandleFunc("GET /metrics", s.handleMetrics)
 	mux.HandleFunc("POST /metrics:reset", s.handleMetricsReset)
 	mux.HandleFunc("POST /verify", s.handleVerify)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -63,15 +63,15 @@ func TestServerHealthAndRootLifecycle(t *testing.T) {
 		t.Fatalf("health status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
-	var health httpapi.HealthResponse
+	var health map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
 		t.Fatalf("decode health response: %v", err)
 	}
-	if health.Status != "ok" {
-		t.Fatalf("health status payload = %q, want %q", health.Status, "ok")
+	if health["status"] != "ok" {
+		t.Fatalf("health status payload = %v, want ok", health["status"])
 	}
-	if health.LifecycleToken != "" {
-		t.Fatalf("health lifecycle token = %q, want empty", health.LifecycleToken)
+	if _, ok := health["lifecycle_token"]; ok {
+		t.Fatalf("health response exposed lifecycle_token: %#v", health)
 	}
 
 	createBody, err := json.Marshal(&httpapi.CreateStructureRequest{
@@ -107,7 +107,7 @@ func TestServerHealthAndRootLifecycle(t *testing.T) {
 	}
 }
 
-func TestServerHealthIncludesLifecycleTokenWhenConfigured(t *testing.T) {
+func TestServerHealthDoesNotExposeLifecycleTokenWhenConfigured(t *testing.T) {
 	node := newTestNode(t)
 
 	ts := httptest.NewServer(New(node, "127.0.0.1:0", WithLifecycleToken("managed-token")).Handler())
@@ -119,15 +119,116 @@ func TestServerHealthIncludesLifecycleTokenWhenConfigured(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	var health httpapi.HealthResponse
-	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+	var raw map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		t.Fatalf("decode health response: %v", err)
 	}
-	if health.Status != "ok" {
-		t.Fatalf("health status payload = %q, want %q", health.Status, "ok")
+	if raw["status"] != "ok" {
+		t.Fatalf("health status payload = %v, want ok", raw["status"])
 	}
-	if health.LifecycleToken != "managed-token" {
-		t.Fatalf("health lifecycle token = %q, want managed-token", health.LifecycleToken)
+	if _, ok := raw["lifecycle_token"]; ok {
+		t.Fatalf("health response exposed lifecycle_token: %#v", raw)
+	}
+}
+
+func TestServerLifecycleIdentityRequiresHeaderAndNoOrigin(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0", WithLifecycleToken("managed-token")).Handler())
+	defer ts.Close()
+
+	t.Run("matching token", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/_lifecycle/identity", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set(lifecycleIdentityTokenHeader, "managed-token")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("lifecycle identity request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("lifecycle identity status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		var identity httpapi.LifecycleIdentityResponse
+		if err := json.NewDecoder(resp.Body).Decode(&identity); err != nil {
+			t.Fatalf("decode lifecycle identity response: %v", err)
+		}
+		if identity.Status != "ok" {
+			t.Fatalf("lifecycle identity status payload = %q, want ok", identity.Status)
+		}
+	})
+
+	t.Run("browser origin denied", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/_lifecycle/identity", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Origin", "https://docs.example")
+		req.Header.Set(lifecycleIdentityTokenHeader, "managed-token")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("lifecycle identity request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("lifecycle identity with Origin status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+	})
+
+	t.Run("missing token denied", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/_lifecycle/identity")
+		if err != nil {
+			t.Fatalf("lifecycle identity request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("lifecycle identity without token status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+		}
+	})
+}
+
+func TestServerHealthCORSDoesNotExposeLifecycleToken(t *testing.T) {
+	node := newTestNode(t)
+
+	ts := httptest.NewServer(New(
+		node,
+		"127.0.0.1:0",
+		WithLifecycleToken("managed-token"),
+		WithBrowserOrigins([]string{"https://docs.example"}),
+	).Handler())
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/health", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Origin", "https://docs.example")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("health request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://docs.example" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want configured origin", got)
+	}
+	var raw map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if raw["status"] != "ok" {
+		t.Fatalf("health status payload = %v, want ok", raw["status"])
+	}
+	if _, ok := raw["lifecycle_token"]; ok {
+		t.Fatalf("health response exposed lifecycle_token: %#v", raw)
 	}
 }
 


### PR DESCRIPTION
## Summary
- V4: keep /health status-only and move lifecycle daemon identity verification to a local /_lifecycle/identity probe that requires no Origin and X-Malt-Lifecycle-Token
- add a temporary client-side fallback for old managed daemons that only expose the lifecycle token on /health, so Stop still signals matching legacy daemons during upgrade
- V5: stop malt init/config examples from enabling browser CORS by default; document empty/omitted cors_allowed_origins as the default opt-in boundary
- V6: write daemon.json with 0600 permissions, including tightening existing state files
- tighten already-existing daemon.json files to 0600 after Status/Start successfully loads and verifies a managed daemon

## Tests
- env GOCACHE=/tmp/go-build-cache go test ./server ./daemon ./cmd/malt ./config
- env GOCACHE=/tmp/go-build-cache go test ./daemon
- env GOCACHE=/tmp/go-build-cache go test -run '^$' ./...