### PR TITLE
Cache node commitment scheme during initialization

### DIFF
--- a/runtime/node/node.go
+++ b/runtime/node/node.go
@@ -37,14 +37,14 @@ func canonicalArcTableType(t string) string {
 // Node is the stateless MALT node that holds shared infrastructure.
 // It is the entry point for the MALT system and a factory for per-graph instances.
 type Node struct {
-	cfg  *config.Config
-	opts *options
+	cfg *config.Config
 
 	// Shared components (namespace by namespace)
 	kv           kvstore.KVStore
 	arctable     arctable.ArcTable
 	cas          cas.Reader
 	graphManager *runtimegraph.Manager
+	commitment   commitment.IndexCommitment
 
 	metricsArcTable *metrics.ArcTable
 	proofStats      metrics.ProofStatsRecorder
@@ -70,7 +70,17 @@ func NewNode(opts ...Option) (*Node, error) {
 		opt(options)
 	}
 
-	node := &Node{opts: options}
+	node := &Node{}
+	ownsKV := false
+	ownsArcTable := false
+	cleanupOnError := func() {
+		if ownsArcTable && node.arctable != nil {
+			_ = node.arctable.Close()
+		}
+		if ownsKV && node.kv != nil {
+			_ = node.kv.Close()
+		}
+	}
 
 	// Load config if explicitly provided or file specified.
 	if options.config != nil {
@@ -89,8 +99,13 @@ func NewNode(opts ...Option) (*Node, error) {
 		node.cfg = cfg
 	}
 
+	scheme, err := node.initCommitmentSchemeType(node.cfg.Structure.DefaultBackend)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize commitment scheme: %w", err)
+	}
+	node.commitment = scheme
+
 	// Initialize components (use provided or create from config)
-	var err error
 
 	// KVStore
 	if options.kvStore != nil {
@@ -100,6 +115,7 @@ func NewNode(opts ...Option) (*Node, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize KVStore: %w", err)
 		}
+		ownsKV = true
 	}
 
 	// ArcTable
@@ -108,8 +124,10 @@ func NewNode(opts ...Option) (*Node, error) {
 	} else {
 		err = node.initArcTable()
 		if err != nil {
+			cleanupOnError()
 			return nil, fmt.Errorf("failed to initialize ArcTable: %w", err)
 		}
+		ownsArcTable = true
 	}
 	node.installMetricsArcTable()
 
@@ -127,6 +145,7 @@ func NewNode(opts ...Option) (*Node, error) {
 	} else {
 		node.cas, err = node.initCAS()
 		if err != nil {
+			cleanupOnError()
 			return nil, fmt.Errorf("failed to initialize CAS: %w", err)
 		}
 	}
@@ -284,33 +303,17 @@ func (n *Node) NewGraph(id string, opts ...runtimegraph.Option) (*runtimegraph.R
 		opt(o)
 	}
 
-	// Default commitment scheme from config if not specified
-	scheme := o.Scheme
-	if scheme == nil {
-		var err error
-		scheme, err = n.initCommitmentSchemeType(n.cfg.Structure.DefaultBackend)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create commitment scheme: %w", err)
-		}
+	graphOpts := opts
+	if o.Scheme == nil {
+		graphOpts = append([]runtimegraph.Option{runtimegraph.WithCommitmentScheme(n.commitment)}, opts...)
 	}
-
-	graphOpts := []runtimegraph.Option{
-		runtimegraph.WithCommitmentScheme(scheme),
-	}
-
-	// Apply user options (they can override)
-	graphOpts = append(graphOpts, opts...)
 
 	return runtimegraph.NewGraph(id, n.arctable, n.cas, graphOpts...)
 }
 
 // Commitment returns the default commitment scheme type from config.
 func (n *Node) Commitment() commitment.IndexCommitment {
-	scheme, err := n.initCommitmentSchemeType(n.cfg.Structure.DefaultBackend)
-	if err != nil {
-		return nil
-	}
-	return scheme
+	return n.commitment
 }
 
 // ArcTable returns the shared ArcTable.

--- a/runtime/node/node_test.go
+++ b/runtime/node/node_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/dewebprotocol/malt/config"
 	runtimegraph "github.com/dewebprotocol/malt/runtime/graph"
 	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
+	kvstore "github.com/dewebprotocol/malt/storage/kv"
+	kvmemory "github.com/dewebprotocol/malt/storage/kv/memory"
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -21,6 +23,16 @@ func newTestCID(seed string) cid.Cid {
 		panic(err)
 	}
 	return cid.NewCidV1(cid.Raw, mhash)
+}
+
+type closeTrackingKV struct {
+	kvstore.KVStore
+	closed bool
+}
+
+func (kv *closeTrackingKV) Close() error {
+	kv.closed = true
+	return kv.KVStore.Close()
 }
 
 func TestCreateManagedGraphUsesNodeRuntimeProfile(t *testing.T) {
@@ -40,6 +52,50 @@ func TestCreateManagedGraphUsesNodeRuntimeProfile(t *testing.T) {
 	}
 	if meta.ArcTableType != "versioned" {
 		t.Fatalf("arctable_type = %q, want %q", meta.ArcTableType, "versioned")
+	}
+}
+
+func TestNewNodeRejectsUnknownDefaultCommitment(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Structure.DefaultBackend = "unknown"
+
+	_, err := NewNode(WithConfig(cfg), WithCAS(casmock.NewCAS()))
+	if err == nil {
+		t.Fatal("NewNode succeeded with unknown default backend")
+	}
+	if !strings.Contains(err.Error(), "failed to initialize commitment scheme") {
+		t.Fatalf("NewNode error = %v, want commitment initialization failure", err)
+	}
+}
+
+func TestNewNodeDoesNotCloseExternalKVOnLaterFailure(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.CAS.Mode = "unsupported"
+	externalKV := &closeTrackingKV{KVStore: kvmemory.New()}
+
+	_, err := NewNode(WithConfig(cfg), WithKVStore(externalKV))
+	if err == nil {
+		t.Fatal("NewNode succeeded with unsupported CAS mode")
+	}
+	if externalKV.closed {
+		t.Fatal("NewNode closed caller-owned KVStore after later initialization failure")
+	}
+}
+
+func TestNodeCommitmentReturnsCachedScheme(t *testing.T) {
+	node, err := NewNode(testNodeOptions(t)...)
+	if err != nil {
+		t.Fatalf("NewNode failed: %v", err)
+	}
+	defer node.Close()
+
+	first := node.Commitment()
+	second := node.Commitment()
+	if first == nil {
+		t.Fatal("Commitment returned nil")
+	}
+	if first != second {
+		t.Fatalf("Commitment returned different scheme instances: %p vs %p", first, second)
 	}
 }
 


### PR DESCRIPTION
## Summary
- initialize and cache the node default commitment scheme in `NewNode`
- make `Commitment()` return the cached scheme instead of constructing a new one each call
- clean up node-owned KV/ArcTable resources when later initialization stages fail
- avoid applying user graph options twice when `Node.NewGraph` injects the default scheme

## Tests
- `go test ./runtime/node ./runtime/graph`