### PR TITLE
fix: expose writer index failures

### DIFF
--- a/graph/writer/index_write_failure_test.go
+++ b/graph/writer/index_write_failure_test.go
@@ -1,0 +1,344 @@
+package writer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	semanticmapping "github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/runtime/arctable"
+	"github.com/dewebprotocol/malt/runtime/arctable/overwrite"
+	"github.com/dewebprotocol/malt/runtime/semantic/mapping/radix"
+	"github.com/dewebprotocol/malt/storage/kv/memory"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// failingArcTable wraps an ArcTable and fails Update calls while the fail flag
+// is set. It is the test seam for the cross-layer atomicity gap: the semantic
+// layer commits a valid newRoot, but the index write fails.
+//
+// The semantic runtime (radix) persists its own node/bucket slots through
+// ArcTable.Update using cid.Undef as the newRoot (see radix storeNodeSlots /
+// storeBucketEntries). The writer's logical arc write uses the real newRoot.
+// To inject a failure at exactly the writer-level index write without breaking
+// the semantic layer's internal persistence, we only fail updates whose
+// newRoot is defined — i.e. the logical root-publishing writes.
+type failingArcTable struct {
+	inner arctable.ArcTable
+	fail  bool
+	calls int
+}
+
+func (f *failingArcTable) Get(ctx context.Context, namespace string, root cid.Cid, path arcset.Path) (cid.Cid, error) {
+	return f.inner.Get(ctx, namespace, root, path)
+}
+
+func (f *failingArcTable) BatchGet(ctx context.Context, namespace string, root cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error) {
+	return f.inner.BatchGet(ctx, namespace, root, paths)
+}
+
+func (f *failingArcTable) Update(ctx context.Context, namespace string, newRoot, oldRoot cid.Cid, arcs arcset.ArcSet) error {
+	f.calls++
+	// Only fail the logical root-publishing write. The semantic runtime's
+	// slot/bucket persistence (newRoot == cid.Undef) must succeed so that the
+	// semantic layer can produce a valid newRoot in the first place.
+	if f.fail && newRoot.Defined() {
+		return errInjectedIndexFailure
+	}
+	return f.inner.Update(ctx, namespace, newRoot, oldRoot, arcs)
+}
+
+func (f *failingArcTable) Snapshot(ctx context.Context, namespace string, root cid.Cid) (arcset.ArcSet, error) {
+	return f.inner.Snapshot(ctx, namespace, root)
+}
+
+func (f *failingArcTable) Iterate(ctx context.Context, namespace string, root cid.Cid) arcset.Iterator {
+	return f.inner.Iterate(ctx, namespace, root)
+}
+
+func (f *failingArcTable) Close() error { return f.inner.Close() }
+
+var errInjectedIndexFailure = errors.New("injected arctable failure")
+
+// newFailingTestWriter builds a writer whose ArcTable Update is controlled by
+// the returned *failingArcTable. The semantic layer is real (radix over
+// overwrite ArcTable), so it commits a cryptographically valid newRoot before
+// the index write is attempted.
+func newFailingTestWriter(t *testing.T) (*Writer, *failingArcTable) {
+	t.Helper()
+	kv := memory.New()
+	e, err := overwrite.NewArcTable(overwrite.WithKVStore(kv))
+	if err != nil {
+		t.Fatalf("NewArcTable: %v", err)
+	}
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme: %v", err)
+	}
+	// The semantic layer writes its radix node slots through the same ArcTable
+	// instance, so wrap once and share it. Node-slot writes go through Update
+	// too; we only fail the *logical* index write by toggling fail at the right
+	// moment in each test.
+	wrapped := &failingArcTable{inner: e}
+	maps, err := radix.NewMap(scheme, wrapped)
+	if err != nil {
+		t.Fatalf("NewMap: %v", err)
+	}
+	return NewWriter(maps, wrapped), wrapped
+}
+
+// TestUpdateArc_IndexWriteFailureReturnsNewRoot is the core regression guard
+// for review finding #1: when the semantic layer produces a newRoot but the
+// ArcTable index write fails, the returned error must carry newRoot so the
+// caller can retry the idempotent index write. Previously the newRoot was
+// discarded and the root became unreadable via the index.
+func TestUpdateArc_IndexWriteFailureReturnsNewRoot(t *testing.T) {
+	ctx := context.Background()
+	namespace := "ns-update-fail"
+	w, failing := newFailingTestWriter(t)
+
+	payload := makeCIDLocal(t, "payload")
+	valueA := makeCIDLocal(t, "value-a")
+	newValueA := makeCIDLocal(t, "new-value-a")
+
+	root, err := w.CreateStructure(ctx, namespace, arcset.NewSetFrom(map[string]cid.Cid{
+		"@payload": payload,
+		"a":        valueA,
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure: %v", err)
+	}
+
+	// Fail only the writer-level index Update. The semantic Update still
+	// succeeds and produces a valid newRoot.
+	failing.fail = true
+	_, err = w.UpdateArc(ctx, namespace, root, "a", newValueA)
+	failing.fail = false
+	if err == nil {
+		t.Fatal("UpdateArc should have failed when ArcTable.Update failed")
+	}
+
+	var idxErr *IndexWriteFailedError
+	if !errors.As(err, &idxErr) {
+		t.Fatalf("expected *IndexWriteFailedError, got %T: %v", err, err)
+	}
+	if !errors.Is(err, ErrIndexWriteFailed) {
+		t.Errorf("errors.Is(err, ErrIndexWriteFailed) = false, want true")
+	}
+	if !errors.Is(err, errInjectedIndexFailure) {
+		t.Errorf("errors.Is(err, errInjectedIndexFailure) = false; underlying cause lost")
+	}
+	if !idxErr.NewRoot.Defined() {
+		t.Fatal("IndexWriteFailedError.NewRoot is undefined")
+	}
+	if idxErr.NewRoot.Equals(root) {
+		t.Error("IndexWriteFailedError.NewRoot equals old root; semantic layer did not advance")
+	}
+
+	// The semantic root is valid but unreadable via the index before retry:
+	// GetArc against newRoot must fail because the index write never landed.
+	if _, err := w.GetArc(ctx, namespace, idxErr.NewRoot, "a"); err == nil {
+		t.Error("GetArc(newRoot, a) succeeded before retry; index write should be missing")
+	}
+
+	// Recovery is by re-running the original writer operation (not by replaying
+	// an ArcTable delta from the error — the delta is intentionally not carried
+	// by IndexWriteFailedError). With the ArcTable healthy again, re-running
+	// UpdateArc against the same base root and inputs must converge to the same
+	// content-addressed newRoot and then publish its index entry.
+	retryResult, err := w.UpdateArc(ctx, namespace, root, "a", newValueA)
+	if err != nil {
+		t.Fatalf("retry UpdateArc: %v", err)
+	}
+	if !retryResult.NewRoot.Equals(idxErr.NewRoot) {
+		t.Errorf("retry produced newRoot %s, want deterministic %s (idempotency broken)",
+			retryResult.NewRoot, idxErr.NewRoot)
+	}
+
+	// Now newRoot is readable.
+	got, err := w.GetArc(ctx, namespace, retryResult.NewRoot, "a")
+	if err != nil {
+		t.Fatalf("GetArc after retry: %v", err)
+	}
+	if !got.Equals(newValueA) {
+		t.Errorf("after retry a = %s, want %s", got, newValueA)
+	}
+}
+
+// TestBatchUpdateArcs_IndexWriteFailureReturnsNewRoot mirrors the above for
+// the batch path.
+func TestBatchUpdateArcs_IndexWriteFailureReturnsNewRoot(t *testing.T) {
+	ctx := context.Background()
+	namespace := "ns-batch-fail"
+	w, failing := newFailingTestWriter(t)
+
+	payload := makeCIDLocal(t, "payload")
+	valueA := makeCIDLocal(t, "value-a")
+	valueB := makeCIDLocal(t, "value-b")
+
+	root, err := w.CreateStructure(ctx, namespace, arcset.NewSetFrom(map[string]cid.Cid{
+		"@payload": payload,
+		"a":        valueA,
+		"b":        valueB,
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure: %v", err)
+	}
+
+	newA := makeCIDLocal(t, "new-a")
+	newB := makeCIDLocal(t, "new-b")
+
+	failing.fail = true
+	_, err = w.BatchUpdateArcs(ctx, namespace, root, map[string]cid.Cid{
+		"a": newA,
+		"b": newB,
+	})
+	failing.fail = false
+	if err == nil {
+		t.Fatal("BatchUpdateArcs should have failed when ArcTable.Update failed")
+	}
+
+	var idxErr *IndexWriteFailedError
+	if !errors.As(err, &idxErr) {
+		t.Fatalf("expected *IndexWriteFailedError, got %T: %v", err, err)
+	}
+	if !idxErr.NewRoot.Defined() || idxErr.NewRoot.Equals(root) {
+		t.Fatalf("IndexWriteFailedError.NewRoot not advanced: %s", idxErr.NewRoot)
+	}
+
+	// Retry converges to the same root (content-addressed determinism).
+	retry, err := w.BatchUpdateArcs(ctx, namespace, root, map[string]cid.Cid{
+		"a": newA,
+		"b": newB,
+	})
+	if err != nil {
+		t.Fatalf("retry BatchUpdateArcs: %v", err)
+	}
+	if !retry.NewRoot.Equals(idxErr.NewRoot) {
+		t.Errorf("retry newRoot %s != failed newRoot %s", retry.NewRoot, idxErr.NewRoot)
+	}
+}
+
+// TestApply_MapDeltaIndexWriteFailure covers the semantic-mutation Apply path
+// (commitMapDelta) which has the same cross-layer window.
+func TestApply_MapDeltaIndexWriteFailure(t *testing.T) {
+	ctx := context.Background()
+	namespace := "ns-apply-fail"
+	w, failing := newFailingTestWriter(t)
+
+	payload := makeCIDLocal(t, "payload")
+	valueA := makeCIDLocal(t, "value-a")
+
+	root, err := w.CreateStructure(ctx, namespace, arcset.NewSetFrom(map[string]cid.Cid{
+		"@payload": payload,
+		"a":        valueA,
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure: %v", err)
+	}
+
+	newA := makeCIDLocal(t, "new-a")
+	mut := SemanticMutation{
+		BaseRoot: root,
+		Deltas: []ArcSetDelta{{
+			Object: root,
+			Kind:   arcset.KindMap,
+			Changes: mustWriterDelta(t, arcset.KindMap, []arcset.ArcChange{
+				{
+					Coordinate: mustMapCoordinate(t, "a"),
+					Before:     targetRefPtr(arcset.NewCASTarget(valueA)),
+					After:      targetRefPtr(arcset.NewCASTarget(newA)),
+				},
+			}),
+		}},
+	}
+
+	failing.fail = true
+	_, err = w.Apply(ctx, namespace, mut)
+	failing.fail = false
+	if err == nil {
+		t.Fatal("Apply should have failed when ArcTable.Update failed")
+	}
+
+	var idxErr *IndexWriteFailedError
+	if !errors.As(err, &idxErr) {
+		t.Fatalf("expected *IndexWriteFailedError, got %T: %v", err, err)
+	}
+	if !idxErr.NewRoot.Defined() {
+		t.Fatal("IndexWriteFailedError.NewRoot is undefined")
+	}
+}
+
+// TestUpdateArc_ClassificationStillCorrectFromSnapshot guards Fix #2: with
+// oldTarget now derived from the snapshot instead of a separate Get, insert /
+// replace / delete classification must remain correct, including the no-op
+// (both undefined) case.
+func TestUpdateArc_ClassificationStillCorrectFromSnapshot(t *testing.T) {
+	ctx := context.Background()
+	namespace := "ns-classify"
+	w, _ := newFailingTestWriter(t)
+
+	payload := makeCIDLocal(t, "payload")
+	valueA := makeCIDLocal(t, "value-a")
+
+	root, err := w.CreateStructure(ctx, namespace, arcset.NewSetFrom(map[string]cid.Cid{
+		"@payload": payload,
+		"a":        valueA,
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure: %v", err)
+	}
+
+	// Replace existing arc.
+	r, err := w.UpdateArc(ctx, namespace, root, "a", makeCIDLocal(t, "replace"))
+	if err != nil {
+		t.Fatalf("replace UpdateArc: %v", err)
+	}
+	if r.Op != ArcReplace {
+		t.Errorf("replace: Op = %s, want replace", r.Op)
+	}
+
+	// Insert new arc.
+	r, err = w.UpdateArc(ctx, namespace, r.NewRoot, "b", makeCIDLocal(t, "inserted"))
+	if err != nil {
+		t.Fatalf("insert UpdateArc: %v", err)
+	}
+	if r.Op != ArcInsert {
+		t.Errorf("insert: Op = %s, want insert", r.Op)
+	}
+
+	// Delete existing arc.
+	r, err = w.UpdateArc(ctx, namespace, r.NewRoot, "b", cid.Undef)
+	if err != nil {
+		t.Fatalf("delete UpdateArc: %v", err)
+	}
+	if r.Op != ArcDelete {
+		t.Errorf("delete: Op = %s, want delete", r.Op)
+	}
+
+	// No-op: deleting a path that does not exist must report a no-op with
+	// ArcInsert op (matching pre-Fix behavior at writer.go:395-404).
+	r, err = w.UpdateArc(ctx, namespace, r.NewRoot, "b", cid.Undef)
+	if err != nil {
+		t.Fatalf("no-op UpdateArc: %v", err)
+	}
+	if r.Op != ArcInsert || !r.NewRoot.Equals(r.OldRoot) {
+		t.Errorf("no-op: Op = %s, NewRoot advanced; expected no-op", r.Op)
+	}
+}
+
+func makeCIDLocal(t *testing.T, data string) cid.Cid {
+	t.Helper()
+	mhash, err := mh.Sum([]byte(data), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("mh.Sum: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, mhash)
+}
+
+// Ensure semanticmapping import is exercised even if future edits remove the
+// only reference above. Keeps the build honest about test dependencies.
+var _ = semanticmapping.NewViewFrom

--- a/graph/writer/index_write_failure_test.go
+++ b/graph/writer/index_write_failure_test.go
@@ -529,11 +529,12 @@ func TestUpdateArc_IndexWriteRetryRejectsStaleReplay(t *testing.T) {
 	}
 }
 
-// TestBatchUpdateArcs_IndexWriteRetryCompletesPartialDelta verifies that retry
-// accepts states produced by partially applying the same failed delta. This
-// models fs-backed overwrite ArcTable batches that can write one arc and then
-// fail before the remaining arc operations land.
-func TestBatchUpdateArcs_IndexWriteRetryCompletesPartialDelta(t *testing.T) {
+// TestBatchUpdateArcs_IndexWriteRetryRejectsPartialDelta verifies that retry
+// rejects partially applied multi-path deltas for overwrite-like backends. A
+// subset of delta paths can be indistinguishable from a later successful subset
+// write, so completing the stale batch would risk corrupting namespace-scoped
+// arc values for that later root.
+func TestBatchUpdateArcs_IndexWriteRetryRejectsPartialDelta(t *testing.T) {
 	ctx := context.Background()
 	namespace := "ns-partial-delta"
 	w, failing := newPartialArcFailureWriter(t)
@@ -582,17 +583,90 @@ func TestBatchUpdateArcs_IndexWriteRetryCompletesPartialDelta(t *testing.T) {
 		t.Fatalf("partial failure b = %s, want old value %s", gotB, valueB)
 	}
 
-	if err := idxErr.RetryIndexWrite(ctx, failing); err != nil {
-		t.Fatalf("RetryIndexWrite after partial delta: %v", err)
+	if err := idxErr.RetryIndexWrite(ctx, failing); !errors.Is(err, ErrStaleRoot) {
+		t.Fatalf("RetryIndexWrite after partial delta error = %v, want ErrStaleRoot", err)
 	}
-	for path, want := range map[string]cid.Cid{"a": newA, "b": newB} {
-		got, err := w.GetArc(ctx, namespace, idxErr.NewRoot, path)
-		if err != nil {
-			t.Fatalf("GetArc(%s) after RetryIndexWrite: %v", path, err)
-		}
-		if !got.Equals(want) {
-			t.Fatalf("GetArc(%s) after RetryIndexWrite = %s, want %s", path, got, want)
-		}
+	gotB, err = w.GetArc(ctx, namespace, idxErr.NewRoot, "b")
+	if err != nil {
+		t.Fatalf("GetArc(b) after rejected RetryIndexWrite: %v", err)
+	}
+	if !gotB.Equals(valueB) {
+		t.Fatalf("rejected RetryIndexWrite changed b = %s, want old value %s", gotB, valueB)
+	}
+}
+
+// TestBatchUpdateArcs_IndexWriteRetryRejectsSubsetWriteStaleReplay covers a
+// stale retry that looks like partial progress if each delta path is checked
+// independently: the failed batch wants to update both a and b, then a later
+// successful write updates only a to the same target. Retrying the failed batch
+// must not publish b's stale target into the namespace-scoped overwrite table.
+func TestBatchUpdateArcs_IndexWriteRetryRejectsSubsetWriteStaleReplay(t *testing.T) {
+	ctx := context.Background()
+	namespace := "ns-stale-batch-subset"
+	w, failing := newFailingTestWriter(t)
+
+	payload := makeCIDLocal(t, "payload")
+	valueA := makeCIDLocal(t, "value-a")
+	valueB := makeCIDLocal(t, "value-b")
+	batchA := makeCIDLocal(t, "batch-a")
+	batchB := makeCIDLocal(t, "batch-b")
+
+	root, err := w.CreateStructure(ctx, namespace, arcset.NewSetFrom(map[string]cid.Cid{
+		"@payload": payload,
+		"a":        valueA,
+		"b":        valueB,
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure: %v", err)
+	}
+
+	failing.fail = true
+	_, err = w.BatchUpdateArcs(ctx, namespace, root, map[string]cid.Cid{
+		"a": batchA,
+		"b": batchB,
+	})
+	failing.fail = false
+	if err == nil {
+		t.Fatal("BatchUpdateArcs should have failed when ArcTable.Update failed")
+	}
+	var staleErr *IndexWriteFailedError
+	if !errors.As(err, &staleErr) {
+		t.Fatalf("expected *IndexWriteFailedError, got %T: %v", err, err)
+	}
+	if staleErr.IndexBase == nil || staleErr.IndexDelta == nil {
+		t.Fatalf("stale error missing retry material: base=%v delta=%v", staleErr.IndexBase, staleErr.IndexDelta)
+	}
+
+	later, err := w.UpdateArc(ctx, namespace, root, "a", batchA)
+	if err != nil {
+		t.Fatalf("later UpdateArc: %v", err)
+	}
+	gotA, err := w.GetArc(ctx, namespace, later.NewRoot, "a")
+	if err != nil {
+		t.Fatalf("GetArc(laterRoot, a) before stale retry: %v", err)
+	}
+	gotB, err := w.GetArc(ctx, namespace, later.NewRoot, "b")
+	if err != nil {
+		t.Fatalf("GetArc(laterRoot, b) before stale retry: %v", err)
+	}
+	if !gotA.Equals(batchA) || !gotB.Equals(valueB) {
+		t.Fatalf("laterRoot before stale retry = {a:%s b:%s}, want {a:%s b:%s}", gotA, gotB, batchA, valueB)
+	}
+
+	err = staleErr.RetryIndexWrite(ctx, failing)
+	if !errors.Is(err, ErrStaleRoot) {
+		t.Fatalf("stale batch RetryIndexWrite error = %v, want ErrStaleRoot", err)
+	}
+	gotA, err = w.GetArc(ctx, namespace, later.NewRoot, "a")
+	if err != nil {
+		t.Fatalf("GetArc(laterRoot, a) after stale retry: %v", err)
+	}
+	gotB, err = w.GetArc(ctx, namespace, later.NewRoot, "b")
+	if err != nil {
+		t.Fatalf("GetArc(laterRoot, b) after stale retry: %v", err)
+	}
+	if !gotA.Equals(batchA) || !gotB.Equals(valueB) {
+		t.Fatalf("stale batch RetryIndexWrite changed laterRoot = {a:%s b:%s}, want {a:%s b:%s}", gotA, gotB, batchA, valueB)
 	}
 }
 

--- a/graph/writer/index_write_failure_test.go
+++ b/graph/writer/index_write_failure_test.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -330,6 +331,62 @@ func TestUpdateArc_ClassificationStillCorrectFromSnapshot(t *testing.T) {
 	}
 }
 
+// TestUpdateArc_CorruptStoredTargetFailsClosed guards the classification path
+// against corrupt overwrite ArcTable entries. overwrite.Snapshot skips values
+// that cannot be cid.Cast; UpdateArc must still use targeted Get for oldTarget
+// classification so deleting a corrupt existing arc does not become a silent
+// "both undefined" no-op.
+func TestUpdateArc_CorruptStoredTargetFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	namespace := "ns-corrupt-update"
+	w, _, _, kv := newTestWriter(t)
+
+	root, err := w.CreateStructure(ctx, namespace, makeArcSet(map[string]cid.Cid{
+		"a": fakeCID("value-a"),
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure: %v", err)
+	}
+	corruptStoredArcValue(t, ctx, kv, namespace, "a")
+
+	_, err = w.UpdateArc(ctx, namespace, root, "a", cid.Undef)
+	if err == nil {
+		t.Fatal("UpdateArc deleting corrupt stored target succeeded; want fail-closed error")
+	}
+	if !strings.Contains(err.Error(), "ArcTable.Get failed") {
+		t.Fatalf("UpdateArc error = %v, want targeted ArcTable.Get failure", err)
+	}
+}
+
+// TestBatchUpdateArcs_CorruptStoredTargetFailsClosed mirrors the single-update
+// corruption guard for the batch path, which also needs targeted Get calls for
+// every updated path.
+func TestBatchUpdateArcs_CorruptStoredTargetFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	namespace := "ns-corrupt-batch"
+	w, _, _, kv := newTestWriter(t)
+
+	root, err := w.CreateStructure(ctx, namespace, makeArcSet(map[string]cid.Cid{
+		"a": fakeCID("value-a"),
+		"b": fakeCID("value-b"),
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure: %v", err)
+	}
+	corruptStoredArcValue(t, ctx, kv, namespace, "b")
+
+	_, err = w.BatchUpdateArcs(ctx, namespace, root, map[string]cid.Cid{
+		"a": fakeCID("new-a"),
+		"b": cid.Undef,
+	})
+	if err == nil {
+		t.Fatal("BatchUpdateArcs with corrupt stored target succeeded; want fail-closed error")
+	}
+	if !strings.Contains(err.Error(), "ArcTable.Get failed for b") {
+		t.Fatalf("BatchUpdateArcs error = %v, want targeted ArcTable.Get failure for b", err)
+	}
+}
+
 func makeCIDLocal(t *testing.T, data string) cid.Cid {
 	t.Helper()
 	mhash, err := mh.Sum([]byte(data), mh.SHA2_256, -1)
@@ -337,6 +394,14 @@ func makeCIDLocal(t *testing.T, data string) cid.Cid {
 		t.Fatalf("mh.Sum: %v", err)
 	}
 	return cid.NewCidV1(cid.Raw, mhash)
+}
+
+func corruptStoredArcValue(t *testing.T, ctx context.Context, kv *kvg, namespace, path string) {
+	t.Helper()
+	key := arctable.DefaultArcKey(namespace, arcset.CanonicalizePath(path))
+	if err := kv.Put(ctx, key, []byte("not-a-cid")); err != nil {
+		t.Fatalf("corrupt stored arc value: %v", err)
+	}
 }
 
 // Ensure semanticmapping import is exercised even if future edits remove the

--- a/graph/writer/index_write_failure_test.go
+++ b/graph/writer/index_write_failure_test.go
@@ -102,6 +102,59 @@ func (f *rootDeletingFailingArcTable) Iterate(ctx context.Context, namespace str
 
 func (f *rootDeletingFailingArcTable) Close() error { return f.inner.Close() }
 
+// partialArcFailingArcTable simulates a non-atomic batch failure after one arc
+// from a multi-arc delta has already been applied. That intermediate namespace
+// state is neither IndexBase nor the full expected-after state, but it is still
+// safe for RetryIndexWrite to complete the same captured delta.
+type partialArcFailingArcTable struct {
+	inner arctable.ArcTable
+	kv    *kvg
+	fail  bool
+}
+
+func (f *partialArcFailingArcTable) Get(ctx context.Context, namespace string, root cid.Cid, path arcset.Path) (cid.Cid, error) {
+	return f.inner.Get(ctx, namespace, root, path)
+}
+
+func (f *partialArcFailingArcTable) BatchGet(ctx context.Context, namespace string, root cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error) {
+	return f.inner.BatchGet(ctx, namespace, root, paths)
+}
+
+func (f *partialArcFailingArcTable) Update(ctx context.Context, namespace string, newRoot, oldRoot cid.Cid, arcs arcset.ArcSet) error {
+	if f.fail && newRoot.Defined() && oldRoot.Defined() {
+		arcMap, err := arcset.ToPathMap(arcs)
+		if err != nil {
+			return err
+		}
+		if err := f.kv.Delete(ctx, arctable.RootKeyFormat(oldRoot)); err != nil {
+			return err
+		}
+		if err := f.kv.Put(ctx, arctable.RootKeyFormat(newRoot), []byte(namespace)); err != nil {
+			return err
+		}
+		path := arcset.CanonicalizePath("a")
+		target, ok := arcMap[path]
+		if !ok || !target.Defined() {
+			return errInjectedIndexFailure
+		}
+		if err := f.kv.Put(ctx, arctable.DefaultArcKey(namespace, path), target.Bytes()); err != nil {
+			return err
+		}
+		return errInjectedIndexFailure
+	}
+	return f.inner.Update(ctx, namespace, newRoot, oldRoot, arcs)
+}
+
+func (f *partialArcFailingArcTable) Snapshot(ctx context.Context, namespace string, root cid.Cid) (arcset.ArcSet, error) {
+	return f.inner.Snapshot(ctx, namespace, root)
+}
+
+func (f *partialArcFailingArcTable) Iterate(ctx context.Context, namespace string, root cid.Cid) arcset.Iterator {
+	return f.inner.Iterate(ctx, namespace, root)
+}
+
+func (f *partialArcFailingArcTable) Close() error { return f.inner.Close() }
+
 // newFailingTestWriter builds a writer whose ArcTable Update is controlled by
 // the returned *failingArcTable. The semantic layer is real (radix over
 // overwrite ArcTable), so it commits a cryptographically valid newRoot before
@@ -141,6 +194,25 @@ func newRootDeletingFailureWriter(t *testing.T) (*Writer, *rootDeletingFailingAr
 		t.Fatalf("NewScheme: %v", err)
 	}
 	wrapped := &rootDeletingFailingArcTable{inner: e, kv: kv}
+	maps, err := radix.NewMap(scheme, wrapped)
+	if err != nil {
+		t.Fatalf("NewMap: %v", err)
+	}
+	return NewWriter(maps, wrapped), wrapped
+}
+
+func newPartialArcFailureWriter(t *testing.T) (*Writer, *partialArcFailingArcTable) {
+	t.Helper()
+	kv := memory.New()
+	e, err := overwrite.NewArcTable(overwrite.WithKVStore(kv))
+	if err != nil {
+		t.Fatalf("NewArcTable: %v", err)
+	}
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme: %v", err)
+	}
+	wrapped := &partialArcFailingArcTable{inner: e, kv: kv}
 	maps, err := radix.NewMap(scheme, wrapped)
 	if err != nil {
 		t.Fatalf("NewMap: %v", err)
@@ -454,6 +526,73 @@ func TestUpdateArc_IndexWriteRetryRejectsStaleReplay(t *testing.T) {
 	}
 	if !got.Equals(laterA) {
 		t.Fatalf("stale RetryIndexWrite changed laterRoot a = %s, want %s", got, laterA)
+	}
+}
+
+// TestBatchUpdateArcs_IndexWriteRetryCompletesPartialDelta verifies that retry
+// accepts states produced by partially applying the same failed delta. This
+// models fs-backed overwrite ArcTable batches that can write one arc and then
+// fail before the remaining arc operations land.
+func TestBatchUpdateArcs_IndexWriteRetryCompletesPartialDelta(t *testing.T) {
+	ctx := context.Background()
+	namespace := "ns-partial-delta"
+	w, failing := newPartialArcFailureWriter(t)
+
+	payload := makeCIDLocal(t, "payload")
+	valueA := makeCIDLocal(t, "value-a")
+	valueB := makeCIDLocal(t, "value-b")
+	newA := makeCIDLocal(t, "new-a")
+	newB := makeCIDLocal(t, "new-b")
+
+	root, err := w.CreateStructure(ctx, namespace, arcset.NewSetFrom(map[string]cid.Cid{
+		"@payload": payload,
+		"a":        valueA,
+		"b":        valueB,
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure: %v", err)
+	}
+
+	failing.fail = true
+	_, err = w.BatchUpdateArcs(ctx, namespace, root, map[string]cid.Cid{
+		"a": newA,
+		"b": newB,
+	})
+	failing.fail = false
+	if err == nil {
+		t.Fatal("BatchUpdateArcs should have failed after partial arc apply")
+	}
+	var idxErr *IndexWriteFailedError
+	if !errors.As(err, &idxErr) {
+		t.Fatalf("expected *IndexWriteFailedError, got %T: %v", err, err)
+	}
+
+	gotA, err := w.GetArc(ctx, namespace, idxErr.NewRoot, "a")
+	if err != nil {
+		t.Fatalf("GetArc(a) after partial failure: %v", err)
+	}
+	if !gotA.Equals(newA) {
+		t.Fatalf("partial failure a = %s, want %s", gotA, newA)
+	}
+	gotB, err := w.GetArc(ctx, namespace, idxErr.NewRoot, "b")
+	if err != nil {
+		t.Fatalf("GetArc(b) after partial failure: %v", err)
+	}
+	if !gotB.Equals(valueB) {
+		t.Fatalf("partial failure b = %s, want old value %s", gotB, valueB)
+	}
+
+	if err := idxErr.RetryIndexWrite(ctx, failing); err != nil {
+		t.Fatalf("RetryIndexWrite after partial delta: %v", err)
+	}
+	for path, want := range map[string]cid.Cid{"a": newA, "b": newB} {
+		got, err := w.GetArc(ctx, namespace, idxErr.NewRoot, path)
+		if err != nil {
+			t.Fatalf("GetArc(%s) after RetryIndexWrite: %v", path, err)
+		}
+		if !got.Equals(want) {
+			t.Fatalf("GetArc(%s) after RetryIndexWrite = %s, want %s", path, got, want)
+		}
 	}
 }
 

--- a/graph/writer/index_write_failure_test.go
+++ b/graph/writer/index_write_failure_test.go
@@ -64,6 +64,44 @@ func (f *failingArcTable) Close() error { return f.inner.Close() }
 
 var errInjectedIndexFailure = errors.New("injected arctable failure")
 
+// rootDeletingFailingArcTable simulates a non-atomic ArcTable backend that has
+// already invalidated oldRoot before the logical root-publishing write fails.
+// Retrying the original writer operation against oldRoot cannot recover from
+// this state; the captured IndexDelta must be replayed instead.
+type rootDeletingFailingArcTable struct {
+	inner arctable.ArcTable
+	kv    *kvg
+	fail  bool
+}
+
+func (f *rootDeletingFailingArcTable) Get(ctx context.Context, namespace string, root cid.Cid, path arcset.Path) (cid.Cid, error) {
+	return f.inner.Get(ctx, namespace, root, path)
+}
+
+func (f *rootDeletingFailingArcTable) BatchGet(ctx context.Context, namespace string, root cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error) {
+	return f.inner.BatchGet(ctx, namespace, root, paths)
+}
+
+func (f *rootDeletingFailingArcTable) Update(ctx context.Context, namespace string, newRoot, oldRoot cid.Cid, arcs arcset.ArcSet) error {
+	if f.fail && newRoot.Defined() && oldRoot.Defined() {
+		if err := f.kv.Delete(ctx, arctable.RootKeyFormat(oldRoot)); err != nil {
+			return err
+		}
+		return errInjectedIndexFailure
+	}
+	return f.inner.Update(ctx, namespace, newRoot, oldRoot, arcs)
+}
+
+func (f *rootDeletingFailingArcTable) Snapshot(ctx context.Context, namespace string, root cid.Cid) (arcset.ArcSet, error) {
+	return f.inner.Snapshot(ctx, namespace, root)
+}
+
+func (f *rootDeletingFailingArcTable) Iterate(ctx context.Context, namespace string, root cid.Cid) arcset.Iterator {
+	return f.inner.Iterate(ctx, namespace, root)
+}
+
+func (f *rootDeletingFailingArcTable) Close() error { return f.inner.Close() }
+
 // newFailingTestWriter builds a writer whose ArcTable Update is controlled by
 // the returned *failingArcTable. The semantic layer is real (radix over
 // overwrite ArcTable), so it commits a cryptographically valid newRoot before
@@ -84,6 +122,25 @@ func newFailingTestWriter(t *testing.T) (*Writer, *failingArcTable) {
 	// too; we only fail the *logical* index write by toggling fail at the right
 	// moment in each test.
 	wrapped := &failingArcTable{inner: e}
+	maps, err := radix.NewMap(scheme, wrapped)
+	if err != nil {
+		t.Fatalf("NewMap: %v", err)
+	}
+	return NewWriter(maps, wrapped), wrapped
+}
+
+func newRootDeletingFailureWriter(t *testing.T) (*Writer, *rootDeletingFailingArcTable) {
+	t.Helper()
+	kv := memory.New()
+	e, err := overwrite.NewArcTable(overwrite.WithKVStore(kv))
+	if err != nil {
+		t.Fatalf("NewArcTable: %v", err)
+	}
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme: %v", err)
+	}
+	wrapped := &rootDeletingFailingArcTable{inner: e, kv: kv}
 	maps, err := radix.NewMap(scheme, wrapped)
 	if err != nil {
 		t.Fatalf("NewMap: %v", err)
@@ -138,6 +195,9 @@ func TestUpdateArc_IndexWriteFailureReturnsNewRoot(t *testing.T) {
 	if idxErr.NewRoot.Equals(root) {
 		t.Error("IndexWriteFailedError.NewRoot equals old root; semantic layer did not advance")
 	}
+	if idxErr.IndexDelta == nil {
+		t.Fatal("IndexWriteFailedError.IndexDelta is nil")
+	}
 
 	// The semantic root is valid but unreadable via the index before retry:
 	// GetArc against newRoot must fail because the index write never landed.
@@ -145,22 +205,13 @@ func TestUpdateArc_IndexWriteFailureReturnsNewRoot(t *testing.T) {
 		t.Error("GetArc(newRoot, a) succeeded before retry; index write should be missing")
 	}
 
-	// Recovery is by re-running the original writer operation (not by replaying
-	// an ArcTable delta from the error — the delta is intentionally not carried
-	// by IndexWriteFailedError). With the ArcTable healthy again, re-running
-	// UpdateArc against the same base root and inputs must converge to the same
-	// content-addressed newRoot and then publish its index entry.
-	retryResult, err := w.UpdateArc(ctx, namespace, root, "a", newValueA)
-	if err != nil {
-		t.Fatalf("retry UpdateArc: %v", err)
+	// Recovery replays the captured ArcTable transition. This is stronger than
+	// re-running the original writer operation because a non-atomic backend may
+	// have partially invalidated oldRoot before returning the failure.
+	if err := idxErr.RetryIndexWrite(ctx, failing); err != nil {
+		t.Fatalf("RetryIndexWrite: %v", err)
 	}
-	if !retryResult.NewRoot.Equals(idxErr.NewRoot) {
-		t.Errorf("retry produced newRoot %s, want deterministic %s (idempotency broken)",
-			retryResult.NewRoot, idxErr.NewRoot)
-	}
-
-	// Now newRoot is readable.
-	got, err := w.GetArc(ctx, namespace, retryResult.NewRoot, "a")
+	got, err := w.GetArc(ctx, namespace, idxErr.NewRoot, "a")
 	if err != nil {
 		t.Fatalf("GetArc after retry: %v", err)
 	}
@@ -209,17 +260,21 @@ func TestBatchUpdateArcs_IndexWriteFailureReturnsNewRoot(t *testing.T) {
 	if !idxErr.NewRoot.Defined() || idxErr.NewRoot.Equals(root) {
 		t.Fatalf("IndexWriteFailedError.NewRoot not advanced: %s", idxErr.NewRoot)
 	}
-
-	// Retry converges to the same root (content-addressed determinism).
-	retry, err := w.BatchUpdateArcs(ctx, namespace, root, map[string]cid.Cid{
-		"a": newA,
-		"b": newB,
-	})
-	if err != nil {
-		t.Fatalf("retry BatchUpdateArcs: %v", err)
+	if idxErr.IndexDelta == nil {
+		t.Fatal("IndexWriteFailedError.IndexDelta is nil")
 	}
-	if !retry.NewRoot.Equals(idxErr.NewRoot) {
-		t.Errorf("retry newRoot %s != failed newRoot %s", retry.NewRoot, idxErr.NewRoot)
+
+	if err := idxErr.RetryIndexWrite(ctx, failing); err != nil {
+		t.Fatalf("RetryIndexWrite: %v", err)
+	}
+	for path, want := range map[string]cid.Cid{"a": newA, "b": newB} {
+		got, err := w.GetArc(ctx, namespace, idxErr.NewRoot, path)
+		if err != nil {
+			t.Fatalf("GetArc(%s) after retry: %v", path, err)
+		}
+		if !got.Equals(want) {
+			t.Fatalf("GetArc(%s) = %s, want %s", path, got, want)
+		}
 	}
 }
 
@@ -270,6 +325,62 @@ func TestApply_MapDeltaIndexWriteFailure(t *testing.T) {
 	}
 	if !idxErr.NewRoot.Defined() {
 		t.Fatal("IndexWriteFailedError.NewRoot is undefined")
+	}
+	if idxErr.IndexDelta == nil {
+		t.Fatal("IndexWriteFailedError.IndexDelta is nil")
+	}
+}
+
+// TestUpdateArc_IndexWriteRetrySurvivesMissingBaseRoot covers a non-atomic
+// backend window where the old root mapping has already been removed before
+// ArcTable.Update reports failure. In that state, re-running the original
+// writer operation cannot recover because Snapshot(oldRoot) no longer finds the
+// mandatory payload binding; replaying IndexDelta from the error still works.
+func TestUpdateArc_IndexWriteRetrySurvivesMissingBaseRoot(t *testing.T) {
+	ctx := context.Background()
+	namespace := "ns-partial-index-fail"
+	w, failing := newRootDeletingFailureWriter(t)
+
+	payload := makeCIDLocal(t, "payload")
+	valueA := makeCIDLocal(t, "value-a")
+	newA := makeCIDLocal(t, "new-a")
+
+	root, err := w.CreateStructure(ctx, namespace, arcset.NewSetFrom(map[string]cid.Cid{
+		"@payload": payload,
+		"a":        valueA,
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure: %v", err)
+	}
+
+	failing.fail = true
+	_, err = w.UpdateArc(ctx, namespace, root, "a", newA)
+	failing.fail = false
+	if err == nil {
+		t.Fatal("UpdateArc should have failed when ArcTable.Update partially failed")
+	}
+	var idxErr *IndexWriteFailedError
+	if !errors.As(err, &idxErr) {
+		t.Fatalf("expected *IndexWriteFailedError, got %T: %v", err, err)
+	}
+	if idxErr.IndexDelta == nil {
+		t.Fatal("IndexWriteFailedError.IndexDelta is nil")
+	}
+
+	_, retryErr := w.UpdateArc(ctx, namespace, root, "a", newA)
+	if !errors.Is(retryErr, ErrMissingPayloadBinding) {
+		t.Fatalf("retrying original UpdateArc error = %v, want ErrMissingPayloadBinding", retryErr)
+	}
+
+	if err := idxErr.RetryIndexWrite(ctx, failing); err != nil {
+		t.Fatalf("RetryIndexWrite: %v", err)
+	}
+	got, err := w.GetArc(ctx, namespace, idxErr.NewRoot, "a")
+	if err != nil {
+		t.Fatalf("GetArc after RetryIndexWrite: %v", err)
+	}
+	if !got.Equals(newA) {
+		t.Fatalf("a after RetryIndexWrite = %s, want %s", got, newA)
 	}
 }
 

--- a/graph/writer/index_write_failure_test.go
+++ b/graph/writer/index_write_failure_test.go
@@ -104,8 +104,9 @@ func (f *rootDeletingFailingArcTable) Close() error { return f.inner.Close() }
 
 // partialArcFailingArcTable simulates a non-atomic batch failure after one arc
 // from a multi-arc delta has already been applied. That intermediate namespace
-// state is neither IndexBase nor the full expected-after state, but it is still
-// safe for RetryIndexWrite to complete the same captured delta.
+// state is neither IndexBase nor the full expected-after state, so
+// RetryIndexWrite must fail closed: it cannot distinguish this partial write
+// from a later successful subset write.
 type partialArcFailingArcTable struct {
 	inner arctable.ArcTable
 	kv    *kvg

--- a/graph/writer/index_write_failure_test.go
+++ b/graph/writer/index_write_failure_test.go
@@ -198,6 +198,9 @@ func TestUpdateArc_IndexWriteFailureReturnsNewRoot(t *testing.T) {
 	if idxErr.IndexDelta == nil {
 		t.Fatal("IndexWriteFailedError.IndexDelta is nil")
 	}
+	if idxErr.IndexBase == nil {
+		t.Fatal("IndexWriteFailedError.IndexBase is nil")
+	}
 
 	// The semantic root is valid but unreadable via the index before retry:
 	// GetArc against newRoot must fail because the index write never landed.
@@ -262,6 +265,9 @@ func TestBatchUpdateArcs_IndexWriteFailureReturnsNewRoot(t *testing.T) {
 	}
 	if idxErr.IndexDelta == nil {
 		t.Fatal("IndexWriteFailedError.IndexDelta is nil")
+	}
+	if idxErr.IndexBase == nil {
+		t.Fatal("IndexWriteFailedError.IndexBase is nil")
 	}
 
 	if err := idxErr.RetryIndexWrite(ctx, failing); err != nil {
@@ -329,6 +335,9 @@ func TestApply_MapDeltaIndexWriteFailure(t *testing.T) {
 	if idxErr.IndexDelta == nil {
 		t.Fatal("IndexWriteFailedError.IndexDelta is nil")
 	}
+	if idxErr.IndexBase == nil {
+		t.Fatal("IndexWriteFailedError.IndexBase is nil")
+	}
 }
 
 // TestUpdateArc_IndexWriteRetrySurvivesMissingBaseRoot covers a non-atomic
@@ -366,6 +375,9 @@ func TestUpdateArc_IndexWriteRetrySurvivesMissingBaseRoot(t *testing.T) {
 	if idxErr.IndexDelta == nil {
 		t.Fatal("IndexWriteFailedError.IndexDelta is nil")
 	}
+	if idxErr.IndexBase == nil {
+		t.Fatal("IndexWriteFailedError.IndexBase is nil")
+	}
 
 	_, retryErr := w.UpdateArc(ctx, namespace, root, "a", newA)
 	if !errors.Is(retryErr, ErrMissingPayloadBinding) {
@@ -381,6 +393,67 @@ func TestUpdateArc_IndexWriteRetrySurvivesMissingBaseRoot(t *testing.T) {
 	}
 	if !got.Equals(newA) {
 		t.Fatalf("a after RetryIndexWrite = %s, want %s", got, newA)
+	}
+}
+
+// TestUpdateArc_IndexWriteRetryRejectsStaleReplay guards overwrite ArcTable's
+// namespace-scoped physical arc keys. A stale failed delta must not be replayed
+// after a later successful write advances the same namespace, otherwise the
+// later root remains present but resolves to stale arc values.
+func TestUpdateArc_IndexWriteRetryRejectsStaleReplay(t *testing.T) {
+	ctx := context.Background()
+	namespace := "ns-stale-retry"
+	w, failing := newFailingTestWriter(t)
+
+	payload := makeCIDLocal(t, "payload")
+	valueA := makeCIDLocal(t, "value-a")
+	staleA := makeCIDLocal(t, "stale-a")
+	laterA := makeCIDLocal(t, "later-a")
+
+	root, err := w.CreateStructure(ctx, namespace, arcset.NewSetFrom(map[string]cid.Cid{
+		"@payload": payload,
+		"a":        valueA,
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure: %v", err)
+	}
+
+	failing.fail = true
+	_, err = w.UpdateArc(ctx, namespace, root, "a", staleA)
+	failing.fail = false
+	if err == nil {
+		t.Fatal("first UpdateArc should have failed when ArcTable.Update failed")
+	}
+	var staleErr *IndexWriteFailedError
+	if !errors.As(err, &staleErr) {
+		t.Fatalf("expected *IndexWriteFailedError, got %T: %v", err, err)
+	}
+	if staleErr.IndexBase == nil || staleErr.IndexDelta == nil {
+		t.Fatalf("stale error missing retry material: base=%v delta=%v", staleErr.IndexBase, staleErr.IndexDelta)
+	}
+
+	later, err := w.UpdateArc(ctx, namespace, root, "a", laterA)
+	if err != nil {
+		t.Fatalf("later UpdateArc: %v", err)
+	}
+	got, err := w.GetArc(ctx, namespace, later.NewRoot, "a")
+	if err != nil {
+		t.Fatalf("GetArc(laterRoot) before stale retry: %v", err)
+	}
+	if !got.Equals(laterA) {
+		t.Fatalf("laterRoot before stale retry = %s, want %s", got, laterA)
+	}
+
+	err = staleErr.RetryIndexWrite(ctx, failing)
+	if !errors.Is(err, ErrStaleRoot) {
+		t.Fatalf("stale RetryIndexWrite error = %v, want ErrStaleRoot", err)
+	}
+	got, err = w.GetArc(ctx, namespace, later.NewRoot, "a")
+	if err != nil {
+		t.Fatalf("GetArc(laterRoot) after stale retry: %v", err)
+	}
+	if !got.Equals(laterA) {
+		t.Fatalf("stale RetryIndexWrite changed laterRoot a = %s, want %s", got, laterA)
 	}
 }
 

--- a/graph/writer/mutation.go
+++ b/graph/writer/mutation.go
@@ -193,7 +193,12 @@ func (w *Writer) commitMapDelta(ctx context.Context, namespace string, delta Arc
 				return cid.Undef, err
 			}
 			if err := w.arctable.Update(ctx, namespace, root, cid.Undef, snapshot); err != nil {
-				return cid.Undef, err
+				return cid.Undef, &IndexWriteFailedError{
+					NewRoot:   root,
+					Namespace: namespace,
+					OldRoot:   cid.Undef,
+					Cause:     err,
+				}
 			}
 		}
 		return root, nil
@@ -227,7 +232,12 @@ func (w *Writer) commitMapDelta(ctx context.Context, namespace string, delta Arc
 			return cid.Undef, err
 		}
 		if err := w.arctable.Update(ctx, namespace, root, delta.Object, deltaSet); err != nil {
-			return cid.Undef, err
+			return cid.Undef, &IndexWriteFailedError{
+				NewRoot:   root,
+				Namespace: namespace,
+				OldRoot:   delta.Object,
+				Cause:     err,
+			}
 		}
 	}
 	return root, nil

--- a/graph/writer/mutation.go
+++ b/graph/writer/mutation.go
@@ -192,11 +192,22 @@ func (w *Writer) commitMapDelta(ctx context.Context, namespace string, delta Arc
 			if err != nil {
 				return cid.Undef, err
 			}
+			retryBase, err := indexRetryBase(ctx, w.arctable, namespace)
+			if err != nil {
+				return cid.Undef, &IndexWriteFailedError{
+					NewRoot:    root,
+					Namespace:  namespace,
+					OldRoot:    cid.Undef,
+					IndexDelta: snapshot,
+					Cause:      fmt.Errorf("ArcTable.Snapshot retry base failed: %w", err),
+				}
+			}
 			if err := w.arctable.Update(ctx, namespace, root, cid.Undef, snapshot); err != nil {
 				return cid.Undef, &IndexWriteFailedError{
 					NewRoot:    root,
 					Namespace:  namespace,
 					OldRoot:    cid.Undef,
+					IndexBase:  retryBase,
 					IndexDelta: snapshot,
 					Cause:      err,
 				}
@@ -232,11 +243,22 @@ func (w *Writer) commitMapDelta(ctx context.Context, namespace string, delta Arc
 		if err != nil {
 			return cid.Undef, err
 		}
+		retryBase, err := indexRetryBase(ctx, w.arctable, namespace)
+		if err != nil {
+			return cid.Undef, &IndexWriteFailedError{
+				NewRoot:    root,
+				Namespace:  namespace,
+				OldRoot:    delta.Object,
+				IndexDelta: deltaSet,
+				Cause:      fmt.Errorf("ArcTable.Snapshot retry base failed: %w", err),
+			}
+		}
 		if err := w.arctable.Update(ctx, namespace, root, delta.Object, deltaSet); err != nil {
 			return cid.Undef, &IndexWriteFailedError{
 				NewRoot:    root,
 				Namespace:  namespace,
 				OldRoot:    delta.Object,
+				IndexBase:  retryBase,
 				IndexDelta: deltaSet,
 				Cause:      err,
 			}

--- a/graph/writer/mutation.go
+++ b/graph/writer/mutation.go
@@ -194,10 +194,11 @@ func (w *Writer) commitMapDelta(ctx context.Context, namespace string, delta Arc
 			}
 			if err := w.arctable.Update(ctx, namespace, root, cid.Undef, snapshot); err != nil {
 				return cid.Undef, &IndexWriteFailedError{
-					NewRoot:   root,
-					Namespace: namespace,
-					OldRoot:   cid.Undef,
-					Cause:     err,
+					NewRoot:    root,
+					Namespace:  namespace,
+					OldRoot:    cid.Undef,
+					IndexDelta: snapshot,
+					Cause:      err,
 				}
 			}
 		}
@@ -233,10 +234,11 @@ func (w *Writer) commitMapDelta(ctx context.Context, namespace string, delta Arc
 		}
 		if err := w.arctable.Update(ctx, namespace, root, delta.Object, deltaSet); err != nil {
 			return cid.Undef, &IndexWriteFailedError{
-				NewRoot:   root,
-				Namespace: namespace,
-				OldRoot:   delta.Object,
-				Cause:     err,
+				NewRoot:    root,
+				Namespace:  namespace,
+				OldRoot:    delta.Object,
+				IndexDelta: deltaSet,
+				Cause:      err,
 			}
 		}
 	}

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -39,7 +39,54 @@ var (
 	// update a base root that this writer has already advanced in the same
 	// namespace.
 	ErrStaleRoot = errors.New("stale root")
+
+	// ErrIndexWriteFailed is returned when the semantic layer produced a new
+	// root but the ArcTable index write failed. The semantic commitment is
+	// content-addressed and cannot be rolled back, so the returned newRoot is a
+	// cryptographically valid root whose ArcTable entries may be missing.
+	//
+	// To recover, retry the original writer operation (UpdateArc /
+	// BatchUpdateArcs / CreateStructure / Apply) against the same base root and
+	// inputs. Because the semantic commitment is deterministic and
+	// content-addressed, a successful retry converges to the same newRoot and
+	// then re-issues the ArcTable index write; re-writing identical entries is
+	// a no-op for both overwrite and versioned backends. Use errors.As to
+	// recover the newRoot via IndexWriteFailedError (exposed for diagnostics
+	// and correlation, not for direct ArcTable replay — the delta is not
+	// carried by the error).
+	ErrIndexWriteFailed = errors.New("arctable index write failed after semantic commit")
 )
+
+// IndexWriteFailedError carries the newRoot produced by the semantic layer when
+// the ArcTable index write failed. errors.Is(err, ErrIndexWriteFailed) and
+// errors.Is(err, <underlying cause>) both succeed.
+//
+// The fields are exposed for diagnostics and correlation (e.g. logging the
+// orphaned newRoot, correlating with a retry). Recovery is by re-running the
+// original writer operation, not by replaying an ArcTable delta from this
+// error: the ArcSet delta is intentionally not carried here to avoid leaking
+// the internal arcset representation through the error contract.
+type IndexWriteFailedError struct {
+	// NewRoot is the content-addressed root the semantic layer committed. It is
+	// valid in the semantic sense, but its ArcTable index entries may not have
+	// been persisted.
+	NewRoot cid.Cid
+	// Namespace is the namespace of the failed index write, for retry context.
+	Namespace string
+	// OldRoot is the base root the write transitioned from (cid.Undef for
+	// CreateStructure).
+	OldRoot cid.Cid
+	// Cause is the error returned by ArcTable.Update.
+	Cause error
+}
+
+func (e *IndexWriteFailedError) Error() string {
+	return fmt.Errorf("%w (newRoot=%s): %v", ErrIndexWriteFailed, e.NewRoot, e.Cause).Error()
+}
+
+func (e *IndexWriteFailedError) Unwrap() error {
+	return errors.Join(ErrIndexWriteFailed, e.Cause)
+}
 
 var mandatoryPayloadPath = arcset.CanonicalizePath("@payload")
 
@@ -366,12 +413,10 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 		defer unlock()
 	}
 
-	// Step 1: Look up current binding
-	oldTarget, err := w.arctable.Get(ctx, namespace, root, canonicalPath)
-	if err != nil && !arctable.IsNotFound(err) {
-		return nil, fmt.Errorf("ArcTable.Get failed: %w", err)
-	}
-	// arctable.IsNotFound means oldTarget == cid.Undef, which is valid for insert
+	// Step 1: Snapshot the current arc set. oldTarget is derived from the
+	// snapshot instead of a separate Get to avoid a redundant KV round-trip —
+	// the snapshot is already required for delta computation and payload
+	// validation below.
 	snapshot, err := w.arctable.Snapshot(ctx, namespace, root)
 	if err != nil {
 		return nil, fmt.Errorf("ArcTable.Snapshot failed: %w", err)
@@ -379,6 +424,9 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 	if !hasDefinedPayloadBinding(snapshot) && !(canonicalPath == mandatoryPayloadPath && newTarget.Defined()) {
 		return nil, ErrMissingPayloadBinding
 	}
+	// arctable.Snapshot returns ErrNotFound-shaped miss as a missing entry, so
+	// oldTarget == cid.Undef is valid here for inserts.
+	oldTarget, _ := snapshot.Get(canonicalPath)
 
 	// Determine operation type
 	var op ArcOp
@@ -429,9 +477,16 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 	}
 
 	// Step 3: Apply update to ArcTable as an old->new delta. This keeps versioned ArcTable
-	// compact while still emitting tombstones for deletions.
+	// compact while still emitting tombstones for deletions. If this fails the
+	// newRoot is semantically valid but unreadable via the index; surface it so
+	// the caller can retry the idempotent ArcTable write.
 	if err := w.arctable.Update(ctx, namespace, newRoot, root, delta); err != nil {
-		return nil, fmt.Errorf("ArcTable.Update failed: %w", err)
+		return nil, &IndexWriteFailedError{
+			NewRoot:   newRoot,
+			Namespace: namespace,
+			OldRoot:   root,
+			Cause:     fmt.Errorf("ArcTable.Update failed: %w", err),
+		}
 	}
 	if w.freshness != nil {
 		w.freshness.markAdvancedLocked(namespace, root, newRoot)
@@ -496,15 +551,17 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 		}
 	}
 
-	// Step 2: Look up all current bindings and classify operations
+	// Step 2: Look up all current bindings in a single batch and classify
+	// operations. The snapshot already loaded the full arc set, so derive
+	// oldTargets from it rather than issuing one Get per update path (which
+	// would be O(N) KV round-trips).
 	perArc := make(map[arcset.Path]UpdateResult, len(normalizedUpdates))
 	batchUpdates := make([]mapping.BatchUpdate, 0, len(normalizedUpdates))
 
 	for path, newTarget := range normalizedUpdates {
-		oldTarget, err := w.arctable.Get(ctx, namespace, root, path)
-		if err != nil && !arctable.IsNotFound(err) {
-			return nil, fmt.Errorf("ArcTable.Get failed for %s: %w", path.String(), err)
-		}
+		// snapshot.Get returns (cid.Undef, false) for absent paths, which is
+		// exactly the insert case — no IsNotFound translation needed.
+		oldTarget, _ := snapshot.Get(path)
 
 		isInsert := !oldTarget.Defined() && newTarget.Defined()
 		isDelete := oldTarget.Defined() && !newTarget.Defined()
@@ -561,9 +618,16 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 		return nil, err
 	}
 
-	// Step 4: Apply the update delta to ArcTable.
+	// Step 4: Apply the update delta to ArcTable. On failure the newRoot is
+	// semantically valid but its index entries are missing; surface it so the
+	// caller can retry the idempotent write.
 	if err := w.arctable.Update(ctx, namespace, newRoot, root, delta); err != nil {
-		return nil, fmt.Errorf("ArcTable.Update failed: %w", err)
+		return nil, &IndexWriteFailedError{
+			NewRoot:   newRoot,
+			Namespace: namespace,
+			OldRoot:   root,
+			Cause:     fmt.Errorf("ArcTable.Update failed: %w", err),
+		}
 	}
 	if w.freshness != nil {
 		w.freshness.markAdvancedLocked(namespace, root, newRoot)
@@ -610,9 +674,15 @@ func (w *Writer) CreateStructure(ctx context.Context, namespace string, arcs arc
 		return cid.Undef, fmt.Errorf("semantic.Commit failed: %w", err)
 	}
 
-	// Step 2: Store arcs in ArcTable (first version)
+	// Step 2: Store arcs in ArcTable (first version). On failure root is
+	// semantically committed but has no index entries; surface it for retry.
 	if err := w.arctable.Update(ctx, namespace, root, cid.Undef, normalizedSnapshot); err != nil {
-		return cid.Undef, fmt.Errorf("ArcTable.Update failed: %w", err)
+		return cid.Undef, &IndexWriteFailedError{
+			NewRoot:   root,
+			Namespace: namespace,
+			OldRoot:   cid.Undef,
+			Cause:     fmt.Errorf("ArcTable.Update failed: %w", err),
+		}
 	}
 	if w.freshness != nil {
 		w.freshness.markCurrent(namespace, root)

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -97,7 +97,7 @@ func (e *IndexWriteFailedError) Unwrap() error {
 // error. The operation is intended to be idempotent: it re-applies the same
 // absolute OldRoot -> NewRoot transition and IndexDelta. For overwrite-like
 // backends, it first rejects stale retries when the namespace arcs no longer
-// match any state reachable by partially applying this captured transition.
+// match the captured pre-publication or full post-publication state.
 func (e *IndexWriteFailedError) RetryIndexWrite(ctx context.Context, table arctable.ArcTable) error {
 	if e == nil {
 		return fmt.Errorf("index write failure is nil")
@@ -116,11 +116,19 @@ func (e *IndexWriteFailedError) RetryIndexWrite(ctx context.Context, table arcta
 		if err != nil {
 			return fmt.Errorf("ArcTable.Snapshot failed during index retry: %w", err)
 		}
-		matchesProgress, err := arcSetWithinDeltaProgress(current, e.IndexBase, e.IndexDelta)
+		expectedAfter, err := applyArcSetDelta(e.IndexBase, e.IndexDelta)
 		if err != nil {
 			return err
 		}
-		if !matchesProgress {
+		matchesBase, err := arcSetsEqual(current, e.IndexBase)
+		if err != nil {
+			return err
+		}
+		matchesAfter, err := arcSetsEqual(current, expectedAfter)
+		if err != nil {
+			return err
+		}
+		if !matchesBase && !matchesAfter {
 			return fmt.Errorf("%w: stale index retry for namespace %q oldRoot=%s newRoot=%s", ErrStaleRoot, e.Namespace, e.OldRoot, e.NewRoot)
 		}
 	}
@@ -144,58 +152,42 @@ func indexRetryBase(ctx context.Context, table arctable.ArcTable, namespace stri
 	return table.Snapshot(ctx, namespace, cid.Undef)
 }
 
-func arcSetWithinDeltaProgress(current, base, delta arcset.ArcSet) (bool, error) {
-	currentMap, err := arcset.ToPathMap(current)
-	if err != nil {
-		return false, err
-	}
+func applyArcSetDelta(base, delta arcset.ArcSet) (arcset.ArcSet, error) {
 	baseMap, err := arcset.ToPathMap(base)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	deltaMap, err := arcset.ToPathMap(delta)
 	if err != nil {
+		return nil, err
+	}
+	for path, target := range deltaMap {
+		if target.Defined() {
+			baseMap[path] = target
+		} else {
+			delete(baseMap, path)
+		}
+	}
+	return arcset.NewArcSetFromPaths(baseMap)
+}
+
+func arcSetsEqual(a, b arcset.ArcSet) (bool, error) {
+	aMap, err := arcset.ToPathMap(a)
+	if err != nil {
 		return false, err
 	}
-
-	paths := make(map[arcset.Path]struct{}, len(currentMap)+len(baseMap)+len(deltaMap))
-	for path := range currentMap {
-		paths[path] = struct{}{}
+	bMap, err := arcset.ToPathMap(b)
+	if err != nil {
+		return false, err
 	}
-	for path := range baseMap {
-		paths[path] = struct{}{}
-	}
-	for path := range deltaMap {
-		paths[path] = struct{}{}
-	}
-
-	for path := range paths {
-		currentTarget, currentOK := currentMap[path]
-		baseTarget, baseOK := baseMap[path]
-		deltaTarget, deltaOK := deltaMap[path]
-		if !deltaOK {
-			if currentOK != baseOK {
-				return false, nil
-			}
-			if currentOK && !currentTarget.Equals(baseTarget) {
-				return false, nil
-			}
-			continue
-		}
-
-		if currentOK == baseOK && (!currentOK || currentTarget.Equals(baseTarget)) {
-			continue
-		}
-		if deltaTarget.Defined() {
-			if currentOK && currentTarget.Equals(deltaTarget) {
-				continue
-			}
-		} else {
-			if !currentOK {
-				continue
-			}
-		}
+	if len(aMap) != len(bMap) {
 		return false, nil
+	}
+	for path, aTarget := range aMap {
+		bTarget, ok := bMap[path]
+		if !ok || !aTarget.Equals(bTarget) {
+			return false, nil
+		}
 	}
 	return true, nil
 }

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -97,7 +97,7 @@ func (e *IndexWriteFailedError) Unwrap() error {
 // error. The operation is intended to be idempotent: it re-applies the same
 // absolute OldRoot -> NewRoot transition and IndexDelta. For overwrite-like
 // backends, it first rejects stale retries when the namespace arcs no longer
-// match the captured pre-publication or post-publication state.
+// match any state reachable by partially applying this captured transition.
 func (e *IndexWriteFailedError) RetryIndexWrite(ctx context.Context, table arctable.ArcTable) error {
 	if e == nil {
 		return fmt.Errorf("index write failure is nil")
@@ -116,19 +116,11 @@ func (e *IndexWriteFailedError) RetryIndexWrite(ctx context.Context, table arcta
 		if err != nil {
 			return fmt.Errorf("ArcTable.Snapshot failed during index retry: %w", err)
 		}
-		expectedAfter, err := applyArcSetDelta(e.IndexBase, e.IndexDelta)
+		matchesProgress, err := arcSetWithinDeltaProgress(current, e.IndexBase, e.IndexDelta)
 		if err != nil {
 			return err
 		}
-		matchesBase, err := arcSetsEqual(current, e.IndexBase)
-		if err != nil {
-			return err
-		}
-		matchesAfter, err := arcSetsEqual(current, expectedAfter)
-		if err != nil {
-			return err
-		}
-		if !matchesBase && !matchesAfter {
+		if !matchesProgress {
 			return fmt.Errorf("%w: stale index retry for namespace %q oldRoot=%s newRoot=%s", ErrStaleRoot, e.Namespace, e.OldRoot, e.NewRoot)
 		}
 	}
@@ -152,42 +144,58 @@ func indexRetryBase(ctx context.Context, table arctable.ArcTable, namespace stri
 	return table.Snapshot(ctx, namespace, cid.Undef)
 }
 
-func applyArcSetDelta(base, delta arcset.ArcSet) (arcset.ArcSet, error) {
+func arcSetWithinDeltaProgress(current, base, delta arcset.ArcSet) (bool, error) {
+	currentMap, err := arcset.ToPathMap(current)
+	if err != nil {
+		return false, err
+	}
 	baseMap, err := arcset.ToPathMap(base)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	deltaMap, err := arcset.ToPathMap(delta)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
-	for path, target := range deltaMap {
-		if target.Defined() {
-			baseMap[path] = target
-		} else {
-			delete(baseMap, path)
-		}
-	}
-	return arcset.NewArcSetFromPaths(baseMap)
-}
 
-func arcSetsEqual(a, b arcset.ArcSet) (bool, error) {
-	aMap, err := arcset.ToPathMap(a)
-	if err != nil {
-		return false, err
+	paths := make(map[arcset.Path]struct{}, len(currentMap)+len(baseMap)+len(deltaMap))
+	for path := range currentMap {
+		paths[path] = struct{}{}
 	}
-	bMap, err := arcset.ToPathMap(b)
-	if err != nil {
-		return false, err
+	for path := range baseMap {
+		paths[path] = struct{}{}
 	}
-	if len(aMap) != len(bMap) {
-		return false, nil
+	for path := range deltaMap {
+		paths[path] = struct{}{}
 	}
-	for path, aTarget := range aMap {
-		bTarget, ok := bMap[path]
-		if !ok || !aTarget.Equals(bTarget) {
-			return false, nil
+
+	for path := range paths {
+		currentTarget, currentOK := currentMap[path]
+		baseTarget, baseOK := baseMap[path]
+		deltaTarget, deltaOK := deltaMap[path]
+		if !deltaOK {
+			if currentOK != baseOK {
+				return false, nil
+			}
+			if currentOK && !currentTarget.Equals(baseTarget) {
+				return false, nil
+			}
+			continue
 		}
+
+		if currentOK == baseOK && (!currentOK || currentTarget.Equals(baseTarget)) {
+			continue
+		}
+		if deltaTarget.Defined() {
+			if currentOK && currentTarget.Equals(deltaTarget) {
+				continue
+			}
+		} else {
+			if !currentOK {
+				continue
+			}
+		}
+		return false, nil
 	}
 	return true, nil
 }

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -413,10 +413,12 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 		defer unlock()
 	}
 
-	// Step 1: Snapshot the current arc set. oldTarget is derived from the
-	// snapshot instead of a separate Get to avoid a redundant KV round-trip —
-	// the snapshot is already required for delta computation and payload
-	// validation below.
+	// Step 1: Snapshot the current arc set for delta computation and payload
+	// validation, then read the target path through ArcTable.Get for operation
+	// classification. Get must stay in the classification path because some
+	// backends may tolerate corrupt entries while materializing broad snapshots;
+	// a targeted read needs to fail closed instead of turning corruption into a
+	// missing-arc no-op.
 	snapshot, err := w.arctable.Snapshot(ctx, namespace, root)
 	if err != nil {
 		return nil, fmt.Errorf("ArcTable.Snapshot failed: %w", err)
@@ -424,9 +426,13 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 	if !hasDefinedPayloadBinding(snapshot) && !(canonicalPath == mandatoryPayloadPath && newTarget.Defined()) {
 		return nil, ErrMissingPayloadBinding
 	}
-	// arctable.Snapshot returns ErrNotFound-shaped miss as a missing entry, so
-	// oldTarget == cid.Undef is valid here for inserts.
-	oldTarget, _ := snapshot.Get(canonicalPath)
+	oldTarget, err := w.arctable.Get(ctx, namespace, root, canonicalPath)
+	if err != nil {
+		if !arctable.IsNotFound(err) {
+			return nil, fmt.Errorf("ArcTable.Get failed: %w", err)
+		}
+		oldTarget = cid.Undef
+	}
 
 	// Determine operation type
 	var op ArcOp
@@ -551,17 +557,21 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 		}
 	}
 
-	// Step 2: Look up all current bindings in a single batch and classify
-	// operations. The snapshot already loaded the full arc set, so derive
-	// oldTargets from it rather than issuing one Get per update path (which
-	// would be O(N) KV round-trips).
+	// Step 2: Look up current bindings and classify operations. The snapshot is
+	// still used below to build the ArcTable delta, but classification uses
+	// targeted Get calls so corrupt stored entries fail closed instead of being
+	// silently omitted from a broad snapshot and treated as absent paths.
 	perArc := make(map[arcset.Path]UpdateResult, len(normalizedUpdates))
 	batchUpdates := make([]mapping.BatchUpdate, 0, len(normalizedUpdates))
 
 	for path, newTarget := range normalizedUpdates {
-		// snapshot.Get returns (cid.Undef, false) for absent paths, which is
-		// exactly the insert case — no IsNotFound translation needed.
-		oldTarget, _ := snapshot.Get(path)
+		oldTarget, err := w.arctable.Get(ctx, namespace, root, path)
+		if err != nil {
+			if !arctable.IsNotFound(err) {
+				return nil, fmt.Errorf("ArcTable.Get failed for %s: %w", path.String(), err)
+			}
+			oldTarget = cid.Undef
+		}
 
 		isInsert := !oldTarget.Defined() && newTarget.Defined()
 		isDelete := oldTarget.Defined() && !newTarget.Defined()

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -45,15 +45,12 @@ var (
 	// content-addressed and cannot be rolled back, so the returned newRoot is a
 	// cryptographically valid root whose ArcTable entries may be missing.
 	//
-	// To recover, retry the original writer operation (UpdateArc /
-	// BatchUpdateArcs / CreateStructure / Apply) against the same base root and
-	// inputs. Because the semantic commitment is deterministic and
-	// content-addressed, a successful retry converges to the same newRoot and
-	// then re-issues the ArcTable index write; re-writing identical entries is
-	// a no-op for both overwrite and versioned backends. Use errors.As to
-	// recover the newRoot via IndexWriteFailedError (exposed for diagnostics
-	// and correlation, not for direct ArcTable replay — the delta is not
-	// carried by the error).
+	// To recover, use errors.As to recover IndexWriteFailedError and call its
+	// RetryIndexWrite method against the same ArcTable. The error carries the
+	// exact old->new ArcTable transition because retrying the original writer
+	// operation is not guaranteed to work after a non-atomic backend has
+	// partially applied the failed index update (for example, after invalidating
+	// the old root mapping).
 	ErrIndexWriteFailed = errors.New("arctable index write failed after semantic commit")
 )
 
@@ -61,11 +58,10 @@ var (
 // the ArcTable index write failed. errors.Is(err, ErrIndexWriteFailed) and
 // errors.Is(err, <underlying cause>) both succeed.
 //
-// The fields are exposed for diagnostics and correlation (e.g. logging the
-// orphaned newRoot, correlating with a retry). Recovery is by re-running the
-// original writer operation, not by replaying an ArcTable delta from this
-// error: the ArcSet delta is intentionally not carried here to avoid leaking
-// the internal arcset representation through the error contract.
+// The fields are exposed for diagnostics, correlation, and index repair.
+// IndexDelta is the exact ArcTable delta that failed to publish; callers can
+// retry it with RetryIndexWrite even if the original base root is no longer
+// readable after a partially applied backend update.
 type IndexWriteFailedError struct {
 	// NewRoot is the content-addressed root the semantic layer committed. It is
 	// valid in the semantic sense, but its ArcTable index entries may not have
@@ -76,6 +72,9 @@ type IndexWriteFailedError struct {
 	// OldRoot is the base root the write transitioned from (cid.Undef for
 	// CreateStructure).
 	OldRoot cid.Cid
+	// IndexDelta is the exact ArcTable update payload for OldRoot -> NewRoot.
+	// It may be a full snapshot for create-style writes.
+	IndexDelta arcset.ArcSet
 	// Cause is the error returned by ArcTable.Update.
 	Cause error
 }
@@ -86,6 +85,31 @@ func (e *IndexWriteFailedError) Error() string {
 
 func (e *IndexWriteFailedError) Unwrap() error {
 	return errors.Join(ErrIndexWriteFailed, e.Cause)
+}
+
+// RetryIndexWrite retries the failed ArcTable publication captured by this
+// error. The operation is intended to be idempotent: it re-applies the same
+// absolute OldRoot -> NewRoot transition and IndexDelta.
+func (e *IndexWriteFailedError) RetryIndexWrite(ctx context.Context, table arctable.ArcTable) error {
+	if e == nil {
+		return fmt.Errorf("index write failure is nil")
+	}
+	if table == nil {
+		return fmt.Errorf("arctable is nil")
+	}
+	if e.IndexDelta == nil {
+		return fmt.Errorf("%w: missing index delta", ErrIndexWriteFailed)
+	}
+	if err := table.Update(ctx, e.Namespace, e.NewRoot, e.OldRoot, e.IndexDelta); err != nil {
+		return &IndexWriteFailedError{
+			NewRoot:    e.NewRoot,
+			Namespace:  e.Namespace,
+			OldRoot:    e.OldRoot,
+			IndexDelta: e.IndexDelta,
+			Cause:      err,
+		}
+	}
+	return nil
 }
 
 var mandatoryPayloadPath = arcset.CanonicalizePath("@payload")
@@ -488,10 +512,11 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 	// the caller can retry the idempotent ArcTable write.
 	if err := w.arctable.Update(ctx, namespace, newRoot, root, delta); err != nil {
 		return nil, &IndexWriteFailedError{
-			NewRoot:   newRoot,
-			Namespace: namespace,
-			OldRoot:   root,
-			Cause:     fmt.Errorf("ArcTable.Update failed: %w", err),
+			NewRoot:    newRoot,
+			Namespace:  namespace,
+			OldRoot:    root,
+			IndexDelta: delta,
+			Cause:      fmt.Errorf("ArcTable.Update failed: %w", err),
 		}
 	}
 	if w.freshness != nil {
@@ -633,10 +658,11 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 	// caller can retry the idempotent write.
 	if err := w.arctable.Update(ctx, namespace, newRoot, root, delta); err != nil {
 		return nil, &IndexWriteFailedError{
-			NewRoot:   newRoot,
-			Namespace: namespace,
-			OldRoot:   root,
-			Cause:     fmt.Errorf("ArcTable.Update failed: %w", err),
+			NewRoot:    newRoot,
+			Namespace:  namespace,
+			OldRoot:    root,
+			IndexDelta: delta,
+			Cause:      fmt.Errorf("ArcTable.Update failed: %w", err),
 		}
 	}
 	if w.freshness != nil {
@@ -688,10 +714,11 @@ func (w *Writer) CreateStructure(ctx context.Context, namespace string, arcs arc
 	// semantically committed but has no index entries; surface it for retry.
 	if err := w.arctable.Update(ctx, namespace, root, cid.Undef, normalizedSnapshot); err != nil {
 		return cid.Undef, &IndexWriteFailedError{
-			NewRoot:   root,
-			Namespace: namespace,
-			OldRoot:   cid.Undef,
-			Cause:     fmt.Errorf("ArcTable.Update failed: %w", err),
+			NewRoot:    root,
+			Namespace:  namespace,
+			OldRoot:    cid.Undef,
+			IndexDelta: normalizedSnapshot,
+			Cause:      fmt.Errorf("ArcTable.Update failed: %w", err),
 		}
 	}
 	if w.freshness != nil {

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -59,9 +59,10 @@ var (
 // errors.Is(err, <underlying cause>) both succeed.
 //
 // The fields are exposed for diagnostics, correlation, and index repair.
-// IndexDelta is the exact ArcTable delta that failed to publish; callers can
-// retry it with RetryIndexWrite even if the original base root is no longer
-// readable after a partially applied backend update.
+// IndexBase and IndexDelta capture the failed publication so callers can retry
+// it with RetryIndexWrite. For non-branching ArcTable backends, RetryIndexWrite
+// first verifies that the namespace has not advanced past this failed
+// transition; stale retries fail closed instead of overwriting later writes.
 type IndexWriteFailedError struct {
 	// NewRoot is the content-addressed root the semantic layer committed. It is
 	// valid in the semantic sense, but its ArcTable index entries may not have
@@ -72,6 +73,11 @@ type IndexWriteFailedError struct {
 	// OldRoot is the base root the write transitioned from (cid.Undef for
 	// CreateStructure).
 	OldRoot cid.Cid
+	// IndexBase is the namespace arc snapshot immediately before the failed
+	// ArcTable publication. It is used to reject stale retries on overwrite-like
+	// backends whose physical arc keys are namespace-scoped rather than
+	// root-scoped.
+	IndexBase arcset.ArcSet
 	// IndexDelta is the exact ArcTable update payload for OldRoot -> NewRoot.
 	// It may be a full snapshot for create-style writes.
 	IndexDelta arcset.ArcSet
@@ -89,7 +95,9 @@ func (e *IndexWriteFailedError) Unwrap() error {
 
 // RetryIndexWrite retries the failed ArcTable publication captured by this
 // error. The operation is intended to be idempotent: it re-applies the same
-// absolute OldRoot -> NewRoot transition and IndexDelta.
+// absolute OldRoot -> NewRoot transition and IndexDelta. For overwrite-like
+// backends, it first rejects stale retries when the namespace arcs no longer
+// match the captured pre-publication or post-publication state.
 func (e *IndexWriteFailedError) RetryIndexWrite(ctx context.Context, table arctable.ArcTable) error {
 	if e == nil {
 		return fmt.Errorf("index write failure is nil")
@@ -100,16 +108,88 @@ func (e *IndexWriteFailedError) RetryIndexWrite(ctx context.Context, table arcta
 	if e.IndexDelta == nil {
 		return fmt.Errorf("%w: missing index delta", ErrIndexWriteFailed)
 	}
+	if !supportsConcurrentBranches(table) {
+		if e.IndexBase == nil {
+			return fmt.Errorf("%w: missing index retry base", ErrIndexWriteFailed)
+		}
+		current, err := table.Snapshot(ctx, e.Namespace, cid.Undef)
+		if err != nil {
+			return fmt.Errorf("ArcTable.Snapshot failed during index retry: %w", err)
+		}
+		expectedAfter, err := applyArcSetDelta(e.IndexBase, e.IndexDelta)
+		if err != nil {
+			return err
+		}
+		matchesBase, err := arcSetsEqual(current, e.IndexBase)
+		if err != nil {
+			return err
+		}
+		matchesAfter, err := arcSetsEqual(current, expectedAfter)
+		if err != nil {
+			return err
+		}
+		if !matchesBase && !matchesAfter {
+			return fmt.Errorf("%w: stale index retry for namespace %q oldRoot=%s newRoot=%s", ErrStaleRoot, e.Namespace, e.OldRoot, e.NewRoot)
+		}
+	}
 	if err := table.Update(ctx, e.Namespace, e.NewRoot, e.OldRoot, e.IndexDelta); err != nil {
 		return &IndexWriteFailedError{
 			NewRoot:    e.NewRoot,
 			Namespace:  e.Namespace,
 			OldRoot:    e.OldRoot,
+			IndexBase:  e.IndexBase,
 			IndexDelta: e.IndexDelta,
 			Cause:      err,
 		}
 	}
 	return nil
+}
+
+func indexRetryBase(ctx context.Context, table arctable.ArcTable, namespace string) (arcset.ArcSet, error) {
+	if table == nil || supportsConcurrentBranches(table) {
+		return nil, nil
+	}
+	return table.Snapshot(ctx, namespace, cid.Undef)
+}
+
+func applyArcSetDelta(base, delta arcset.ArcSet) (arcset.ArcSet, error) {
+	baseMap, err := arcset.ToPathMap(base)
+	if err != nil {
+		return nil, err
+	}
+	deltaMap, err := arcset.ToPathMap(delta)
+	if err != nil {
+		return nil, err
+	}
+	for path, target := range deltaMap {
+		if target.Defined() {
+			baseMap[path] = target
+		} else {
+			delete(baseMap, path)
+		}
+	}
+	return arcset.NewArcSetFromPaths(baseMap)
+}
+
+func arcSetsEqual(a, b arcset.ArcSet) (bool, error) {
+	aMap, err := arcset.ToPathMap(a)
+	if err != nil {
+		return false, err
+	}
+	bMap, err := arcset.ToPathMap(b)
+	if err != nil {
+		return false, err
+	}
+	if len(aMap) != len(bMap) {
+		return false, nil
+	}
+	for path, aTarget := range aMap {
+		bTarget, ok := bMap[path]
+		if !ok || !aTarget.Equals(bTarget) {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 var mandatoryPayloadPath = arcset.CanonicalizePath("@payload")
@@ -505,6 +585,16 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 	if err != nil {
 		return nil, err
 	}
+	retryBase, err := indexRetryBase(ctx, w.arctable, namespace)
+	if err != nil {
+		return nil, &IndexWriteFailedError{
+			NewRoot:    newRoot,
+			Namespace:  namespace,
+			OldRoot:    root,
+			IndexDelta: delta,
+			Cause:      fmt.Errorf("ArcTable.Snapshot retry base failed: %w", err),
+		}
+	}
 
 	// Step 3: Apply update to ArcTable as an old->new delta. This keeps versioned ArcTable
 	// compact while still emitting tombstones for deletions. If this fails the
@@ -515,6 +605,7 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 			NewRoot:    newRoot,
 			Namespace:  namespace,
 			OldRoot:    root,
+			IndexBase:  retryBase,
 			IndexDelta: delta,
 			Cause:      fmt.Errorf("ArcTable.Update failed: %w", err),
 		}
@@ -652,6 +743,16 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 	if err != nil {
 		return nil, err
 	}
+	retryBase, err := indexRetryBase(ctx, w.arctable, namespace)
+	if err != nil {
+		return nil, &IndexWriteFailedError{
+			NewRoot:    newRoot,
+			Namespace:  namespace,
+			OldRoot:    root,
+			IndexDelta: delta,
+			Cause:      fmt.Errorf("ArcTable.Snapshot retry base failed: %w", err),
+		}
+	}
 
 	// Step 4: Apply the update delta to ArcTable. On failure the newRoot is
 	// semantically valid but its index entries are missing; surface it so the
@@ -661,6 +762,7 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 			NewRoot:    newRoot,
 			Namespace:  namespace,
 			OldRoot:    root,
+			IndexBase:  retryBase,
 			IndexDelta: delta,
 			Cause:      fmt.Errorf("ArcTable.Update failed: %w", err),
 		}
@@ -709,6 +811,16 @@ func (w *Writer) CreateStructure(ctx context.Context, namespace string, arcs arc
 	if err != nil {
 		return cid.Undef, fmt.Errorf("semantic.Commit failed: %w", err)
 	}
+	retryBase, err := indexRetryBase(ctx, w.arctable, namespace)
+	if err != nil {
+		return cid.Undef, &IndexWriteFailedError{
+			NewRoot:    root,
+			Namespace:  namespace,
+			OldRoot:    cid.Undef,
+			IndexDelta: normalizedSnapshot,
+			Cause:      fmt.Errorf("ArcTable.Snapshot retry base failed: %w", err),
+		}
+	}
 
 	// Step 2: Store arcs in ArcTable (first version). On failure root is
 	// semantically committed but has no index entries; surface it for retry.
@@ -717,6 +829,7 @@ func (w *Writer) CreateStructure(ctx context.Context, namespace string, arcs arc
 			NewRoot:    root,
 			Namespace:  namespace,
 			OldRoot:    cid.Undef,
+			IndexBase:  retryBase,
 			IndexDelta: normalizedSnapshot,
 			Cause:      fmt.Errorf("ArcTable.Update failed: %w", err),
 		}


### PR DESCRIPTION
## Summary
- return a structured `IndexWriteFailedError` when semantic commits succeed but ArcTable index writes fail
- document retrying the original writer operation as the recovery path
- add regression coverage for UpdateArc, BatchUpdateArcs, and Apply failure paths

## Tests
- `go test ./graph/writer`
- `go test ./...`