### PR TITLE
docs: define core and gateway repository boundary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,6 +12,13 @@ of the abstraction. A MALT graph is not a Go runtime object that merely holds
 dependencies. It is the authenticated structure induced by list/map semantics,
 ArcTable arcset persistence, and stateless commitment proofs.
 
+This repository packages that core as a specification implementation with a
+reference runtime and evaluation gateway. Production managed-gateway behavior
+such as tenancy, identity, authorization, S3 backend orchestration, cache
+policy, quota, billing, pinning, garbage collection, and operations belongs in
+the separate `DeWebProtocol/gateway` service repository or private deployment
+overlays.
+
 ```text
 GraphRead(root, query) -> result + ProofList
 VerifyRead(root, query, result, ProofList) -> valid / invalid
@@ -49,7 +56,7 @@ The target model has four distinct layers:
 | ArcTable | Namespace-scoped arcset persistence/materialization |
 | Commitment backend | Stateless proof and verification over semantic-layer representations |
 | Resolver / writer ports | Read/proof and mutation boundaries over semantic state |
-| Server API | Runtime surface exposing resolver/writer ports |
+| Server API | Reference runtime and eval-gateway surface exposing resolver/writer ports |
 | Application layout | Product data model built above list/map semantics and immutable payload objects |
 
 The public structure layer should expose list/map semantics, not storage
@@ -65,7 +72,7 @@ Conceptually, graph reads return `result + ProofList`, where the ProofList is
 the vector-commitment proof chain from root to destination. Root-centric writer
 mutation accepts semantic mutations that have already been produced by a layout
 and returns an operational receipt without publishing a managed head. The HTTP
-server returns default `GET /{root}/{path}` file and directory reads with
+server in this repository returns default `GET /{root}/{path}` file and directory reads with
 `ProofList` metadata in `X-Malt-ProofList` response
 headers encoded as `base64url-json`. Clients can opt out of default proof
 generation with `?proof=false` or `X-Malt-Proof: omit`; default GET responses
@@ -74,8 +81,9 @@ byte-range reads include path/`@payload` proof plus one measured-list
 `list_range` step. That step carries authenticated fixed chunk metadata, the
 covered segment CIDs, and a proof payload composed from the metadata slot proof
 and the required index proofs. Response-body range binding is still a
-ProofList verifier-contract TODO. File routes are product surfaces around the same
-root-centric mutation namespace.
+ProofList verifier-contract TODO. File routes are reference/evaluation surfaces
+around the same root-centric mutation namespace. They are not a production
+multi-tenant gateway contract.
 
 ### List Semantic
 
@@ -219,8 +227,16 @@ Current package roles are:
 
 ## Runtime Packaging
 
-The product shape is a small primary runtime binary named `malt`, plus one
-evaluation binary named `malt-eval` with workload-specific subcommands.
+The repository shape is a small primary reference runtime binary named `malt`,
+plus one evaluation binary named `malt-eval` with workload-specific
+subcommands. The `malt` daemon and `server` package are retained as a
+reference/evaluation gateway so end-to-end core behavior can be exercised
+without pulling product tenancy and deployment policy into MALT core.
+
+The managed service gateway is separate. It should depend on MALT core
+contracts and return verifier-facing `result + ProofList` responses, but it
+owns product-layer policy such as tenants, identity, authorization, backend
+credentials, cache policy, root publication, quota, and operations.
 
 Current command model:
 
@@ -284,7 +300,7 @@ malt/
 |-- config/
 |-- daemon/
 |-- api/http/         # shared daemon API payloads
-|-- server/          # daemon HTTP server
+|-- server/          # reference daemon and eval-gateway HTTP server
 |-- auth/             # data-authentication core
 |   |-- arcset/       # canonical arcs and coordinates
 |   |-- commitment/   # primitive commitment backends

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 It lets applications update and resolve authenticated relationships among
 immutable objects without rewriting unrelated payload blocks.
 
+This repository is the MALT core specification implementation. It owns the
+verifier-facing semantics, ProofList behavior, root/query/result contracts,
+wire formats, reference runtime, and core benchmark/evaluation framework. The
+managed product gateway lives outside this repository.
+
 [Documentation](./docs/README.md) · [Architecture](./ARCHITECTURE.md) ·
 [Threat Model](./docs/policy/threat-model.md) ·
 [Compatibility](./docs/policy/compatibility.md) · [Evaluation](./docs/evaluation/README.md) ·
@@ -48,11 +53,31 @@ MALT separates those concerns:
 The claim is not that updates are free. The claim is that MALT replaces
 implicit ancestor-rewrite cost with explicit, verifiable structure maintenance.
 
+## Repository Boundary
+
+This repository owns:
+
+- MALT core semantics and verifier-facing contracts
+- root CID, ProofList, and wire-format documentation
+- reference CLI, daemon, HTTP server, and local/mock CAS surfaces
+- component benchmarks, conformance tests, and end-to-end evaluation harnesses
+- implementation-bound MIPs and evaluator schemas
+
+This repository does not own production managed-gateway behavior:
+
+- tenant isolation, identity providers, API keys, or authorization policy
+- root publication, latest-head, freshness, or multi-writer product policy
+- S3/Filecoin/IPFS production backend orchestration
+- quota, billing, pinning, garbage collection, abuse control, or operations
+
+Those deployment and product concerns belong in the separate
+`DeWebProtocol/gateway` repository or private deployment overlays.
+
 ## Current Architecture
 
 ```mermaid
 flowchart TB
