### PR TITLE
[codex] Split MIP proposals from specs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 ## Overview
 
 MALT targets authentication for structured data whose relationships can be
-normalized into graph-shaped nodes and relations.
+normalized into semantic objects and authenticated relations.
 
 MALT core consists of ArcTable, stateless commitment backends, and the list/map
 semantic layer. Immutable payload bytes can be stored naturally in CAS, but CAS
@@ -21,9 +21,10 @@ ApplyMutation(baseRoot, semantic mutation) -> newRoot + writeReceipt
 
 List and map are semantic abstractions:
 
-- list semantic: complex graph nodes with stable-indexed or range-addressed
+- list semantic: authenticated structure with stable-indexed or range-addressed
   child references
-- map semantic: authenticated keyed/path-like relations among graph nodes
+- map semantic: authenticated keyed/path-like relations from semantic objects
+  to target CIDs
 
 ArcTable is namespace-scoped arcset persistence/materialization and does
 not provide correctness by itself. Commitment backends are stateless
@@ -78,8 +79,8 @@ root-centric mutation namespace.
 
 ### List Semantic
 
-The list semantic authenticates stable-indexed child references inside complex
-graph nodes.
+The list semantic authenticates stable-indexed child references inside
+authenticated list structure.
 
 Read semantics:
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -73,7 +73,7 @@ byte-range reads include path/`@payload` proof plus one measured-list
 `list_range` step. That step carries authenticated fixed chunk metadata, the
 covered segment CIDs, and a proof payload composed from the metadata slot proof
 and the required index proofs. Response-body range binding is still a
-ProofList-schema TODO. File routes are product surfaces around the same
+ProofList verifier-contract TODO. File routes are product surfaces around the same
 root-centric mutation namespace.
 
 ### List Semantic
@@ -412,7 +412,7 @@ step proofs, terminal `@payload` proofs, list index proofs, measured-list
 `list_range` evidence for range reads, and blob target binding proofs from the
 queried root to the destination. Current `list_range` steps carry fixed chunk
 metadata, covered segment CIDs, and metadata/index proof payload. Response-body
-range binding remains a schema TODO.
+range binding remains a verifier-contract TODO.
 
 The current daemon has two HTTP proof-bearing read surfaces:
 
@@ -468,10 +468,10 @@ Current boundary:
   and `cas.Client`; current `graph`, `graph/writer`, and `graph/resolver`
   remain runtime composition and compatibility adapters rather than semantic
   owners.
-- The current writer semantic-mutation and `ProofList` schemas are
-  implemented. Paper-facing formalization, write metadata semantics,
-  graph-runtime boundary terminology, and benchmark-facing proof reporting
-  remain tracked as proposal-stage MIPs in `docs/mips/`.
+- The current writer receipt, artifact, and `ProofList` reference docs live
+  under `docs/spec/`. Proposal-stage MIPs in `docs/mips/` track acceptance,
+  remaining open decisions, and follow-up implementation planning rather than
+  serving as the only schema copy.
 - Graph manager metadata is limited to lifecycle and runtime profile
   compatibility. It does not store an authoritative current root or publish
   freshness. The current daemon path creates an ad hoc default `Graph` through
@@ -496,25 +496,19 @@ Metrics:
 
 Open proposal-stage MIPs for the next discussion:
 
-- define graph terminology as list/map-induced authenticated structure rather
-  than a standalone Go node-interface hierarchy
-- simplify the root `graph` package toward resolver/writer port interfaces and
-  a concrete runtime composition struct, removing empty `Graph` interface
-  layers when callers can inject resolver and writer directly
-- formalize the current writer semantic-mutation schema
-- formalize how `layout/unixfs` exposes semantic mutations for writer
-  application and how much of the current UnixFS convenience route
-  remains public API versus test/demo scaffolding
-- formalize the current `ProofList` schema and verification semantics for path
-  lookup, terminal `@payload`, blob bindings, measured-list `list_range`
-  evidence for range reads, and response-body range binding
-- decide how UnixFS reads should map onto resolver read queries and `ProofList`
-- define the final UnixFS write receipt and application-level concurrency
-  contract for the already-wired root APIs
-- decide after the first benchmark whether list needs a future compact
-  range-proof API; the current prototype uses path/`@payload` proof plus one
-  measured-list `list_range` step carrying metadata, segment CIDs, and
-  metadata/index proofs
+- accept or revise the semantic terminology now summarized in
+  `docs/spec/semantic.md`
+- decide whether writer receipts in `docs/spec/writer-receipts.md` become a
+  stable API and evaluation accounting contract
+- accept the current ProofList verifier contract in
+  `docs/spec/prooflist-format.md`, especially response-body range binding
+- decide whether resolve JSON and bare ProofList JSON need stable named schemas
+  beyond the artifact reference in `docs/spec/artifacts.md`
+- decide whether list needs a future variable-size or compact range-proof API;
+  the current prototype uses path/`@payload` proof plus one measured-list
+  `list_range` step carrying metadata, segment CIDs, and metadata/index proofs
+- stabilize benchmark-facing proof, receipt, and metrics reporting for paper
+  figures
 
 ## ArcTable and Versioning
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@ schemas and deployment policy.
 - Stabilize the public `malt` CLI around root-centric add, resolve, verify, and
   daemon lifecycle workflows.
 - Keep proof-bearing HTTP reads explicit and verifier-facing.
-- Tighten `ProofList` schema documentation for path resolution, terminal
+- Tighten `ProofList` verifier documentation for path resolution, terminal
   `@payload` binding, and list-backed byte-range evidence.
 - Keep `malt-eval` schemas, raw envelopes, manifests, and summary outputs stable
   enough for repeatable research runs.
@@ -54,5 +54,6 @@ Before the first public release tag:
 - `malt-eval run --plan examples/eval-smoke-plan.json` writes a manifest and
   summaries.
 - Security reporting path is enabled in GitHub repository settings.
-- Release notes state experimental limits and any known proof-schema TODOs.
+- Release notes state experimental limits and any known ProofList verifier
+  contract TODOs.
 - Public docs avoid claims that are not implemented in the current code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,9 +28,13 @@ MALT Improvement Proposals live in [docs/mips](./mips/). MIPs are the review
 path for semantic, verifier-facing, API, layout, tooling, and evaluation
 changes before they become implementation work.
 
-The previous `documents/MIPs` directory in the research-paper workspace is kept
-as historical research context. New implementation-bound MIP work should happen
-here.
+MIPs should define the proposal boundary, motivation, decision, alternatives,
+compatibility impact, security impact, and implementation planning state. Long
+field lists, wire formats, JSON schemas, and benchmark record rules belong in
+the reference docs under `spec/` or `evaluation/`, with MIPs linking to them.
+
+The previous `documents/MIPs` mirror in the research-paper workspace was
+removed after migration. New implementation-bound MIP work should happen here.
 
 ## What Goes Where
 

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -2,6 +2,60 @@
 
 This folder collects the implementation-bound evaluation surface.
 
