### PR TITLE
Propagate writer arc iteration errors

### DIFF
--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -149,6 +149,8 @@ func indexRetryBase(ctx context.Context, table arctable.ArcTable, namespace stri
 	if table == nil || supportsConcurrentBranches(table) {
 		return nil, nil
 	}
+	// Overwrite-like backends need a namespace snapshot so retry can reject
+	// stale replays after a non-atomic index write failure.
 	return table.Snapshot(ctx, namespace, cid.Undef)
 }
 
@@ -440,9 +442,9 @@ func diffArcMaps(oldArcs, newArcs map[arcset.Path]cid.Cid) (arcset.ArcSet, error
 	return arcset.NewArcSetFromPaths(diff)
 }
 
-func filterLogicalArcSet(arcs arcset.ArcSet) arcset.ArcSet {
+func filterLogicalArcSet(arcs arcset.ArcSet) (arcset.ArcSet, error) {
 	if arcs == nil {
-		return nil
+		return nil, nil
 	}
 
 	out := make(map[arcset.Path]cid.Cid)
@@ -457,26 +459,33 @@ func filterLogicalArcSet(arcs arcset.ArcSet) arcset.ArcSet {
 		}
 		out[path] = target
 	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("arc iteration error: %w", err)
+	}
 	filtered, err := arcset.NewArcSetFromPaths(out)
 	if err != nil {
-		return arcset.NewSet()
+		return nil, err
 	}
-	return filtered
+	return filtered, nil
 }
 
