### PR TITLE
docs: remove stale MALT acronym

### DIFF
--- a/runtime/node/node.go
+++ b/runtime/node/node.go
@@ -1,6 +1,6 @@
 // Package node provides the application-level API for MALT.
-// MALT (Mutable structure LAyer on Top) provides verifiable, evolvable
-// structures on top of content-addressed storage.
+// MALT provides verifiable, evolvable structures on top of content-addressed
+// storage.
 package node
 
 import (


### PR DESCRIPTION
## Summary

- Removes an outdated MALT acronym expansion from the runtime node package comment.
- Keeps implementation wording aligned with the current project framing: MALT as verifiable, evolvable structure over content-addressed storage.

## Validation

- `env GOCACHE=/tmp/go-build-cache go test ./...`
- `git diff --check`