-  app["Applications / CLI / Go client"] --> api["MALT daemon and HTTP API"]
+  app["Applications / CLI / Go client"] --> api["Reference daemon / eval gateway HTTP API"]
   api --> rw["Resolver / Writer"]
   rw --> semantics["Authenticated list / map semantics"]
   semantics --> proofs["ProofList and commitment backends"]
@@ -73,6 +98,7 @@ change. It is not production-ready.
 Current in-tree capabilities:
 
 - root-centric `malt` CLI for local daemon lifecycle, add, resolve, and verify
+- reference/evaluation gateway surface for explicit-root HTTP reads and writes
 - proof-bearing HTTP reads for file bytes, directory JSON, and byte ranges
 - pure MALT UnixFS-style layout built from map/list semantics and CAS-backed
   immutable payloads
@@ -86,6 +112,7 @@ Current experimental boundaries:
 - no managed global head publication service
 - no multi-writer merge or freshness protocol
 - no tenant, quota, pinning, or garbage-collection policy
+- no production managed gateway or hosted service semantics
 - no stable public API compatibility guarantee yet
 - response-body binding for large-file byte ranges is still a ProofList-schema
   design item
@@ -227,7 +254,7 @@ For a deeper implementation walkthrough, see [ARCHITECTURE.md](./ARCHITECTURE.md
 ## Repository Layout
 
 ```text
-cmd/malt/                      primary runtime CLI
+cmd/malt/                      reference runtime CLI
 cmd/eval/                      malt-eval workloads, schemas, and helpers
 api/http/                      daemon request/response DTOs
 auth/                          arcset, commitment, proof, list/map semantics
@@ -235,7 +262,7 @@ graph/                         resolver and writer port definitions/adapters
 layout/unixfs/                 UnixFS-style layout over map/list semantics and CAS-backed payloads
 runtime/                       node, runtime graph composition, ArcTable, metrics
 sdk/client/                    Go daemon client facade
-server/                        daemon HTTP server
+server/                        reference daemon and eval-gateway HTTP server
 storage/                       CAS and KV storage libraries
 wire/maltcid/                  MALT map/list root CID codecs
 docs/                          implementation docs: policy, evaluation, specs, and MIPs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,8 @@
 # MALT Roadmap
 
-This roadmap describes the implementation repository. It is intentionally
-focused on executable behavior, public schemas, and maintainer workflows.
+This roadmap describes the MALT core implementation repository. It is
+intentionally focused on executable core behavior, public schemas, evaluator
+artifacts, and maintainer workflows.
 
 ## Current Focus
 
@@ -11,13 +12,17 @@ change. It is not production-ready.
 
 The near-term goal is to make the repository easier to understand, validate,
 and integrate experimentally while preserving honest boundaries around unstable
-schemas and deployment policy.
+schemas and deployment policy. The in-tree daemon/server remains a
+reference/evaluation gateway for explicit-root behavior, not the production
+managed gateway.
 
 ## Near Term
 
 - Stabilize the public `malt` CLI around root-centric add, resolve, verify, and
   daemon lifecycle workflows.
 - Keep proof-bearing HTTP reads explicit and verifier-facing.
+- Document and test the reference/evaluation gateway boundary for
+  `Read(root, query) -> result + ProofList`.
 - Tighten `ProofList` verifier documentation for path resolution, terminal
   `@payload` binding, and list-backed byte-range evidence.
 - Keep `malt-eval` schemas, raw envelopes, manifests, and summary outputs stable
@@ -41,6 +46,9 @@ schemas and deployment policy.
 - Production storage-service guarantees.
 - Managed global head publication.
 - Multi-tenant ACL, quota, pinning, and garbage-collection policy.
+- Production managed gateway behavior such as identity providers, authorization
+  policy, S3 backend orchestration, billing, abuse control, or operational
+  deployment.
 - Stable API compatibility across releases.
 - A full replacement for Kubo, IPFS, or any CAS implementation.
 
@@ -57,3 +65,5 @@ Before the first public release tag:
 - Release notes state experimental limits and any known ProofList verifier
   contract TODOs.
 - Public docs avoid claims that are not implemented in the current code.
+- Repository docs distinguish MALT core/reference evaluation surfaces from
+  managed gateway product behavior in `DeWebProtocol/gateway`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,12 @@ with code, tests, schemas, wire formats, and evaluator artifacts. Public
 website pages in `DeWebProtocol/malt-web` may summarize this material, but they
 should link back here for protocol, policy, and compatibility details.
 
+Managed gateway service behavior, including tenancy, identity, authorization,
+root publication, backend orchestration, S3/Filecoin/IPFS deployment policy,
+quota, cache policy, and operations, belongs in `DeWebProtocol/gateway` or
+private deployment overlays. This repository may keep a reference/evaluation
+gateway only to exercise MALT core end to end.
+
 ## Policy
 
 - [Threat model](./policy/threat-model.md)


### PR DESCRIPTION
## Summary

- Define `DeWebProtocol/malt` as the MALT core specification implementation, reference runtime, and evaluation gateway repository.
- Clarify that production managed-gateway behavior belongs in `DeWebProtocol/gateway` or private deployment overlays.
- Update README, architecture, roadmap, and implementation docs to distinguish MALT core/reference evaluation surfaces from managed service policy.

## Validation

- `env GOCACHE=/tmp/go-build-cache-gateway-split go test ./...`
- `git diff --check`
