### PR TITLE
Thread context through graph resolution

### DIFF
--- a/cmd/eval/internal/compat/hamt/hamt.go
+++ b/cmd/eval/internal/compat/hamt/hamt.go
@@ -89,7 +89,7 @@ func NewResolver(c cas.Reader, opts ...Option) *Resolver {
 // Resolve resolves a path through the HAMT.
 // The path is treated as a key to look up in the HAMT.
 // Returns the matched path (key), the target CID (value), and evidence.
-func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.Path, target cid.Cid, ev evidence.Evidence, err error) {
+func (r *Resolver) Resolve(ctx context.Context, root cid.Cid, path arcset.Path) (matchedPath arcset.Path, target cid.Cid, ev evidence.Evidence, err error) {
 	if !root.Defined() {
 		return "", cid.Cid{}, nil, fmt.Errorf("root is not defined")
 	}
@@ -104,7 +104,7 @@ func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.P
 	}
 
 	// Resolve the key in HAMT
-	valueCID, proof, err := r.resolveKey(root, path.String())
+	valueCID, proof, err := r.resolveKey(ctx, root, path.String())
 	if err != nil {
 		return "", cid.Cid{}, nil, err
 	}
@@ -116,7 +116,7 @@ func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.P
 }
 
 // Verify verifies the HAMT evidence.
