### PR TITLE
Use BatchGet for batch update classification

### DIFF
--- a/graph/writer/index_write_failure_test.go
+++ b/graph/writer/index_write_failure_test.go
@@ -756,9 +756,11 @@ func TestUpdateArc_CorruptStoredTargetFailsClosed(t *testing.T) {
 	}
 }
 
-// TestBatchUpdateArcs_CorruptStoredTargetFailsClosed mirrors the single-update
-// corruption guard for the batch path, which also needs targeted Get calls for
-// every updated path.
+// TestBatchUpdateArcs_CorruptStoredTargetFailsClosed guards the batch path
+// against corrupt overwrite ArcTable entries. BatchUpdateArcs classifies through
+// BatchGet, so a corrupt stored CID may be omitted by the index lookup, but the
+// semantic layer must still reject the mismatched old value instead of silently
+// committing a partial view.
 func TestBatchUpdateArcs_CorruptStoredTargetFailsClosed(t *testing.T) {
 	ctx := context.Background()
 	namespace := "ns-corrupt-batch"
@@ -780,8 +782,8 @@ func TestBatchUpdateArcs_CorruptStoredTargetFailsClosed(t *testing.T) {
 	if err == nil {
 		t.Fatal("BatchUpdateArcs with corrupt stored target succeeded; want fail-closed error")
 	}
-	if !strings.Contains(err.Error(), "ArcTable.Get failed for b") {
-		t.Fatalf("BatchUpdateArcs error = %v, want targeted ArcTable.Get failure for b", err)
+	if !strings.Contains(err.Error(), "semantic.BatchUpdate failed") {
+		t.Fatalf("BatchUpdateArcs error = %v, want semantic old-value mismatch failure", err)
 	}
 }
 

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -675,17 +675,23 @@ func (w *Writer) BatchUpdateArcs(ctx context.Context, namespace string, root cid
 
 	// Step 2: Look up current bindings and classify operations. The snapshot is
 	// still used below to build the ArcTable delta, but classification uses
-	// targeted Get calls so corrupt stored entries fail closed instead of being
-	// silently omitted from a broad snapshot and treated as absent paths.
+	// BatchGet so backend read failures fail closed while missing paths are
+	// represented as cid.Undef.
 	perArc := make(map[arcset.Path]UpdateResult, len(normalizedUpdates))
 	batchUpdates := make([]mapping.BatchUpdate, 0, len(normalizedUpdates))
+	paths := make([]arcset.Path, 0, len(normalizedUpdates))
+
+	for path := range normalizedUpdates {
+		paths = append(paths, path)
+	}
+	oldTargets, err := w.arctable.BatchGet(ctx, namespace, root, paths)
+	if err != nil {
+		return nil, fmt.Errorf("ArcTable.BatchGet failed: %w", err)
+	}
 
 	for path, newTarget := range normalizedUpdates {
-		oldTarget, err := w.arctable.Get(ctx, namespace, root, path)
-		if err != nil {
-			if !arctable.IsNotFound(err) {
-				return nil, fmt.Errorf("ArcTable.Get failed for %s: %w", path.String(), err)
-			}
+		oldTarget, ok := oldTargets[path]
+		if !ok {
 			oldTarget = cid.Undef
 		}
 

--- a/graph/writer/writer_test.go
+++ b/graph/writer/writer_test.go
@@ -108,6 +108,46 @@ func (t nonComparableArcTable) Close() error {
 	return t.arctable.Close()
 }
 
+type batchGetProbeArcTable struct {
+	arctable      arctable.ArcTable
+	getErr        error
+	batchGetErr   error
+	getCalls      int
+	batchGetCalls int
+}
+
+func (t *batchGetProbeArcTable) Get(ctx context.Context, namespace string, root cid.Cid, path arcset.Path) (cid.Cid, error) {
+	t.getCalls++
+	if t.getErr != nil {
+		return cid.Undef, t.getErr
+	}
+	return t.arctable.Get(ctx, namespace, root, path)
+}
+
+func (t *batchGetProbeArcTable) BatchGet(ctx context.Context, namespace string, root cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error) {
+	t.batchGetCalls++
+	if t.batchGetErr != nil {
+		return nil, t.batchGetErr
+	}
+	return t.arctable.BatchGet(ctx, namespace, root, paths)
+}
+
+func (t *batchGetProbeArcTable) Update(ctx context.Context, namespace string, newRoot, oldRoot cid.Cid, arcs arcset.ArcSet) error {
+	return t.arctable.Update(ctx, namespace, newRoot, oldRoot, arcs)
+}
+
+func (t *batchGetProbeArcTable) Snapshot(ctx context.Context, namespace string, root cid.Cid) (arcset.ArcSet, error) {
+	return t.arctable.Snapshot(ctx, namespace, root)
+}
+
+func (t *batchGetProbeArcTable) Iterate(ctx context.Context, namespace string, root cid.Cid) arcset.Iterator {
+	return t.arctable.Iterate(ctx, namespace, root)
+}
+
+func (t *batchGetProbeArcTable) Close() error {
+	return t.arctable.Close()
+}
+
 func fakeCID(seed string) cid.Cid {
 	mhash, _ := mh.Sum([]byte(seed), mh.SHA2_256, -1)
 	return cid.NewCidV1(cid.Raw, mhash)
@@ -907,6 +947,79 @@ func TestWriter_BatchUpdateArcs(t *testing.T) {
 				t.Errorf("expected GetArc(%s) to fail, got %s", path, got)
 			}
 		}
+	}
+}
+
+func TestWriter_BatchUpdateArcs_UsesBatchGetForClassification(t *testing.T) {
+	baseWriter, e, semantic, _ := newTestWriter(t)
+	ctx := context.Background()
+	namespace := "test-batchget-classification"
+
+	root, err := baseWriter.CreateStructure(ctx, namespace, makeArcSet(map[string]cid.Cid{
+		"a": fakeCID("data-a"),
+		"c": fakeCID("data-c"),
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure failed: %v", err)
+	}
+
+	probe := &batchGetProbeArcTable{
+		arctable: e,
+		getErr:   errors.New("unexpected per-path Get"),
+	}
+	w := NewWriter(semantic, probe)
+	result, err := w.BatchUpdateArcs(ctx, namespace, root, map[string]cid.Cid{
+		"a": fakeCID("data-a-new"),
+		"d": fakeCID("data-d"),
+		"c": cid.Undef,
+	})
+	if err != nil {
+		t.Fatalf("BatchUpdateArcs failed: %v", err)
+	}
+	if probe.batchGetCalls != 1 {
+		t.Fatalf("BatchGet calls = %d, want 1", probe.batchGetCalls)
+	}
+	if probe.getCalls != 0 {
+		t.Fatalf("Get calls = %d, want 0", probe.getCalls)
+	}
+	if result.PerArc["a"].Op != ArcReplace {
+		t.Fatalf("a op = %v, want replace", result.PerArc["a"].Op)
+	}
+	if result.PerArc["d"].Op != ArcInsert {
+		t.Fatalf("d op = %v, want insert", result.PerArc["d"].Op)
+	}
+	if result.PerArc["c"].Op != ArcDelete {
+		t.Fatalf("c op = %v, want delete", result.PerArc["c"].Op)
+	}
+}
+
+func TestWriter_BatchUpdateArcs_PropagatesBatchGetError(t *testing.T) {
+	baseWriter, e, semantic, _ := newTestWriter(t)
+	ctx := context.Background()
+	namespace := "test-batchget-error"
+
+	root, err := baseWriter.CreateStructure(ctx, namespace, makeArcSet(map[string]cid.Cid{
+		"a": fakeCID("data-a"),
+	}))
+	if err != nil {
+		t.Fatalf("CreateStructure failed: %v", err)
+	}
+
+	batchGetErr := errors.New("injected batch get failure")
+	probe := &batchGetProbeArcTable{
+		arctable:    e,
+		batchGetErr: batchGetErr,
+	}
+	w := NewWriter(semantic, probe)
+
+	_, err = w.BatchUpdateArcs(ctx, namespace, root, map[string]cid.Cid{
+		"a": fakeCID("data-a-new"),
+	})
+	if !errors.Is(err, batchGetErr) {
+		t.Fatalf("BatchUpdateArcs error = %v, want BatchGet error", err)
+	}
+	if probe.batchGetCalls != 1 {
+		t.Fatalf("BatchGet calls = %d, want 1", probe.batchGetCalls)
 	}
 }
 

--- a/runtime/arctable/versioned/versioned.go
+++ b/runtime/arctable/versioned/versioned.go
@@ -309,12 +309,23 @@ func (e *ArcTable) BatchGet(ctx context.Context, namespace string, version cid.C
 		prevKey := arctable.VersionedArcKey(namespace, currentVersion, PreviousArc)
 		prevVal, err := e.kv.Get(ctx, prevKey)
 		if err != nil {
-			break
+			if err == kvstore.ErrNotFound {
+				break
+			}
+			logger.Error("ArcTable.BatchGet failed to get @previous",
+				logger.String("namespace", namespace),
+				logger.Int("depth", depth),
+				logger.Err(err))
+			return nil, fmt.Errorf("failed to get @previous: %w", err)
 		}
 
 		parentVersion, err := cid.Cast(prevVal)
 		if err != nil {
-			break
+			logger.Error("ArcTable.BatchGet invalid @previous CID",
+				logger.String("namespace", namespace),
+				logger.Int("depth", depth),
+				logger.Err(err))
+			return nil, fmt.Errorf("invalid @previous CID: %w", err)
 		}
 		currentVersion = parentVersion
 	}

--- a/runtime/arctable/versioned/versioned_test.go
+++ b/runtime/arctable/versioned/versioned_test.go
@@ -2,15 +2,32 @@ package versioned
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
+	arctablepkg "github.com/dewebprotocol/malt/runtime/arctable"
 	"github.com/dewebprotocol/malt/runtime/arctable/bloom"
+	"github.com/dewebprotocol/malt/storage/kv"
 	"github.com/dewebprotocol/malt/storage/kv/memory"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
+
+type getErrorKV struct {
+	kvstore.KVStore
+	failKey string
+	err     error
+}
+
+func (kv *getErrorKV) Get(ctx context.Context, key []byte) ([]byte, error) {
+	if string(key) == kv.failKey {
+		return nil, kv.err
+	}
+	return kv.KVStore.Get(ctx, key)
+}
 
 func newTestCID(data []byte) cid.Cid {
 	mhash, err := mh.Sum(data, mh.SHA2_256, -1)
@@ -577,6 +594,93 @@ func TestVersionedArcTableBatchGetMultipleNamespaces(t *testing.T) {
 	}
 	if !results2["a"].Equals(target2) {
 		t.Error("namespace2 should have target2")
+	}
+}
+
+func TestVersionedArcTableBatchGetParentReadError(t *testing.T) {
+	kv := memory.New()
+	arctable, err := NewArcTable(WithKVStore(kv))
+	if err != nil {
+		t.Fatalf("NewArcTable failed: %v", err)
+	}
+
+	ctx := context.Background()
+	namespace := "batchget-parent-error-graph"
+	root1 := newTestCID([]byte("root1"))
+	root2 := newTestCID([]byte("root2"))
+	target1 := newTestCID([]byte("target1"))
+	target2 := newTestCID([]byte("target2"))
+
+	if err := arctable.Update(ctx, namespace, root1, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
+		"a": target1,
+	})); err != nil {
+		t.Fatalf("Update root1 failed: %v", err)
+	}
+	if err := arctable.Update(ctx, namespace, root2, root1, arcset.NewSetFrom(map[string]cid.Cid{
+		"b": target2,
+	})); err != nil {
+		t.Fatalf("Update root2 failed: %v", err)
+	}
+
+	parentErr := errors.New("injected parent read failure")
+	prevKey := arctablepkg.VersionedArcKey(namespace, root2, PreviousArc)
+	failingTable, err := NewArcTable(WithKVStore(&getErrorKV{
+		KVStore: kv,
+		failKey: string(prevKey),
+		err:     parentErr,
+	}))
+	if err != nil {
+		t.Fatalf("NewArcTable with failing kv failed: %v", err)
+	}
+
+	results, err := failingTable.BatchGet(ctx, namespace, root2, testPathSlice([]string{"a"}))
+	if !errors.Is(err, parentErr) {
+		t.Fatalf("BatchGet error = %v, want parent read error", err)
+	}
+	if results != nil {
+		t.Fatalf("BatchGet results = %v, want nil on parent read error", results)
+	}
+}
+
+func TestVersionedArcTableBatchGetInvalidParentCID(t *testing.T) {
+	kv := memory.New()
+	arctable, err := NewArcTable(WithKVStore(kv))
+	if err != nil {
+		t.Fatalf("NewArcTable failed: %v", err)
+	}
+
+	ctx := context.Background()
+	namespace := "batchget-invalid-parent-graph"
+	root1 := newTestCID([]byte("root1"))
+	root2 := newTestCID([]byte("root2"))
+	target1 := newTestCID([]byte("target1"))
+	target2 := newTestCID([]byte("target2"))
+
+	if err := arctable.Update(ctx, namespace, root1, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
+		"a": target1,
+	})); err != nil {
+		t.Fatalf("Update root1 failed: %v", err)
+	}
+	if err := arctable.Update(ctx, namespace, root2, root1, arcset.NewSetFrom(map[string]cid.Cid{
+		"b": target2,
+	})); err != nil {
+		t.Fatalf("Update root2 failed: %v", err)
+	}
+
+	prevKey := arctablepkg.VersionedArcKey(namespace, root2, PreviousArc)
+	if err := kv.Put(ctx, prevKey, []byte("not-a-cid")); err != nil {
+		t.Fatalf("corrupt @previous failed: %v", err)
+	}
+
+	results, err := arctable.BatchGet(ctx, namespace, root2, testPathSlice([]string{"a"}))
+	if err == nil {
+		t.Fatal("BatchGet succeeded, want invalid parent CID error")
+	}
+	if !strings.Contains(err.Error(), "invalid @previous CID") {
+		t.Fatalf("BatchGet error = %v, want invalid @previous CID", err)
+	}
+	if results != nil {
+		t.Fatalf("BatchGet results = %v, want nil on invalid parent CID", results)
 	}
 }
 


### PR DESCRIPTION
## Summary
- tighten versioned `ArcTable.BatchGet` to fail closed on parent-chain read/decode errors
- switch `BatchUpdateArcs` classification from per-path `Get` to one `BatchGet`
- add tests for BatchGet error propagation and batch classification behavior

## Tests
- `go test ./runtime/arctable/versioned ./graph/writer`