-- [Evaluation guide](./README.md)
-
 See also the evaluator code under `cmd/eval/`.
+
+## Commands
+
+`malt-eval` supports:
+
+- `malt-eval read` for read-query records
+- `malt-eval write` for write-trace replay records
+- `malt-eval run` for JSON run plans and durable run directories
+- `malt-eval summarize` for summary CSV regeneration
+- `malt-eval schema` for embedded JSON schema listing and printing
+- `malt-eval metrics` for daemon runtime counters
+
+## Artifacts
+
+The framework runner writes durable results under `result/<run_id>` and
+disposable workspace state under `output/<run_id>`.
+
+Current machine-readable schemas live in `cmd/eval/schemas`:
+
+- `run-plan.schema.json`
+- `run-manifest.schema.json`
+- `common-record.schema.json`
+- `readbench-result.schema.json`
+- `read-query-result.schema.json`
+- `write-trace-result.schema.json`
+- `cas-model-result.schema.json`
+- `proof-overhead-result.schema.json`
+- `storage-overhead-result.schema.json`
+
+When a record shape changes, update the matching schema and focused schema or
+normalization tests in the same PR.
+
+## Benchmark Reporting
+
+Paper-facing reports should keep these dimensions separate:
+
+- payload bytes
+- proof bytes
+- ProofList step counts
+- comparable baseline evidence items, such as CAS block fetches
+- CAS operation counters
+- ArcTable operation counters
+- writer receipt counts
+- summary CSV fields used in figures
+
+Do not count unverifiable helper metadata as proof evidence. Do not present
+writer receipt counts as correctness proofs. Receipts and metrics are
+operational accounting unless tied to verifier evidence.
+
+Historical smoke artifacts that predate the current schemas should be labeled
+legacy rather than silently mixed into paper-facing aggregates.
+
+## Related Proposals
+
+[MIP-1009](../mips/mip-1009-benchmark-proof-reporting.md) tracks remaining
+decisions about stable benchmark-facing proof, receipt, and metric reporting.

--- a/docs/mips/README.md
+++ b/docs/mips/README.md
@@ -74,7 +74,7 @@ not become the only copy of a schema or specification.
 | MIP | Status | Type | Category | Summary |
 |---|---|---|---|---|
 | [MIP-1](mip-1.md) | Living | Meta | Process | Define the MALT Improvement Proposal process and document format. |
-| [MIP-1001](mip-1001-semantic-object-and-arc-terminology.md) | Draft | Standards Track | Core | Define graph node, semantic object, payload, outgoing arc, map relation, and list node terminology. |
+| [MIP-1001](mip-1001-semantic-object-and-arc-terminology.md) | Draft | Standards Track | Core | Define graph root, semantic object, payload, outgoing arc, map relation, and list child-reference terminology. |
 | [MIP-1002](mip-1002-writer-receipt-accounting.md) | Draft | Standards Track | Interface | Decide how writer receipts support storage, indexing, accounting, and benchmark reporting. |
 | [MIP-1003](mip-1003-prooflist-verification-schema.md) | Draft | Standards Track | Core | Formalize ProofList verifier contract, body/header binding, omission behavior, and range-body verification. |
 | [MIP-1004](mip-1004-resolve-prooflist-artifact-schema.md) | Draft | Standards Track | Interface | Decide whether `malt resolve` JSON and bare ProofList JSON need stable named schemas. |

--- a/docs/mips/README.md
+++ b/docs/mips/README.md
@@ -36,6 +36,24 @@ for the one-sentence summary and `Abstract` for the short technical summary.
 
 Use [`mip-template.md`](mip-template.md) when drafting a new MIP.
 
+## MIPs Versus Reference Specs
+
+MIPs are proposal and decision records. They should state the change boundary,
+motivation, selected direction, alternatives, compatibility impact, security
+impact, and implementation planning state.
+
+Long-lived protocol definitions, field tables, wire formats, JSON artifact
+shapes, and benchmark record rules belong in:
+
+- [`../spec/`](../spec/) for protocol, API, proof, receipt, artifact, and wire
+  references
+- [`../evaluation/`](../evaluation/) for evaluator artifacts and reporting
+  rules
+- `cmd/eval/schemas` for machine-readable evaluator JSON schemas
+
+A MIP may link to those reference docs and propose changing them, but it should
+not become the only copy of a schema or specification.
+
 ## Status Lifecycle
 
 | Status | Meaning | Planning rule |
@@ -58,7 +76,7 @@ Use [`mip-template.md`](mip-template.md) when drafting a new MIP.
 | [MIP-1](mip-1.md) | Living | Meta | Process | Define the MALT Improvement Proposal process and document format. |
 | [MIP-1001](mip-1001-semantic-object-and-arc-terminology.md) | Draft | Standards Track | Core | Define graph node, semantic object, payload, outgoing arc, map relation, and list node terminology. |
 | [MIP-1002](mip-1002-writer-receipt-accounting.md) | Draft | Standards Track | Interface | Decide how writer receipts support storage, indexing, accounting, and benchmark reporting. |
-| [MIP-1003](mip-1003-prooflist-verification-schema.md) | Draft | Standards Track | Core | Formalize ProofList step semantics, body/header binding, omission behavior, and range-body verification. |
+| [MIP-1003](mip-1003-prooflist-verification-schema.md) | Draft | Standards Track | Core | Formalize ProofList verifier contract, body/header binding, omission behavior, and range-body verification. |
 | [MIP-1004](mip-1004-resolve-prooflist-artifact-schema.md) | Draft | Standards Track | Interface | Decide whether `malt resolve` JSON and bare ProofList JSON need stable named schemas. |
 | [MIP-1005](mip-1005-kzg-map-label-domain.md) | Final | Standards Track | Core | Record the canonical binding-CID slot model for storage-free map commitment primitives. |
 | [MIP-1006](mip-1006-variable-size-measured-list-evidence.md) | Draft | Standards Track | Core | Specify a future range-addressable list model for variable-size children. |
@@ -71,8 +89,9 @@ Use [`mip-template.md`](mip-template.md) when drafting a new MIP.
 
 1. Keep the proposal process itself in MIP-1.
 2. Keep open design questions in Draft MIPs.
-3. Move a MIP to Review only when its specification and rationale are concrete
-   enough for maintainer judgment.
+3. Move a MIP to Review only when its proposal boundary and rationale are
+   concrete enough for maintainer judgment. Reference-spec details may live in
+   `../spec/`, `../evaluation/`, or schema files and be linked from the MIP.
 4. Move a MIP to Accepted only after maintainer approval.
 5. For Accepted MIPs, create a GitHub issue, PR plan, or repository planning
    note that names the implementation owner and review boundary.

--- a/docs/mips/mip-1.md
+++ b/docs/mips/mip-1.md
@@ -43,6 +43,11 @@ A MIP is a versioned design document. It can describe:
 
 A MIP is not implementation work by default.
 
