### PR TITLE
Respect MVCC branching in writer freshness

### DIFF
--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -221,9 +221,11 @@ func (g *rootFreshnessGuard) markAdvanced(namespace string, oldRoot, newRoot cid
 	if !oldRoot.Defined() || !newRoot.Defined() || oldRoot.Equals(newRoot) {
 		return
 	}
-	key := freshnessKey(namespace, oldRoot)
+	oldKey := freshnessKey(namespace, oldRoot)
+	newKey := freshnessKey(namespace, newRoot)
 	g.mu.Lock()
-	g.consumed[key] = newRoot
+	g.consumed[oldKey] = newRoot
+	delete(g.consumed, newKey)
 	g.mu.Unlock()
 }
 

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -151,11 +152,22 @@ func newRootFreshnessGuard() *rootFreshnessGuard {
 }
 
 func sharedRootFreshnessGuard(table arctable.ArcTable) *rootFreshnessGuard {
-	if table == nil {
+	key, ok := arctableFreshnessIdentity(table)
+	if !ok {
 		return newRootFreshnessGuard()
 	}
-	guard, _ := sharedFreshnessGuards.LoadOrStore(table, newRootFreshnessGuard())
+	guard, _ := sharedFreshnessGuards.LoadOrStore(key, newRootFreshnessGuard())
 	return guard.(*rootFreshnessGuard)
+}
+
+func arctableFreshnessIdentity(table arctable.ArcTable) (any, bool) {
+	if table == nil {
+		return nil, false
+	}
+	if !reflect.TypeOf(table).Comparable() {
+		return nil, false
+	}
+	return table, true
 }
 
 func rootFreshnessGuardFor(table arctable.ArcTable) *rootFreshnessGuard {

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -141,13 +141,11 @@ var sharedFreshnessGuards sync.Map
 
 type rootFreshnessGuard struct {
 	mu       sync.Mutex
-	locks    map[string]*sync.Mutex
 	consumed map[string]cid.Cid
 }
 
 func newRootFreshnessGuard() *rootFreshnessGuard {
 	return &rootFreshnessGuard{
-		locks:    make(map[string]*sync.Mutex),
 		consumed: make(map[string]cid.Cid),
 	}
 }
@@ -179,40 +177,42 @@ func freshnessKey(namespace string, root cid.Cid) string {
 	return namespace + "\x00" + root.String()
 }
 
-func (g *rootFreshnessGuard) lock(namespace string, root cid.Cid) func() {
-	key := freshnessKey(namespace, root)
-	g.mu.Lock()
-	rootLock := g.locks[key]
-	if rootLock == nil {
-		rootLock = &sync.Mutex{}
-		g.locks[key] = rootLock
-	}
-	g.mu.Unlock()
-
-	rootLock.Lock()
-	return rootLock.Unlock
-}
-
-func (g *rootFreshnessGuard) check(namespace string, root cid.Cid) error {
+func (g *rootFreshnessGuard) beginUpdate(namespace string, root cid.Cid) (func(), error) {
 	key := freshnessKey(namespace, root)
 	g.mu.Lock()
 	advancedTo, ok := g.consumed[key]
-	g.mu.Unlock()
 	if !ok {
-		return nil
+		return g.mu.Unlock, nil
 	}
-	return fmt.Errorf("%w: root %s in namespace %q already advanced to %s", ErrStaleRoot, root, namespace, advancedTo)
+	g.mu.Unlock()
+	return nil, fmt.Errorf("%w: root %s in namespace %q already advanced to %s", ErrStaleRoot, root, namespace, advancedTo)
 }
 
 func (g *rootFreshnessGuard) markAdvanced(namespace string, oldRoot, newRoot cid.Cid) {
 	if !oldRoot.Defined() || !newRoot.Defined() || oldRoot.Equals(newRoot) {
 		return
 	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.markAdvancedLocked(namespace, oldRoot, newRoot)
+}
+
+func (g *rootFreshnessGuard) markAdvancedLocked(namespace string, oldRoot, newRoot cid.Cid) {
+	if !oldRoot.Defined() || !newRoot.Defined() || oldRoot.Equals(newRoot) {
+		return
+	}
 	oldKey := freshnessKey(namespace, oldRoot)
 	newKey := freshnessKey(namespace, newRoot)
-	g.mu.Lock()
 	g.consumed[oldKey] = newRoot
 	delete(g.consumed, newKey)
+}
+
+func (g *rootFreshnessGuard) markCurrent(namespace string, root cid.Cid) {
+	if !root.Defined() {
+		return
+	}
+	g.mu.Lock()
+	delete(g.consumed, freshnessKey(namespace, root))
 	g.mu.Unlock()
 }
 
@@ -347,11 +347,11 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 	}
 
 	if w.freshness != nil {
-		unlock := w.freshness.lock(namespace, root)
-		defer unlock()
-		if err := w.freshness.check(namespace, root); err != nil {
+		unlock, err := w.freshness.beginUpdate(namespace, root)
+		if err != nil {
 			return nil, err
 		}
+		defer unlock()
 	}
 
 	// Step 1: Look up current binding
@@ -422,7 +422,7 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 		return nil, fmt.Errorf("ArcTable.Update failed: %w", err)
 	}
 	if w.freshness != nil {
-		w.freshness.markAdvanced(namespace, root, newRoot)
+		w.freshness.markAdvancedLocked(namespace, root, newRoot)
 	}
 
 	return &UpdateResult{
@@ -465,11 +465,11 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 	}
 
 	if w.freshness != nil {
-		unlock := w.freshness.lock(namespace, root)
-		defer unlock()
-		if err := w.freshness.check(namespace, root); err != nil {
+		unlock, err := w.freshness.beginUpdate(namespace, root)
+		if err != nil {
 			return nil, err
 		}
+		defer unlock()
 	}
 
 	// Step 1: Get current arc set snapshot
@@ -554,7 +554,7 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 		return nil, fmt.Errorf("ArcTable.Update failed: %w", err)
 	}
 	if w.freshness != nil {
-		w.freshness.markAdvanced(namespace, root, newRoot)
+		w.freshness.markAdvancedLocked(namespace, root, newRoot)
 	}
 
 	// Update NewRoot for all per-arc results
@@ -601,6 +601,9 @@ func (w *Writer) CreateStructure(ctx context.Context, namespace string, arcs arc
 	// Step 2: Store arcs in ArcTable (first version)
 	if err := w.arctable.Update(ctx, namespace, root, cid.Undef, normalizedSnapshot); err != nil {
 		return cid.Undef, fmt.Errorf("ArcTable.Update failed: %w", err)
+	}
+	if w.freshness != nil {
+		w.freshness.markCurrent(namespace, root)
 	}
 
 	return root, nil

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -105,6 +105,11 @@ type BatchUpdateResult struct {
 // It coordinates keyed-map semantics and ArcTable (index) updates to execute
 // the unified arc update procedure from Sec 4.5.
 //
+// The legacy UpdateArc/BatchUpdateArcs paths only enforce single-consumer root
+// freshness for non-branching ArcTable backends. MVCC-style backends such as
+// versioned ArcTable remain branchable and may accept multiple children from
+// the same parent root.
+//
 // Symmetric to Resolver on the read side:
 //   - Resolver: (root, path) -> (target, transcript) via ArcTable lookup + semantic prove
 //   - Writer:   (root, path, newTarget) -> newRoot via semantic update + ArcTable apply
@@ -129,7 +134,7 @@ func NewWriter(semantic mapping.Semantics, arctable arctable.ArcTable, lists ...
 		semantic:     semantic,
 		listSemantic: listSemantic,
 		arctable:     arctable,
-		freshness:    sharedRootFreshnessGuard(arctable),
+		freshness:    rootFreshnessGuardFor(arctable),
 	}
 }
 
@@ -157,6 +162,13 @@ func sharedRootFreshnessGuard(table arctable.ArcTable) *rootFreshnessGuard {
 	return guard.(*rootFreshnessGuard)
 }
 
+func rootFreshnessGuardFor(table arctable.ArcTable) *rootFreshnessGuard {
+	if supportsConcurrentBranches(table) {
+		return nil
+	}
+	return sharedRootFreshnessGuard(table)
+}
+
 func arctableFreshnessIdentity(table arctable.ArcTable) (string, bool) {
 	if table == nil {
 		return "", false
@@ -166,6 +178,14 @@ func arctableFreshnessIdentity(table arctable.ArcTable) (string, bool) {
 		return "", false
 	}
 	return fmt.Sprintf("%T:%x", table, value.Pointer()), true
+}
+
+func supportsConcurrentBranches(table arctable.ArcTable) bool {
+	if table == nil {
+		return false
+	}
+	branching, ok := table.(arctable.BranchingArcTable)
+	return ok && branching.SupportsConcurrentBranches()
 }
 
 func freshnessKey(namespace string, root cid.Cid) string {
@@ -337,10 +357,12 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 		return nil, ErrDeletingPayloadBinding
 	}
 
-	unlock := w.freshness.lock(namespace, root)
-	defer unlock()
-	if err := w.freshness.check(namespace, root); err != nil {
-		return nil, err
+	if w.freshness != nil {
+		unlock := w.freshness.lock(namespace, root)
+		defer unlock()
+		if err := w.freshness.check(namespace, root); err != nil {
+			return nil, err
+		}
 	}
 
 	// Step 1: Look up current binding
@@ -410,7 +432,9 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 	if err := w.arctable.Update(ctx, namespace, newRoot, root, delta); err != nil {
 		return nil, fmt.Errorf("ArcTable.Update failed: %w", err)
 	}
-	w.freshness.markAdvanced(namespace, root, newRoot)
+	if w.freshness != nil {
+		w.freshness.markAdvanced(namespace, root, newRoot)
+	}
 
 	return &UpdateResult{
 		OldRoot:   root,
@@ -451,10 +475,12 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 		return nil, ErrDeletingPayloadBinding
 	}
 
-	unlock := w.freshness.lock(namespace, root)
-	defer unlock()
-	if err := w.freshness.check(namespace, root); err != nil {
-		return nil, err
+	if w.freshness != nil {
+		unlock := w.freshness.lock(namespace, root)
+		defer unlock()
+		if err := w.freshness.check(namespace, root); err != nil {
+			return nil, err
+		}
 	}
 
 	// Step 1: Get current arc set snapshot
@@ -538,7 +564,9 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 	if err := w.arctable.Update(ctx, namespace, newRoot, root, delta); err != nil {
 		return nil, fmt.Errorf("ArcTable.Update failed: %w", err)
 	}
-	w.freshness.markAdvanced(namespace, root, newRoot)
+	if w.freshness != nil {
+		w.freshness.markAdvanced(namespace, root, newRoot)
+	}
 
 	// Update NewRoot for all per-arc results
 	for path := range perArc {

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -154,11 +153,10 @@ func newRootFreshnessGuard() *rootFreshnessGuard {
 }
 
 func sharedRootFreshnessGuard(table arctable.ArcTable) *rootFreshnessGuard {
-	key, ok := arctableFreshnessIdentity(table)
-	if !ok {
+	if table == nil {
 		return newRootFreshnessGuard()
 	}
-	guard, _ := sharedFreshnessGuards.LoadOrStore(key, newRootFreshnessGuard())
+	guard, _ := sharedFreshnessGuards.LoadOrStore(table, newRootFreshnessGuard())
 	return guard.(*rootFreshnessGuard)
 }
 
@@ -167,17 +165,6 @@ func rootFreshnessGuardFor(table arctable.ArcTable) *rootFreshnessGuard {
 		return nil
 	}
 	return sharedRootFreshnessGuard(table)
-}
-
-func arctableFreshnessIdentity(table arctable.ArcTable) (string, bool) {
-	if table == nil {
-		return "", false
-	}
-	value := reflect.ValueOf(table)
-	if value.Kind() != reflect.Pointer || value.IsNil() {
-		return "", false
-	}
-	return fmt.Sprintf("%T:%x", table, value.Pointer()), true
 }
 
 func supportsConcurrentBranches(table arctable.ArcTable) bool {

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+	"sync"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/auth/semantic/list"
@@ -32,6 +34,11 @@ var (
 	// ErrDeletingPayloadBinding is returned when an update attempts to remove the
 	// mandatory @payload binding from a MALT-native object.
 	ErrDeletingPayloadBinding = errors.New("mandatory @payload binding cannot be deleted")
+
+	// ErrStaleRoot is returned when a legacy root-consuming write attempts to
+	// update a base root that this writer has already advanced in the same
+	// namespace.
+	ErrStaleRoot = errors.New("stale root")
 )
 
 var mandatoryPayloadPath = arcset.CanonicalizePath("@payload")
@@ -105,6 +112,7 @@ type Writer struct {
 	semantic     mapping.Semantics
 	listSemantic list.Semantics
 	arctable     arctable.ArcTable
+	freshness    *rootFreshnessGuard
 }
 
 // NewWriter creates a new Writer.
@@ -121,7 +129,82 @@ func NewWriter(semantic mapping.Semantics, arctable arctable.ArcTable, lists ...
 		semantic:     semantic,
 		listSemantic: listSemantic,
 		arctable:     arctable,
+		freshness:    sharedRootFreshnessGuard(arctable),
 	}
+}
+
+var sharedFreshnessGuards sync.Map
+
+type rootFreshnessGuard struct {
+	mu       sync.Mutex
+	locks    map[string]*sync.Mutex
+	consumed map[string]cid.Cid
+}
+
+func newRootFreshnessGuard() *rootFreshnessGuard {
+	return &rootFreshnessGuard{
+		locks:    make(map[string]*sync.Mutex),
+		consumed: make(map[string]cid.Cid),
+	}
+}
+
+func sharedRootFreshnessGuard(table arctable.ArcTable) *rootFreshnessGuard {
+	key, ok := arctableFreshnessIdentity(table)
+	if !ok {
+		return newRootFreshnessGuard()
+	}
+	guard, _ := sharedFreshnessGuards.LoadOrStore(key, newRootFreshnessGuard())
+	return guard.(*rootFreshnessGuard)
+}
+
+func arctableFreshnessIdentity(table arctable.ArcTable) (string, bool) {
+	if table == nil {
+		return "", false
+	}
+	value := reflect.ValueOf(table)
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return "", false
+	}
+	return fmt.Sprintf("%T:%x", table, value.Pointer()), true
+}
+
+func freshnessKey(namespace string, root cid.Cid) string {
+	return namespace + "\x00" + root.String()
+}
+
+func (g *rootFreshnessGuard) lock(namespace string, root cid.Cid) func() {
+	key := freshnessKey(namespace, root)
+	g.mu.Lock()
+	rootLock := g.locks[key]
+	if rootLock == nil {
+		rootLock = &sync.Mutex{}
+		g.locks[key] = rootLock
+	}
+	g.mu.Unlock()
+
+	rootLock.Lock()
+	return rootLock.Unlock
+}
+
+func (g *rootFreshnessGuard) check(namespace string, root cid.Cid) error {
+	key := freshnessKey(namespace, root)
+	g.mu.Lock()
+	advancedTo, ok := g.consumed[key]
+	g.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	return fmt.Errorf("%w: root %s in namespace %q already advanced to %s", ErrStaleRoot, root, namespace, advancedTo)
+}
+
+func (g *rootFreshnessGuard) markAdvanced(namespace string, oldRoot, newRoot cid.Cid) {
+	if !oldRoot.Defined() || !newRoot.Defined() || oldRoot.Equals(newRoot) {
+		return
+	}
+	key := freshnessKey(namespace, oldRoot)
+	g.mu.Lock()
+	g.consumed[key] = newRoot
+	g.mu.Unlock()
 }
 
 func canonicalizeUpdateMap(updates map[string]cid.Cid) (map[arcset.Path]cid.Cid, error) {
@@ -233,6 +316,11 @@ func hasDefinedPayloadBinding(arcs arcset.ArcSet) bool {
 //  2. Updates the commitment: newRoot = semantic.Update(root, path, c, newTarget)
 //  3. Applies the update to ArcTable using the full new arc set for newRoot
 //
+// UpdateArc is a legacy root-consuming API. Within one process, writers that
+// share the same ArcTable instance advance (namespace, root) exactly once for
+// successful non-no-op calls; later attempts to update the same base root return
+// ErrStaleRoot instead of silently forking or overwriting ArcTable state.
+//
 // The operation covers three semantic cases:
 //   - Insert (⊥ → c)
 //   - Replace (c -> c')
@@ -247,6 +335,12 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 	}
 	if canonicalPath == mandatoryPayloadPath && !newTarget.Defined() {
 		return nil, ErrDeletingPayloadBinding
+	}
+
+	unlock := w.freshness.lock(namespace, root)
+	defer unlock()
+	if err := w.freshness.check(namespace, root); err != nil {
+		return nil, err
 	}
 
 	// Step 1: Look up current binding
@@ -316,6 +410,7 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 	if err := w.arctable.Update(ctx, namespace, newRoot, root, delta); err != nil {
 		return nil, fmt.Errorf("ArcTable.Update failed: %w", err)
 	}
+	w.freshness.markAdvanced(namespace, root, newRoot)
 
 	return &UpdateResult{
 		OldRoot:   root,
@@ -334,6 +429,11 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 //  2. Applies semantic.BatchUpdate atomically over the current keyed view
 //  3. Applies all updates to ArcTable
 //
+// BatchUpdateArcs is a legacy root-consuming API. Within one process, writers
+// that share the same ArcTable instance advance (namespace, root) exactly once
+// for successful non-no-op calls; later attempts to update the same base root
+// return ErrStaleRoot instead of silently forking or overwriting ArcTable state.
+//
 // If any update in the batch fails, the entire operation is rejected and
 // no state is modified.
 func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid.Cid, updates map[string]cid.Cid) (*BatchUpdateResult, error) {
@@ -349,6 +449,12 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 	}
 	if payloadTarget, ok := normalizedUpdates[mandatoryPayloadPath]; ok && !payloadTarget.Defined() {
 		return nil, ErrDeletingPayloadBinding
+	}
+
+	unlock := w.freshness.lock(namespace, root)
+	defer unlock()
+	if err := w.freshness.check(namespace, root); err != nil {
+		return nil, err
 	}
 
 	// Step 1: Get current arc set snapshot
@@ -432,6 +538,7 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 	if err := w.arctable.Update(ctx, namespace, newRoot, root, delta); err != nil {
 		return nil, fmt.Errorf("ArcTable.Update failed: %w", err)
 	}
+	w.freshness.markAdvanced(namespace, root, newRoot)
 
 	// Update NewRoot for all per-arc results
 	for path := range perArc {

--- a/graph/writer/writer_test.go
+++ b/graph/writer/writer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dewebprotocol/malt/auth/semantic/list"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
 	"github.com/dewebprotocol/malt/runtime/arctable/overwrite"
+	versionedtable "github.com/dewebprotocol/malt/runtime/arctable/versioned"
 	listtree "github.com/dewebprotocol/malt/runtime/semantic/list/tree"
 	mappingradix "github.com/dewebprotocol/malt/runtime/semantic/mapping/radix"
 	kvmemory "github.com/dewebprotocol/malt/storage/kv/memory"
@@ -652,6 +653,62 @@ func TestWriter_UpdateArc_SharedArcTableRejectsConsumedBaseRoot(t *testing.T) {
 	_, err = w2.UpdateArc(ctx, namespace, root, "second", fakeCID("second"))
 	if !errors.Is(err, ErrStaleRoot) {
 		t.Fatalf("second writer UpdateArc error = %v, want ErrStaleRoot", err)
+	}
+}
+
+func TestWriter_UpdateArc_VersionedArcTableAllowsBranching(t *testing.T) {
+	ctx := context.Background()
+	namespace := "test-versioned-branch"
+
+	kv := kvmemory.New()
+	at, err := versionedtable.NewArcTable(versionedtable.WithKVStore(kv))
+	if err != nil {
+		t.Fatalf("failed to create versioned ArcTable: %v", err)
+	}
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("failed to create KZG scheme: %v", err)
+	}
+	semantic, err := mappingradix.NewMap(scheme, at)
+	if err != nil {
+		t.Fatalf("failed to create mapping semantic: %v", err)
+	}
+	w := NewWriter(semantic, at)
+	w2 := NewWriter(semantic, at)
+
+	root, err := w.CreateStructure(ctx, namespace, makeArcSet(map[string]cid.Cid{
+		"base": fakeCID("base"),
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure failed: %v", err)
+	}
+
+	first, err := w.UpdateArc(ctx, namespace, root, "left", fakeCID("left"))
+	if err != nil {
+		t.Fatalf("first UpdateArc failed: %v", err)
+	}
+	second, err := w2.UpdateArc(ctx, namespace, root, "right", fakeCID("right"))
+	if err != nil {
+		t.Fatalf("second UpdateArc failed: %v", err)
+	}
+
+	if !first.NewRoot.Defined() || !second.NewRoot.Defined() {
+		t.Fatal("expected both branches to produce defined roots")
+	}
+	if first.NewRoot.Equals(second.NewRoot) {
+		t.Fatal("expected versioned branches to produce distinct roots")
+	}
+	if got, err := w.GetArc(ctx, namespace, first.NewRoot, "left"); err != nil || !got.Equals(fakeCID("left")) {
+		t.Fatalf("left branch lookup = %v, %v", got, err)
+	}
+	if got, err := w.GetArc(ctx, namespace, second.NewRoot, "right"); err != nil || !got.Equals(fakeCID("right")) {
+		t.Fatalf("right branch lookup = %v, %v", got, err)
+	}
+	if got, err := w.GetArc(ctx, namespace, first.NewRoot, "base"); err != nil || !got.Equals(fakeCID("base")) {
+		t.Fatalf("left branch base lookup = %v, %v", got, err)
+	}
+	if got, err := w.GetArc(ctx, namespace, second.NewRoot, "base"); err != nil || !got.Equals(fakeCID("base")) {
+		t.Fatalf("right branch base lookup = %v, %v", got, err)
 	}
 }
 

--- a/graph/writer/writer_test.go
+++ b/graph/writer/writer_test.go
@@ -696,6 +696,43 @@ func TestWriter_UpdateArc_AllowsReturnedRootAfterCycle(t *testing.T) {
 	}
 }
 
+func TestWriter_CreateStructureRevivesRecreatedRoot(t *testing.T) {
+	w, _, _, _ := newTestWriter(t)
+	ctx := context.Background()
+	namespace := "test-recreated-root"
+	arcs := makeArcSet(map[string]cid.Cid{
+		"base": fakeCID("base"),
+	})
+
+	rootA, err := w.CreateStructure(ctx, namespace, arcs)
+	if err != nil {
+		t.Fatalf("CreateStructure failed: %v", err)
+	}
+	resultB, err := w.UpdateArc(ctx, namespace, rootA, "temp", fakeCID("temp"))
+	if err != nil {
+		t.Fatalf("A -> B UpdateArc failed: %v", err)
+	}
+	if resultB.NewRoot.Equals(rootA) {
+		t.Fatal("A -> B should produce a distinct root")
+	}
+
+	rootA2, err := w.CreateStructure(ctx, namespace, arcs)
+	if err != nil {
+		t.Fatalf("recreate A failed: %v", err)
+	}
+	if !rootA2.Equals(rootA) {
+		t.Fatalf("recreated root = %s, want original root %s", rootA2, rootA)
+	}
+
+	resultC, err := w.UpdateArc(ctx, namespace, rootA2, "next", fakeCID("next"))
+	if err != nil {
+		t.Fatalf("A -> C UpdateArc failed after CreateStructure revived A: %v", err)
+	}
+	if !resultC.NewRoot.Defined() || resultC.NewRoot.Equals(rootA2) {
+		t.Fatalf("A -> C returned invalid root %s", resultC.NewRoot)
+	}
+}
+
 func TestWriter_UpdateArc_VersionedArcTableAllowsBranching(t *testing.T) {
 	ctx := context.Background()
 	namespace := "test-versioned-branch"

--- a/graph/writer/writer_test.go
+++ b/graph/writer/writer_test.go
@@ -656,6 +656,46 @@ func TestWriter_UpdateArc_SharedArcTableRejectsConsumedBaseRoot(t *testing.T) {
 	}
 }
 
+func TestWriter_UpdateArc_AllowsReturnedRootAfterCycle(t *testing.T) {
+	w, _, _, _ := newTestWriter(t)
+	ctx := context.Background()
+	namespace := "test-root-cycle"
+
+	rootA, err := w.CreateStructure(ctx, namespace, makeArcSet(map[string]cid.Cid{
+		"base": fakeCID("base"),
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure failed: %v", err)
+	}
+
+	inserted := fakeCID("inserted")
+	resultB, err := w.UpdateArc(ctx, namespace, rootA, "temp", inserted)
+	if err != nil {
+		t.Fatalf("A -> B UpdateArc failed: %v", err)
+	}
+	rootB := resultB.NewRoot
+	if rootB.Equals(rootA) {
+		t.Fatal("A -> B should produce a distinct root")
+	}
+
+	resultA2, err := w.UpdateArc(ctx, namespace, rootB, "temp", cid.Undef)
+	if err != nil {
+		t.Fatalf("B -> A UpdateArc failed: %v", err)
+	}
+	rootA2 := resultA2.NewRoot
+	if !rootA2.Equals(rootA) {
+		t.Fatalf("B -> A root = %s, want original root %s", rootA2, rootA)
+	}
+
+	resultC, err := w.UpdateArc(ctx, namespace, rootA2, "next", fakeCID("next"))
+	if err != nil {
+		t.Fatalf("A -> C UpdateArc failed after root returned current: %v", err)
+	}
+	if !resultC.NewRoot.Defined() || resultC.NewRoot.Equals(rootA2) {
+		t.Fatalf("A -> C returned invalid root %s", resultC.NewRoot)
+	}
+}
+
 func TestWriter_UpdateArc_VersionedArcTableAllowsBranching(t *testing.T) {
 	ctx := context.Background()
 	namespace := "test-versioned-branch"

--- a/graph/writer/writer_test.go
+++ b/graph/writer/writer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -576,6 +577,84 @@ func TestWriter_UpdateArc_InvalidInputs(t *testing.T) {
 	}
 }
 
+func TestWriter_UpdateArc_ConcurrentSameRootReturnsStaleRoot(t *testing.T) {
+	w, _, _, _ := newTestWriter(t)
+	ctx := context.Background()
+	namespace := "test-concurrent-update"
+
+	root, err := w.CreateStructure(ctx, namespace, makeArcSet(map[string]cid.Cid{
+		"base": fakeCID("base"),
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure failed: %v", err)
+	}
+
+	const workers = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	roots := make(chan cid.Cid, workers)
+
+	for i := 0; i < workers; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			result, err := w.UpdateArc(ctx, namespace, root, "child-"+strconv.Itoa(i), fakeCID("child-"+strconv.Itoa(i)))
+			if err != nil {
+				errs <- err
+				return
+			}
+			roots <- result.NewRoot
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	close(roots)
+
+	successes := 0
+	for newRoot := range roots {
+		successes++
+		if !newRoot.Defined() || newRoot.Equals(root) {
+			t.Fatalf("successful update returned invalid new root %s", newRoot)
+		}
+	}
+	stale := 0
+	for err := range errs {
+		if !errors.Is(err, ErrStaleRoot) {
+			t.Fatalf("concurrent update error = %v, want ErrStaleRoot", err)
+		}
+		stale++
+	}
+	if successes != 1 || stale != workers-1 {
+		t.Fatalf("successes/stale = %d/%d, want 1/%d", successes, stale, workers-1)
+	}
+}
+
+func TestWriter_UpdateArc_SharedArcTableRejectsConsumedBaseRoot(t *testing.T) {
+	w, at, semantic, _ := newTestWriter(t)
+	w2 := NewWriter(semantic, at)
+	ctx := context.Background()
+	namespace := "test-shared-writer"
+
+	root, err := w.CreateStructure(ctx, namespace, makeArcSet(map[string]cid.Cid{
+		"base": fakeCID("base"),
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure failed: %v", err)
+	}
+
+	if _, err := w.UpdateArc(ctx, namespace, root, "first", fakeCID("first")); err != nil {
+		t.Fatalf("first UpdateArc failed: %v", err)
+	}
+	_, err = w2.UpdateArc(ctx, namespace, root, "second", fakeCID("second"))
+	if !errors.Is(err, ErrStaleRoot) {
+		t.Fatalf("second writer UpdateArc error = %v, want ErrStaleRoot", err)
+	}
+}
+
 func TestWriter_BatchUpdateArcs(t *testing.T) {
 	w, _, _, _ := newTestWriter(t)
 	ctx := context.Background()
@@ -646,6 +725,41 @@ func TestWriter_BatchUpdateArcs(t *testing.T) {
 				t.Errorf("expected GetArc(%s) to fail, got %s", path, got)
 			}
 		}
+	}
+}
+
+func TestWriter_BatchUpdateArcs_RejectsConsumedBaseRoot(t *testing.T) {
+	w, _, _, _ := newTestWriter(t)
+	ctx := context.Background()
+	namespace := "test-batch-stale"
+
+	root, err := w.CreateStructure(ctx, namespace, makeArcSet(map[string]cid.Cid{
+		"a": fakeCID("data-a"),
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure failed: %v", err)
+	}
+
+	first, err := w.BatchUpdateArcs(ctx, namespace, root, map[string]cid.Cid{
+		"a": fakeCID("data-a-new"),
+	})
+	if err != nil {
+		t.Fatalf("first BatchUpdateArcs failed: %v", err)
+	}
+
+	_, err = w.BatchUpdateArcs(ctx, namespace, root, map[string]cid.Cid{
+		"b": fakeCID("data-b"),
+	})
+	if !errors.Is(err, ErrStaleRoot) {
+		t.Fatalf("second BatchUpdateArcs error = %v, want ErrStaleRoot", err)
+	}
+
+	got, err := w.GetArc(ctx, namespace, first.NewRoot, "a")
+	if err != nil {
+		t.Fatalf("GetArc(a) from first root failed: %v", err)
+	}
+	if !got.Equals(fakeCID("data-a-new")) {
+		t.Fatalf("a = %s, want updated target", got)
 	}
 }
 

--- a/graph/writer/writer_test.go
+++ b/graph/writer/writer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dewebprotocol/malt/auth/commitment/kzg"
 	"github.com/dewebprotocol/malt/auth/semantic/list"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/runtime/arctable"
 	"github.com/dewebprotocol/malt/runtime/arctable/overwrite"
 	versionedtable "github.com/dewebprotocol/malt/runtime/arctable/versioned"
 	listtree "github.com/dewebprotocol/malt/runtime/semantic/list/tree"
@@ -77,6 +78,35 @@ func newTestWriterWithList(t *testing.T) (*Writer, *overwrite.ArcTable, mapping.
 }
 
 type kvg = kvmemory.KV
+
+type nonComparableArcTable struct {
+	arctable arctable.ArcTable
+	tags     []string
+}
+
+func (t nonComparableArcTable) Get(ctx context.Context, namespace string, root cid.Cid, path arcset.Path) (cid.Cid, error) {
+	return t.arctable.Get(ctx, namespace, root, path)
+}
+
+func (t nonComparableArcTable) BatchGet(ctx context.Context, namespace string, root cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error) {
+	return t.arctable.BatchGet(ctx, namespace, root, paths)
+}
+
+func (t nonComparableArcTable) Update(ctx context.Context, namespace string, newRoot, oldRoot cid.Cid, arcs arcset.ArcSet) error {
+	return t.arctable.Update(ctx, namespace, newRoot, oldRoot, arcs)
+}
+
+func (t nonComparableArcTable) Snapshot(ctx context.Context, namespace string, root cid.Cid) (arcset.ArcSet, error) {
+	return t.arctable.Snapshot(ctx, namespace, root)
+}
+
+func (t nonComparableArcTable) Iterate(ctx context.Context, namespace string, root cid.Cid) arcset.Iterator {
+	return t.arctable.Iterate(ctx, namespace, root)
+}
+
+func (t nonComparableArcTable) Close() error {
+	return t.arctable.Close()
+}
 
 func fakeCID(seed string) cid.Cid {
 	mhash, _ := mh.Sum([]byte(seed), mh.SHA2_256, -1)
@@ -653,6 +683,24 @@ func TestWriter_UpdateArc_SharedArcTableRejectsConsumedBaseRoot(t *testing.T) {
 	_, err = w2.UpdateArc(ctx, namespace, root, "second", fakeCID("second"))
 	if !errors.Is(err, ErrStaleRoot) {
 		t.Fatalf("second writer UpdateArc error = %v, want ErrStaleRoot", err)
+	}
+}
+
+func TestWriter_NonComparableArcTableUsesPerWriterFreshnessGuard(t *testing.T) {
+	_, at, semantic, _ := newTestWriter(t)
+	table := arctable.ArcTable(nonComparableArcTable{
+		arctable: at,
+		tags:     []string{"custom"},
+	})
+
+	w := NewWriter(semantic, table)
+	w2 := NewWriter(semantic, table)
+
+	if w.freshness == nil || w2.freshness == nil {
+		t.Fatal("non-branching ArcTable should install freshness guards")
+	}
+	if w.freshness == w2.freshness {
+		t.Fatal("non-comparable ArcTable value should fall back to per-writer freshness guards")
 	}
 }
 

--- a/runtime/arctable/arctable.go
+++ b/runtime/arctable/arctable.go
@@ -60,6 +60,15 @@ type ArcTable interface {
 	Close() error
 }
 
+// BranchingArcTable may be implemented by ArcTable backends that preserve
+// multiple concurrent children from the same parent root.
+//
+// Writers can skip stale-root guards for backends that report support for
+// concurrent branches.
+type BranchingArcTable interface {
+	SupportsConcurrentBranches() bool
+}
+
 // NamespaceCreator is an optional interface for ArcTable implementations
 // that support creating namespaces with custom bloom filter configuration.
 type NamespaceCreator interface {

--- a/runtime/arctable/versioned/versioned.go
+++ b/runtime/arctable/versioned/versioned.go
@@ -33,6 +33,12 @@ type ArcTable struct {
 	bloomManager *arctable.BloomFilterManager
 }
 
+// SupportsConcurrentBranches reports that versioned ArcTable preserves
+// multiple children from the same parent root.
+func (e *ArcTable) SupportsConcurrentBranches() bool {
+	return true
+}
+
 // NewArcTable creates a new versioned ArcTable with the given KVStore and optional configuration.
 // Bloom filter is disabled by default; use WithBloomCache to enable it.
 //

--- a/runtime/metrics/arctable.go
+++ b/runtime/metrics/arctable.go
@@ -80,6 +80,13 @@ func (m *ArcTable) Base() arctable.ArcTable {
 	return m.base
 }
 
+// SupportsConcurrentBranches forwards branching capability to the wrapped
+// ArcTable when it advertises MVCC-style children from the same parent root.
+func (m *ArcTable) SupportsConcurrentBranches() bool {
+	branching, ok := m.base.(arctable.BranchingArcTable)
+	return ok && branching.SupportsConcurrentBranches()
+}
+
 // SnapshotStats returns the current ArcTable counters.
 func (m *ArcTable) SnapshotStats() ArcTableStats {
 	return m.stats.snapshot()
@@ -155,3 +162,4 @@ func (m *ArcTable) GetParent(ctx context.Context, namespace string, version cid.
 
 var _ arctable.ArcTable = (*ArcTable)(nil)
 var _ arctable.NamespaceCreator = (*ArcTable)(nil)
+var _ arctable.BranchingArcTable = (*ArcTable)(nil)

--- a/runtime/node/node_test.go
+++ b/runtime/node/node_test.go
@@ -165,6 +165,54 @@ func TestOpenGraphRejectsArcTableMismatch(t *testing.T) {
 	}
 }
 
+func TestNewGraphVersionedBackendAllowsConcurrentBranchesThroughMetricsWrapper(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.State.ArcTable.Type = "versioned"
+
+	node, err := NewNode(WithConfig(cfg), WithCAS(casmock.NewCAS()))
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+	defer node.Close()
+
+	g, err := node.NewGraph("branching")
+	if err != nil {
+		t.Fatalf("NewGraph failed: %v", err)
+	}
+
+	root, err := g.Writer().CreateStructure(context.Background(), g.Namespace(), arcset.NewSetFrom(map[string]cid.Cid{
+		"@payload": newTestCID("payload"),
+		"base":     newTestCID("base"),
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure failed: %v", err)
+	}
+
+	first, err := g.Writer().UpdateArc(context.Background(), g.Namespace(), root, "left", newTestCID("left"))
+	if err != nil {
+		t.Fatalf("first UpdateArc failed: %v", err)
+	}
+	second, err := g.Writer().BatchUpdateArcs(context.Background(), g.Namespace(), root, map[string]cid.Cid{
+		"right": newTestCID("right"),
+	})
+	if err != nil {
+		t.Fatalf("second BatchUpdateArcs failed: %v", err)
+	}
+
+	if !first.NewRoot.Defined() || !second.NewRoot.Defined() {
+		t.Fatal("expected both branches to produce defined roots")
+	}
+	if first.NewRoot.Equals(second.NewRoot) {
+		t.Fatal("expected distinct roots for sibling branches")
+	}
+	if got, err := g.Writer().GetArc(context.Background(), g.Namespace(), first.NewRoot, "left"); err != nil || !got.Equals(newTestCID("left")) {
+		t.Fatalf("left branch lookup = %v, %v", got, err)
+	}
+	if got, err := g.Writer().GetArc(context.Background(), g.Namespace(), second.NewRoot, "right"); err != nil || !got.Equals(newTestCID("right")) {
+		t.Fatalf("right branch lookup = %v, %v", got, err)
+	}
+}
+
 func testConfig(t *testing.T) *config.Config {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- preserve MVCC branching for versioned ArcTable backends
- scope stale-root guards to non-branching backends only
- add SupportsConcurrentBranches() on the metrics ArcTable wrapper so Node/Graph wiring preserves the capability
- clear stale markers when a previously consumed root becomes current again, allowing overwrite cycles such as A -> B -> A -> C
- key shared writer freshness guards by comparable ArcTable identities, and fall back to per-writer guards for non-comparable custom ArcTable values instead of panicking
- clear/reconcile stale markers when CreateStructure recreates and publishes a deterministic current root
- simplify the non-branching freshness guard so it no longer retains one mutex per namespace/root
- add regression tests for metrics-wrapped versioned branches, overwrite root reuse cycles, recreated-root freshness, and non-comparable ArcTable adapters

## Design notes
- Writer.Apply remains materialization-only and does not arbitrate freshness.
- overwrite/simple backends still get stale-root protection to prevent silent overwrite.
- versioned backends may accept multiple legal children from the same parent root, matching MVCC semantics.
- the metrics wrapper transparently forwards branching support, so the default Node path no longer loses this capability.
- the overwrite freshness guard tracks consumed roots as a current-state hint, not a permanent ban; when a root is reintroduced as the current root, including through CreateStructure, its stale marker is removed.
- shared freshness guards are used only when the ArcTable dynamic type is comparable; custom non-comparable value implementations use a per-writer guard because ArcTable does not require comparable identity.

## Tests
- env GOCACHE=/tmp/go-build-cache go test ./graph/writer ./runtime/metrics ./runtime/node
- env GOCACHE=/tmp/go-build-cache go test -run '^$' ./...