-func hasDefinedPayloadBinding(arcs arcset.ArcSet) bool {
+func hasDefinedPayloadBinding(arcs arcset.ArcSet) (bool, error) {
 	if arcs == nil {
-		return false
+		return false, nil
 	}
 
 	iter := arcs.Iterate()
+	found := false
 	for {
 		path, target, ok := iter.Next()
 		if !ok {
-			return false
+			if err := iter.Err(); err != nil {
+				return false, fmt.Errorf("arc iteration error: %w", err)
+			}
+			return found, nil
 		}
 		if path == mandatoryPayloadPath && target.Defined() {
-			return true
+			found = true
 		}
 	}
 }
@@ -527,7 +536,11 @@ func (w *Writer) UpdateArc(ctx context.Context, namespace string, root cid.Cid, 
 	if err != nil {
 		return nil, fmt.Errorf("ArcTable.Snapshot failed: %w", err)
 	}
-	if !hasDefinedPayloadBinding(snapshot) && !(canonicalPath == mandatoryPayloadPath && newTarget.Defined()) {
+	hasPayload, err := hasDefinedPayloadBinding(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	if !hasPayload && !(canonicalPath == mandatoryPayloadPath && newTarget.Defined()) {
 		return nil, ErrMissingPayloadBinding
 	}
 	oldTarget, err := w.arctable.Get(ctx, namespace, root, canonicalPath)
@@ -666,7 +679,11 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 	if err != nil {
 		return nil, fmt.Errorf("ArcTable.Snapshot failed: %w", err)
 	}
-	if !hasDefinedPayloadBinding(snapshot) {
+	hasPayload, err := hasDefinedPayloadBinding(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	if !hasPayload {
 		payloadTarget, ok := normalizedUpdates[mandatoryPayloadPath]
 		if !ok || !payloadTarget.Defined() {
 			return nil, ErrMissingPayloadBinding
@@ -798,7 +815,11 @@ func (w *Writer) CreateStructure(ctx context.Context, namespace string, arcs arc
 	if err != nil {
 		return cid.Undef, err
 	}
-	if !hasDefinedPayloadBinding(normalizedSnapshot) {
+	hasPayload, err := hasDefinedPayloadBinding(normalizedSnapshot)
+	if err != nil {
+		return cid.Undef, err
+	}
+	if !hasPayload {
 		return cid.Undef, ErrMissingPayloadBinding
 	}
 
@@ -876,5 +897,5 @@ func (w *Writer) GetSnapshot(ctx context.Context, namespace string, root cid.Cid
 		return nil, fmt.Errorf("ArcTable.Snapshot failed: %w", err)
 	}
 
-	return filterLogicalArcSet(snapshot), nil
+	return filterLogicalArcSet(snapshot)
 }

--- a/graph/writer/writer_test.go
+++ b/graph/writer/writer_test.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -78,6 +79,55 @@ func newTestWriterWithList(t *testing.T) (*Writer, *overwrite.ArcTable, mapping.
 }
 
 type kvg = kvmemory.KV
+
+type errArcSet struct {
+	arcs []struct {
+		path   arcset.Path
+		target cid.Cid
+	}
+	err error
+}
+
+func (s errArcSet) Get(path arcset.Path) (cid.Cid, bool) {
+	for _, arc := range s.arcs {
+		if arc.path == path {
+			return arc.target, true
+		}
+	}
+	return cid.Undef, false
+}
+
+func (s errArcSet) Iterate() arcset.Iterator {
+	return &errArcIterator{arcs: s.arcs, err: s.err}
+}
+
+func (s errArcSet) Len() int {
+	return len(s.arcs)
+}
+
+type errArcIterator struct {
+	arcs []struct {
+		path   arcset.Path
+		target cid.Cid
+	}
+	err   error
+	index int
+}
+
+func (it *errArcIterator) Next() (arcset.Path, cid.Cid, bool) {
+	if it.index >= len(it.arcs) {
+		return "", cid.Undef, false
+	}
+	arc := it.arcs[it.index]
+	it.index++
+	return arc.path, arc.target, true
+}
+
+func (it *errArcIterator) Err() error {
+	return it.err
+}
+
+func (it *errArcIterator) Close() {}
 
 type nonComparableArcTable struct {
 	arctable arctable.ArcTable
@@ -1085,6 +1135,78 @@ func TestWriter_GetSnapshot(t *testing.T) {
 	}
 	if target != fakeCID("data-x") {
 		t.Errorf("snapshot arc 'x' wrong: got %s", target)
+	}
+}
+
+func TestHasDefinedPayloadBindingPropagatesIteratorError(t *testing.T) {
+	iterErr := fmt.Errorf("iterator exploded")
+	found, err := hasDefinedPayloadBinding(errArcSet{
+		arcs: []struct {
+			path   arcset.Path
+			target cid.Cid
+		}{{
+			path:   arcset.CanonicalizePath("a"),
+			target: fakeCID("data-a"),
+		}},
+		err: iterErr,
+	})
+	if err == nil {
+		t.Fatal("hasDefinedPayloadBinding returned nil error for failing iterator")
+	}
+	if !errors.Is(err, iterErr) {
+		t.Fatalf("hasDefinedPayloadBinding error = %v, want %v", err, iterErr)
+	}
+	if found {
+		t.Fatal("hasDefinedPayloadBinding found payload despite iterator error")
+	}
+}
+
+func TestHasDefinedPayloadBindingChecksErrorAfterPayload(t *testing.T) {
+	iterErr := fmt.Errorf("iterator exploded")
+	found, err := hasDefinedPayloadBinding(errArcSet{
+		arcs: []struct {
+			path   arcset.Path
+			target cid.Cid
+		}{{
+			path:   mandatoryPayloadPath,
+			target: fakeCID("payload"),
+		}, {
+			path:   arcset.CanonicalizePath("a"),
+			target: fakeCID("data-a"),
+		}},
+		err: iterErr,
+	})
+	if err == nil {
+		t.Fatal("hasDefinedPayloadBinding returned nil error after seeing payload")
+	}
+	if !errors.Is(err, iterErr) {
+		t.Fatalf("hasDefinedPayloadBinding error = %v, want %v", err, iterErr)
+	}
+	if found {
+		t.Fatal("hasDefinedPayloadBinding returned found=true with iterator error")
+	}
+}
+
+func TestFilterLogicalArcSetPropagatesErrors(t *testing.T) {
+	iterErr := fmt.Errorf("iterator exploded")
+	_, err := filterLogicalArcSet(errArcSet{
+		arcs: []struct {
+			path   arcset.Path
+			target cid.Cid
+		}{{
+			path:   arcset.CanonicalizePath("runtime/internal"),
+			target: fakeCID("runtime"),
+		}, {
+			path:   arcset.CanonicalizePath("a"),
+			target: fakeCID("data-a"),
+		}},
+		err: iterErr,
+	})
+	if err == nil {
+		t.Fatal("filterLogicalArcSet returned nil error for failing iterator")
+	}
+	if !errors.Is(err, iterErr) {
+		t.Fatalf("filterLogicalArcSet error = %v, want %v", err, iterErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make `hasDefinedPayloadBinding` surface iterator errors instead of reporting missing payload
- make `filterLogicalArcSet` return errors instead of silently returning an empty set
- document the overwrite retry-base snapshot cost

## Tests
- `go test ./graph/writer`