+A MIP is also not the canonical home for long-lived field tables, wire formats,
+JSON schemas, benchmark record rules, or other reference specifications. Those
+belong in `docs/spec/`, `docs/evaluation/`, or implementation-owned schema
+directories. A MIP may propose or record changes to those references.
+
 ### MIP Types
 
 MIPs use these `type` values:
@@ -122,6 +127,12 @@ Each non-template MIP should include:
 
 Do not add a separate `Summary` section. The `description` field is the
 one-sentence summary, and `Abstract` is the short technical summary.
+
+The `Specification` section should describe the proposed decision or behavior
+boundary precisely enough for review. If the change needs a durable reference
+document, link to the relevant file under `docs/spec/`, `docs/evaluation/`, or
+an implementation schema directory instead of duplicating the full reference
+inside the MIP.
 
 ### Relationship To Implementation Planning
 

--- a/docs/mips/mip-1001-semantic-object-and-arc-terminology.md
+++ b/docs/mips/mip-1001-semantic-object-and-arc-terminology.md
@@ -13,8 +13,10 @@ replaces: none
 
 ## Abstract
 
-This MIP defines the paper-facing terminology for graph nodes, semantic objects,
-payloads, outgoing arcs, map relations, list child references, and CAS blobs.
+This MIP proposes adopting the terminology in
+[`docs/spec/semantic.md`](../spec/semantic.md) for graph roots, semantic
+objects, payloads, outgoing arcs, map relations, list child references, and CAS
+blobs.
 
 ## Motivation
 
@@ -25,16 +27,19 @@ boundary and avoids turning implementation helpers into semantic definitions.
 
 ## Specification
 
-The MIP should define each term and classify it as semantic, implementation, or
-layout-specific:
+Adopt [`docs/spec/semantic.md`](../spec/semantic.md) as the implementation
+reference for semantic terminology. That reference classifies:
 
 - semantic object
-- graph node
+- graph root
 - payload
 - outgoing arc
 - map relation
 - list child reference
 - CAS blob
+
+This MIP remains the proposal record for accepting or revising that vocabulary.
+The reference document owns the current term definitions.
 
 ## Rationale
 
@@ -61,9 +66,11 @@ proofs and published roots.
 ## Implementation Plan
 
 No implementation work is approved while this MIP is Draft. If accepted, update
-`README.md`, `paper.md`, active memory notes, and any code comments that use
-conflicting terminology.
+`README.md`, `ARCHITECTURE.md`, `docs/spec/semantic.md`, and any code comments
+that use conflicting terminology.
 
 ## History
 
 - 2026-05-25: Created from the previous open TODO list.
+- 2026-06-25: Moved term definitions to `docs/spec/semantic.md`; this MIP now
+  tracks terminology adoption rather than duplicating the glossary.

--- a/docs/mips/mip-1001-semantic-object-and-arc-terminology.md
+++ b/docs/mips/mip-1001-semantic-object-and-arc-terminology.md
@@ -1,7 +1,7 @@
 ---
 mip: 1001
 title: Semantic Object And Arc Terminology
-description: Define graph node, semantic object, payload, outgoing arc, map relation, and list node terminology.
+description: Define graph root, semantic object, payload, outgoing arc, map relation, and list child-reference terminology.
 author: MALT maintainers
 status: Draft
 type: Standards Track

--- a/docs/mips/mip-1002-writer-receipt-accounting.md
+++ b/docs/mips/mip-1002-writer-receipt-accounting.md
@@ -13,9 +13,9 @@ replaces: none
 
 ## Abstract
 
-This MIP defines the meaning of writer receipt fields and decides which fields
-are API contract, storage accounting, indexing hints, benchmark metrics, or
-operational diagnostics.
+This MIP proposes whether the writer receipt meanings documented in
+[`docs/spec/writer-receipts.md`](../spec/writer-receipts.md) should become a
+stable API and evaluation accounting contract.
 
 ## Motivation
 
@@ -25,15 +25,17 @@ for those counts before treating them as evidence.
 
 ## Specification
 
-The MIP should classify current and possible receipt fields:
+The current receipt reference lives in
+[`docs/spec/writer-receipts.md`](../spec/writer-receipts.md). This MIP should
+decide whether to accept that reference as:
 
-- base root and new root
-- delta count
-- arc count
-- map count
-- list count
-- persisted byte or record counts, if added
-- root publication metadata, if explicitly kept out of core
+- API contract
+- storage and indexing accounting input
+- benchmark reporting input
+- operational diagnostics only
+
+Root publication metadata remains outside MALT core unless a future accepted
+proposal explicitly adds it.
 
 ## Rationale
 
@@ -59,8 +61,11 @@ verification evidence unless tied to a ProofList or commitment proof.
 
 No implementation work is approved while this MIP is Draft. If accepted, a
 phase plan should cover `graph/writer`, `api/http`, server routes, eval schemas,
-summary generation, and tests.
+summary generation, `docs/spec/writer-receipts.md`, and tests.
 
 ## History
 
 - 2026-05-25: Created from the previous open TODO list.
+- 2026-06-25: Moved receipt field definitions to
+  `docs/spec/writer-receipts.md`; this MIP now tracks stabilization and
+  accounting policy.

--- a/docs/mips/mip-1003-prooflist-verification-schema.md
+++ b/docs/mips/mip-1003-prooflist-verification-schema.md
@@ -1,6 +1,6 @@
 ---
 mip: 1003
-title: ProofList Verification Schema
+title: ProofList Verification Contract
 description: Formalize ProofList step semantics, body/header binding, proof omission, and range-body verification.
 author: MALT maintainers
 status: Draft
@@ -13,8 +13,9 @@ replaces: none
 
 ## Abstract
 
-This MIP formalizes the paper-facing ProofList schema and verifier contract for
-map traversal, terminal `@payload`, raw blob binding, measured-list `list_range`
+This MIP proposes formalizing the verifier contract described in
+[`docs/spec/prooflist-format.md`](../spec/prooflist-format.md), including map
+traversal, terminal `@payload`, blob binding, measured-list `list_range`
 evidence, proof omission, and returned-body binding.
 
 ## Motivation
@@ -25,7 +26,10 @@ bytes to the requested byte range and proved segment contents.
 
 ## Specification
 
-The MIP should define verifier behavior for:
+The current ProofList reference lives in
+[`docs/spec/prooflist-format.md`](../spec/prooflist-format.md). This MIP should
+decide which parts of that reference are ready to become accepted verifier
+contract:
 
 - ordered path traversal
 - terminal `@payload` binding
@@ -34,6 +38,9 @@ The MIP should define verifier behavior for:
 - optional proof omission via query/header
 - `X-Malt-ProofList` header semantics
 - returned byte range binding to proved segment contents
+
+The last item remains the main open design issue. The reference document states
+the current implementation boundary and the gap.
 
 ## Rationale
 
@@ -62,9 +69,12 @@ and mismatches between returned bytes and proved segment contents.
 ## Implementation Plan
 
 No implementation work is approved while this MIP is Draft. If accepted, a