-func (r *Resolver) Verify(root cid.Cid, path arcset.Path, target cid.Cid, ev evidence.Evidence) (bool, error) {
+func (r *Resolver) Verify(ctx context.Context, root cid.Cid, path arcset.Path, target cid.Cid, ev evidence.Evidence) (bool, error) {
 	if ev == nil {
 		return false, fmt.Errorf("evidence is nil")
 	}
@@ -127,7 +127,7 @@ func (r *Resolver) Verify(root cid.Cid, path arcset.Path, target cid.Cid, ev evi
 	}
 
 	// Re-resolve to verify
-	actualCID, _, err := r.resolveKey(root, path.String())
+	actualCID, _, err := r.resolveKey(ctx, root, path.String())
 	if err != nil {
 		return false, err
 	}
@@ -136,7 +136,7 @@ func (r *Resolver) Verify(root cid.Cid, path arcset.Path, target cid.Cid, ev evi
 }
 
 // resolveKey finds a key in the HAMT and returns its value CID and proof.
-func (r *Resolver) resolveKey(root cid.Cid, key string) (cid.Cid, []byte, error) {
+func (r *Resolver) resolveKey(ctx context.Context, root cid.Cid, key string) (cid.Cid, []byte, error) {
 	// Hash the key for routing
 	keyHash := r.config.HashFunc([]byte(key))
 
@@ -146,7 +146,7 @@ func (r *Resolver) resolveKey(root cid.Cid, key string) (cid.Cid, []byte, error)
 
 	for depth := 0; depth < r.config.MaxDepth; depth++ {
 		// Fetch the node from CAS
-		block, err := r.cas.Get(context.Background(), current)
+		block, err := r.cas.Get(ctx, current)
 		if err != nil {
 			return cid.Cid{}, nil, fmt.Errorf("failed to fetch HAMT node %s: %w", current, err)
 		}

--- a/cmd/eval/internal/compat/hamt/hamt_test.go
+++ b/cmd/eval/internal/compat/hamt/hamt_test.go
@@ -1,6 +1,7 @@
 package hamt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dewebprotocol/malt/cmd/eval/internal/compat/hamt"
@@ -38,7 +39,7 @@ func TestResolveEmptyPath(t *testing.T) {
 	root := newTestCID("test")
 
 	// Resolve with empty path should return the root
-	matchedPath, target, ev, err := r.Resolve(root, "")
+	matchedPath, target, ev, err := r.Resolve(context.Background(), root, "")
 	if err != nil {
 		t.Errorf("Resolve with empty path should not error: %v", err)
 	}
@@ -57,7 +58,7 @@ func TestResolveUndefinedRoot(t *testing.T) {
 	c := mock.NewCAS()
 	r := hamt.NewResolver(c)
 
-	_, _, _, err := r.Resolve(cid.Cid{}, "key")
+	_, _, _, err := r.Resolve(context.Background(), cid.Cid{}, "key")
 	if err == nil {
 		t.Error("Resolve with undefined root should error")
 	}
@@ -67,7 +68,7 @@ func TestResolveNilCAS(t *testing.T) {
 	r := hamt.NewResolver(nil)
 
 	root := newTestCID("test")
-	_, _, _, err := r.Resolve(root, "key")
+	_, _, _, err := r.Resolve(context.Background(), root, "key")
 	if err == nil {
 		t.Error("Resolve with nil CAS should error")
 	}

--- a/cmd/eval/internal/compat/implicit/implicit.go
+++ b/cmd/eval/internal/compat/implicit/implicit.go
@@ -77,7 +77,7 @@ func NewResolverWithCodecs(c cas.Reader, registry *codec.Registry) *Resolver {
 //
 // This resolver only handles a single hop. The caller is responsible for
 // continuing traversal if needed.
-func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.Path, target cid.Cid, ev evidence.Evidence, err error) {
+func (r *Resolver) Resolve(ctx context.Context, root cid.Cid, path arcset.Path) (matchedPath arcset.Path, target cid.Cid, ev evidence.Evidence, err error) {
 	if !root.Defined() {
 		return "", cid.Cid{}, nil, fmt.Errorf("root is not defined")
 	}
@@ -87,7 +87,7 @@ func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.P
 	}
 
 	// Fetch block from CAS
-	blockContent, err := r.cas.Get(context.Background(), root)
+	blockContent, err := r.cas.Get(ctx, root)
 	if err != nil {
 		return "", cid.Cid{}, nil, fmt.Errorf("failed to fetch block %s: %w", root, err)
 	}
@@ -120,7 +120,7 @@ func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.P
 
 	// For dag-pb blocks, check if it's a HAMT structure
 	if codecName == "dag-pb" {
-		hamtResult := r.tryHAMTResolution(root, blockContent, path)
+		hamtResult := r.tryHAMTResolution(ctx, root, blockContent, path)
 		if hamtResult.isHAMT {
 			return hamtResult.matchedPath, hamtResult.target, hamtResult.evidence, hamtResult.err
 		}
@@ -148,7 +148,8 @@ func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.P
 // It performs two checks:
 //  1. Verifies that the block content in evidence hashes to the root CID
 //  2. Verifies that the path resolves to the target CID within the block
-func (r *Resolver) Verify(root cid.Cid, path arcset.Path, target cid.Cid, ev evidence.Evidence) (bool, error) {
+func (r *Resolver) Verify(ctx context.Context, root cid.Cid, path arcset.Path, target cid.Cid, ev evidence.Evidence) (bool, error) {
+	_ = ctx
 	if ev == nil {
 		return false, fmt.Errorf("evidence is nil")
 	}
@@ -267,7 +268,7 @@ type hamtResult struct {
 // tryHAMTResolution attempts to detect and resolve a HAMT structure.
 // HAMT nodes are dag-pb blocks where the Data field contains a dag-cbor
 // encoded map with "0" (bitfield) and "1" (entries) keys.
-func (r *Resolver) tryHAMTResolution(root cid.Cid, blockContent []byte, path arcset.Path) hamtResult {
+func (r *Resolver) tryHAMTResolution(ctx context.Context, root cid.Cid, blockContent []byte, path arcset.Path) hamtResult {
 	// Try to parse as HAMT node
 	_, err := hamt.ParseNode(blockContent)
 	if err != nil {
@@ -292,7 +293,7 @@ func (r *Resolver) tryHAMTResolution(root cid.Cid, blockContent []byte, path arc
 		hamt.WithMaxDepth(r.hamtConfig.MaxDepth),
 	)
 
-	matchedPath, target, ev, err := hamtResolver.Resolve(root, path)
+	matchedPath, target, ev, err := hamtResolver.Resolve(ctx, root, path)
 	if err != nil {
 		return hamtResult{
 			isHAMT: true,

--- a/cmd/eval/internal/compat/implicit/implicit_test.go
+++ b/cmd/eval/internal/compat/implicit/implicit_test.go
@@ -43,7 +43,7 @@ func TestResolve_EmptyPath(t *testing.T) {
 	c := helperCID(blockData)
 	mockCAS.AddBlock(c, blockData)
 
-	matchedPath, target, ev, err := resolver.Resolve(c, "")
+	matchedPath, target, ev, err := resolver.Resolve(context.Background(), c, "")
 	if err != nil {
 		t.Fatalf("Resolve with empty path should not error: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestResolve_UndefinedRoot(t *testing.T) {
 	mockCAS := mock.NewCAS()
 	resolver := implicit.NewResolver(mockCAS)
 
-	_, _, _, err := resolver.Resolve(cid.Cid{}, "some/path")
+	_, _, _, err := resolver.Resolve(context.Background(), cid.Cid{}, "some/path")
 	if err == nil {
 		t.Fatal("expected error for undefined root, got nil")
 	}
@@ -87,7 +87,7 @@ func TestResolve_NilCAS(t *testing.T) {
 	resolver := implicit.NewResolver(nil)
 
 	c := helperCID([]byte("data"))
-	_, _, _, err := resolver.Resolve(c, "")
+	_, _, _, err := resolver.Resolve(context.Background(), c, "")
 	if err == nil {
 		t.Fatal("expected error for nil CAS, got nil")
 	}
@@ -106,7 +106,7 @@ func TestResolve_BlockNotFound(t *testing.T) {
 
 	c := helperCID([]byte("missing block"))
 
-	_, _, _, err := resolver.Resolve(c, "")
+	_, _, _, err := resolver.Resolve(context.Background(), c, "")
 	if err == nil {
 		t.Fatal("expected error for missing block, got nil")
 	}
@@ -129,7 +129,7 @@ func TestResolve_RawBlock(t *testing.T) {
 	c := helperCID(blockData)
 	mockCAS.AddBlock(c, blockData)
 
-	matchedPath, target, ev, err := resolver.Resolve(c, "")
+	matchedPath, target, ev, err := resolver.Resolve(context.Background(), c, "")
 	if err != nil {
 		t.Fatalf("Resolve raw block should not error: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestVerify_NilEvidence(t *testing.T) {
 	c := helperCID([]byte("data"))
 	target := helperCID([]byte("target"))
 
-	ok, err := resolver.Verify(c, "", target, nil)
+	ok, err := resolver.Verify(context.Background(), c, "", target, nil)
 	if err == nil {
 		t.Fatal("expected error for nil evidence, got nil")
 	}
@@ -181,7 +181,7 @@ func TestVerify_WrongEvidenceType(t *testing.T) {
 
 	wrongEv := evidence.NewExplicitEvidence([]byte("proof bytes"))
 
-	ok, err := resolver.Verify(c, "", target, wrongEv)
+	ok, err := resolver.Verify(context.Background(), c, "", target, wrongEv)
 	if err == nil {
 		t.Fatal("expected error for wrong evidence type, got nil")
 	}
@@ -208,7 +208,7 @@ func TestVerify_BlockHashMismatch(t *testing.T) {
 
 	target := cid.Cid{}
 
-	ok, err := resolver.Verify(c, "", target, ev)
+	ok, err := resolver.Verify(context.Background(), c, "", target, ev)
 	if err != nil {
 		t.Fatalf("Verify should not error on hash mismatch, got: %v", err)
 	}
@@ -232,13 +232,13 @@ func TestVerify_ValidImplicitEvidence(t *testing.T) {
 	}
 
 	// Resolve to get evidence
-	_, _, ev, err := resolver.Resolve(c, "")
+	_, _, ev, err := resolver.Resolve(context.Background(), c, "")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
 
 	// Verify the evidence - for empty path, target should equal root
-	ok, err := resolver.Verify(c, "", c, ev)
+	ok, err := resolver.Verify(context.Background(), c, "", c, ev)
 	if err != nil {
 		t.Fatalf("Verify failed: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestResolve_PathOnRawBlock(t *testing.T) {
 
 	// Raw blocks cannot resolve path segments; they should just return
 	// the block content as evidence with no target.
-	matchedPath, target, ev, err := resolver.Resolve(c, "some/segment")
+	matchedPath, target, ev, err := resolver.Resolve(context.Background(), c, "some/segment")
 	if err != nil {
 		t.Fatalf("Resolve on raw block with path should not error: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestResolve_DagCborBlock(t *testing.T) {
 	c := helperCIDWithCodec(blockData, cid.DagCBOR)
 	mockCAS.AddBlock(c, blockData)
 
-	matchedPath, target, ev, err := resolver.Resolve(c, "")
+	matchedPath, target, ev, err := resolver.Resolve(context.Background(), c, "")
 	if err != nil {
 		t.Fatalf("Resolve dag-cbor block should not error: %v", err)
 	}
@@ -359,7 +359,7 @@ func TestResolve_UnknownCodec(t *testing.T) {
 	c := helperCIDWithCodec(blockData, 0x00)
 	mockCAS.AddBlock(c, blockData)
 
-	matchedPath, target, ev, err := resolver.Resolve(c, "")
+	matchedPath, target, ev, err := resolver.Resolve(context.Background(), c, "")
 	if err != nil {
 		t.Fatalf("Resolve with unknown codec should not error: %v", err)
 	}
@@ -387,7 +387,7 @@ func TestResolve_NilCASWithHAMTConfig(t *testing.T) {
 	resolver := implicit.NewResolverWithHAMTConfig(nil, cfg)
 
 	c := helperCID([]byte("data"))
-	_, _, _, err := resolver.Resolve(c, "")
+	_, _, _, err := resolver.Resolve(context.Background(), c, "")
 	if err == nil {
 		t.Fatal("expected error for nil CAS, got nil")
 	}
@@ -402,7 +402,7 @@ func TestResolve_NilCASWithCodecs(t *testing.T) {
 	resolver := implicit.NewResolverWithCodecs(nil, registry)
 
 	c := helperCID([]byte("data"))
-	_, _, _, err := resolver.Resolve(c, "")
+	_, _, _, err := resolver.Resolve(context.Background(), c, "")
 	if err == nil {
 		t.Fatal("expected error for nil CAS, got nil")
 	}

--- a/cmd/eval/internal/eval/readbench/local_malt.go
+++ b/cmd/eval/internal/eval/readbench/local_malt.go
@@ -85,7 +85,7 @@ func NewLocalMALTSystem(ctx context.Context, store *casmock.CAS, multiFix MultiD
 // MeasureResolve measures a single resolve_path operation at the given path.
 func (s *LocalMALTSystem) MeasureResolve(ctx context.Context, iteration int, fixtureName string, filePath string) (*Result, error) {
 	start := time.Now()
-	result, err := s.g.Resolver().Resolve(s.root, filePath)
+	result, err := s.g.Resolver().Resolve(ctx, s.root, filePath)
 	elapsed := positiveElapsedNS(start, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("resolve %q: %w", filePath, err)

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -11,9 +11,9 @@ import (
 
 // Resolver is the graph read/proof port.
 type Resolver interface {
-	ResolveKey(root cid.Cid, path string) (*resolver.ResolveResult, error)
-	Resolve(root cid.Cid, path string) (*resolver.ResolveResult, error)
-	VerifyTranscript(root cid.Cid, transcript *resolver.Transcript) (bool, error)
+	ResolveKey(ctx context.Context, root cid.Cid, path string) (*resolver.ResolveResult, error)
+	Resolve(ctx context.Context, root cid.Cid, path string) (*resolver.ResolveResult, error)
+	VerifyTranscript(ctx context.Context, root cid.Cid, transcript *resolver.Transcript) (bool, error)
 }
 
 // Writer is the graph mutation port.

--- a/graph/resolver/resolver.go
+++ b/graph/resolver/resolver.go
@@ -3,6 +3,7 @@
 package resolver
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -39,7 +40,7 @@ type ResolveResult struct {
 
 // ResolveKey resolves a path to its terminal typed key without terminal payload
 // materialization. For list roots, traversal is terminal (no auto @payload).
-func (r *Resolver) ResolveKey(root cid.Cid, path string) (*ResolveResult, error) {
+func (r *Resolver) ResolveKey(ctx context.Context, root cid.Cid, path string) (*ResolveResult, error) {
 	if !root.Defined() {
 		return nil, ErrUndefinedRoot
 	}
@@ -70,7 +71,7 @@ func (r *Resolver) ResolveKey(root cid.Cid, path string) (*ResolveResult, error)
 				Transcript:    transcript,
 			}, nil
 		}
-		matchedPath, target, ev, err = r.explicitStep.Resolve(currentCID, remainingPath)
+		matchedPath, target, ev, err = r.explicitStep.Resolve(ctx, currentCID, remainingPath)
 
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", ErrResolutionFailed, err)
@@ -113,8 +114,8 @@ func (r *Resolver) ResolveKey(root cid.Cid, path string) (*ResolveResult, error)
 // Resolve resolves a path from a root CID through explicit MALT arcs only.
 // It stops with RemainingPath set when it reaches a non-MALT CID, a terminal
 // list root, or a root with no matching explicit arc.
-func (r *Resolver) Resolve(root cid.Cid, path string) (*ResolveResult, error) {
-	keyResult, err := r.ResolveKey(root, path)
+func (r *Resolver) Resolve(ctx context.Context, root cid.Cid, path string) (*ResolveResult, error) {
+	keyResult, err := r.ResolveKey(ctx, root, path)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +125,7 @@ func (r *Resolver) Resolve(root cid.Cid, path string) (*ResolveResult, error) {
 
 	// Terminal materialization is map-only. List roots must remain terminal.
 	if maltcid.SemanticKindOf(keyResult.Target) == maltcid.SemanticKindMap && r.explicitStep != nil {
-		_, target, ev, err := r.explicitStep.Resolve(keyResult.Target, explicit.PayloadArc)
+		_, target, ev, err := r.explicitStep.Resolve(ctx, keyResult.Target, explicit.PayloadArc)
 		if err != nil {
 			return nil, fmt.Errorf("%w: map root %s is missing mandatory @payload binding: %w", ErrResolutionFailed, keyResult.Target.String(), err)
 		}
@@ -144,7 +145,7 @@ func (r *Resolver) Resolve(root cid.Cid, path string) (*ResolveResult, error) {
 }
 
 // VerifyTranscript verifies all steps in a transcript.
-func (r *Resolver) VerifyTranscript(root cid.Cid, transcript *Transcript) (bool, error) {
+func (r *Resolver) VerifyTranscript(ctx context.Context, root cid.Cid, transcript *Transcript) (bool, error) {
 	if transcript == nil {
 		return false, ErrTranscriptNil
 	}
@@ -164,7 +165,7 @@ func (r *Resolver) VerifyTranscript(root cid.Cid, transcript *Transcript) (bool,
 			return false, fmt.Errorf("%w for evidence kind: %v", ErrStepExecutorNotAvailable, stepEv.Evidence.Kind())
 		}
 
-		valid, err := s.Verify(currentRoot, stepEv.Path, stepEv.Target, stepEv.Evidence)
+		valid, err := s.Verify(ctx, currentRoot, stepEv.Path, stepEv.Target, stepEv.Evidence)
 		if err != nil {
 			return false, fmt.Errorf("verification failed: %w", err)
 		}

--- a/graph/resolver/resolver_test.go
+++ b/graph/resolver/resolver_test.go
@@ -93,7 +93,7 @@ func TestResolverExplicitOnly(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result, err := g.Resolve(root, tt.path)
+		result, err := g.Resolve(ctx, root, tt.path)
 		if err != nil {
 			t.Errorf("Resolve(%s) failed: %v", tt.path, err)
 			continue
@@ -105,7 +105,7 @@ func TestResolverExplicitOnly(t *testing.T) {
 			t.Errorf("Resolve(%s) should have exactly one step, got %d", tt.path, len(result.Transcript.Steps))
 		}
 
-		valid, err := g.VerifyTranscript(root, result.Transcript)
+		valid, err := g.VerifyTranscript(ctx, root, result.Transcript)
 		if err != nil {
 			t.Errorf("VerifyTranscript(%s) failed: %v", tt.path, err)
 		}
@@ -129,7 +129,7 @@ func TestResolverCanonicalizesResolvePath(t *testing.T) {
 	explicitR := explicit.NewResolver(e, semantic, testNamespace)
 	g := resolver.NewResolver(explicitR)
 
-	result, err := g.Resolve(root, "/a//b/")
+	result, err := g.Resolve(ctx, root, "/a//b/")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestResolverExplicitLongestPrefix(t *testing.T) {
 	explicitR := explicit.NewResolver(e, semantic, testNamespace)
 	g := resolver.NewResolver(explicitR)
 
-	result, err := g.Resolve(root, "a/b/c/d")
+	result, err := g.Resolve(ctx, root, "a/b/c/d")
 	if err == nil && !result.Target.Equals(k3) {
 		t.Errorf("Resolve(a/b/c/d) = %v, want %v", result.Target, k3)
 	}
@@ -178,7 +178,7 @@ func TestResolverStopsAtNonMaltPayload(t *testing.T) {
 	explicitR := explicit.NewResolver(e, semantic, testNamespace)
 	g := resolver.NewResolver(explicitR)
 
-	result, err := g.Resolve(root, "data")
+	result, err := g.Resolve(ctx, root, "data")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestResolverTranscript(t *testing.T) {
 	explicitR := explicit.NewResolver(e, semantic, testNamespace)
 	g := resolver.NewResolver(explicitR)
 
-	result, err := g.Resolve(root, "inner")
+	result, err := g.Resolve(ctx, root, "inner")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestResolverPayloadRedirect(t *testing.T) {
 	explicitR := explicit.NewResolver(e, semantic, testNamespace)
 	g := resolver.NewResolver(explicitR)
 
-	result, err := g.Resolve(root, "")
+	result, err := g.Resolve(ctx, root, "")
 	if err != nil {
 		t.Fatalf("Resolve with empty path failed: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestResolverPayloadRedirect(t *testing.T) {
 		t.Errorf("Step path = %s, want @payload", result.Transcript.Steps[0].Path)
 	}
 
-	valid, err := g.VerifyTranscript(root, result.Transcript)
+	valid, err := g.VerifyTranscript(ctx, root, result.Transcript)
 	if err != nil {
 		t.Fatalf("VerifyTranscript failed: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestResolveKeyAndResolve_ListTerminalNoPayloadRedirect(t *testing.T) {
 	explicitR := explicit.NewResolver(e, semantic, testNamespace)
 	g := resolver.NewResolver(explicitR)
 
-	keyResult, err := g.ResolveKey(root, "file")
+	keyResult, err := g.ResolveKey(ctx, root, "file")
 	if err != nil {
 		t.Fatalf("ResolveKey failed: %v", err)
 	}
@@ -296,7 +296,7 @@ func TestResolveKeyAndResolve_ListTerminalNoPayloadRedirect(t *testing.T) {
 		t.Fatalf("ResolveKey steps = %d, want 1", len(keyResult.Transcript.Steps))
 	}
 
-	resolveResult, err := g.Resolve(root, "file")
+	resolveResult, err := g.Resolve(ctx, root, "file")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -307,7 +307,7 @@ func TestResolveKeyAndResolve_ListTerminalNoPayloadRedirect(t *testing.T) {
 		t.Fatalf("Resolve should not append @payload for list; steps = %d", len(resolveResult.Transcript.Steps))
 	}
 
-	incompleteResult, err := g.Resolve(root, "file/extra")
+	incompleteResult, err := g.Resolve(ctx, root, "file/extra")
 	if err != nil {
 		t.Fatalf("Resolve incomplete list path failed: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestResolverMissingPayloadBindingFails(t *testing.T) {
 	explicitR := explicit.NewResolver(e, semantic, testNamespace)
 	g := resolver.NewResolver(explicitR)
 
-	result, err := g.Resolve(root, "")
+	result, err := g.Resolve(ctx, root, "")
 	if err == nil {
 		t.Fatalf("Resolve unexpectedly succeeded: %+v", result)
 	}
@@ -344,12 +344,13 @@ func TestResolverNonMaltEmptyPathIsTerminal(t *testing.T) {
 	e := newTestArcTable()
 	semantic := newSemantic(t, e)
 
+	ctx := context.Background()
 	payloadCID, _ := newPayloadCID([]byte("raw-data"))
 
 	explicitR := explicit.NewResolver(e, semantic, testNamespace)
 	g := resolver.NewResolver(explicitR)
 
-	result, err := g.Resolve(payloadCID, "")
+	result, err := g.Resolve(ctx, payloadCID, "")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -365,12 +366,13 @@ func TestResolverNonMaltPathReportsRemaining(t *testing.T) {
 	e := newTestArcTable()
 	semantic := newSemantic(t, e)
 
+	ctx := context.Background()
 	payloadCID, _ := newPayloadCID([]byte("raw-data"))
 
 	explicitR := explicit.NewResolver(e, semantic, testNamespace)
 	g := resolver.NewResolver(explicitR)
 
-	result, err := g.Resolve(payloadCID, "missing/path")
+	result, err := g.Resolve(ctx, payloadCID, "missing/path")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}

--- a/graph/resolver/step/explicit/explicit.go
+++ b/graph/resolver/step/explicit/explicit.go
@@ -47,7 +47,7 @@ func NewResolver(e arctable.ArcTable, semantic mapping.Semantics, namespace stri
 //
 // Example: if ArcTable contains "a/b/c" → key1 and path is "a/b/c/d/e",
 // it matches "a/b/c" and returns that path with its target and evidence.
-func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.Path, target cid.Cid, ev evidence.Evidence, err error) {
+func (r *Resolver) Resolve(ctx context.Context, root cid.Cid, path arcset.Path) (matchedPath arcset.Path, target cid.Cid, ev evidence.Evidence, err error) {
 	start := time.Now()
 
 	logger.Debug("Resolver.Resolve started",
@@ -63,8 +63,6 @@ func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.P
 		logger.Error("Resolver.Resolve path is empty")
 		return "", cid.Cid{}, nil, fmt.Errorf("path is empty")
 	}
-
-	ctx := context.Background()
 
 	// Try to find the longest matching prefix
 	segments := splitPath(path)
@@ -109,7 +107,8 @@ func (r *Resolver) Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.P
 }
 
 // Verify verifies a single step's evidence.
-func (r *Resolver) Verify(root cid.Cid, path arcset.Path, target cid.Cid, ev evidence.Evidence) (bool, error) {
+func (r *Resolver) Verify(ctx context.Context, root cid.Cid, path arcset.Path, target cid.Cid, ev evidence.Evidence) (bool, error) {
+	_ = ctx
 	start := time.Now()
 
 	logger.Debug("Resolver.Verify started",

--- a/graph/resolver/step/explicit/explicit_test.go
+++ b/graph/resolver/step/explicit/explicit_test.go
@@ -67,6 +67,7 @@ func setupArcSet(t *testing.T, e *overwrite.ArcTable, semantic mapping.Semantics
 
 func TestResolve_LongestPrefixMatch(t *testing.T) {
 	e, semantic, _ := newTestComponents()
+	ctx := context.Background()
 
 	// Create target CIDs
 	target1 := makeCID(1)
@@ -85,7 +86,7 @@ func TestResolve_LongestPrefixMatch(t *testing.T) {
 	r := explicit.NewResolver(e, semantic, testNamespace)
 
 	// Resolve "a/b/c/d" should match longest prefix "a/b/c" -> target3
-	matchedPath, target, ev, err := r.Resolve(root, "a/b/c/d")
+	matchedPath, target, ev, err := r.Resolve(ctx, root, "a/b/c/d")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -103,7 +104,7 @@ func TestResolve_LongestPrefixMatch(t *testing.T) {
 	}
 
 	// Verify the evidence
-	valid, err := r.Verify(root, matchedPath, target, ev)
+	valid, err := r.Verify(ctx, root, matchedPath, target, ev)
 	if err != nil {
 		t.Fatalf("Verify failed: %v", err)
 	}
@@ -112,7 +113,7 @@ func TestResolve_LongestPrefixMatch(t *testing.T) {
 	}
 
 	// Resolve "a/b/x" should match longest prefix "a/b" -> target2
-	matchedPath, target, ev, err = r.Resolve(root, "a/b/x")
+	matchedPath, target, ev, err = r.Resolve(ctx, root, "a/b/x")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -124,7 +125,7 @@ func TestResolve_LongestPrefixMatch(t *testing.T) {
 	}
 
 	// Verify this evidence too
-	valid, err = r.Verify(root, matchedPath, target, ev)
+	valid, err = r.Verify(ctx, root, matchedPath, target, ev)
 	if err != nil {
 		t.Fatalf("Verify failed: %v", err)
 	}
@@ -134,7 +135,7 @@ func TestResolve_LongestPrefixMatch(t *testing.T) {
 
 	// Verify that "a/b" is still stored in the snapshot (needed for semantic.Prove)
 	// by resolving "a/x" -> should match "a" -> target1
-	matchedPath, target, ev, err = r.Resolve(root, "a/x")
+	matchedPath, target, ev, err = r.Resolve(ctx, root, "a/x")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -146,7 +147,7 @@ func TestResolve_LongestPrefixMatch(t *testing.T) {
 	}
 
 	// Verify
-	valid, err = r.Verify(root, matchedPath, target, ev)
+	valid, err = r.Verify(ctx, root, matchedPath, target, ev)
 	if err != nil {
 		t.Fatalf("Verify failed: %v", err)
 	}
@@ -158,6 +159,7 @@ func TestResolve_LongestPrefixMatch(t *testing.T) {
 
 func TestResolve_ExactMatch(t *testing.T) {
 	e, semantic, _ := newTestComponents()
+	ctx := context.Background()
 
 	target1 := makeCID(1)
 	target2 := makeCID(2)
@@ -171,7 +173,7 @@ func TestResolve_ExactMatch(t *testing.T) {
 	r := explicit.NewResolver(e, semantic, testNamespace)
 
 	// Exact match: resolve "a/b" should return "a/b" -> target2
-	matchedPath, target, ev, err := r.Resolve(root, "a/b")
+	matchedPath, target, ev, err := r.Resolve(ctx, root, "a/b")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -186,7 +188,7 @@ func TestResolve_ExactMatch(t *testing.T) {
 	}
 
 	// Verify the evidence
-	valid, err := r.Verify(root, matchedPath, target, ev)
+	valid, err := r.Verify(ctx, root, matchedPath, target, ev)
 	if err != nil {
 		t.Fatalf("Verify failed: %v", err)
 	}
@@ -197,6 +199,7 @@ func TestResolve_ExactMatch(t *testing.T) {
 
 func TestResolve_NoMatch(t *testing.T) {
 	e, semantic, _ := newTestComponents()
+	ctx := context.Background()
 
 	target := makeCID(1)
 	arcsMap := map[string]cid.Cid{
@@ -207,7 +210,7 @@ func TestResolve_NoMatch(t *testing.T) {
 	r := explicit.NewResolver(e, semantic, testNamespace)
 
 	// Resolve "x/y/z" has no matching prefix
-	_, _, _, err := r.Resolve(root, "x/y/z")
+	_, _, _, err := r.Resolve(ctx, root, "x/y/z")
 	if err == nil {
 		t.Fatal("expected error for non-matching path, got nil")
 	}
@@ -215,6 +218,7 @@ func TestResolve_NoMatch(t *testing.T) {
 
 func TestResolve_EmptyPath(t *testing.T) {
 	e, semantic, _ := newTestComponents()
+	ctx := context.Background()
 
 	target := makeCID(1)
 	arcsMap := map[string]cid.Cid{
@@ -225,7 +229,7 @@ func TestResolve_EmptyPath(t *testing.T) {
 	r := explicit.NewResolver(e, semantic, testNamespace)
 
 	// Empty path should error with "path is empty"
-	_, _, _, err := r.Resolve(root, "")
+	_, _, _, err := r.Resolve(ctx, root, "")
 	if err == nil {
 		t.Fatal("expected error for empty path, got nil")
 	}
@@ -236,11 +240,12 @@ func TestResolve_EmptyPath(t *testing.T) {
 
 func TestResolve_UndefinedRoot(t *testing.T) {
 	e, semantic, _ := newTestComponents()
+	ctx := context.Background()
 
 	r := explicit.NewResolver(e, semantic, testNamespace)
 
 	// Undefined root should error with "root is not defined"
-	_, _, _, err := r.Resolve(cid.Undef, "a/b")
+	_, _, _, err := r.Resolve(ctx, cid.Undef, "a/b")
 	if err == nil {
 		t.Fatal("expected error for undefined root, got nil")
 	}
@@ -251,6 +256,7 @@ func TestResolve_UndefinedRoot(t *testing.T) {
 
 func TestVerify_ValidProof(t *testing.T) {
 	e, semantic, _ := newTestComponents()
+	ctx := context.Background()
 
 	target := makeCID(1)
 	arcsMap := map[string]cid.Cid{
@@ -261,13 +267,13 @@ func TestVerify_ValidProof(t *testing.T) {
 	r := explicit.NewResolver(e, semantic, testNamespace)
 
 	// First resolve to get valid evidence
-	matchedPath, resolvedTarget, ev, err := r.Resolve(root, "a/b")
+	matchedPath, resolvedTarget, ev, err := r.Resolve(ctx, root, "a/b")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
 
 	// Verify the evidence
-	valid, err := r.Verify(root, matchedPath, resolvedTarget, ev)
+	valid, err := r.Verify(ctx, root, matchedPath, resolvedTarget, ev)
 	if err != nil {
 		t.Fatalf("Verify failed: %v", err)
 	}
@@ -278,6 +284,7 @@ func TestVerify_ValidProof(t *testing.T) {
 
 func TestVerify_WrongProof(t *testing.T) {
 	e, semantic, _ := newTestComponents()
+	ctx := context.Background()
 
 	target := makeCID(1)
 	arcsMap := map[string]cid.Cid{
@@ -288,7 +295,7 @@ func TestVerify_WrongProof(t *testing.T) {
 	r := explicit.NewResolver(e, semantic, testNamespace)
 
 	// Resolve to get a valid evidence
-	matchedPath, resolvedTarget, ev, err := r.Resolve(root, "a/b")
+	matchedPath, resolvedTarget, ev, err := r.Resolve(ctx, root, "a/b")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -304,7 +311,7 @@ func TestVerify_WrongProof(t *testing.T) {
 	wrongEv := evidence.NewExplicitEvidence(wrongProof)
 
 	// Verify should fail with the wrong proof
-	valid, err := r.Verify(root, matchedPath, resolvedTarget, wrongEv)
+	valid, err := r.Verify(ctx, root, matchedPath, resolvedTarget, wrongEv)
 	if err != nil {
 		// An error is acceptable for a corrupted proof
 		t.Logf("Verify returned error (expected for wrong proof): %v", err)
@@ -317,13 +324,14 @@ func TestVerify_WrongProof(t *testing.T) {
 
 func TestVerify_NilEvidence(t *testing.T) {
 	e, semantic, _ := newTestComponents()
+	ctx := context.Background()
 
 	r := explicit.NewResolver(e, semantic, testNamespace)
 	root := makeCID(1)
 	target := makeCID(2)
 
 	// Nil evidence should error
-	_, err := r.Verify(root, "a/b", target, nil)
+	_, err := r.Verify(ctx, root, "a/b", target, nil)
 	if err == nil {
 		t.Fatal("expected error for nil evidence, got nil")
 	}
@@ -334,6 +342,7 @@ func TestVerify_NilEvidence(t *testing.T) {
 
 func TestVerify_WrongEvidenceType(t *testing.T) {
 	e, semantic, _ := newTestComponents()
+	ctx := context.Background()
 
 	r := explicit.NewResolver(e, semantic, testNamespace)
 	root := makeCID(1)
@@ -341,7 +350,7 @@ func TestVerify_WrongEvidenceType(t *testing.T) {
 
 	// Pass ImplicitEvidence instead of ExplicitEvidence
 	implicitEv := evidence.NewImplicitEvidence([]byte("some block content"))
-	_, err := r.Verify(root, "a/b", target, implicitEv)
+	_, err := r.Verify(ctx, root, "a/b", target, implicitEv)
 	if err == nil {
 		t.Fatal("expected error for wrong evidence type, got nil")
 	}
@@ -390,7 +399,7 @@ func TestBloomFilterWithResolver(t *testing.T) {
 
 	r := explicit.NewResolver(e, semantic, namespace)
 
-	matchedPath, resolvedTarget, ev, err := r.Resolve(root, "data/file")
+	matchedPath, resolvedTarget, ev, err := r.Resolve(ctx, root, "data/file")
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -402,7 +411,7 @@ func TestBloomFilterWithResolver(t *testing.T) {
 	}
 
 	// Verify evidence
-	valid, err := r.Verify(root, matchedPath, resolvedTarget, ev)
+	valid, err := r.Verify(ctx, root, matchedPath, resolvedTarget, ev)
 	if err != nil {
 		t.Fatalf("Verify failed: %v", err)
 	}

--- a/graph/resolver/step/step.go
+++ b/graph/resolver/step/step.go
@@ -6,6 +6,8 @@
 package step
 
 import (
+	"context"
+
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/auth/proof/evidence"
 	cid "github.com/ipfs/go-cid"
@@ -16,8 +18,8 @@ import (
 type Step interface {
 	// Resolve finds the longest matching prefix and returns evidence.
 	// Returns: matchedPath, target, evidence, error
-	Resolve(root cid.Cid, path arcset.Path) (matchedPath arcset.Path, target cid.Cid, ev evidence.Evidence, err error)
+	Resolve(ctx context.Context, root cid.Cid, path arcset.Path) (matchedPath arcset.Path, target cid.Cid, ev evidence.Evidence, err error)
 
 	// Verify verifies the evidence for a resolution step.
-	Verify(root cid.Cid, path arcset.Path, target cid.Cid, ev evidence.Evidence) (bool, error)
+	Verify(ctx context.Context, root cid.Cid, path arcset.Path, target cid.Cid, ev evidence.Evidence) (bool, error)
 }

--- a/runtime/node/e2e_test.go
+++ b/runtime/node/e2e_test.go
@@ -66,7 +66,7 @@ func TestAPI_CreateAndResolve(t *testing.T) {
 	}
 
 	for path, expected := range arcs {
-		result, err := g.Resolver().Resolve(root, path)
+		result, err := g.Resolver().Resolve(ctx, root, path)
 		if err != nil {
 			t.Fatalf("Resolve failed for %s: %v", path, err)
 		}
@@ -74,7 +74,7 @@ func TestAPI_CreateAndResolve(t *testing.T) {
 			t.Errorf("target mismatch for %s: got %s, want %s", path, result.Target, expected)
 		}
 
-		valid, err := g.Resolver().VerifyTranscript(root, result.Transcript)
+		valid, err := g.Resolver().VerifyTranscript(ctx, root, result.Transcript)
 		if err != nil {
 			t.Fatalf("Verify failed for %s: %v", path, err)
 		}
@@ -100,14 +100,14 @@ func TestAPI_UpdateResolveCycle(t *testing.T) {
 
 	// Verify initial state
 	path := "arc5"
-	result, err := g.Resolver().Resolve(root1, path)
+	result, err := g.Resolver().Resolve(ctx, root1, path)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
 	if !result.Target.Equals(arcs[path]) {
 		t.Fatalf("initial target mismatch: got %s, want %s", result.Target, arcs[path])
 	}
-	valid, err := g.Resolver().VerifyTranscript(root1, result.Transcript)
+	valid, err := g.Resolver().VerifyTranscript(ctx, root1, result.Transcript)
 	if err != nil {
 		t.Fatalf("initial transcript verification failed: %v", err)
 	}
@@ -125,20 +125,20 @@ func TestAPI_UpdateResolveCycle(t *testing.T) {
 	}
 
 	// Resolve on new root
-	result2, err := g.Resolver().Resolve(root2, path)
+	result2, err := g.Resolver().Resolve(ctx, root2, path)
 	if err != nil {
 		t.Fatalf("Resolve after update failed: %v", err)
 	}
 	if !result2.Target.Equals(newTarget) {
 		t.Fatalf("updated target mismatch: got %s, want %s", result2.Target, newTarget)
 	}
-	valid, err = g.Resolver().VerifyTranscript(root2, result2.Transcript)
+	valid, err = g.Resolver().VerifyTranscript(ctx, root2, result2.Transcript)
 	if err != nil || !valid {
 		t.Fatalf("proof invalid after update: %v", err)
 	}
 
 	// Old root should still resolve to old target
-	result1, err := g.Resolver().Resolve(root1, path)
+	result1, err := g.Resolver().Resolve(ctx, root1, path)
 	if err != nil {
 		t.Fatalf("Resolve on old root failed: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestAPI_UpdateResolveCycle(t *testing.T) {
 	if !result1.Target.Equals(oldTarget) {
 		t.Fatalf("old root target mismatch: got %s, want %s", result1.Target, oldTarget)
 	}
-	valid, err = g.Resolver().VerifyTranscript(root1, result1.Transcript)
+	valid, err = g.Resolver().VerifyTranscript(ctx, root1, result1.Transcript)
 	if err != nil {
 		t.Fatalf("old root transcript verification failed: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestAPI_ChainedUpdatesResolveLatestRoot(t *testing.T) {
 
 	current := roots[len(roots)-1]
 	// Verify latest version is resolvable
-	_, err = g.Resolver().Resolve(current, "arc0")
+	_, err = g.Resolver().Resolve(ctx, current, "arc0")
 	if err != nil {
 		t.Fatalf("Resolve for latest version failed: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestAPI_InsertDelete(t *testing.T) {
 	}
 
 	// Verify new arc
-	result, err := g.Resolver().Resolve(root2, newPath)
+	result, err := g.Resolver().Resolve(ctx, root2, newPath)
 	if err != nil {
 		t.Fatalf("Resolve new arc failed: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestAPI_InsertDelete(t *testing.T) {
 	}
 
 	// Verify initial arc still exists
-	arc0Result, err := g.Resolver().Resolve(root2, "arc0")
+	arc0Result, err := g.Resolver().Resolve(ctx, root2, "arc0")
 	if err != nil {
 		t.Fatalf("Resolve arc0 failed: %v", err)
 	}
@@ -250,13 +250,13 @@ func TestAPI_InsertDelete(t *testing.T) {
 	root3 := updateResult.NewRoot
 
 	// Verify deleted
-	_, err = g.Resolver().Resolve(root3, "arc0")
+	_, err = g.Resolver().Resolve(ctx, root3, "arc0")
 	if err == nil {
 		t.Error("deleted arc should not be found on new root")
 	}
 
 	// Verify remaining arcs
-	remainingResult, err := g.Resolver().Resolve(root3, "arc1")
+	remainingResult, err := g.Resolver().Resolve(ctx, root3, "arc1")
 	if err != nil {
 		t.Errorf("arc1 should exist on root3: %v", err)
 	}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -155,7 +155,7 @@ func (s *Server) statFromFlatTarget(ctx context.Context, g runtimeGraph, target 
 }
 
 func (s *Server) legacyPathStat(ctx context.Context, g runtimeGraph, root cid.Cid, path string) (*httpapi.PathStatResponse, error) {
-	keyResult, err := g.Resolver().ResolveKey(root, path)
+	keyResult, err := g.Resolver().ResolveKey(ctx, root, path)
 	if err != nil {
 		return nil, err
 	}

--- a/server/routes_resolve.go
+++ b/server/routes_resolve.go
@@ -43,7 +43,7 @@ func (s *Server) serveResolve(w http.ResponseWriter, r *http.Request, svc graphS
 }
 
 func (s *Server) resolvePath(ctx context.Context, svc graphService, root cid.Cid, rawPath string, wantProof bool) (*pathResolution, error) {
-	cleanPath, keyResult, err := svc.ResolveKey(root, rawPath)
+	cleanPath, keyResult, err := svc.ResolveKey(ctx, root, rawPath)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (s *Server) resolvePath(ctx context.Context, svc graphService, root cid.Cid
 
 	transcript := keyResult.Transcript
 	if maltcid.SemanticKindOf(key) == maltcid.SemanticKindMap {
-		payloadResult, err := svc.ResolveMapPayload(key)
+		payloadResult, err := svc.ResolveMapPayload(ctx, key)
 		if err != nil {
 			return nil, err
 		}

--- a/server/routes_verify.go
+++ b/server/routes_verify.go
@@ -18,7 +18,7 @@ func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
 		writeBodyDecodeError(w, err)
 		return
 	}
-	valid, err := (proofVerifier{runtime: svc.runtime}).VerifyProofList(req.ProofList)
+	valid, err := (proofVerifier{runtime: svc.runtime}).VerifyProofList(r.Context(), req.ProofList)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/server/service_graph.go
+++ b/server/service_graph.go
@@ -44,12 +44,12 @@ func (svc graphService) CreateStructure(ctx context.Context, snapshot arcset.Arc
 	return svc.runtime.Writer().CreateStructure(ctx, svc.runtime.Namespace(), snapshot)
 }
 
-func (svc graphService) ResolveKey(root cid.Cid, rawPath string) (string, *resolver.ResolveResult, error) {
+func (svc graphService) ResolveKey(ctx context.Context, root cid.Cid, rawPath string) (string, *resolver.ResolveResult, error) {
 	cleanPath, err := querypath.CanonicalizeQueryPath(rawPath)
 	if err != nil {
 		return "", nil, err
 	}
-	result, err := svc.runtime.Resolver().ResolveKey(root, cleanPath)
+	result, err := svc.runtime.Resolver().ResolveKey(ctx, root, cleanPath)
 	if err != nil {
 		return "", nil, err
 	}
@@ -59,8 +59,8 @@ func (svc graphService) ResolveKey(root cid.Cid, rawPath string) (string, *resol
 	return cleanPath, result, nil
 }
 
-func (svc graphService) ResolveMapPayload(root cid.Cid) (*resolver.ResolveResult, error) {
-	result, err := svc.runtime.Resolver().ResolveKey(root, explicit.PayloadArc.String())
+func (svc graphService) ResolveMapPayload(ctx context.Context, root cid.Cid) (*resolver.ResolveResult, error) {
+	result, err := svc.runtime.Resolver().ResolveKey(ctx, root, explicit.PayloadArc.String())
 	if err != nil {
 		return nil, err
 	}

--- a/server/service_verify.go
+++ b/server/service_verify.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -43,13 +44,13 @@ func (p proofListVerifiedPath) logicalQueryPath() string {
 	return strings.Join(p.parts, "/")
 }
 
-func (v proofVerifier) VerifyProofList(pl prooflist.ProofList) (bool, error) {
+func (v proofVerifier) VerifyProofList(ctx context.Context, pl prooflist.ProofList) (bool, error) {
 	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
 		return false, err
 	}
 	var verifiedPath proofListVerifiedPath
 	for i, step := range pl.Steps {
-		ok, err := v.verifyStep(i, step)
+		ok, err := v.verifyStep(ctx, i, step)
 		if err != nil || !ok {
 			return ok, err
 		}
@@ -97,14 +98,14 @@ func validateProofListQuery(pl prooflist.ProofList, verifiedPath proofListVerifi
 	return fmt.Errorf("prooflist query %q does not match ordered traversal path %q", want, got)
 }
 
-func (v proofVerifier) verifyStep(index int, step prooflist.Step) (bool, error) {
+func (v proofVerifier) verifyStep(ctx context.Context, index int, step prooflist.Step) (bool, error) {
 	switch step.EvidenceKind {
 	case "explicit":
 		ev, err := decodeEvidence(step.EvidenceKind, step.Evidence)
 		if err != nil {
 			return false, fmt.Errorf("invalid evidence at step %d: %w", index, err)
 		}
-		return v.runtime.Resolver().VerifyTranscript(step.From, &resolver.Transcript{Steps: []resolver.StepEvidence{{
+		return v.runtime.Resolver().VerifyTranscript(ctx, step.From, &resolver.Transcript{Steps: []resolver.StepEvidence{{
 			Path:     arcset.CanonicalizePath(step.Path),
 			Target:   step.Target,
 			Evidence: ev,


### PR DESCRIPTION
## Summary
- add `context.Context` to graph resolver and step interfaces
- pass request contexts through server resolve/verify and eval resolver paths
- remove the internal `context.Background()` from explicit arc resolution

## Tests
- `go test ./graph/resolver/... ./server ./runtime/node`
- `go test ./cmd/eval/internal/compat/... ./cmd/eval/internal/eval/readbench`

## Notes
- `mapping.Semantics.Verify` still has no context parameter, so explicit verify accepts ctx at the step boundary but cannot pass it deeper yet.