-phase plan should include schema docs, verifier tests, CLI validation, and
+phase plan should include reference docs, verifier tests, CLI validation, and
 benchmark artifact validation.
 
 ## History
 
 - 2026-05-25: Created from the previous open TODO list.
+- 2026-06-25: Moved current ProofList shape and transport rules to
+  `docs/spec/prooflist-format.md`; this MIP now tracks formal acceptance and
+  remaining body-binding work.

--- a/docs/mips/mip-1004-resolve-prooflist-artifact-schema.md
+++ b/docs/mips/mip-1004-resolve-prooflist-artifact-schema.md
@@ -13,8 +13,9 @@ replaces: none
 
 ## Abstract
 
-This MIP decides whether `malt resolve` JSON, bare ProofList JSON, and related
-proof-bearing artifacts should become stable named schemas.
+This MIP decides whether the artifact surfaces described in
+[`docs/spec/artifacts.md`](../spec/artifacts.md) should become stable named
+schemas.
 
 ## Motivation
 
@@ -25,14 +26,16 @@ need a stronger schema contract.
 
 ## Specification
 
-The MIP should decide whether to add named schemas for:
+The current artifact reference lives in
+[`docs/spec/artifacts.md`](../spec/artifacts.md). This MIP should decide
+whether to add stable named schemas for:
 
 - resolve response JSON
 - bare ProofList JSON
 - proof-bearing content response metadata
 
-It should also define schema paths, compatibility expectations, and CLI help
-wording.
+If accepted, it should also choose schema paths, compatibility expectations,
+schema listing behavior, and CLI help wording.
 
 ## Rationale
 
@@ -64,3 +67,5 @@ listing integration.
 ## History
 
 - 2026-05-25: Created from the previous open TODO list.
+- 2026-06-25: Moved current artifact boundaries to `docs/spec/artifacts.md`;
+  this MIP now tracks whether those artifacts need stable named schemas.

--- a/docs/mips/mip-1005-kzg-map-label-domain.md
+++ b/docs/mips/mip-1005-kzg-map-label-domain.md
@@ -41,6 +41,9 @@ This is distinct from the primary runtime map layout. `runtime/semantic/mapping/
 uses digest-keyed radix traversal and bucket materialization, but it composes
 that runtime path from the same single-step slot proof primitive.
 
+The current reference summary lives in
+[`docs/spec/commitment.md`](../spec/commitment.md).
+
 ## Rationale
 
 Current code evidence:

--- a/docs/mips/mip-1006-variable-size-measured-list-evidence.md
+++ b/docs/mips/mip-1006-variable-size-measured-list-evidence.md
@@ -13,8 +13,10 @@ replaces: none
 
 ## Abstract
 
-This MIP specifies a future measured-list proof model for variable-size child
-segments.
+This MIP proposes a future measured-list proof model for variable-size child
+segments. The current fixed-width measured-list behavior is documented in
+[`docs/spec/semantic.md`](../spec/semantic.md) and
+[`docs/spec/prooflist-format.md`](../spec/prooflist-format.md).
 
 ## Motivation
 
@@ -25,13 +27,17 @@ authenticates child count and total size.
 
 ## Specification
 
-If accepted, the MIP should define:
+The current implementation uses fixed-width measured-list evidence. If this
+proposal is accepted, the future variable-size model should define:
 
 - child descriptor shape
 - root metadata
 - range selection algorithm
 - proof payload contents
 - verifier checks
+
+It should also describe how the new model coexists with or replaces the
+current fixed-width `list_range` proof shape.
 
 ## Rationale
 
@@ -58,8 +64,10 @@ proof that shifts byte boundaries while preserving the same segment CIDs.
 
 No implementation work is approved while this MIP is Draft. If accepted, a
 phase plan should cover list backend changes, ProofList updates, server
-verification, and evaluation schemas.
+verification, reference spec updates, and evaluation schemas.
 
 ## History
 
 - 2026-05-25: Created from the previous open TODO list.
+- 2026-06-25: Clarified that current fixed-width measured-list evidence is a
+  reference-spec topic and this MIP tracks only the future variable-size model.

--- a/docs/mips/mip-1007-incremental-add-root-optimization.md
+++ b/docs/mips/mip-1007-incremental-add-root-optimization.md
@@ -25,13 +25,17 @@ current-tree reconstruction.
 
 ## Specification
 
-The MIP should decide whether the next mainline implementation needs:
+This MIP should decide whether the next mainline implementation needs a
+path-local update mode for `malt add --root` with:
 
 - path-local current-root loading
 - path-local mutation planning
 - unchanged CAS dedup behavior
 - unchanged layout-side root computation
 - compatible writer receipts and ProofList behavior
+
+It does not define a protocol schema. If accepted, implementation details
+belong in a phase plan and any affected reference docs.
 
 ## Rationale
 
@@ -63,3 +67,5 @@ large-file lists, symlink directory boundaries, and CAS dedup behavior.
 ## History
 
 - 2026-05-25: Created from the previous open TODO list.
+- 2026-06-25: Clarified that this is an optimization proposal, not a schema or
+  reference specification.

--- a/docs/mips/mip-1008-semantic-reachability-demo.md
+++ b/docs/mips/mip-1008-semantic-reachability-demo.md
@@ -24,13 +24,16 @@ concrete without turning it into the primary benchmark path.
 
 ## Specification
 
-The MIP should choose:
+This MIP should choose a demo shape:
 
 - relation types to demonstrate
 - source dataset
 - verifier story
 - CLI, eval-suite, or documentation-only delivery
 - whether the result is a paper-facing capability case study
+
+It does not define a protocol schema. If accepted, any reusable benchmark or
+artifact rules should be documented under `docs/evaluation/`.
 
 ## Rationale
 
@@ -58,3 +61,5 @@ phase plan should name the command, suite, fixture, and docs paths to change.
 ## History
 
 - 2026-05-25: Created from the previous open TODO list.
+- 2026-06-25: Clarified that this is a demo/case-study proposal, not a
+  reference specification.

--- a/docs/mips/mip-1009-benchmark-proof-reporting.md
+++ b/docs/mips/mip-1009-benchmark-proof-reporting.md
@@ -13,8 +13,10 @@ replaces: none
 
 ## Abstract
 
-This MIP defines benchmark-facing reporting for proof bytes, evidence items,
-writer receipts, CAS counters, ArcTable counters, and summary CSV fields.
+This MIP proposes stabilizing the benchmark-facing reporting rules summarized
+in [`docs/evaluation/README.md`](../evaluation/README.md), including proof
+bytes, evidence items, writer receipts, CAS counters, ArcTable counters, and
+summary CSV fields.
 
 ## Motivation
 
@@ -24,7 +26,9 @@ figures.
 
 ## Specification
 
-The MIP should define reporting rules for:
+The current evaluation reference lives in
+[`docs/evaluation/README.md`](../evaluation/README.md). This MIP should decide
+which reporting rules must become stable for paper-facing figures:
 
 - ProofList bytes and step counts
 - comparable Merkle DAG and HAMT evidence items
@@ -61,3 +65,5 @@ benchmark protocol docs, and fixture/result validation.
 ## History
 
 - 2026-05-25: Created from the previous open TODO list.
+- 2026-06-25: Moved current reporting guidance to `docs/evaluation/README.md`;
+  this MIP now tracks stabilization of paper-facing benchmark reporting.

--- a/docs/mips/mip-template.md
+++ b/docs/mips/mip-template.md
@@ -27,7 +27,9 @@ Explain the problem and why it matters now.
 
 ## Specification
 
-Describe the proposed behavior or decision precisely enough for review.
+Describe the proposed behavior or decision boundary precisely enough for
+review. Link to `docs/spec/`, `docs/evaluation/`, or schema files for durable
+field tables, wire formats, and artifact definitions.
 
 ## Rationale
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -3,17 +3,22 @@
 This folder holds implementation-bound protocol and schema documents.
 
 These documents stay aligned with code, tests, and MIPs in this repository.
+They are the reference layer for current behavior; MIPs propose or record
+changes to this layer.
 
 ## Documents
 
 - [Semantic model](./semantic.md)
 - [ProofList format](./prooflist-format.md)
+- [Writer receipts](./writer-receipts.md)
+- [Artifacts and schemas](./artifacts.md)
 - [Commitment model](./commitment.md)
 - [CID and wire format](./cid-and-wire-format.md)
 - [HTTP API](./http-api.md)
 
 ## Notes
 
-- `mips/` remains the proposal and process bucket.
+- `mips/` remains the proposal, decision, and process bucket. It should link to
+  reference specs instead of duplicating long schema definitions.
 - `policy/` holds compatibility, release, and threat-model policy.
 - `evaluation/` holds evaluator-facing protocol and artifact rules.

--- a/docs/spec/artifacts.md
+++ b/docs/spec/artifacts.md
@@ -1,0 +1,70 @@
+# Artifacts and Schemas
+
+This document records the current artifact boundaries for CLI JSON, ProofList
+JSON, content-proof headers, and evaluator schemas.
+
+## Status
+
+Experimental and implementation-bound. Only evaluator schemas currently have
+machine-readable JSON Schema files in the repository.
+
+## Current Artifact Surfaces
+
+| Surface | Current owner | Stability |
+| --- | --- | --- |
+| `malt resolve` JSON | `api/http.ResolveResponse` | Experimental |
+| bare ProofList JSON | `auth/proof/prooflist.ProofList` | Experimental and verifier-facing |
+| content proof headers | `server` and `sdk/client` | Experimental |
+| evaluator records | `cmd/eval/schemas` | Versioned where practical |
+
+## Resolve JSON
+
+`malt resolve` prints the daemon `ResolveResponse` shape:
+
+```json
+{
+  "target": "cid-string",
+  "prooflist": {}
+}
+```
+
+The `prooflist` field is omitted when proof generation is disabled. The target
+CID is not self-authenticating as a path result; callers need the root, query,
+target, and ProofList to verify the binding.
+
+## Bare ProofList JSON
+
+`malt verify --prooflist` accepts a bare ProofList JSON document and also accepts
+resolve JSON containing a `prooflist` field. The structural shape is documented
+in [ProofList format](./prooflist-format.md).
+
+## Content Proof Headers
+
+Default content reads return proof evidence in headers instead of the response
+body:
+
+- `X-Malt-ProofList: <base64url-json>`
+- `X-Malt-ProofList-Encoding: base64url-json`
+
+Clients must decode the header before running ProofList verification.
+
+## Machine-Readable Schemas
+
+Evaluator JSON schemas live under `cmd/eval/schemas` and are embedded in the
+`malt-eval schema` command. Resolve JSON and bare ProofList JSON do not yet have
+stable named schema files.
+
+If resolve or ProofList artifacts are promoted to stable named schemas, the
+same change should:
+
+- add the schema file in an implementation-owned path
+- add schema listing or discovery if needed by CLI users
+- update CLI help and examples
+- add tests that validate representative artifacts
+- keep schema validation separate from proof verification
+
+## Related Proposals
+
+[MIP-1004](../mips/mip-1004-resolve-prooflist-artifact-schema.md) tracks the
+decision about whether resolve JSON, bare ProofList JSON, and content proof
+metadata need stable named schemas.

--- a/docs/spec/cid-and-wire-format.md
+++ b/docs/spec/cid-and-wire-format.md
@@ -1,26 +1,63 @@
 # CID and Wire Format
 
-MALT uses typed root CIDs and related wire encodings for map/list roots and
-their verifier-facing metadata.
-
-## Scope
-
-This document should define:
-
-- typed MALT root CID forms
-- multicodec and codec helper behavior
-- canonical wire encoding for roots and related proof artifacts
-- compatibility expectations for serialized forms
-
-## Current References
-
-Current implementation references include:
-
-- `wire/maltcid`
-- `api/http`
-- `auth/encoding`
-- [MIP-1010](../mips/mip-1010-data-authentication-core-boundary.md)
+MALT uses typed CIDv1 roots for authenticated map and list structure. Payload
+objects remain ordinary CAS CIDs.
 
 ## Status
 
-Experimental and implementation-bound.
+Experimental and implementation-bound. The current codec values are locked for
+the prototype but are not yet a stable release contract.
+
+## MALT Root Codecs
+
+MALT uses the multicodec Private Use Area `0x300000-0x3FFFFF` for typed
+structure roots:
+
+| Name | Value | Semantic kind | Backend |
+| --- | ---: | --- | --- |
+| `malt-map-kzg` | `0x300001` | map | KZG |
+| `malt-list-kzg` | `0x300002` | list | KZG |
+| `malt-map-ipa` | `0x300003` | map | IPA |
+| `malt-list-ipa` | `0x300004` | list | IPA |
+
+The implementation owner is `wire/maltcid`.
+
+## Commitment Encoding
+
+Typed MALT root CIDs use CIDv1 with an identity multihash carrying the raw
+commitment bytes.
+
+Current commitment byte sizes:
+
+| Backend | Size |
+| --- | ---: |
+| KZG | 48 bytes |
+| IPA | 32 bytes |
+
+Code that creates or validates typed roots must reject commitment byte lengths
+that do not match the selected backend.
+
+## Root Classification
+
+`wire/maltcid` exposes helpers for:
+
+- detecting whether a CID is a MALT structure root
+- extracting semantic kind: `map`, `list`, or `unknown`
+- extracting backend kind: `kzg`, `ipa`, or `unknown`
+- extracting raw commitment bytes from a typed MALT root CID
+- comparing commitment bytes across typed roots
+
+Verifiers should reject roots or proof steps whose semantic kind, backend kind,
+or expected target type does not match the query and evidence.
+
+## Payload CIDs
+
+Immutable file bytes, chunks, manifests, and other payload objects keep their
+ordinary CAS CIDs. MALT authenticates bindings to those payload CIDs; it does
+not redefine the payload CID format.
+
+## Related Documents
+
+- [Commitment model](./commitment.md)
+- [ProofList format](./prooflist-format.md)
+- [Compatibility policy](../policy/compatibility.md)

--- a/docs/spec/commitment.md
+++ b/docs/spec/commitment.md
@@ -1,26 +1,64 @@
 # Commitment Model
 
-MALT uses a stateless commitment backend to authenticate semantic-layer
-representations.
-
-## Scope
-
-This document should define:
-
-- commitment inputs and outputs
-- proof generation and verification contracts
-- backend-specific assumptions
-- which state belongs to the backend versus the semantic layer
-
-## Current References
-
-Current implementation references include:
-
-- `auth/commitment`
-- `auth/semantic/list`
-- `auth/semantic/mapping`
-- [MIP-1005](../mips/mip-1005-kzg-map-label-domain.md)
+MALT uses stateless commitment backends to authenticate semantic-layer
+representations. The semantic layer chooses what is committed; the backend
+commits, proves, and verifies already-positioned values.
 
 ## Status
 
-Experimental and implementation-bound.
+Experimental and implementation-bound. Current in-tree backends are KZG and
+IPA, with KZG used by the default prototype profile.
+
+## Backend Boundary
+
+Commitment backends own:
+
+- commitment byte generation
+- proof generation
+- proof verification
+- update primitives when a backend supports efficient local updates
+
+They do not own:
+
+- map key semantics
+- list index or range semantics
+- path resolution
+- application layouts
+- ArcTable materialization
+- head publication or freshness policy
+
+The current public backend interfaces live under `auth/commitment`.
+Semantic-facing list and map contracts live under `auth/semantic/list` and
+`auth/semantic/mapping`.
+
+## Map Binding-CID Slot Model
+
+The storage-free map commitment primitive commits canonical binding CID slots.
+Each committed slot is derived from:
+
+- the fixed domain prefix `malt:map:binding:v1:`
+- canonical path key bytes
+- target CID bytes
+
+This binds map labels and values together. A verifier must not accept a bare
+value proof as a map binding proof unless the committed cell also encodes the
+expected key.
+
+This model is distinct from the runtime map layout.
+`runtime/semantic/mapping/radix` uses digest-keyed radix traversal and bucket
+materialization, but composes that runtime traversal from the same single-step
+slot proof primitive.
+
+## Typed Roots
+
+Commitment outputs are carried in typed MALT root CIDs. See
+[CID and wire format](./cid-and-wire-format.md) for codec values and commitment
+byte-size rules.
+
+## Related Proposals
+
+- [MIP-1005](../mips/mip-1005-kzg-map-label-domain.md) records the accepted
+  binding-CID slot decision.
+- [MIP-1010](../mips/mip-1010-data-authentication-core-boundary.md) records the
+  package-boundary decision that keeps commitment primitives inside the
+  data-authentication core.

--- a/docs/spec/http-api.md
+++ b/docs/spec/http-api.md
@@ -1,26 +1,120 @@
 # HTTP API
 
-This document should define the current root-centric daemon HTTP surface.
-
-## Scope
-
-This document should cover:
-
-- read, resolve, verify, and mutation routes
-- request and response DTOs
-- proof transport headers and body binding rules
-- compatibility expectations for CLI and programmatic clients
-
-## Current References
-
-Current implementation references include:
-
-- `server/`
-- `api/http/`
-- `cmd/malt`
-- [MIP-1002](../mips/mip-1002-writer-receipt-accounting.md)
-- [MIP-1004](../mips/mip-1004-resolve-prooflist-artifact-schema.md)
+This document describes the current root-centric daemon HTTP surface and DTO
+boundaries. It is a reference for implementation docs, not a stable public API
+contract.
 
 ## Status
 
-Experimental and implementation-bound.
+Experimental and implementation-bound. Breaking route or DTO changes are
+allowed before a stable release, but they should update tests and docs in the
+same PR.
+
+## Core Routes
+
+| Route | Method | Purpose |
+| --- | --- | --- |
+| `/health` | `GET` | Runtime health check. |
+| `/_lifecycle/identity` | `GET` | Local managed-daemon identity check. |
+| `/metrics` | `GET` | Runtime evaluation counters. |
+| `/metrics:reset` | `POST` | Reset runtime evaluation counters. |
+| `/verify` | `POST` | Verify a ProofList. |
+| `/{root}/_mutate` | `POST` | Apply a root-relative semantic mutation. |
+| `/_unixfs?path=...` | `POST` | Create a new UnixFS-style root from uploaded payload data. |
+| `/resolve/{root}` and `/resolve/{root}/{path...}` | `GET` | Resolve a target CID and optional ProofList. |
+| `/{root}` and `/{root}/{path...}` | `GET` | Read content or directory JSON with optional proof headers. |
+| `/{root}` and `/{root}/{path...}` | `HEAD` | Return stat headers without proof metadata. |
+| `/{root}/{path...}` | `POST` | UnixFS layout convenience write through the writer path. |
+| `/_` | `POST` | Create a low-level structure from an arc set. |
+
+Removed lineage and batch-update public routes intentionally return removed or
+not-found behavior and should not be documented as active API.
+
+## Proof Transport
+
+Resolve responses include proof evidence by default:
+
+```json
+{
+  "target": "cid-string",
+  "prooflist": {}
+}
+```
+
+Content responses place proof evidence in headers:
+
+- `X-Malt-ProofList`
+- `X-Malt-ProofList-Encoding: base64url-json`
+- `Vary: X-Malt-Proof`
+
+Clients can omit default proof generation with either `?proof=false` or
+`X-Malt-Proof: omit`. `HEAD` responses are stat-only and do not include proof
+headers.
+
+Range content reads use standard byte range headers where supported:
+
+- request: `Range: bytes=start-end`
+- response: `Accept-Ranges: bytes`
+- partial response: `Content-Range: bytes start-end/total`
+
+See [ProofList format](./prooflist-format.md) for proof semantics.
+
+## Main DTOs
+
+Current DTOs live in `api/http/types.go`.
+
+### ResolveResponse
+
+| JSON field | Meaning |
+| --- | --- |
+| `target` | Resolved target CID string. |
+| `prooflist` | Optional ProofList evidence. |
+
+### SemanticMutationResponse
+
+| JSON field | Meaning |
+| --- | --- |
+| `base_root` | Caller-supplied root for the mutation. |
+| `new_root` | Resulting root after writer application. |
+| `result_root` | Optional application-level result root. |
+| `delta_count` | Number of semantic deltas applied. |
+| `arc_count` | Number of canonical arc changes applied. |
+| `malt_object_count` | Optional layout count of produced MALT objects. |
+| `map_count` | Optional layout count of map objects. |
+| `list_count` | Optional layout count of list objects. |
+
+Receipt counts are operational accounting, not correctness proofs. See
+[Writer receipts](./writer-receipts.md).
+
+### PathStatResponse
+
+| JSON field | Meaning |
+| --- | --- |
+| `kind` | `file` or `dir`. |
+| `storage_kind` | `raw`, `list`, or `map`. |
+| `key` | Terminal key CID. |
+| `payload` | Optional directory payload CID. |
+| `size` | File size when known. |
+| `entries` | Directory entries when available. |
+
+### VerifyRequest / VerifyResponse
+
+`VerifyRequest` carries one `prooflist` field. `VerifyResponse` returns one
+boolean `valid` field.
+
+Schema validation is not proof verification. JSON shape checks can reject
+malformed artifacts, but semantic and cryptographic verification must run
+through the verifier.
+
+## CORS Boundary
+
+Browser CORS, when configured, exposes read/proof surfaces, `POST /verify`, and
+UnixFS browser write routes. Admin and semantic-mutation routes are not exposed
+through browser CORS by default.
+
+## Related Proposals
+
+- [MIP-1002](../mips/mip-1002-writer-receipt-accounting.md) tracks receipt
+  accounting decisions.
+- [MIP-1004](../mips/mip-1004-resolve-prooflist-artifact-schema.md) tracks the
+  decision about stable named schemas for resolve and ProofList artifacts.

--- a/docs/spec/prooflist-format.md
+++ b/docs/spec/prooflist-format.md
@@ -1,27 +1,116 @@
 # ProofList Format
 
-ProofList is the verifier-facing read artifact returned by MALT reads.
-
-## Scope
-
-This document should define:
-
-- the ProofList envelope
-- proof-step ordering
-- terminal target binding
-- body/header binding for HTTP responses
-- range-read evidence for large files
-
-## Current References
-
-Current implementation references include:
-
-- `auth/proof/prooflist`
-- `server/service_verify.go`
-- `server/routes_content.go`
-- `layout/unixfs/prooflist.go`
-- [MIP-1003](../mips/mip-1003-prooflist-verification-schema.md)
+ProofList is the verifier-facing read artifact returned by MALT resolve and
+content reads. It records the ordered proof path from a trusted root to a
+resolved target.
 
 ## Status
 
-Experimental and implementation-bound.
+Experimental and implementation-bound. The JSON shape is verifier-facing but
+not yet a stable release contract.
+
+## Envelope
+
+The current Go shape is `auth/proof/prooflist.ProofList`:
+
+| Field | JSON | Meaning |
+| --- | --- | --- |
+| `Root` | `root` | Trusted MALT structure root for this proof. |
+| `Query` | `query` | Optional query/path string the proof was assembled for. |
+| `Steps` | `steps` | Ordered proof steps. |
+
+`ValidateShape(RequireSteps())` rejects an undefined root, an empty step list,
+unknown step kinds, undefined `from` or `target` CIDs, and any step whose
+`from` CID does not continue from the current target.
+
+## Step Kinds
+
+| Kind | Role |
+| --- | --- |
+| `map_step` | Authenticates a keyed map relation. |
+| `payload_binding` | Authenticates the reserved terminal `@payload` map binding. |
+| `list_index` | Authenticates one list index binding. |
+| `list_range` | Authenticates measured-list byte range metadata and covered segments. |
+| `blob_binding` | Binds a resolved structure target to an immutable blob target. |
+| `implicit_block` | Compatibility evidence for implicit block traversal. |
+| `legacy_unknown` | Legacy adapter marker retained for older evidence. |
+
+List evidence is label-checked: `list_index` must carry
+`evidence_kind="structure"` and `evidence_backend="list"`, while `list_range`
+must carry `evidence_kind="structure"` and
+`evidence_backend="measured_list"`.
+
+## Step Fields
+
+Each step has:
+
+- `kind`
+- `from`
+- `target`
+- optional query fields: `query`, `coordinate`, `path`, `index`
+- optional range fields: `start`, `end`, `length`, `child_count`,
+  `total_size`, `chunk_size`, `segments`
+- optional proof labels: `evidence_kind`, `evidence_backend`
+- opaque proof bytes: `evidence`, `proof`
+
+The byte fields are JSON-encoded by Go's standard `encoding/json` rules for
+`[]byte`, currently base64 strings.
+
+## Ordering Rules
+
+Steps form a linear chain unless they are terminal list evidence:
+
+1. The first step starts at `root`.
+2. Non-list traversal steps advance the current target to `step.target`.
+3. List index or list range evidence may appear at the terminal phase.
+4. No later traversal step may appear after list index or list range evidence.
+
+This shape validation is structural. Cryptographic or semantic verification is
+owned by the concrete backend that emitted each proof payload.
+
+## HTTP Transport
+
+`GET /resolve/{root}/{path}` returns JSON:
+
+```json
+{
+  "target": "cid-string",
+  "prooflist": { "root": "cid-string", "steps": [] }
+}
+```
+
+`prooflist` is omitted when the caller uses `?proof=false` or
+`X-Malt-Proof: omit`.
+
+Default content reads, `GET /{root}/{path}`, return body bytes or directory
+JSON and place proof evidence in headers:
+
+- `X-Malt-ProofList: <base64url-json>`
+- `X-Malt-ProofList-Encoding: base64url-json`
+- `Vary: X-Malt-Proof`
+
+`HEAD /{root}/{path}` is stat-only and does not return ProofList headers.
+
+## Range Evidence
+
+Large-file byte-range reads currently use:
+
+1. map/path proof to the file object
+2. terminal `@payload` proof to the list root
+3. one measured-list `list_range` step over the requested byte interval
+
+The `list_range` step carries fixed chunk metadata, covered segment CIDs, and
+metadata/index proof bytes. Verifiers must reject range proofs that shift byte
+boundaries, omit covered segment bindings, or mismatch the measured metadata.
+
+Full response-body binding for returned range bytes remains an open
+verifier-contract design item. The current proof authenticates the range
+metadata and segment CIDs; clients must still validate fetched payload bytes
+against their CIDs.
+
+## Related Proposals
+
+- [MIP-1003](../mips/mip-1003-prooflist-verification-schema.md) tracks the
+  remaining formalization work and body-binding decision.
+- [MIP-1006](../mips/mip-1006-variable-size-measured-list-evidence.md) tracks a
+  future variable-size measured-list model.

--- a/docs/spec/semantic.md
+++ b/docs/spec/semantic.md
@@ -1,27 +1,98 @@
 # Semantic Model
 
-MALT's core semantic model is list/map over immutable CAS payloads.
-
-## Scope
-
-This document is the home for the normative description of:
-
-- list semantics
-- map semantics
-- resolver and writer ports
-- root-centric read and write behavior
-- the relationship between semantic state and ArcTable materialization
-
-## Current References
-
-Until this document is expanded, the current implementation-facing references
-are:
-
-- [README](../README.md)
-- [Architecture](../../ARCHITECTURE.md)
-- [MIP-1001](../mips/mip-1001-semantic-object-and-arc-terminology.md)
-- [MIP-1010](../mips/mip-1010-data-authentication-core-boundary.md)
+MALT's core semantic model is an authenticated list/map layer over immutable
+CAS payload objects. This document is the implementation-bound reference for
+the terms used by code, docs, and MIPs.
 
 ## Status
 
-Experimental and implementation-bound.
+Experimental and implementation-bound. Public names may still change before a
+stable release, but new docs should use this terminology.
+
+## Core Terms
+
+| Term | Meaning |
+| --- | --- |
+| Semantic object | A typed authenticated structure object, currently a map root or list root. |
+| Graph root | A caller-supplied MALT structure root used as the verification handle for a read or mutation. |
+| Payload | Immutable application bytes or metadata stored as ordinary CAS content and bound from MALT structure. |
+| Outgoing arc | A canonical coordinate-to-CID binding represented in an arc set. |
+| Map relation | A key/path-like authenticated binding from a map object to a target CID. |
+| List child reference | An index-addressed authenticated binding from a list object to a child CID. |
+| CAS blob | Immutable content-addressed bytes outside the MALT semantic layer. |
+
+The implementation uses `auth/arcset` for canonical arc and coordinate
+representations. Runtime materialization may use bucket or namespace keys
+internally, but those storage keys are not semantic coordinates.
+
+## Map Semantics
+
+Map semantics authenticate key-to-CID relations. The current public abstraction
+lives in `auth/semantic/mapping`, and the primary runtime implementation lives
+under `runtime/semantic/mapping/radix`.
+
+Native map operations are:
+
+- exact key lookup with binding proof
+- insert, replace, and delete of canonical keyed bindings
+- commitment and verification of committed map state
+
+Every MALT-native map object carries a reserved `@payload` binding. That
+binding is the terminal materialization edge for file, directory, or other
+layout payloads. It is not UnixFS-specific.
+
+## List Semantics
+
+List semantics authenticate ordered child references. The current public
+abstraction lives in `auth/semantic/list`, and the primary runtime
+implementation lives under `runtime/semantic/list/tree`.
+
+Native list operations are:
+
+- index lookup with proof
+- append
+- replace existing index
+- truncate
+- optional measured range proof when the implementation authenticates byte
+  layout metadata
+
+List objects do not auto-redirect through `@payload`, and list reads do not own
+path-resolution semantics. Application layouts translate file ranges or domain
+queries into list index or measured-range reads.
+
+The current measured-list implementation is fixed-width. It authenticates child
+count, total size, chunk size, index-to-CID bindings, and the selected byte
+range's covered segment CIDs. A future variable-size measured list remains a
+proposal-stage topic in [MIP-1006](../mips/mip-1006-variable-size-measured-list-evidence.md).
+
+## Resolver And Writer Ports
+
+The `graph` package is a small port/composition surface, not a separate
+semantic owner.
+
+- resolver is the read/proof port: `(root, query) -> result + ProofList`
+- writer is the mutation port: `(baseRoot, semantic mutation) -> newRoot + receipt`
+
+Resolver traversal lives under `graph/resolver`. Mutation application lives
+under `graph/writer`. Layouts translate source-domain data into semantic
+queries and mutations; they do not redefine map or list semantics.
+
+## ArcTable Boundary
+
+ArcTable is namespace-scoped arcset persistence and materialization. It helps
+the runtime prove and update structure efficiently, but it is not the trust
+root. Incorrect materialized state should either fail proof generation or
+produce evidence that the verifier rejects.
+
+Freshness, head publication, merge policy, CAS availability, pinning, garbage
+collection, tenant isolation, and quotas are deployment or application policy,
+not core MALT semantics.
+
+## Related Proposals
+
+- [MIP-1001](../mips/mip-1001-semantic-object-and-arc-terminology.md) tracks
+  terminology adoption.
+- [MIP-1010](../mips/mip-1010-data-authentication-core-boundary.md) records the
+  package-boundary decision that moved verifier-critical semantics into
+  `auth/` and kept runtime, storage, API, and SDK code outside the data-auth
+  core.

--- a/docs/spec/writer-receipts.md
+++ b/docs/spec/writer-receipts.md
@@ -1,0 +1,66 @@
+# Writer Receipts
+
+Writer receipts report the operational outcome of applying semantic mutations.
+They help clients, APIs, and evaluations account for work, but they are not
+correctness proofs.
+
+## Status
+
+Experimental and implementation-bound. Field names may still change before a
+stable release.
+
+## Library Receipt
+
+`graph/writer.WriteReceipt` records:
+
+| Field | Meaning |
+| --- | --- |
+| `BaseRoot` | Caller-supplied root for the mutation. |
+| `NewRoot` | Root produced after applying semantic deltas. |
+| `DeltaCount` | Number of semantic deltas applied. |
+| `ArcCount` | Number of canonical arc changes applied. |
+
+The writer does not publish authoritative heads, choose freshness, or merge
+concurrent roots. Applications decide whether a produced root becomes current.
+
+## HTTP Projection
+
+`api/http.SemanticMutationResponse` exposes:
+
+| JSON field | Meaning |
+| --- | --- |
+| `base_root` | Request base root. |
+| `new_root` | Root produced by writer application. |
+| `result_root` | Optional application-level result root. |
+| `delta_count` | Semantic delta count. |
+| `arc_count` | Canonical arc change count. |
+| `malt_object_count` | Optional layout-produced object count. |
+| `map_count` | Optional layout-produced map object count. |
+| `list_count` | Optional layout-produced list object count. |
+
+Layout-level counts are diagnostics and evaluation aids. They should not be
+treated as verifier evidence unless separately tied to a ProofList or
+commitment proof.
+
+## Accounting Boundary
+
+Receipts can support:
+
+- client progress reporting
+- API diagnostics
+- benchmark write accounting
+- storage or indexing estimates when paired with explicit metrics
+
+Receipts do not prove:
+
+- payload availability
+- freshness of the selected root
+- correctness of an unverified read
+- publication or merge policy
+
+## Related Proposals
+
+- [MIP-1002](../mips/mip-1002-writer-receipt-accounting.md) tracks whether the
+  current receipt fields should become a stable API and evaluation contract.
+- [Benchmark reporting](../evaluation/README.md#benchmark-reporting) describes
+  how receipts are interpreted in evaluator output.


### PR DESCRIPTION
## Summary

- Clarify that MIPs are proposal and decision records, not the canonical home for schemas, wire formats, or benchmark record definitions.
- Move stable reference material into `docs/spec/` and `docs/evaluation/`, including ProofList, HTTP API, CID/wire format, semantic terminology, artifact, and writer receipt references.
- Rewrite the current draft MIPs so they link to the reference docs and track motivation, decision state, alternatives, acceptance criteria, and open questions.
- Update architecture and roadmap references from schema-formalization language to verifier-contract and reference-spec language.

## Validation

- `git diff --check`
- stale wording scan: `rg -n "The MIP should|If accepted, the MIP should|This document should|ProofList Verification Schema|schema TODO|proof-schema|formalize the current|documents/MIPs.*kept|kept.*documents/MIPs" docs ARCHITECTURE.md ROADMAP.md README.md CONTRIBUTING.md SECURITY.md`
- Markdown relative link checker: `markdown relative links OK`
- `env GOCACHE=/tmp/go-build-cache-mipdoc-final go test -run '^$' ./...`