### PR TITLE
Add path-depth read matrix benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ examples/                      small runnable plans and examples
 MALT's evaluation framework compares authenticated object layouts along four
 primary dimensions:
 
-- traversal depth and shared-dataset read latency
+- path depth under fixed per-CAS-Get latency models
 - verifier-facing proof size
 - rewrite amplification under structural updates
 - materialized-index and storage overhead
@@ -287,8 +287,8 @@ primary dimensions:
 - `malt-eval write` replays Git traces and emits write-amplification JSONL
 - `malt-eval run` executes JSON plans and writes `manifest.json`, raw
   envelopes, and summary CSVs under `result/<run_id>`
-- `malt-eval run` plans can use the `read_matrix` suite for fair read
-  comparisons over the same logical source dataset materialized into MALT,
+- `malt-eval run` plans can use the `read_matrix` suite for fair resolve-path
+  comparisons over the same logical paths materialized as flat MALT arcs,
   MerkleDAG, and HAMT
 - `malt-eval schema` lists or prints embedded JSON schemas
 - `malt-eval summarize` regenerates summary CSVs from a result directory

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ examples/                      small runnable plans and examples
 MALT's evaluation framework compares authenticated object layouts along four
 primary dimensions:
 
-- traversal depth and end-to-end read latency
+- traversal depth and shared-dataset read latency
 - verifier-facing proof size
 - rewrite amplification under structural updates
 - materialized-index and storage overhead
@@ -287,6 +287,9 @@ primary dimensions:
 - `malt-eval write` replays Git traces and emits write-amplification JSONL
 - `malt-eval run` executes JSON plans and writes `manifest.json`, raw
   envelopes, and summary CSVs under `result/<run_id>`
+- `malt-eval run` plans can use the `read_matrix` suite for fair read
+  comparisons over the same logical source dataset materialized into MALT,
+  MerkleDAG, and HAMT
 - `malt-eval schema` lists or prints embedded JSON schemas
 - `malt-eval summarize` regenerates summary CSVs from a result directory
 - `malt-eval metrics` inspects daemon evaluation metrics

--- a/README.md
+++ b/README.md
@@ -281,8 +281,9 @@ primary dimensions:
 
 `malt-eval` supports both direct commands and a framework runner:
 
-- `malt-eval read` emits read-query JSONL records for MALT and IPLD UnixFS
-  baselines
+- `malt-eval read` emits paper-facing read benchmark records for MALT and IPLD
+  UnixFS baselines, including deep path lookup, small file read, and large file
+  range read workloads
 - `malt-eval write` replays Git traces and emits write-amplification JSONL
 - `malt-eval run` executes JSON plans and writes `manifest.json`, raw
   envelopes, and summary CSVs under `result/<run_id>`

--- a/cmd/eval/helper/evalsuites/registry.go
+++ b/cmd/eval/helper/evalsuites/registry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/proofoverhead"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/readdepthsweep"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/readlatencysweep"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/readmatrix"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/readquery"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/storageoverhead"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/writetrace"
@@ -16,6 +17,7 @@ import (
 func NewRegistry() framework.Registry {
 	registry := framework.NewRegistry()
 	mustRegister(registry, writetrace.Suite{})
+	mustRegister(registry, readmatrix.Suite{})
 	mustRegister(registry, readquery.Suite{})
 	mustRegister(registry, readdepthsweep.Suite{})
 	mustRegister(registry, readlatencysweep.Suite{})

--- a/cmd/eval/helper/evalsuites/registry.go
+++ b/cmd/eval/helper/evalsuites/registry.go
@@ -4,6 +4,7 @@ package evalsuites
 import (
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/casmodel"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/flatindexcardinality"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/proofoverhead"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/readdepthsweep"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/readlatencysweep"
@@ -18,6 +19,7 @@ func NewRegistry() framework.Registry {
 	registry := framework.NewRegistry()
 	mustRegister(registry, writetrace.Suite{})
 	mustRegister(registry, readmatrix.Suite{})
+	mustRegister(registry, flatindexcardinality.Suite{})
 	mustRegister(registry, readquery.Suite{})
 	mustRegister(registry, readdepthsweep.Suite{})
 	mustRegister(registry, readlatencysweep.Suite{})

--- a/cmd/eval/helper/evalsuites/registry_test.go
+++ b/cmd/eval/helper/evalsuites/registry_test.go
@@ -7,6 +7,7 @@ func TestNewRegistryRegistersProductionSuites(t *testing.T) {
 	for _, name := range []string{
 		"write_trace",
 		"read_matrix",
+		"flat_index_cardinality",
 		"read_query",
 		"cas_model",
 		"proof_overhead",

--- a/cmd/eval/helper/evalsuites/registry_test.go
+++ b/cmd/eval/helper/evalsuites/registry_test.go
@@ -6,6 +6,7 @@ func TestNewRegistryRegistersProductionSuites(t *testing.T) {
 	registry := NewRegistry()
 	for _, name := range []string{
 		"write_trace",
+		"read_matrix",
 		"read_query",
 		"cas_model",
 		"proof_overhead",

--- a/cmd/eval/helper/evalsummary/command_test.go
+++ b/cmd/eval/helper/evalsummary/command_test.go
@@ -29,6 +29,7 @@ func TestCommandWritesKnownSuiteFilenames(t *testing.T) {
 
 	wantFiles := map[string]string{
 		"write_trace":      "figure_write_trace.csv",
+		"read_matrix":      "figure_read_matrix.csv",
 		"read_query":       "figure_read_query.csv",
 		"cas_model":        "figure_cas_model.csv",
 		"proof_overhead":   "figure_proof.csv",

--- a/cmd/eval/internal/eval/readbench/baseline.go
+++ b/cmd/eval/internal/eval/readbench/baseline.go
@@ -117,7 +117,7 @@ func baselineDirLayout(system SystemName) (string, error) {
 
 // MeasureResolve measures a single resolve_path operation at the given path.
 func (b *BaselineSystem) MeasureResolve(ctx context.Context, iteration int, fixture string, filePath string) (*Result, error) {
-	op := operation{kind: OperationResolvePath, path: filePath}
+	op := operation{kind: OperationResolvePath, workload: WorkloadDeepPathLookup, path: filePath}
 	return b.measureOperation(ctx, iteration, fixture, op)
 }
 
@@ -139,7 +139,7 @@ func (b *BaselineSystem) measureOperation(ctx context.Context, iteration int, fi
 			return nil, fmt.Errorf("%s resolve path %q: %w", b.system, op.path, err)
 		}
 		target = node.Cid().String()
-	case OperationContentRange:
+	case OperationContentFull, OperationContentRange:
 		node, err := b.resolvePath(ctx, op.path)
 		if err != nil {
 			return nil, fmt.Errorf("%s resolve content path %q: %w", b.system, op.path, err)
@@ -158,6 +158,7 @@ func (b *BaselineSystem) measureOperation(ctx context.Context, iteration int, fi
 	return &Result{
 		System:            b.system,
 		OperationKind:     op.kind,
+		Workload:          op.workload,
 		Iteration:         iteration,
 		FixtureName:       fixture,
 		Path:              op.path,

--- a/cmd/eval/internal/eval/readbench/dataset.go
+++ b/cmd/eval/internal/eval/readbench/dataset.go
@@ -6,14 +6,13 @@ import (
 	"slices"
 )
 
-// MatrixDatasetConfig describes one logical source dataset shared by all read
+// MatrixDatasetConfig describes one logical lookup dataset shared by all read
 // systems in read_matrix.
 type MatrixDatasetConfig struct {
-	Name       string
-	FileCount  int
-	Depths     []int
-	SmallBytes int
-	LargeBytes int
+	Name         string
+	FileCount    int
+	Depths       []int
+	PayloadBytes int
 }
 
 // MatrixDatasetFile is one logical source file before materialization into a
@@ -37,30 +36,22 @@ type MatrixDataset struct {
 	SmallFileBytes      int
 	LargeFileBytes      int
 	SmallPaths          map[int]string
-	LargePaths          map[int]string
 }
 
-// NewMatrixDataset builds a deterministic logical file tree. The first two
-// files for every requested depth are the measured small and large files; any
-// remaining files are deterministic filler files that increase dataset scale.
+// NewMatrixDataset builds a deterministic logical file tree for path lookup.
+// The measured dataset has one small payload at each requested path depth.
 func NewMatrixDataset(cfg MatrixDatasetConfig) (*MatrixDataset, error) {
 	if cfg.Name == "" {
 		cfg.Name = "read-matrix"
 	}
-	if cfg.SmallBytes <= 0 {
-		cfg.SmallBytes = DefaultSmallFileBytes
-	}
-	if cfg.LargeBytes == 0 {
-		cfg.LargeBytes = DefaultLargeFileBytes
-	}
-	if cfg.LargeBytes < minListBackedFileBytes {
-		return nil, fmt.Errorf("large file bytes must be at least %d for list-backed storage", minListBackedFileBytes)
+	if cfg.PayloadBytes <= 0 {
+		cfg.PayloadBytes = DefaultSmallFileBytes
 	}
 	depths, err := normalizeDepths(cfg.Depths)
 	if err != nil {
 		return nil, err
 	}
-	minFiles := len(depths) * 2
+	minFiles := len(depths)
 	if cfg.FileCount == 0 {
 		cfg.FileCount = minFiles
 	}
@@ -69,31 +60,21 @@ func NewMatrixDataset(cfg MatrixDatasetConfig) (*MatrixDataset, error) {
 	}
 
 	dataset := &MatrixDataset{
-		Name:           matrixDatasetName(cfg.Name, cfg.FileCount, depths),
+		Name:           matrixDatasetName(cfg.Name, depths),
 		Depths:         depths,
 		FileCount:      cfg.FileCount,
-		SmallFileBytes: cfg.SmallBytes,
-		LargeFileBytes: cfg.LargeBytes,
+		SmallFileBytes: cfg.PayloadBytes,
 		SmallPaths:     make(map[int]string, len(depths)),
-		LargePaths:     make(map[int]string, len(depths)),
 	}
 	seen := map[string]struct{}{}
 	for _, depth := range depths {
-		smallPath := fixturePath(depth, "small.txt")
-		largePath := fixturePath(depth, "large.bin")
-		dataset.SmallPaths[depth] = smallPath
-		dataset.LargePaths[depth] = largePath
+		lookupPath := fixturePath(depth, "lookup.txt")
+		dataset.SmallPaths[depth] = lookupPath
 		dataset.addFile(seen, MatrixDatasetFile{
-			Path:  smallPath,
-			Data:  deterministicBytes(fmt.Sprintf("small-d%d", depth), cfg.SmallBytes),
+			Path:  lookupPath,
+			Data:  deterministicBytes(fmt.Sprintf("lookup-d%d", depth), cfg.PayloadBytes),
 			Depth: depth,
-			Role:  "small",
-		})
-		dataset.addFile(seen, MatrixDatasetFile{
-			Path:  largePath,
-			Data:  deterministicBytes(fmt.Sprintf("large-d%d", depth), cfg.LargeBytes),
-			Depth: depth,
-			Role:  "large",
+			Role:  "lookup",
 		})
 	}
 	for i := 0; len(dataset.Files) < cfg.FileCount; i++ {
@@ -104,7 +85,7 @@ func NewMatrixDataset(cfg MatrixDatasetConfig) (*MatrixDataset, error) {
 		}
 		dataset.addFile(seen, MatrixDatasetFile{
 			Path:  filePath,
-			Data:  deterministicBytes(fmt.Sprintf("scale-%d-d%d", i, depth), cfg.SmallBytes),
+			Data:  deterministicBytes(fmt.Sprintf("scale-%d-d%d", i, depth), cfg.PayloadBytes),
 			Depth: depth,
 			Role:  "scale",
 		})
@@ -125,7 +106,7 @@ func (d *MatrixDataset) addFile(seen map[string]struct{}, file MatrixDatasetFile
 
 func normalizeDepths(depths []int) ([]int, error) {
 	if len(depths) == 0 {
-		depths = []int{2, 4, 8}
+		depths = []int{1, 2, 4, 8, 16}
 	}
 	out := append([]int(nil), depths...)
 	slices.Sort(out)
@@ -138,8 +119,8 @@ func normalizeDepths(depths []int) ([]int, error) {
 	return out, nil
 }
 
-func matrixDatasetName(base string, fileCount int, depths []int) string {
-	return fmt.Sprintf("%s-files%d-depth%d-%d", base, fileCount, depths[0], depths[len(depths)-1])
+func matrixDatasetName(base string, depths []int) string {
+	return fmt.Sprintf("%s-depth%d-%d", base, depths[0], depths[len(depths)-1])
 }
 
 func countDirectories(files []MatrixDatasetFile) int {

--- a/cmd/eval/internal/eval/readbench/dataset.go
+++ b/cmd/eval/internal/eval/readbench/dataset.go
@@ -13,6 +13,10 @@ type MatrixDatasetConfig struct {
 	FileCount    int
 	Depths       []int
 	PayloadBytes int
+	// PathsPerDepth controls how many independent lookup keys are measured for
+	// each depth. Multiple keys reduce single-key radix/HAMT artifacts in
+	// latency aggregates.
+	PathsPerDepth int
 }
 
 // MatrixDatasetFile is one logical source file before materialization into a
@@ -36,6 +40,7 @@ type MatrixDataset struct {
 	SmallFileBytes      int
 	LargeFileBytes      int
 	SmallPaths          map[int]string
+	LookupPaths         map[int][]string
 }
 
 // NewMatrixDataset builds a deterministic logical file tree for path lookup.
@@ -47,11 +52,14 @@ func NewMatrixDataset(cfg MatrixDatasetConfig) (*MatrixDataset, error) {
 	if cfg.PayloadBytes <= 0 {
 		cfg.PayloadBytes = DefaultSmallFileBytes
 	}
+	if cfg.PathsPerDepth <= 0 {
+		cfg.PathsPerDepth = 1
+	}
 	depths, err := normalizeDepths(cfg.Depths)
 	if err != nil {
 		return nil, err
 	}
-	minFiles := len(depths)
+	minFiles := len(depths) * cfg.PathsPerDepth
 	if cfg.FileCount == 0 {
 		cfg.FileCount = minFiles
 	}
@@ -65,21 +73,27 @@ func NewMatrixDataset(cfg MatrixDatasetConfig) (*MatrixDataset, error) {
 		FileCount:      cfg.FileCount,
 		SmallFileBytes: cfg.PayloadBytes,
 		SmallPaths:     make(map[int]string, len(depths)),
+		LookupPaths:    make(map[int][]string, len(depths)),
 	}
 	seen := map[string]struct{}{}
 	for _, depth := range depths {
-		lookupPath := fixturePath(depth, "lookup.txt")
-		dataset.SmallPaths[depth] = lookupPath
-		dataset.addFile(seen, MatrixDatasetFile{
-			Path:  lookupPath,
-			Data:  deterministicBytes(fmt.Sprintf("lookup-d%d", depth), cfg.PayloadBytes),
-			Depth: depth,
-			Role:  "lookup",
-		})
+		for sample := 0; sample < cfg.PathsPerDepth; sample++ {
+			lookupPath := matrixLookupPath(depth, sample)
+			if sample == 0 {
+				dataset.SmallPaths[depth] = lookupPath
+			}
+			dataset.LookupPaths[depth] = append(dataset.LookupPaths[depth], lookupPath)
+			dataset.addFile(seen, MatrixDatasetFile{
+				Path:  lookupPath,
+				Data:  deterministicBytes(fmt.Sprintf("lookup-d%d-s%d", depth, sample), cfg.PayloadBytes),
+				Depth: depth,
+				Role:  "lookup",
+			})
+		}
 	}
 	for i := 0; len(dataset.Files) < cfg.FileCount; i++ {
 		depth := depths[i%len(depths)]
-		filePath := path.Join(fixturePath(depth, fmt.Sprintf("scale-%06d.dat", i)))
+		filePath := path.Join(matrixPathAtDepth(depth, fmt.Sprintf("scale-%06d.dat", i)))
 		if _, ok := seen[filePath]; ok {
 			continue
 		}
@@ -93,6 +107,22 @@ func NewMatrixDataset(cfg MatrixDatasetConfig) (*MatrixDataset, error) {
 	dataset.DirectoryCount = countDirectories(dataset.Files)
 	dataset.PathCount = dataset.FileCount + dataset.DirectoryCount
 	return dataset, nil
+}
+
+func matrixLookupPath(depth int, sample int) string {
+	return matrixPathAtDepth(depth, fmt.Sprintf("lookup-%02d.txt", sample))
+}
+
+func matrixPathAtDepth(depth int, filename string) string {
+	if depth <= 1 {
+		return filename
+	}
+	parts := make([]string, 0, depth)
+	for i := 0; i < depth-1; i++ {
+		parts = append(parts, fmt.Sprintf("dir%02d", i))
+	}
+	parts = append(parts, filename)
+	return path.Join(parts...)
 }
 
 func (d *MatrixDataset) addFile(seen map[string]struct{}, file MatrixDatasetFile) {

--- a/cmd/eval/internal/eval/readbench/dataset.go
+++ b/cmd/eval/internal/eval/readbench/dataset.go
@@ -1,0 +1,159 @@
+package readbench
+
+import (
+	"fmt"
+	"path"
+	"slices"
+)
+
+// MatrixDatasetConfig describes one logical source dataset shared by all read
+// systems in read_matrix.
+type MatrixDatasetConfig struct {
+	Name       string
+	FileCount  int
+	Depths     []int
+	SmallBytes int
+	LargeBytes int
+}
+
+// MatrixDatasetFile is one logical source file before materialization into a
+// specific representation.
+type MatrixDatasetFile struct {
+	Path  string
+	Data  []byte
+	Depth int
+	Role  string
+}
+
+// MatrixDataset is the shared logical fixture used by read_matrix.
+type MatrixDataset struct {
+	Name                string
+	Files               []MatrixDatasetFile
+	Depths              []int
+	FileCount           int
+	DirectoryCount      int
+	PathCount           int
+	LogicalPayloadBytes int64
+	SmallFileBytes      int
+	LargeFileBytes      int
+	SmallPaths          map[int]string
+	LargePaths          map[int]string
+}
+
+// NewMatrixDataset builds a deterministic logical file tree. The first two
+// files for every requested depth are the measured small and large files; any
+// remaining files are deterministic filler files that increase dataset scale.
+func NewMatrixDataset(cfg MatrixDatasetConfig) (*MatrixDataset, error) {
+	if cfg.Name == "" {
+		cfg.Name = "read-matrix"
+	}
+	if cfg.SmallBytes <= 0 {
+		cfg.SmallBytes = DefaultSmallFileBytes
+	}
+	if cfg.LargeBytes == 0 {
+		cfg.LargeBytes = DefaultLargeFileBytes
+	}
+	if cfg.LargeBytes < minListBackedFileBytes {
+		return nil, fmt.Errorf("large file bytes must be at least %d for list-backed storage", minListBackedFileBytes)
+	}
+	depths, err := normalizeDepths(cfg.Depths)
+	if err != nil {
+		return nil, err
+	}
+	minFiles := len(depths) * 2
+	if cfg.FileCount == 0 {
+		cfg.FileCount = minFiles
+	}
+	if cfg.FileCount < minFiles {
+		return nil, fmt.Errorf("file_count must be at least %d for %d depths", minFiles, len(depths))
+	}
+
+	dataset := &MatrixDataset{
+		Name:           matrixDatasetName(cfg.Name, cfg.FileCount, depths),
+		Depths:         depths,
+		FileCount:      cfg.FileCount,
+		SmallFileBytes: cfg.SmallBytes,
+		LargeFileBytes: cfg.LargeBytes,
+		SmallPaths:     make(map[int]string, len(depths)),
+		LargePaths:     make(map[int]string, len(depths)),
+	}
+	seen := map[string]struct{}{}
+	for _, depth := range depths {
+		smallPath := fixturePath(depth, "small.txt")
+		largePath := fixturePath(depth, "large.bin")
+		dataset.SmallPaths[depth] = smallPath
+		dataset.LargePaths[depth] = largePath
+		dataset.addFile(seen, MatrixDatasetFile{
+			Path:  smallPath,
+			Data:  deterministicBytes(fmt.Sprintf("small-d%d", depth), cfg.SmallBytes),
+			Depth: depth,
+			Role:  "small",
+		})
+		dataset.addFile(seen, MatrixDatasetFile{
+			Path:  largePath,
+			Data:  deterministicBytes(fmt.Sprintf("large-d%d", depth), cfg.LargeBytes),
+			Depth: depth,
+			Role:  "large",
+		})
+	}
+	for i := 0; len(dataset.Files) < cfg.FileCount; i++ {
+		depth := depths[i%len(depths)]
+		filePath := path.Join(fixturePath(depth, fmt.Sprintf("scale-%06d.dat", i)))
+		if _, ok := seen[filePath]; ok {
+			continue
+		}
+		dataset.addFile(seen, MatrixDatasetFile{
+			Path:  filePath,
+			Data:  deterministicBytes(fmt.Sprintf("scale-%d-d%d", i, depth), cfg.SmallBytes),
+			Depth: depth,
+			Role:  "scale",
+		})
+	}
+	dataset.DirectoryCount = countDirectories(dataset.Files)
+	dataset.PathCount = dataset.FileCount + dataset.DirectoryCount
+	return dataset, nil
+}
+
+func (d *MatrixDataset) addFile(seen map[string]struct{}, file MatrixDatasetFile) {
+	if _, ok := seen[file.Path]; ok {
+		return
+	}
+	seen[file.Path] = struct{}{}
+	d.Files = append(d.Files, file)
+	d.LogicalPayloadBytes += int64(len(file.Data))
+}
+
+func normalizeDepths(depths []int) ([]int, error) {
+	if len(depths) == 0 {
+		depths = []int{2, 4, 8}
+	}
+	out := append([]int(nil), depths...)
+	slices.Sort(out)
+	out = slices.Compact(out)
+	for _, depth := range out {
+		if depth < 1 {
+			return nil, fmt.Errorf("depths must be >= 1")
+		}
+	}
+	return out, nil
+}
+
+func matrixDatasetName(base string, fileCount int, depths []int) string {
+	return fmt.Sprintf("%s-files%d-depth%d-%d", base, fileCount, depths[0], depths[len(depths)-1])
+}
+
+func countDirectories(files []MatrixDatasetFile) int {
+	dirs := map[string]struct{}{}
+	for _, file := range files {
+		dir := path.Dir(file.Path)
+		for dir != "." && dir != "/" && dir != "" {
+			dirs[dir] = struct{}{}
+			next := path.Dir(dir)
+			if next == dir {
+				break
+			}
+			dir = next
+		}
+	}
+	return len(dirs)
+}

--- a/cmd/eval/internal/eval/readbench/dataset.go
+++ b/cmd/eval/internal/eval/readbench/dataset.go
@@ -106,7 +106,7 @@ func (d *MatrixDataset) addFile(seen map[string]struct{}, file MatrixDatasetFile
 
 func normalizeDepths(depths []int) ([]int, error) {
 	if len(depths) == 0 {
-		depths = []int{1, 2, 4, 8, 16}
+		depths = []int{1, 2, 3, 4, 5, 6}
 	}
 	out := append([]int(nil), depths...)
 	slices.Sort(out)

--- a/cmd/eval/internal/eval/readbench/dataset_test.go
+++ b/cmd/eval/internal/eval/readbench/dataset_test.go
@@ -1,0 +1,55 @@
+package readbench
+
+import "testing"
+
+func TestMatrixDatasetDepthCountsRootToTargetEdgesAndSamplesPaths(t *testing.T) {
+	dataset, err := NewMatrixDataset(MatrixDatasetConfig{
+		Name:          "matrix-unit",
+		Depths:        []int{1, 3},
+		PayloadBytes:  16,
+		PathsPerDepth: 3,
+	})
+	if err != nil {
+		t.Fatalf("NewMatrixDataset() error = %v", err)
+	}
+
+	if got := dataset.LookupPaths[1]; len(got) != 3 || got[0] != "lookup-00.txt" || got[2] != "lookup-02.txt" {
+		t.Fatalf("depth 1 lookup paths = %v", got)
+	}
+	if got := dataset.LookupPaths[3]; len(got) != 3 || got[0] != "dir00/dir01/lookup-00.txt" {
+		t.Fatalf("depth 3 lookup paths = %v", got)
+	}
+	if dataset.FileCount != 6 {
+		t.Fatalf("file_count = %d, want one lookup file per depth sample", dataset.FileCount)
+	}
+}
+
+func TestMatrixOperationsReturnsAllPathSamplesAtDepth(t *testing.T) {
+	dataset, err := NewMatrixDataset(MatrixDatasetConfig{
+		Depths:        []int{2},
+		PayloadBytes:  16,
+		PathsPerDepth: 2,
+	})
+	if err != nil {
+		t.Fatalf("NewMatrixDataset() error = %v", err)
+	}
+
+	ops, err := MatrixOperations(dataset, 2)
+	if err != nil {
+		t.Fatalf("MatrixOperations() error = %v", err)
+	}
+	if len(ops) != 2 {
+		t.Fatalf("operation count = %d, want 2", len(ops))
+	}
+	for i, op := range ops {
+		if op.PathDepth != 2 {
+			t.Fatalf("op %d depth = %d, want 2", i, op.PathDepth)
+		}
+		if op.PathSample != i+1 {
+			t.Fatalf("op %d path sample = %d, want %d", i, op.PathSample, i+1)
+		}
+	}
+	if ops[0].Path != "dir00/lookup-00.txt" || ops[1].Path != "dir00/lookup-01.txt" {
+		t.Fatalf("operation paths = %q, %q", ops[0].Path, ops[1].Path)
+	}
+}

--- a/cmd/eval/internal/eval/readbench/flat_hamt.go
+++ b/cmd/eval/internal/eval/readbench/flat_hamt.go
@@ -1,0 +1,116 @@
+package readbench
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dewebprotocol/malt/cmd/internal/merkledagimport"
+	"github.com/dewebprotocol/malt/runtime/metrics"
+	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
+	merkledag "github.com/ipfs/boxo/ipld/merkledag"
+	"github.com/ipfs/boxo/ipld/unixfs/hamt"
+	unixfsio "github.com/ipfs/boxo/ipld/unixfs/io"
+	cid "github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// matrixFlatHAMTSystem stores complete logical paths as keys in one IPFS HAMT.
+// It is a flat map baseline, not a UnixFS directory traversal.
+type matrixFlatHAMTSystem struct {
+	store        *casmock.CAS
+	dag          ipld.DAGService
+	root         cid.Cid
+	casLatencyMS int
+}
+
+func newMatrixFlatHAMTSystem(ctx context.Context, dataset *MatrixDataset, casLatencyMS int) (*matrixFlatHAMTSystem, error) {
+	if dataset == nil {
+		return nil, fmt.Errorf("dataset is nil")
+	}
+	store := newMatrixCAS(casLatencyMS)
+	dag := merkledagimport.NewDAGService(store)
+	shard, err := hamt.NewShard(dag, unixfsio.DefaultShardWidth)
+	if err != nil {
+		return nil, fmt.Errorf("create flat HAMT shard: %w", err)
+	}
+	shard.SetCidBuilder(cid.Prefix{Version: 1, Codec: cid.DagProtobuf, MhType: mh.SHA2_256, MhLength: -1})
+	for _, file := range dataset.Files {
+		if file.Path == "" {
+			return nil, fmt.Errorf("empty file path in flat HAMT dataset")
+		}
+		node := merkledag.NewRawNode(file.Data)
+		if err := shard.Set(ctx, file.Path, node); err != nil {
+			return nil, fmt.Errorf("set flat HAMT key %q: %w", file.Path, err)
+		}
+	}
+	rootNode, err := shard.Node()
+	if err != nil {
+		return nil, fmt.Errorf("serialize flat HAMT root: %w", err)
+	}
+	return &matrixFlatHAMTSystem{
+		store:        store,
+		dag:          dag,
+		root:         rootNode.Cid(),
+		casLatencyMS: casLatencyMS,
+	}, nil
+}
+
+func (s *matrixFlatHAMTSystem) Name() SystemName { return SystemFlatHAMT }
+
+func (s *matrixFlatHAMTSystem) Close() error { return nil }
+
+func (s *matrixFlatHAMTSystem) Measure(ctx context.Context, iteration int, dataset *MatrixDataset, op MatrixOperation) (*Result, error) {
+	if s == nil || s.store == nil || s.dag == nil {
+		return nil, fmt.Errorf("flat HAMT matrix system is nil")
+	}
+	if op.Kind != OperationResolvePath {
+		return nil, fmt.Errorf("unsupported operation kind %q", op.Kind)
+	}
+	s.store.ResetStats()
+
+	start := time.Now()
+	rootNode, err := s.dag.Get(ctx, s.root)
+	if err != nil {
+		return nil, fmt.Errorf("get flat HAMT root %s: %w", s.root, err)
+	}
+	shard, err := hamt.NewHamtFromDag(s.dag, rootNode)
+	if err != nil {
+		return nil, fmt.Errorf("load flat HAMT root %s: %w", s.root, err)
+	}
+	link, err := shard.Find(ctx, op.Path)
+	if err != nil {
+		return nil, fmt.Errorf("flat HAMT lookup %q: %w", op.Path, err)
+	}
+	if link == nil {
+		return nil, fmt.Errorf("flat HAMT lookup %q returned nil link", op.Path)
+	}
+	targetNode, err := s.dag.Get(ctx, link.Cid)
+	if err != nil {
+		return nil, fmt.Errorf("fetch flat HAMT target %s: %w", link.Cid, err)
+	}
+	contentBytes := len(targetNode.RawData())
+	elapsed := positiveElapsedNS(start, time.Now())
+	casStats := s.store.SnapshotStats()
+
+	result := &Result{
+		System:            SystemFlatHAMT,
+		OperationKind:     op.Kind,
+		Workload:          op.Workload,
+		Iteration:         iteration,
+		FixtureName:       dataset.Name,
+		Path:              op.Path,
+		ElapsedNS:         elapsed,
+		ContentBytes:      &contentBytes,
+		EvidenceItemCount: int(casStats.GetCount),
+		Target:            link.Cid.String(),
+		CAS:               casStats,
+		ArcTable:          metrics.ArcTableStats{},
+		Proof:             metrics.ProofStats{},
+	}
+	attachDatasetMetadata(result, dataset, op, s.casLatencyMS)
+	return result, nil
+}
+
+var _ MatrixSystem = (*matrixFlatHAMTSystem)(nil)

--- a/cmd/eval/internal/eval/readbench/flat_hamt_test.go
+++ b/cmd/eval/internal/eval/readbench/flat_hamt_test.go
@@ -1,0 +1,49 @@
+package readbench
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFlatHAMTMatrixSystemLooksUpFullPathKeys(t *testing.T) {
+	ctx := context.Background()
+	dataset, err := NewMatrixDataset(MatrixDatasetConfig{
+		Name:          "flat-hamt-unit",
+		Depths:        []int{1, 4},
+		PayloadBytes:  32,
+		PathsPerDepth: 1,
+	})
+	if err != nil {
+		t.Fatalf("NewMatrixDataset() error = %v", err)
+	}
+	system, err := NewMatrixSystem(ctx, SystemFlatHAMT, dataset, 0)
+	if err != nil {
+		t.Fatalf("NewMatrixSystem(flat hamt) error = %v", err)
+	}
+	defer system.Close()
+
+	var getCounts []uint64
+	for _, depth := range []int{1, 4} {
+		ops, err := MatrixOperations(dataset, depth)
+		if err != nil {
+			t.Fatalf("MatrixOperations(%d) error = %v", depth, err)
+		}
+		result, err := system.Measure(ctx, 0, dataset, ops[0])
+		if err != nil {
+			t.Fatalf("Measure(depth=%d) error = %v", depth, err)
+		}
+		if result.System != SystemFlatHAMT {
+			t.Fatalf("system = %q, want %q", result.System, SystemFlatHAMT)
+		}
+		if result.Target == "" {
+			t.Fatalf("depth %d resolved empty target", depth)
+		}
+		if result.ContentBytes == nil || *result.ContentBytes != 32 {
+			t.Fatalf("depth %d content_bytes = %v, want 32", depth, result.ContentBytes)
+		}
+		getCounts = append(getCounts, result.CAS.GetCount)
+	}
+	if getCounts[1] > getCounts[0]+1 {
+		t.Fatalf("flat HAMT CAS get count grew with path depth: depth1=%d depth4=%d", getCounts[0], getCounts[1])
+	}
+}

--- a/cmd/eval/internal/eval/readbench/local_malt.go
+++ b/cmd/eval/internal/eval/readbench/local_malt.go
@@ -104,13 +104,33 @@ func NewLocalMALTSystemWithFiles(ctx context.Context, store *casmock.CAS, files 
 
 // MeasureResolve measures a single resolve_path operation at the given path.
 func (s *LocalMALTSystem) MeasureResolve(ctx context.Context, iteration int, fixtureName string, filePath string) (*Result, error) {
+	return s.measureResolve(ctx, iteration, fixtureName, filePath, false)
+}
+
+// MeasureResolveWithTargetFetch measures resolve_path plus one target blob
+// fetch. This is the paper-facing read_matrix behavior: MALT resolves the flat
+// authenticated path, then fetches the target payload once from CAS.
+func (s *LocalMALTSystem) MeasureResolveWithTargetFetch(ctx context.Context, iteration int, fixtureName string, filePath string) (*Result, error) {
+	return s.measureResolve(ctx, iteration, fixtureName, filePath, true)
+}
+
+func (s *LocalMALTSystem) measureResolve(ctx context.Context, iteration int, fixtureName string, filePath string, fetchTarget bool) (*Result, error) {
 	s.node.ResetMetrics()
 	start := time.Now()
 	result, err := s.g.Resolver().Resolve(ctx, s.root, filePath)
-	elapsed := positiveElapsedNS(start, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("resolve %q: %w", filePath, err)
 	}
+	var contentBytes *int
+	if fetchTarget {
+		data, err := s.store.Get(ctx, result.Target)
+		if err != nil {
+			return nil, fmt.Errorf("fetch target blob %q: %w", result.Target.String(), err)
+		}
+		count := len(data)
+		contentBytes = &count
+	}
+	elapsed := positiveElapsedNS(start, time.Now())
 	snapshot := s.node.MetricsSnapshot()
 
 	return &Result{
@@ -121,6 +141,7 @@ func (s *LocalMALTSystem) MeasureResolve(ctx context.Context, iteration int, fix
 		FixtureName:        fixtureName,
 		Path:               filePath,
 		ElapsedNS:          elapsed,
+		ContentBytes:       contentBytes,
 		ProofListStepCount: len(result.Transcript.Steps),
 		EvidenceItemCount:  len(result.Transcript.Steps),
 		Target:             result.Target.String(),

--- a/cmd/eval/internal/eval/readbench/local_malt.go
+++ b/cmd/eval/internal/eval/readbench/local_malt.go
@@ -114,6 +114,29 @@ func (s *LocalMALTSystem) MeasureResolveWithTargetFetch(ctx context.Context, ite
 	return s.measureResolve(ctx, iteration, fixtureName, filePath, true)
 }
 
+// MeasureProve measures semantic proof/open generation for one full-path key.
+// It excludes target blob fetching and the resolver's longest-prefix lookup so
+// flat-index cardinality runs can report MALT's proof cost independently from
+// end-to-end read latency.
+func (s *LocalMALTSystem) MeasureProve(ctx context.Context, filePath string) (*int64, error) {
+	if s == nil || s.g == nil {
+		return nil, fmt.Errorf("local malt system is nil")
+	}
+	start := time.Now()
+	binding, proof, err := s.g.Semantic().Prove(ctx, s.g.Namespace(), s.root, arcset.CanonicalizePath(filePath))
+	if err != nil {
+		return nil, fmt.Errorf("prove %q: %w", filePath, err)
+	}
+	if !binding.Present || !binding.Value.Defined() {
+		return nil, fmt.Errorf("prove %q returned no present binding", filePath)
+	}
+	if len(proof) == 0 {
+		return nil, fmt.Errorf("prove %q returned empty proof", filePath)
+	}
+	elapsed := positiveElapsedNS(start, time.Now())
+	return &elapsed, nil
+}
+
 func (s *LocalMALTSystem) measureResolve(ctx context.Context, iteration int, fixtureName string, filePath string, fetchTarget bool) (*Result, error) {
 	s.node.ResetMetrics()
 	start := time.Now()

--- a/cmd/eval/internal/eval/readbench/local_malt.go
+++ b/cmd/eval/internal/eval/readbench/local_malt.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dewebprotocol/malt/config"
 	runtimegraph "github.com/dewebprotocol/malt/runtime/graph"
 	"github.com/dewebprotocol/malt/runtime/node"
+	mappingradix "github.com/dewebprotocol/malt/runtime/semantic/mapping/radix"
 	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
 	cid "github.com/ipfs/go-cid"
 )
@@ -114,16 +115,19 @@ func (s *LocalMALTSystem) MeasureResolveWithTargetFetch(ctx context.Context, ite
 	return s.measureResolve(ctx, iteration, fixtureName, filePath, true)
 }
 
-// MeasureProve measures semantic proof/open generation for one full-path key.
-// It excludes target blob fetching and the resolver's longest-prefix lookup so
-// flat-index cardinality runs can report MALT's proof cost independently from
-// end-to-end read latency.
+// MeasureProve measures only commitment open/prove calls for one full-path key.
+// The radix implementation still loads and validates slots to prepare the
+// proof, but this returned latency excludes that ArcTable materialization, target
+// blob fetching, and the resolver's longest-prefix lookup.
 func (s *LocalMALTSystem) MeasureProve(ctx context.Context, filePath string) (*int64, error) {
 	if s == nil || s.g == nil {
 		return nil, fmt.Errorf("local malt system is nil")
 	}
-	start := time.Now()
-	binding, proof, err := s.g.Semantic().Prove(ctx, s.g.Namespace(), s.root, arcset.CanonicalizePath(filePath))
+	semantic, ok := s.g.Semantic().(*mappingradix.Map)
+	if !ok {
+		return nil, fmt.Errorf("local malt semantic does not expose prove timings")
+	}
+	binding, proof, timings, err := semantic.ProveWithTimings(ctx, s.g.Namespace(), s.root, arcset.CanonicalizePath(filePath))
 	if err != nil {
 		return nil, fmt.Errorf("prove %q: %w", filePath, err)
 	}
@@ -133,7 +137,10 @@ func (s *LocalMALTSystem) MeasureProve(ctx context.Context, filePath string) (*i
 	if len(proof) == 0 {
 		return nil, fmt.Errorf("prove %q returned empty proof", filePath)
 	}
-	elapsed := positiveElapsedNS(start, time.Now())
+	elapsed := timings.OpenElapsedNS
+	if elapsed <= 0 {
+		elapsed = 1
+	}
 	return &elapsed, nil
 }
 

--- a/cmd/eval/internal/eval/readbench/local_malt.go
+++ b/cmd/eval/internal/eval/readbench/local_malt.go
@@ -94,6 +94,7 @@ func (s *LocalMALTSystem) MeasureResolve(ctx context.Context, iteration int, fix
 	return &Result{
 		System:             SystemMALTFlat,
 		OperationKind:      OperationResolvePath,
+		Workload:           WorkloadDeepPathLookup,
 		Iteration:          iteration,
 		FixtureName:        fixtureName,
 		Path:               filePath,

--- a/cmd/eval/internal/eval/readbench/local_malt.go
+++ b/cmd/eval/internal/eval/readbench/local_malt.go
@@ -25,6 +25,29 @@ type LocalMALTSystem struct {
 // NewLocalMALTSystem creates a MALT node backed by the given mock CAS,
 // imports fixture files, and returns a ready-to-measure system.
 func NewLocalMALTSystem(ctx context.Context, store *casmock.CAS, multiFix MultiDepthFixture) (*LocalMALTSystem, error) {
+	files := make([]MatrixDatasetFile, 0, len(multiFix.Fixtures)*2)
+	for _, fix := range multiFix.Fixtures {
+		files = append(files, MatrixDatasetFile{
+			Path:  fix.SmallPath,
+			Data:  fix.SmallData,
+			Depth: fix.Depth,
+			Role:  "small",
+		})
+		if fix.LargePath != "" {
+			files = append(files, MatrixDatasetFile{
+				Path:  fix.LargePath,
+				Data:  fix.LargeData,
+				Depth: fix.Depth,
+				Role:  "large",
+			})
+		}
+	}
+	return NewLocalMALTSystemWithFiles(ctx, store, files)
+}
+
+// NewLocalMALTSystemWithFiles creates a flat authenticated MALT structure from
+// explicit logical files.
+func NewLocalMALTSystemWithFiles(ctx context.Context, store *casmock.CAS, files []MatrixDatasetFile) (*LocalMALTSystem, error) {
 	cfg := config.DefaultConfig()
 	cfg.State.KVStore.Type = "memory"
 
@@ -43,18 +66,15 @@ func NewLocalMALTSystem(ctx context.Context, store *casmock.CAS, multiFix MultiD
 
 	// Build arc set from all fixture files at all depths.
 	arcs := map[string]cid.Cid{}
-	for _, fix := range multiFix.Fixtures {
-		// Store file data in the mock CAS and get CIDs.
-		smallCID, err := store.Put(ctx, fix.SmallData)
-		if err != nil {
-			return nil, fmt.Errorf("put small file at depth %d: %w", fix.Depth, err)
+	for _, file := range files {
+		if file.Path == "" {
+			return nil, fmt.Errorf("empty file path in local malt system")
 		}
-		largeCID, err := store.Put(ctx, fix.LargeData)
+		payloadCID, err := store.Put(ctx, file.Data)
 		if err != nil {
-			return nil, fmt.Errorf("put large file at depth %d: %w", fix.Depth, err)
+			return nil, fmt.Errorf("put file %q: %w", file.Path, err)
 		}
-		arcs[fix.SmallPath] = smallCID
-		arcs[fix.LargePath] = largeCID
+		arcs[file.Path] = payloadCID
 	}
 
 	// Every MALT-native map object requires a @payload binding.
@@ -84,12 +104,14 @@ func NewLocalMALTSystem(ctx context.Context, store *casmock.CAS, multiFix MultiD
 
 // MeasureResolve measures a single resolve_path operation at the given path.
 func (s *LocalMALTSystem) MeasureResolve(ctx context.Context, iteration int, fixtureName string, filePath string) (*Result, error) {
+	s.node.ResetMetrics()
 	start := time.Now()
 	result, err := s.g.Resolver().Resolve(ctx, s.root, filePath)
 	elapsed := positiveElapsedNS(start, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("resolve %q: %w", filePath, err)
 	}
+	snapshot := s.node.MetricsSnapshot()
 
 	return &Result{
 		System:             SystemMALTFlat,
@@ -102,5 +124,8 @@ func (s *LocalMALTSystem) MeasureResolve(ctx context.Context, iteration int, fix
 		ProofListStepCount: len(result.Transcript.Steps),
 		EvidenceItemCount:  len(result.Transcript.Steps),
 		Target:             result.Target.String(),
+		CAS:                snapshot.CAS,
+		ArcTable:           snapshot.ArcTable,
+		Proof:              snapshot.Proof,
 	}, nil
 }

--- a/cmd/eval/internal/eval/readbench/matrix_systems.go
+++ b/cmd/eval/internal/eval/readbench/matrix_systems.go
@@ -6,26 +6,16 @@ import (
 	"io/fs"
 	"time"
 
-	"github.com/dewebprotocol/malt/auth/commitment/kzg"
-	"github.com/dewebprotocol/malt/auth/proof/prooflist"
 	"github.com/dewebprotocol/malt/cmd/internal/merkledagimport"
-	"github.com/dewebprotocol/malt/layout/unixfs"
-	"github.com/dewebprotocol/malt/runtime/arctable/versioned"
-	"github.com/dewebprotocol/malt/runtime/metrics"
-	listtree "github.com/dewebprotocol/malt/runtime/semantic/list/tree"
-	mappingradix "github.com/dewebprotocol/malt/runtime/semantic/mapping/radix"
 	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
-	"github.com/dewebprotocol/malt/storage/kv/memory"
-	cid "github.com/ipfs/go-cid"
 )
 
 // MatrixOperation is one read operation measured against a shared dataset.
 type MatrixOperation struct {
-	Kind        OperationKind
-	Workload    WorkloadKind
-	Path        string
-	PathDepth   int
-	RangeHeader string
+	Kind      OperationKind
+	Workload  WorkloadKind
+	Path      string
+	PathDepth int
 }
 
 // MatrixSystem measures read operations for one materialized representation.
@@ -35,170 +25,78 @@ type MatrixSystem interface {
 	Close() error
 }
 
-// MatrixOperations returns the paper-facing read operations at one depth.
-func MatrixOperations(dataset *MatrixDataset, depth int, rangeHeader string) ([]MatrixOperation, error) {
+// MatrixOperations returns the paper-facing path lookup operation at one depth.
+func MatrixOperations(dataset *MatrixDataset, depth int) ([]MatrixOperation, error) {
 	if dataset == nil {
 		return nil, fmt.Errorf("dataset is nil")
 	}
-	smallPath := dataset.SmallPaths[depth]
-	largePath := dataset.LargePaths[depth]
-	if smallPath == "" || largePath == "" {
-		return nil, fmt.Errorf("dataset %q has no measured paths at depth %d", dataset.Name, depth)
+	lookupPath := dataset.SmallPaths[depth]
+	if lookupPath == "" {
+		return nil, fmt.Errorf("dataset %q has no measured path at depth %d", dataset.Name, depth)
 	}
 	return []MatrixOperation{
-		{Kind: OperationResolvePath, Workload: WorkloadDeepPathLookup, Path: smallPath, PathDepth: depth},
-		{Kind: OperationContentFull, Workload: WorkloadSmallFileRead, Path: smallPath, PathDepth: depth},
-		{Kind: OperationContentRange, Workload: WorkloadLargeFileRangeRead, Path: largePath, PathDepth: depth, RangeHeader: rangeHeader},
+		{Kind: OperationResolvePath, Workload: WorkloadDeepPathLookup, Path: lookupPath, PathDepth: depth},
 	}, nil
 }
 
-// NewMatrixSystem materializes dataset for one read_matrix system.
-func NewMatrixSystem(ctx context.Context, system SystemName, dataset *MatrixDataset) (MatrixSystem, error) {
+// NewMatrixSystem materializes dataset for one read_matrix system and CAS
+// latency point. Only CAS Get has latency; setup writes remain zero-latency.
+func NewMatrixSystem(ctx context.Context, system SystemName, dataset *MatrixDataset, casLatencyMS int) (MatrixSystem, error) {
+	if casLatencyMS < 0 {
+		return nil, fmt.Errorf("cas latency must be non-negative")
+	}
 	switch system {
 	case SystemMALTFlat:
-		return newMatrixMALTSystem(ctx, dataset)
+		return newMatrixMALTSystem(ctx, dataset, casLatencyMS)
 	case SystemMerkleDAG, SystemHAMT:
-		return newMatrixBaselineSystem(ctx, system, dataset)
+		return newMatrixBaselineSystem(ctx, system, dataset, casLatencyMS)
 	default:
 		return nil, fmt.Errorf("unknown system %q", system)
 	}
 }
 
 type matrixMALTSystem struct {
-	store  *casmock.CAS
-	table  *versioned.ArcTable
-	layout *unixfs.Layout
-	root   cid.Cid
+	inner        *LocalMALTSystem
+	casLatencyMS int
 }
 
-func newMatrixMALTSystem(ctx context.Context, dataset *MatrixDataset) (*matrixMALTSystem, error) {
+func newMatrixMALTSystem(ctx context.Context, dataset *MatrixDataset, casLatencyMS int) (*matrixMALTSystem, error) {
 	if dataset == nil {
 		return nil, fmt.Errorf("dataset is nil")
 	}
-	store := casmock.NewCAS()
-	table, err := versioned.NewArcTable(versioned.WithKVStore(memory.New()))
+	store := newMatrixCAS(casLatencyMS)
+	inner, err := NewLocalMALTSystemWithFiles(ctx, store, dataset.Files)
 	if err != nil {
-		return nil, fmt.Errorf("create arctable: %w", err)
-	}
-	scheme, err := kzg.NewScheme()
-	if err != nil {
-		_ = table.Close()
-		return nil, fmt.Errorf("create commitment scheme: %w", err)
-	}
-	maps, err := mappingradix.NewMap(scheme, table)
-	if err != nil {
-		_ = table.Close()
-		return nil, fmt.Errorf("create map semantics: %w", err)
-	}
-	lists, err := listtree.NewList(scheme, table)
-	if err != nil {
-		_ = table.Close()
-		return nil, fmt.Errorf("create list semantics: %w", err)
-	}
-	layout, err := unixfs.New(unixfs.Options{
-		Namespace: "read-matrix",
-		ChunkSize: unixfs.DefaultChunkSize,
-		Map:       maps,
-		List:      lists,
-		Blocks:    store,
-	})
-	if err != nil {
-		_ = table.Close()
 		return nil, err
 	}
-	root := cid.Undef
-	for _, file := range dataset.Files {
-		root, err = layout.AddFile(ctx, root, file.Path, file.Data)
-		if err != nil {
-			_ = table.Close()
-			return nil, fmt.Errorf("materialize %s: %w", file.Path, err)
-		}
-	}
-	return &matrixMALTSystem{store: store, table: table, layout: layout, root: root}, nil
+	return &matrixMALTSystem{inner: inner, casLatencyMS: casLatencyMS}, nil
 }
 
 func (s *matrixMALTSystem) Name() SystemName { return SystemMALTFlat }
 
-func (s *matrixMALTSystem) Close() error {
-	if s == nil || s.table == nil {
-		return nil
-	}
-	return s.table.Close()
-}
+func (s *matrixMALTSystem) Close() error { return nil }
 
 func (s *matrixMALTSystem) Measure(ctx context.Context, iteration int, dataset *MatrixDataset, op MatrixOperation) (*Result, error) {
-	if s == nil || s.store == nil || s.layout == nil {
+	if s == nil || s.inner == nil {
 		return nil, fmt.Errorf("malt matrix system is nil")
 	}
-	s.store.ResetStats()
-
-	start := time.Now()
-	resolution, err := s.layout.Resolve(ctx, s.root, op.Path)
-	if err != nil {
-		return nil, fmt.Errorf("malt resolve %q: %w", op.Path, err)
-	}
-	pl, err := unixfs.ProofListFromSteps(s.root, op.Path, resolution.Steps)
-	if err != nil {
-		return nil, fmt.Errorf("malt prooflist %q: %w", op.Path, err)
-	}
-
-	var contentBytes *int
-	switch op.Kind {
-	case OperationResolvePath:
-	case OperationContentFull:
-		data, err := s.store.Get(ctx, resolution.Payload)
-		if err != nil {
-			return nil, fmt.Errorf("malt content read %q: %w", op.Path, err)
-		}
-		count := len(data)
-		contentBytes = &count
-	case OperationContentRange:
-		startOffset, endExclusive, err := parseReadRangeHeader(op.RangeHeader, int64(dataset.LargeFileBytes))
-		if err != nil {
-			return nil, err
-		}
-		length := uint64(endExclusive - startOffset)
-		data, err := s.layout.ReadListPayloadRange(ctx, resolution.Payload, uint64(startOffset), length)
-		if err != nil {
-			return nil, fmt.Errorf("malt range read %q: %w", op.Path, err)
-		}
-		if err := s.layout.AppendListPayloadRangeProof(ctx, pl, op.Path, resolution.Payload, uint64(startOffset), length); err != nil {
-			return nil, fmt.Errorf("malt range proof %q: %w", op.Path, err)
-		}
-		count := len(data)
-		contentBytes = &count
-	default:
+	if op.Kind != OperationResolvePath {
 		return nil, fmt.Errorf("unsupported operation kind %q", op.Kind)
 	}
-	elapsed := positiveElapsedNS(start, time.Now())
-
-	proofStats := proofStatsFor(pl)
-	result := &Result{
-		System:             SystemMALTFlat,
-		OperationKind:      op.Kind,
-		Workload:           op.Workload,
-		Iteration:          iteration,
-		FixtureName:        dataset.Name,
-		Path:               op.Path,
-		RangeHeader:        op.RangeHeader,
-		ElapsedNS:          elapsed,
-		ContentBytes:       contentBytes,
-		ProofListStepCount: len(pl.Steps),
-		EvidenceItemCount:  len(pl.Steps),
-		Target:             resolution.Payload.String(),
-		CAS:                s.store.SnapshotStats(),
-		ArcTable:           metrics.ArcTableStats{},
-		Proof:              proofStats,
+	result, err := s.inner.MeasureResolve(ctx, iteration, dataset.Name, op.Path)
+	if err != nil {
+		return nil, err
 	}
-	attachDatasetMetadata(result, dataset, op)
+	attachDatasetMetadata(result, dataset, op, s.casLatencyMS)
 	return result, nil
 }
 
 type matrixBaselineSystem struct {
-	inner *BaselineSystem
+	inner        *BaselineSystem
+	casLatencyMS int
 }
 
-func newMatrixBaselineSystem(ctx context.Context, system SystemName, dataset *MatrixDataset) (*matrixBaselineSystem, error) {
+func newMatrixBaselineSystem(ctx context.Context, system SystemName, dataset *MatrixDataset, casLatencyMS int) (*matrixBaselineSystem, error) {
 	if dataset == nil {
 		return nil, fmt.Errorf("dataset is nil")
 	}
@@ -206,7 +104,7 @@ func newMatrixBaselineSystem(ctx context.Context, system SystemName, dataset *Ma
 	if err != nil {
 		return nil, err
 	}
-	store := casmock.NewCAS()
+	store := newMatrixCAS(casLatencyMS)
 	files := make([]merkledagimport.File, 0, len(dataset.Files))
 	for _, file := range dataset.Files {
 		files = append(files, merkledagimport.File{
@@ -224,12 +122,15 @@ func newMatrixBaselineSystem(ctx context.Context, system SystemName, dataset *Ma
 	if err != nil {
 		return nil, fmt.Errorf("%s prepare matrix dataset: %w", system, err)
 	}
-	return &matrixBaselineSystem{inner: &BaselineSystem{
-		system: system,
-		store:  store,
-		dag:    dag,
-		root:   imported.Root,
-	}}, nil
+	return &matrixBaselineSystem{
+		inner: &BaselineSystem{
+			system: system,
+			store:  store,
+			dag:    dag,
+			root:   imported.Root,
+		},
+		casLatencyMS: casLatencyMS,
+	}, nil
 }
 
 func (s *matrixBaselineSystem) Name() SystemName {
@@ -246,28 +147,25 @@ func (s *matrixBaselineSystem) Measure(ctx context.Context, iteration int, datas
 		return nil, fmt.Errorf("baseline matrix system is nil")
 	}
 	result, err := s.inner.measureOperation(ctx, iteration, dataset.Name, operation{
-		kind:        op.Kind,
-		workload:    op.Workload,
-		path:        op.Path,
-		rangeHeader: op.RangeHeader,
+		kind:     op.Kind,
+		workload: op.Workload,
+		path:     op.Path,
 	})
 	if err != nil {
 		return nil, err
 	}
-	attachDatasetMetadata(result, dataset, op)
+	attachDatasetMetadata(result, dataset, op, s.casLatencyMS)
 	return result, nil
 }
 
-func proofStatsFor(pl *prooflist.ProofList) metrics.ProofStats {
-	if pl == nil {
-		return metrics.ProofStats{}
-	}
-	var recorder metrics.ProofStatsRecorder
-	recorder.RecordProofList(*pl)
-	return recorder.Snapshot()
+func newMatrixCAS(casLatencyMS int) *casmock.CAS {
+	return casmock.NewCAS(
+		casmock.WithGetLatency(time.Duration(casLatencyMS)*time.Millisecond),
+		casmock.WithJitter(0),
+	)
 }
 
-func attachDatasetMetadata(result *Result, dataset *MatrixDataset, op MatrixOperation) {
+func attachDatasetMetadata(result *Result, dataset *MatrixDataset, op MatrixOperation, casLatencyMS int) {
 	if result == nil || dataset == nil {
 		return
 	}
@@ -279,6 +177,7 @@ func attachDatasetMetadata(result *Result, dataset *MatrixDataset, op MatrixOper
 	result.LogicalPayloadBytes = dataset.LogicalPayloadBytes
 	result.SmallFileBytes = dataset.SmallFileBytes
 	result.LargeFileBytes = dataset.LargeFileBytes
+	result.CASLatencyMS = casLatencyMS
 }
 
 var _ MatrixSystem = (*matrixMALTSystem)(nil)

--- a/cmd/eval/internal/eval/readbench/matrix_systems.go
+++ b/cmd/eval/internal/eval/readbench/matrix_systems.go
@@ -1,0 +1,285 @@
+package readbench
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"time"
+
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	"github.com/dewebprotocol/malt/cmd/internal/merkledagimport"
+	"github.com/dewebprotocol/malt/layout/unixfs"
+	"github.com/dewebprotocol/malt/runtime/arctable/versioned"
+	"github.com/dewebprotocol/malt/runtime/metrics"
+	listtree "github.com/dewebprotocol/malt/runtime/semantic/list/tree"
+	mappingradix "github.com/dewebprotocol/malt/runtime/semantic/mapping/radix"
+	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
+	"github.com/dewebprotocol/malt/storage/kv/memory"
+	cid "github.com/ipfs/go-cid"
+)
+
+// MatrixOperation is one read operation measured against a shared dataset.
+type MatrixOperation struct {
+	Kind        OperationKind
+	Workload    WorkloadKind
+	Path        string
+	PathDepth   int
+	RangeHeader string
+}
+
+// MatrixSystem measures read operations for one materialized representation.
+type MatrixSystem interface {
+	Name() SystemName
+	Measure(context.Context, int, *MatrixDataset, MatrixOperation) (*Result, error)
+	Close() error
+}
+
+// MatrixOperations returns the paper-facing read operations at one depth.
+func MatrixOperations(dataset *MatrixDataset, depth int, rangeHeader string) ([]MatrixOperation, error) {
+	if dataset == nil {
+		return nil, fmt.Errorf("dataset is nil")
+	}
+	smallPath := dataset.SmallPaths[depth]
+	largePath := dataset.LargePaths[depth]
+	if smallPath == "" || largePath == "" {
+		return nil, fmt.Errorf("dataset %q has no measured paths at depth %d", dataset.Name, depth)
+	}
+	return []MatrixOperation{
+		{Kind: OperationResolvePath, Workload: WorkloadDeepPathLookup, Path: smallPath, PathDepth: depth},
+		{Kind: OperationContentFull, Workload: WorkloadSmallFileRead, Path: smallPath, PathDepth: depth},
+		{Kind: OperationContentRange, Workload: WorkloadLargeFileRangeRead, Path: largePath, PathDepth: depth, RangeHeader: rangeHeader},
+	}, nil
+}
+
+// NewMatrixSystem materializes dataset for one read_matrix system.
+func NewMatrixSystem(ctx context.Context, system SystemName, dataset *MatrixDataset) (MatrixSystem, error) {
+	switch system {
+	case SystemMALTFlat:
+		return newMatrixMALTSystem(ctx, dataset)
+	case SystemMerkleDAG, SystemHAMT:
+		return newMatrixBaselineSystem(ctx, system, dataset)
+	default:
+		return nil, fmt.Errorf("unknown system %q", system)
+	}
+}
+
+type matrixMALTSystem struct {
+	store  *casmock.CAS
+	table  *versioned.ArcTable
+	layout *unixfs.Layout
+	root   cid.Cid
+}
+
+func newMatrixMALTSystem(ctx context.Context, dataset *MatrixDataset) (*matrixMALTSystem, error) {
+	if dataset == nil {
+		return nil, fmt.Errorf("dataset is nil")
+	}
+	store := casmock.NewCAS()
+	table, err := versioned.NewArcTable(versioned.WithKVStore(memory.New()))
+	if err != nil {
+		return nil, fmt.Errorf("create arctable: %w", err)
+	}
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		_ = table.Close()
+		return nil, fmt.Errorf("create commitment scheme: %w", err)
+	}
+	maps, err := mappingradix.NewMap(scheme, table)
+	if err != nil {
+		_ = table.Close()
+		return nil, fmt.Errorf("create map semantics: %w", err)
+	}
+	lists, err := listtree.NewList(scheme, table)
+	if err != nil {
+		_ = table.Close()
+		return nil, fmt.Errorf("create list semantics: %w", err)
+	}
+	layout, err := unixfs.New(unixfs.Options{
+		Namespace: "read-matrix",
+		ChunkSize: unixfs.DefaultChunkSize,
+		Map:       maps,
+		List:      lists,
+		Blocks:    store,
+	})
+	if err != nil {
+		_ = table.Close()
+		return nil, err
+	}
+	root := cid.Undef
+	for _, file := range dataset.Files {
+		root, err = layout.AddFile(ctx, root, file.Path, file.Data)
+		if err != nil {
+			_ = table.Close()
+			return nil, fmt.Errorf("materialize %s: %w", file.Path, err)
+		}
+	}
+	return &matrixMALTSystem{store: store, table: table, layout: layout, root: root}, nil
+}
+
+func (s *matrixMALTSystem) Name() SystemName { return SystemMALTFlat }
+
+func (s *matrixMALTSystem) Close() error {
+	if s == nil || s.table == nil {
+		return nil
+	}
+	return s.table.Close()
+}
+
+func (s *matrixMALTSystem) Measure(ctx context.Context, iteration int, dataset *MatrixDataset, op MatrixOperation) (*Result, error) {
+	if s == nil || s.store == nil || s.layout == nil {
+		return nil, fmt.Errorf("malt matrix system is nil")
+	}
+	s.store.ResetStats()
+
+	start := time.Now()
+	resolution, err := s.layout.Resolve(ctx, s.root, op.Path)
+	if err != nil {
+		return nil, fmt.Errorf("malt resolve %q: %w", op.Path, err)
+	}
+	pl, err := unixfs.ProofListFromSteps(s.root, op.Path, resolution.Steps)
+	if err != nil {
+		return nil, fmt.Errorf("malt prooflist %q: %w", op.Path, err)
+	}
+
+	var contentBytes *int
+	switch op.Kind {
+	case OperationResolvePath:
+	case OperationContentFull:
+		data, err := s.store.Get(ctx, resolution.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("malt content read %q: %w", op.Path, err)
+		}
+		count := len(data)
+		contentBytes = &count
+	case OperationContentRange:
+		startOffset, endExclusive, err := parseReadRangeHeader(op.RangeHeader, int64(dataset.LargeFileBytes))
+		if err != nil {
+			return nil, err
+		}
+		length := uint64(endExclusive - startOffset)
+		data, err := s.layout.ReadListPayloadRange(ctx, resolution.Payload, uint64(startOffset), length)
+		if err != nil {
+			return nil, fmt.Errorf("malt range read %q: %w", op.Path, err)
+		}
+		if err := s.layout.AppendListPayloadRangeProof(ctx, pl, op.Path, resolution.Payload, uint64(startOffset), length); err != nil {
+			return nil, fmt.Errorf("malt range proof %q: %w", op.Path, err)
+		}
+		count := len(data)
+		contentBytes = &count
+	default:
+		return nil, fmt.Errorf("unsupported operation kind %q", op.Kind)
+	}
+	elapsed := positiveElapsedNS(start, time.Now())
+
+	proofStats := proofStatsFor(pl)
+	result := &Result{
+		System:             SystemMALTFlat,
+		OperationKind:      op.Kind,
+		Workload:           op.Workload,
+		Iteration:          iteration,
+		FixtureName:        dataset.Name,
+		Path:               op.Path,
+		RangeHeader:        op.RangeHeader,
+		ElapsedNS:          elapsed,
+		ContentBytes:       contentBytes,
+		ProofListStepCount: len(pl.Steps),
+		EvidenceItemCount:  len(pl.Steps),
+		Target:             resolution.Payload.String(),
+		CAS:                s.store.SnapshotStats(),
+		ArcTable:           metrics.ArcTableStats{},
+		Proof:              proofStats,
+	}
+	attachDatasetMetadata(result, dataset, op)
+	return result, nil
+}
+
+type matrixBaselineSystem struct {
+	inner *BaselineSystem
+}
+
+func newMatrixBaselineSystem(ctx context.Context, system SystemName, dataset *MatrixDataset) (*matrixBaselineSystem, error) {
+	if dataset == nil {
+		return nil, fmt.Errorf("dataset is nil")
+	}
+	dirLayout, err := baselineDirLayout(system)
+	if err != nil {
+		return nil, err
+	}
+	store := casmock.NewCAS()
+	files := make([]merkledagimport.File, 0, len(dataset.Files))
+	for _, file := range dataset.Files {
+		files = append(files, merkledagimport.File{
+			Path: file.Path,
+			Data: file.Data,
+			Mode: fs.FileMode(0o644),
+		})
+	}
+	dag := merkledagimport.NewDAGService(store)
+	imported, err := merkledagimport.ImportFiles(ctx, store, files, merkledagimport.Options{
+		Model:      merkledagimport.ModelUnixFS,
+		FileLayout: merkledagimport.FileLayoutBalanced,
+		DirLayout:  dirLayout,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s prepare matrix dataset: %w", system, err)
+	}
+	return &matrixBaselineSystem{inner: &BaselineSystem{
+		system: system,
+		store:  store,
+		dag:    dag,
+		root:   imported.Root,
+	}}, nil
+}
+
+func (s *matrixBaselineSystem) Name() SystemName {
+	if s == nil || s.inner == nil {
+		return ""
+	}
+	return s.inner.system
+}
+
+func (s *matrixBaselineSystem) Close() error { return nil }
+
+func (s *matrixBaselineSystem) Measure(ctx context.Context, iteration int, dataset *MatrixDataset, op MatrixOperation) (*Result, error) {
+	if s == nil || s.inner == nil {
+		return nil, fmt.Errorf("baseline matrix system is nil")
+	}
+	result, err := s.inner.measureOperation(ctx, iteration, dataset.Name, operation{
+		kind:        op.Kind,
+		workload:    op.Workload,
+		path:        op.Path,
+		rangeHeader: op.RangeHeader,
+	})
+	if err != nil {
+		return nil, err
+	}
+	attachDatasetMetadata(result, dataset, op)
+	return result, nil
+}
+
+func proofStatsFor(pl *prooflist.ProofList) metrics.ProofStats {
+	if pl == nil {
+		return metrics.ProofStats{}
+	}
+	var recorder metrics.ProofStatsRecorder
+	recorder.RecordProofList(*pl)
+	return recorder.Snapshot()
+}
+
+func attachDatasetMetadata(result *Result, dataset *MatrixDataset, op MatrixOperation) {
+	if result == nil || dataset == nil {
+		return
+	}
+	result.DatasetName = dataset.Name
+	result.FileCount = dataset.FileCount
+	result.DirectoryCount = dataset.DirectoryCount
+	result.PathCount = dataset.PathCount
+	result.PathDepth = op.PathDepth
+	result.LogicalPayloadBytes = dataset.LogicalPayloadBytes
+	result.SmallFileBytes = dataset.SmallFileBytes
+	result.LargeFileBytes = dataset.LargeFileBytes
+}
+
+var _ MatrixSystem = (*matrixMALTSystem)(nil)
+var _ MatrixSystem = (*matrixBaselineSystem)(nil)

--- a/cmd/eval/internal/eval/readbench/matrix_systems.go
+++ b/cmd/eval/internal/eval/readbench/matrix_systems.go
@@ -83,7 +83,7 @@ func (s *matrixMALTSystem) Measure(ctx context.Context, iteration int, dataset *
 	if op.Kind != OperationResolvePath {
 		return nil, fmt.Errorf("unsupported operation kind %q", op.Kind)
 	}
-	result, err := s.inner.MeasureResolve(ctx, iteration, dataset.Name, op.Path)
+	result, err := s.inner.MeasureResolveWithTargetFetch(ctx, iteration, dataset.Name, op.Path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/eval/internal/eval/readbench/matrix_systems.go
+++ b/cmd/eval/internal/eval/readbench/matrix_systems.go
@@ -26,6 +26,12 @@ type MatrixSystem interface {
 	Close() error
 }
 
+// MatrixProveSystem optionally exposes proof/open generation timing for flat
+// MALT systems. Baselines that do not generate ProofList evidence omit it.
+type MatrixProveSystem interface {
+	MeasureProve(context.Context, int, *MatrixDataset, MatrixOperation) (*int64, error)
+}
+
 // MatrixOperations returns the paper-facing path lookup operation at one depth.
 func MatrixOperations(dataset *MatrixDataset, depth int) ([]MatrixOperation, error) {
 	if dataset == nil {
@@ -100,6 +106,16 @@ func (s *matrixMALTSystem) Measure(ctx context.Context, iteration int, dataset *
 	}
 	attachDatasetMetadata(result, dataset, op, s.casLatencyMS)
 	return result, nil
+}
+
+func (s *matrixMALTSystem) MeasureProve(ctx context.Context, _ int, _ *MatrixDataset, op MatrixOperation) (*int64, error) {
+	if s == nil || s.inner == nil {
+		return nil, fmt.Errorf("malt matrix system is nil")
+	}
+	if op.Kind != OperationResolvePath {
+		return nil, fmt.Errorf("unsupported operation kind %q", op.Kind)
+	}
+	return s.inner.MeasureProve(ctx, op.Path)
 }
 
 type matrixBaselineSystem struct {
@@ -194,3 +210,4 @@ func attachDatasetMetadata(result *Result, dataset *MatrixDataset, op MatrixOper
 
 var _ MatrixSystem = (*matrixMALTSystem)(nil)
 var _ MatrixSystem = (*matrixBaselineSystem)(nil)
+var _ MatrixProveSystem = (*matrixMALTSystem)(nil)

--- a/cmd/eval/internal/eval/readbench/matrix_systems.go
+++ b/cmd/eval/internal/eval/readbench/matrix_systems.go
@@ -12,10 +12,11 @@ import (
 
 // MatrixOperation is one read operation measured against a shared dataset.
 type MatrixOperation struct {
-	Kind      OperationKind
-	Workload  WorkloadKind
-	Path      string
-	PathDepth int
+	Kind       OperationKind
+	Workload   WorkloadKind
+	Path       string
+	PathDepth  int
+	PathSample int
 }
 
 // MatrixSystem measures read operations for one materialized representation.
@@ -30,13 +31,21 @@ func MatrixOperations(dataset *MatrixDataset, depth int) ([]MatrixOperation, err
 	if dataset == nil {
 		return nil, fmt.Errorf("dataset is nil")
 	}
-	lookupPath := dataset.SmallPaths[depth]
-	if lookupPath == "" {
+	lookupPaths := dataset.LookupPaths[depth]
+	if len(lookupPaths) == 0 {
 		return nil, fmt.Errorf("dataset %q has no measured path at depth %d", dataset.Name, depth)
 	}
-	return []MatrixOperation{
-		{Kind: OperationResolvePath, Workload: WorkloadDeepPathLookup, Path: lookupPath, PathDepth: depth},
-	}, nil
+	ops := make([]MatrixOperation, 0, len(lookupPaths))
+	for i, lookupPath := range lookupPaths {
+		ops = append(ops, MatrixOperation{
+			Kind:       OperationResolvePath,
+			Workload:   WorkloadDeepPathLookup,
+			Path:       lookupPath,
+			PathDepth:  depth,
+			PathSample: i + 1,
+		})
+	}
+	return ops, nil
 }
 
 // NewMatrixSystem materializes dataset for one read_matrix system and CAS
@@ -50,6 +59,8 @@ func NewMatrixSystem(ctx context.Context, system SystemName, dataset *MatrixData
 		return newMatrixMALTSystem(ctx, dataset, casLatencyMS)
 	case SystemMerkleDAG, SystemHAMT:
 		return newMatrixBaselineSystem(ctx, system, dataset, casLatencyMS)
+	case SystemFlatHAMT:
+		return newMatrixFlatHAMTSystem(ctx, dataset, casLatencyMS)
 	default:
 		return nil, fmt.Errorf("unknown system %q", system)
 	}
@@ -174,6 +185,7 @@ func attachDatasetMetadata(result *Result, dataset *MatrixDataset, op MatrixOper
 	result.DirectoryCount = dataset.DirectoryCount
 	result.PathCount = dataset.PathCount
 	result.PathDepth = op.PathDepth
+	result.PathSample = op.PathSample
 	result.LogicalPayloadBytes = dataset.LogicalPayloadBytes
 	result.SmallFileBytes = dataset.SmallFileBytes
 	result.LargeFileBytes = dataset.LargeFileBytes

--- a/cmd/eval/internal/eval/readbench/runner.go
+++ b/cmd/eval/internal/eval/readbench/runner.go
@@ -88,6 +88,7 @@ type Result struct {
 	DirectoryCount      int                   `json:"directory_count,omitempty"`
 	PathCount           int                   `json:"path_count,omitempty"`
 	PathDepth           int                   `json:"path_depth,omitempty"`
+	PathSample          int                   `json:"path_sample,omitempty"`
 	LogicalPayloadBytes int64                 `json:"logical_payload_bytes,omitempty"`
 	SmallFileBytes      int                   `json:"small_file_bytes,omitempty"`
 	LargeFileBytes      int                   `json:"large_file_bytes,omitempty"`
@@ -388,6 +389,11 @@ func normalizeRunConfig(cfg RunConfig) (RunConfig, error) {
 	systems, err := normalizeSystems(cfg.Systems)
 	if err != nil {
 		return RunConfig{}, err
+	}
+	for _, system := range systems {
+		if system == SystemFlatHAMT {
+			return RunConfig{}, fmt.Errorf("system %q is only supported by read_matrix", system)
+		}
 	}
 	fixture, err := normalizeFixtureConfig(cfg.Fixture)
 	if err != nil {

--- a/cmd/eval/internal/eval/readbench/runner.go
+++ b/cmd/eval/internal/eval/readbench/runner.go
@@ -96,6 +96,7 @@ type Result struct {
 	Path                string                `json:"path"`
 	RangeHeader         string                `json:"range_header,omitempty"`
 	ElapsedNS           int64                 `json:"elapsed_ns"`
+	ProveElapsedNS      *int64                `json:"prove_elapsed_ns,omitempty"`
 	VerifyElapsedNS     *int64                `json:"verify_elapsed_ns,omitempty"`
 	ContentBytes        *int                  `json:"content_bytes,omitempty"`
 	ProofListStepCount  int                   `json:"prooflist_step_count"`

--- a/cmd/eval/internal/eval/readbench/runner.go
+++ b/cmd/eval/internal/eval/readbench/runner.go
@@ -91,6 +91,7 @@ type Result struct {
 	LogicalPayloadBytes int64                 `json:"logical_payload_bytes,omitempty"`
 	SmallFileBytes      int                   `json:"small_file_bytes,omitempty"`
 	LargeFileBytes      int                   `json:"large_file_bytes,omitempty"`
+	CASLatencyMS        int                   `json:"cas_latency_ms"`
 	Path                string                `json:"path"`
 	RangeHeader         string                `json:"range_header,omitempty"`
 	ElapsedNS           int64                 `json:"elapsed_ns"`

--- a/cmd/eval/internal/eval/readbench/runner.go
+++ b/cmd/eval/internal/eval/readbench/runner.go
@@ -78,22 +78,30 @@ type Fixture struct {
 
 // Result is one benchmark JSONL record.
 type Result struct {
-	System             SystemName            `json:"system"`
-	OperationKind      OperationKind         `json:"operation_kind"`
-	Workload           WorkloadKind          `json:"workload"`
-	Iteration          int                   `json:"iteration"`
-	FixtureName        string                `json:"fixture"`
-	Path               string                `json:"path"`
-	RangeHeader        string                `json:"range_header,omitempty"`
-	ElapsedNS          int64                 `json:"elapsed_ns"`
-	VerifyElapsedNS    *int64                `json:"verify_elapsed_ns,omitempty"`
-	ContentBytes       *int                  `json:"content_bytes,omitempty"`
-	ProofListStepCount int                   `json:"prooflist_step_count"`
-	EvidenceItemCount  int                   `json:"evidence_item_count"`
-	Target             string                `json:"target,omitempty"`
-	CAS                metrics.CASStats      `json:"cas"`
-	ArcTable           metrics.ArcTableStats `json:"arctable"`
-	Proof              metrics.ProofStats    `json:"proof"`
+	System              SystemName            `json:"system"`
+	OperationKind       OperationKind         `json:"operation_kind"`
+	Workload            WorkloadKind          `json:"workload"`
+	Iteration           int                   `json:"iteration"`
+	FixtureName         string                `json:"fixture"`
+	DatasetName         string                `json:"dataset,omitempty"`
+	FileCount           int                   `json:"file_count,omitempty"`
+	DirectoryCount      int                   `json:"directory_count,omitempty"`
+	PathCount           int                   `json:"path_count,omitempty"`
+	PathDepth           int                   `json:"path_depth,omitempty"`
+	LogicalPayloadBytes int64                 `json:"logical_payload_bytes,omitempty"`
+	SmallFileBytes      int                   `json:"small_file_bytes,omitempty"`
+	LargeFileBytes      int                   `json:"large_file_bytes,omitempty"`
+	Path                string                `json:"path"`
+	RangeHeader         string                `json:"range_header,omitempty"`
+	ElapsedNS           int64                 `json:"elapsed_ns"`
+	VerifyElapsedNS     *int64                `json:"verify_elapsed_ns,omitempty"`
+	ContentBytes        *int                  `json:"content_bytes,omitempty"`
+	ProofListStepCount  int                   `json:"prooflist_step_count"`
+	EvidenceItemCount   int                   `json:"evidence_item_count"`
+	Target              string                `json:"target,omitempty"`
+	CAS                 metrics.CASStats      `json:"cas"`
+	ArcTable            metrics.ArcTableStats `json:"arctable"`
+	Proof               metrics.ProofStats    `json:"proof"`
 }
 
 type operation struct {

--- a/cmd/eval/internal/eval/readbench/runner.go
+++ b/cmd/eval/internal/eval/readbench/runner.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	httpapi "github.com/dewebprotocol/malt/api/http"
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
 	"github.com/dewebprotocol/malt/runtime/metrics"
 	daemonclient "github.com/dewebprotocol/malt/sdk/client"
 )
@@ -34,7 +36,17 @@ type OperationKind string
 
 const (
 	OperationResolvePath  OperationKind = "resolve_path"
+	OperationContentFull  OperationKind = "content_full"
 	OperationContentRange OperationKind = "content_range"
+)
+
+// WorkloadKind identifies the paper-facing read scenario measured by a record.
+type WorkloadKind string
+
+const (
+	WorkloadDeepPathLookup     WorkloadKind = "deep_path_lookup"
+	WorkloadSmallFileRead      WorkloadKind = "small_file_read"
+	WorkloadLargeFileRangeRead WorkloadKind = "large_file_range_read"
 )
 
 // FixtureConfig controls the deterministic fixture fixture.
@@ -68,11 +80,13 @@ type Fixture struct {
 type Result struct {
 	System             SystemName            `json:"system"`
 	OperationKind      OperationKind         `json:"operation_kind"`
+	Workload           WorkloadKind          `json:"workload"`
 	Iteration          int                   `json:"iteration"`
 	FixtureName        string                `json:"fixture"`
 	Path               string                `json:"path"`
 	RangeHeader        string                `json:"range_header,omitempty"`
 	ElapsedNS          int64                 `json:"elapsed_ns"`
+	VerifyElapsedNS    *int64                `json:"verify_elapsed_ns,omitempty"`
 	ContentBytes       *int                  `json:"content_bytes,omitempty"`
 	ProofListStepCount int                   `json:"prooflist_step_count"`
 	EvidenceItemCount  int                   `json:"evidence_item_count"`
@@ -84,6 +98,7 @@ type Result struct {
 
 type operation struct {
 	kind        OperationKind
+	workload    WorkloadKind
 	path        string
 	rangeHeader string
 }
@@ -187,8 +202,9 @@ func (r *Runner) RunJSONL(ctx context.Context, cfg RunConfig, w io.Writer) error
 	}
 
 	ops := []operation{
-		{kind: OperationResolvePath, path: fixture.SmallPath},
-		{kind: OperationContentRange, path: fixture.LargePath, rangeHeader: normalized.RangeHeader},
+		{kind: OperationResolvePath, workload: WorkloadDeepPathLookup, path: fixture.SmallPath},
+		{kind: OperationContentFull, workload: WorkloadSmallFileRead, path: fixture.SmallPath},
+		{kind: OperationContentRange, workload: WorkloadLargeFileRangeRead, path: fixture.LargePath, rangeHeader: normalized.RangeHeader},
 	}
 
 	enc := json.NewEncoder(w)
@@ -226,9 +242,11 @@ func (r *Runner) measureOperation(ctx context.Context, iteration int, fixture st
 
 	start := time.Now()
 	var (
-		target       string
-		contentBytes *int
-		stepCount    int
+		target          string
+		contentBytes    *int
+		stepCount       int
+		pl              *prooflist.ProofList
+		verifyElapsedNS *int64
 	)
 	switch op.kind {
 	case OperationResolvePath:
@@ -236,16 +254,20 @@ func (r *Runner) measureOperation(ctx context.Context, iteration int, fixture st
 		if err != nil {
 			return nil, fmt.Errorf("resolve path %q: %w", op.path, err)
 		}
+		if resp.ProofList == nil {
+			return nil, fmt.Errorf("resolve path %q returned no prooflist", op.path)
+		}
 		target = resp.Target
-		stepCount = len(resp.ProofList.Steps)
-	case OperationContentRange:
+		pl = resp.ProofList
+		stepCount = len(pl.Steps)
+	case OperationContentFull, OperationContentRange:
 		content, _, headers, err := r.client.GetContent(ctx, r.root, op.path, op.rangeHeader)
 		if err != nil {
-			return nil, fmt.Errorf("content range read %q: %w", op.path, err)
+			return nil, fmt.Errorf("%s read %q: %w", op.kind, op.path, err)
 		}
-		pl, err := daemonclient.ProofListFromHeaders(headers)
+		pl, err = daemonclient.ProofListFromHeaders(headers)
 		if err != nil {
-			return nil, fmt.Errorf("content range prooflist %q: %w", op.path, err)
+			return nil, fmt.Errorf("%s prooflist %q: %w", op.kind, op.path, err)
 		}
 		count := len(content)
 		contentBytes = &count
@@ -259,15 +281,21 @@ func (r *Runner) measureOperation(ctx context.Context, iteration int, fixture st
 	if err != nil {
 		return nil, fmt.Errorf("snapshot metrics after %s: %w", op.kind, err)
 	}
+	verifyElapsedNS, err = r.verifyProofList(ctx, op, pl)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Result{
 		System:             SystemMALTFlat,
 		OperationKind:      op.kind,
+		Workload:           op.workload,
 		Iteration:          iteration,
 		FixtureName:        fixture,
 		Path:               op.path,
 		RangeHeader:        op.rangeHeader,
 		ElapsedNS:          elapsed,
+		VerifyElapsedNS:    verifyElapsedNS,
 		ContentBytes:       contentBytes,
 		ProofListStepCount: stepCount,
 		EvidenceItemCount:  stepCount,
@@ -276,6 +304,22 @@ func (r *Runner) measureOperation(ctx context.Context, iteration int, fixture st
 		ArcTable:           snapshot.ArcTable,
 		Proof:              snapshot.Proof,
 	}, nil
+}
+
+func (r *Runner) verifyProofList(ctx context.Context, op operation, pl *prooflist.ProofList) (*int64, error) {
+	if pl == nil {
+		return nil, fmt.Errorf("%s prooflist is nil", op.kind)
+	}
+	start := time.Now()
+	resp, err := r.client.Verify(ctx, &httpapi.VerifyRequest{ProofList: *pl})
+	elapsed := positiveElapsedNS(start, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("%s verify prooflist %q: %w", op.kind, op.path, err)
+	}
+	if !resp.Valid {
+		return nil, fmt.Errorf("%s prooflist %q did not verify", op.kind, op.path)
+	}
+	return &elapsed, nil
 }
 
 func positiveElapsedNS(start, end time.Time) int64 {

--- a/cmd/eval/internal/eval/readbench/runner_test.go
+++ b/cmd/eval/internal/eval/readbench/runner_test.go
@@ -187,8 +187,8 @@ func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 	}
 
 	got := decodeJSONLResults(t, out.Bytes())
-	if len(got) != 2 {
-		t.Fatalf("result count = %d, want 2\n%s", len(got), out.String())
+	if len(got) != 3 {
+		t.Fatalf("result count = %d, want 3\n%s", len(got), out.String())
 	}
 
 	proofRead := got[0]
@@ -197,6 +197,9 @@ func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 	}
 	if proofRead.OperationKind != OperationResolvePath {
 		t.Fatalf("first operation = %q, want %q", proofRead.OperationKind, OperationResolvePath)
+	}
+	if proofRead.Workload != WorkloadDeepPathLookup {
+		t.Fatalf("first workload = %q, want %q", proofRead.Workload, WorkloadDeepPathLookup)
 	}
 	if proofRead.FixtureName != "readbench-run" || proofRead.Path != "dir00/dir01/small.txt" {
 		t.Fatalf("proof read target = fixture %q path %q", proofRead.FixtureName, proofRead.Path)
@@ -219,6 +222,9 @@ func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 	if proofRead.Proof.ProofListCount != 1 {
 		t.Fatalf("prooflist proof metric count = %d, want 1", proofRead.Proof.ProofListCount)
 	}
+	if proofRead.VerifyElapsedNS == nil || *proofRead.VerifyElapsedNS <= 0 {
+		t.Fatalf("verify elapsed ns = %v, want positive MALT verification latency", proofRead.VerifyElapsedNS)
+	}
 	if proofRead.Proof.StepCount != uint64(proofRead.ProofListStepCount) {
 		t.Fatalf("prooflist proof metric steps = %d, result steps = %d", proofRead.Proof.StepCount, proofRead.ProofListStepCount)
 	}
@@ -226,12 +232,41 @@ func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 		t.Fatalf("prooflist arctable metrics should include reads: %+v", proofRead.ArcTable)
 	}
 
-	rangeRead := got[1]
+	smallRead := got[1]
+	if smallRead.System != SystemMALTFlat {
+		t.Fatalf("second system = %q, want %q", smallRead.System, SystemMALTFlat)
+	}
+	if smallRead.OperationKind != OperationContentFull {
+		t.Fatalf("second operation = %q, want %q", smallRead.OperationKind, OperationContentFull)
+	}
+	if smallRead.Workload != WorkloadSmallFileRead {
+		t.Fatalf("second workload = %q, want %q", smallRead.Workload, WorkloadSmallFileRead)
+	}
+	if smallRead.Path != "dir00/dir01/small.txt" {
+		t.Fatalf("small read path = %q", smallRead.Path)
+	}
+	if smallRead.RangeHeader != "" {
+		t.Fatalf("small read range header = %q, want empty", smallRead.RangeHeader)
+	}
+	if smallRead.ContentBytes == nil || *smallRead.ContentBytes != 48 {
+		t.Fatalf("small content bytes = %v, want 48", smallRead.ContentBytes)
+	}
+	if smallRead.ProofListStepCount == 0 {
+		t.Fatal("small read prooflist step count should be recorded")
+	}
+	if smallRead.VerifyElapsedNS == nil || *smallRead.VerifyElapsedNS <= 0 {
+		t.Fatalf("small read verify elapsed ns = %v, want positive", smallRead.VerifyElapsedNS)
+	}
+
+	rangeRead := got[2]
 	if rangeRead.System != SystemMALTFlat {
-		t.Fatalf("second system = %q, want %q", rangeRead.System, SystemMALTFlat)
+		t.Fatalf("third system = %q, want %q", rangeRead.System, SystemMALTFlat)
 	}
 	if rangeRead.OperationKind != OperationContentRange {
-		t.Fatalf("second operation = %q, want %q", rangeRead.OperationKind, OperationContentRange)
+		t.Fatalf("third operation = %q, want %q", rangeRead.OperationKind, OperationContentRange)
+	}
+	if rangeRead.Workload != WorkloadLargeFileRangeRead {
+		t.Fatalf("third workload = %q, want %q", rangeRead.Workload, WorkloadLargeFileRangeRead)
 	}
 	if rangeRead.Path != "dir00/dir01/large.bin" {
 		t.Fatalf("content range path = %q", rangeRead.Path)
@@ -250,6 +285,9 @@ func TestRunJSONLMeasuresResolveAndContentRange(t *testing.T) {
 	}
 	if rangeRead.Proof.ProofListCount != 1 {
 		t.Fatalf("content proof metric count = %d, want reset per operation", rangeRead.Proof.ProofListCount)
+	}
+	if rangeRead.VerifyElapsedNS == nil || *rangeRead.VerifyElapsedNS <= 0 {
+		t.Fatalf("range read verify elapsed ns = %v, want positive", rangeRead.VerifyElapsedNS)
 	}
 	if rangeRead.CAS.GetCount == 0 || rangeRead.CAS.BytesGet == 0 {
 		t.Fatalf("content range CAS metrics should include bytes fetched: %+v", rangeRead.CAS)
@@ -277,11 +315,11 @@ func TestRunJSONLEmitsUnixFSBaselines(t *testing.T) {
 	}
 
 	got := decodeJSONLResults(t, out.Bytes())
-	if len(got) != 4 {
-		t.Fatalf("result count = %d, want 4\n%s", len(got), out.String())
+	if len(got) != 6 {
+		t.Fatalf("result count = %d, want 6\n%s", len(got), out.String())
 	}
 
-	wantSystems := []SystemName{SystemMerkleDAG, SystemMerkleDAG, SystemHAMT, SystemHAMT}
+	wantSystems := []SystemName{SystemMerkleDAG, SystemMerkleDAG, SystemMerkleDAG, SystemHAMT, SystemHAMT, SystemHAMT}
 	for i, result := range got {
 		if result.System != wantSystems[i] {
 			t.Fatalf("record %d system = %q, want %q", i, result.System, wantSystems[i])
@@ -304,12 +342,18 @@ func TestRunJSONLEmitsUnixFSBaselines(t *testing.T) {
 		if result.Proof != (metrics.ProofStats{}) {
 			t.Fatalf("record %d proof metrics = %+v, want zero baseline metrics", i, result.Proof)
 		}
+		if result.VerifyElapsedNS != nil {
+			t.Fatalf("record %d verify elapsed ns = %v, want omitted for IPLD baseline", i, result.VerifyElapsedNS)
+		}
 	}
 
-	resolveRecords := []Result{got[0], got[2]}
+	resolveRecords := []Result{got[0], got[3]}
 	for _, result := range resolveRecords {
 		if result.OperationKind != OperationResolvePath {
 			t.Fatalf("%s first operation = %q, want %q", result.System, result.OperationKind, OperationResolvePath)
+		}
+		if result.Workload != WorkloadDeepPathLookup {
+			t.Fatalf("%s first workload = %q, want %q", result.System, result.Workload, WorkloadDeepPathLookup)
 		}
 		if result.Path != "dir00/dir01/small.txt" {
 			t.Fatalf("%s resolve path = %q", result.System, result.Path)
@@ -322,10 +366,32 @@ func TestRunJSONLEmitsUnixFSBaselines(t *testing.T) {
 		}
 	}
 
-	rangeRecords := []Result{got[1], got[3]}
+	smallReadRecords := []Result{got[1], got[4]}
+	for _, result := range smallReadRecords {
+		if result.OperationKind != OperationContentFull {
+			t.Fatalf("%s second operation = %q, want %q", result.System, result.OperationKind, OperationContentFull)
+		}
+		if result.Workload != WorkloadSmallFileRead {
+			t.Fatalf("%s second workload = %q, want %q", result.System, result.Workload, WorkloadSmallFileRead)
+		}
+		if result.Path != "dir00/dir01/small.txt" {
+			t.Fatalf("%s small read path = %q", result.System, result.Path)
+		}
+		if result.RangeHeader != "" {
+			t.Fatalf("%s small read range header = %q, want empty", result.System, result.RangeHeader)
+		}
+		if result.ContentBytes == nil || *result.ContentBytes != 48 {
+			t.Fatalf("%s small content bytes = %v, want 48", result.System, result.ContentBytes)
+		}
+	}
+
+	rangeRecords := []Result{got[2], got[5]}
 	for _, result := range rangeRecords {
 		if result.OperationKind != OperationContentRange {
-			t.Fatalf("%s second operation = %q, want %q", result.System, result.OperationKind, OperationContentRange)
+			t.Fatalf("%s third operation = %q, want %q", result.System, result.OperationKind, OperationContentRange)
+		}
+		if result.Workload != WorkloadLargeFileRangeRead {
+			t.Fatalf("%s third workload = %q, want %q", result.System, result.Workload, WorkloadLargeFileRangeRead)
 		}
 		if result.Path != "dir00/dir01/large.bin" {
 			t.Fatalf("%s range path = %q", result.System, result.Path)

--- a/cmd/eval/internal/eval/readbench/runner_test.go
+++ b/cmd/eval/internal/eval/readbench/runner_test.go
@@ -505,6 +505,16 @@ func TestNormalizeRunConfigRejectsUnknownSystem(t *testing.T) {
 	}
 }
 
+func TestNormalizeRunConfigRejectsFlatHAMTOutsideReadMatrix(t *testing.T) {
+	_, err := normalizeRunConfig(RunConfig{
+		Systems: []SystemName{SystemFlatHAMT},
+		Fixture: FixtureConfig{LargeFileBytes: 300 * 1024},
+	})
+	if err == nil {
+		t.Fatal("expected flathamt to fail outside read_matrix")
+	}
+}
+
 func TestNormalizeRunConfigRejectsDuplicateSystem(t *testing.T) {
 	_, err := normalizeRunConfig(RunConfig{
 		Systems: []SystemName{SystemMALTFlat, SystemMALTFlat},

--- a/cmd/eval/internal/eval/readbench/systems.go
+++ b/cmd/eval/internal/eval/readbench/systems.go
@@ -12,6 +12,7 @@ const (
 	SystemMALTFlat  SystemName = "maltflat"
 	SystemMerkleDAG SystemName = "merkledag"
 	SystemHAMT      SystemName = "hamt"
+	SystemFlatHAMT  SystemName = "flathamt"
 )
 
 // DefaultSystemsCSV is the default comma-separated read benchmark system list.
@@ -71,7 +72,7 @@ func normalizeSystems(systems []SystemName) ([]SystemName, error) {
 
 func knownSystem(system SystemName) bool {
 	switch system {
-	case SystemMALTFlat, SystemMerkleDAG, SystemHAMT:
+	case SystemMALTFlat, SystemMerkleDAG, SystemHAMT, SystemFlatHAMT:
 		return true
 	default:
 		return false

--- a/cmd/eval/internal/eval/readbench/systems_test.go
+++ b/cmd/eval/internal/eval/readbench/systems_test.go
@@ -1,0 +1,17 @@
+package readbench
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSystemsCSVAcceptsFlatHAMT(t *testing.T) {
+	got, err := ParseSystemsCSV("maltflat,flathamt")
+	if err != nil {
+		t.Fatalf("ParseSystemsCSV() error = %v", err)
+	}
+	want := []SystemName{SystemMALTFlat, SystemFlatHAMT}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("systems = %v, want %v", got, want)
+	}
+}

--- a/cmd/eval/internal/eval/suites/flatindexcardinality/aggregate.go
+++ b/cmd/eval/internal/eval/suites/flatindexcardinality/aggregate.go
@@ -20,6 +20,8 @@ type aggregateRow struct {
 	Samples                         int
 	MedianElapsedNS                 int64
 	P95ElapsedNS                    int64
+	MedianProveElapsedNS            int64
+	P95ProveElapsedNS               int64
 	MedianCASGetCount               uint64
 	P95CASGetCount                  uint64
 	MedianEvidenceItemCount         uint64
@@ -86,6 +88,8 @@ func aggregateResults(results []readbench.Result) []aggregateRow {
 			Samples:                         len(group),
 			MedianElapsedNS:                 medianInt64(mapElapsedNS(group)),
 			P95ElapsedNS:                    p95Int64(mapElapsedNS(group)),
+			MedianProveElapsedNS:            medianInt64(mapProveElapsedNS(group)),
+			P95ProveElapsedNS:               p95Int64(mapProveElapsedNS(group)),
 			MedianCASGetCount:               medianUint64(mapCASGetCount(group)),
 			P95CASGetCount:                  p95Uint64(mapCASGetCount(group)),
 			MedianEvidenceItemCount:         medianUint64(mapEvidenceItemCount(group)),
@@ -122,6 +126,8 @@ func writeAggregateCSV(env framework.Env, suite string, rows []aggregateRow) err
 		"samples",
 		"median_elapsed_ns",
 		"p95_elapsed_ns",
+		"median_prove_elapsed_ns",
+		"p95_prove_elapsed_ns",
 		"median_cas_get_count",
 		"p95_cas_get_count",
 		"median_evidence_item_count",
@@ -146,6 +152,8 @@ func writeAggregateCSV(env framework.Env, suite string, rows []aggregateRow) err
 			strconv.Itoa(row.Samples),
 			strconv.FormatInt(row.MedianElapsedNS, 10),
 			strconv.FormatInt(row.P95ElapsedNS, 10),
+			strconv.FormatInt(row.MedianProveElapsedNS, 10),
+			strconv.FormatInt(row.P95ProveElapsedNS, 10),
 			strconv.FormatUint(row.MedianCASGetCount, 10),
 			strconv.FormatUint(row.P95CASGetCount, 10),
 			strconv.FormatUint(row.MedianEvidenceItemCount, 10),
@@ -177,6 +185,16 @@ func mapElapsedNS(results []readbench.Result) []int64 {
 	out := make([]int64, len(results))
 	for i, result := range results {
 		out[i] = result.ElapsedNS
+	}
+	return out
+}
+
+func mapProveElapsedNS(results []readbench.Result) []int64 {
+	out := make([]int64, len(results))
+	for i, result := range results {
+		if result.ProveElapsedNS != nil {
+			out[i] = *result.ProveElapsedNS
+		}
 	}
 	return out
 }

--- a/cmd/eval/internal/eval/suites/flatindexcardinality/aggregate.go
+++ b/cmd/eval/internal/eval/suites/flatindexcardinality/aggregate.go
@@ -1,0 +1,280 @@
+package flatindexcardinality
+
+import (
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/readbench"
+)
+
+type aggregateRow struct {
+	System                          readbench.SystemName
+	Workload                        readbench.WorkloadKind
+	FileCount                       int
+	PathDepth                       int
+	CASLatencyMS                    int
+	Samples                         int
+	MedianElapsedNS                 int64
+	P95ElapsedNS                    int64
+	MedianCASGetCount               uint64
+	P95CASGetCount                  uint64
+	MedianEvidenceItemCount         uint64
+	P95EvidenceItemCount            uint64
+	MedianProofListStepCount        uint64
+	P95ProofListStepCount           uint64
+	MedianArcTableBatchGetCount     uint64
+	P95ArcTableBatchGetCount        uint64
+	MedianArcTableBatchGetPathCount uint64
+	P95ArcTableBatchGetPathCount    uint64
+}
+
+type aggregateKey struct {
+	system       readbench.SystemName
+	workload     readbench.WorkloadKind
+	fileCount    int
+	pathDepth    int
+	casLatencyMS int
+}
+
+func aggregateResults(results []readbench.Result) []aggregateRow {
+	groups := make(map[aggregateKey][]readbench.Result)
+	for _, result := range results {
+		key := aggregateKey{
+			system:       result.System,
+			workload:     result.Workload,
+			fileCount:    result.FileCount,
+			pathDepth:    result.PathDepth,
+			casLatencyMS: result.CASLatencyMS,
+		}
+		groups[key] = append(groups[key], result)
+	}
+
+	keys := make([]aggregateKey, 0, len(groups))
+	for key := range groups {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		a, b := keys[i], keys[j]
+		if a.system != b.system {
+			return a.system < b.system
+		}
+		if a.workload != b.workload {
+			return a.workload < b.workload
+		}
+		if a.fileCount != b.fileCount {
+			return a.fileCount < b.fileCount
+		}
+		if a.pathDepth != b.pathDepth {
+			return a.pathDepth < b.pathDepth
+		}
+		return a.casLatencyMS < b.casLatencyMS
+	})
+
+	rows := make([]aggregateRow, 0, len(keys))
+	for _, key := range keys {
+		group := groups[key]
+		rows = append(rows, aggregateRow{
+			System:                          key.system,
+			Workload:                        key.workload,
+			FileCount:                       key.fileCount,
+			PathDepth:                       key.pathDepth,
+			CASLatencyMS:                    key.casLatencyMS,
+			Samples:                         len(group),
+			MedianElapsedNS:                 medianInt64(mapElapsedNS(group)),
+			P95ElapsedNS:                    p95Int64(mapElapsedNS(group)),
+			MedianCASGetCount:               medianUint64(mapCASGetCount(group)),
+			P95CASGetCount:                  p95Uint64(mapCASGetCount(group)),
+			MedianEvidenceItemCount:         medianUint64(mapEvidenceItemCount(group)),
+			P95EvidenceItemCount:            p95Uint64(mapEvidenceItemCount(group)),
+			MedianProofListStepCount:        medianUint64(mapProofListStepCount(group)),
+			P95ProofListStepCount:           p95Uint64(mapProofListStepCount(group)),
+			MedianArcTableBatchGetCount:     medianUint64(mapArcTableBatchGetCount(group)),
+			P95ArcTableBatchGetCount:        p95Uint64(mapArcTableBatchGetCount(group)),
+			MedianArcTableBatchGetPathCount: medianUint64(mapArcTableBatchGetPathCount(group)),
+			P95ArcTableBatchGetPathCount:    p95Uint64(mapArcTableBatchGetPathCount(group)),
+		})
+	}
+	return rows
+}
+
+func writeAggregateCSV(env framework.Env, suite string, rows []aggregateRow) error {
+	path := aggregatePath(env, suite)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	header := []string{
+		"system",
+		"workload",
+		"file_count",
+		"path_depth",
+		"cas_latency_ms",
+		"samples",
+		"median_elapsed_ns",
+		"p95_elapsed_ns",
+		"median_cas_get_count",
+		"p95_cas_get_count",
+		"median_evidence_item_count",
+		"p95_evidence_item_count",
+		"median_prooflist_step_count",
+		"p95_prooflist_step_count",
+		"median_arctable_batch_get_count",
+		"p95_arctable_batch_get_count",
+		"median_arctable_batch_get_path_count",
+		"p95_arctable_batch_get_path_count",
+	}
+	if err := w.Write(header); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		record := []string{
+			string(row.System),
+			string(row.Workload),
+			strconv.Itoa(row.FileCount),
+			strconv.Itoa(row.PathDepth),
+			strconv.Itoa(row.CASLatencyMS),
+			strconv.Itoa(row.Samples),
+			strconv.FormatInt(row.MedianElapsedNS, 10),
+			strconv.FormatInt(row.P95ElapsedNS, 10),
+			strconv.FormatUint(row.MedianCASGetCount, 10),
+			strconv.FormatUint(row.P95CASGetCount, 10),
+			strconv.FormatUint(row.MedianEvidenceItemCount, 10),
+			strconv.FormatUint(row.P95EvidenceItemCount, 10),
+			strconv.FormatUint(row.MedianProofListStepCount, 10),
+			strconv.FormatUint(row.P95ProofListStepCount, 10),
+			strconv.FormatUint(row.MedianArcTableBatchGetCount, 10),
+			strconv.FormatUint(row.P95ArcTableBatchGetCount, 10),
+			strconv.FormatUint(row.MedianArcTableBatchGetPathCount, 10),
+			strconv.FormatUint(row.P95ArcTableBatchGetPathCount, 10),
+		}
+		if err := w.Write(record); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}
+
+func aggregatePath(env framework.Env, suite string) string {
+	base := env.ResultDir
+	if base == "" {
+		base = env.OutputDir
+	}
+	return filepath.Join(base, "aggregate", suite+".csv")
+}
+
+func mapElapsedNS(results []readbench.Result) []int64 {
+	out := make([]int64, len(results))
+	for i, result := range results {
+		out[i] = result.ElapsedNS
+	}
+	return out
+}
+
+func mapCASGetCount(results []readbench.Result) []uint64 {
+	out := make([]uint64, len(results))
+	for i, result := range results {
+		out[i] = result.CAS.GetCount
+	}
+	return out
+}
+
+func mapEvidenceItemCount(results []readbench.Result) []uint64 {
+	out := make([]uint64, len(results))
+	for i, result := range results {
+		out[i] = uint64(result.EvidenceItemCount)
+	}
+	return out
+}
+
+func mapProofListStepCount(results []readbench.Result) []uint64 {
+	out := make([]uint64, len(results))
+	for i, result := range results {
+		out[i] = uint64(result.ProofListStepCount)
+	}
+	return out
+}
+
+func mapArcTableBatchGetCount(results []readbench.Result) []uint64 {
+	out := make([]uint64, len(results))
+	for i, result := range results {
+		out[i] = result.ArcTable.BatchGetCount
+	}
+	return out
+}
+
+func mapArcTableBatchGetPathCount(results []readbench.Result) []uint64 {
+	out := make([]uint64, len(results))
+	for i, result := range results {
+		out[i] = result.ArcTable.BatchGetPathCount
+	}
+	return out
+}
+
+func medianInt64(values []int64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}
+
+func p95Int64(values []int64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted[percentileIndex(len(sorted), 95)]
+}
+
+func medianUint64(values []uint64) uint64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]uint64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}
+
+func p95Uint64(values []uint64) uint64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]uint64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted[percentileIndex(len(sorted), 95)]
+}
+
+func percentileIndex(length int, percentile int) int {
+	if length <= 0 {
+		return 0
+	}
+	index := ((percentile * length) + 99) / 100
+	if index < 1 {
+		index = 1
+	}
+	if index > length {
+		index = length
+	}
+	return index - 1
+}

--- a/cmd/eval/internal/eval/suites/flatindexcardinality/doc.go
+++ b/cmd/eval/internal/eval/suites/flatindexcardinality/doc.go
@@ -1,0 +1,4 @@
+// Package flatindexcardinality runs flat full-path index benchmarks across
+// MALT flat authenticated arcs and IPFS/Boxo HAMT keyed by complete logical
+// paths.
+package flatindexcardinality

--- a/cmd/eval/internal/eval/suites/flatindexcardinality/schema.go
+++ b/cmd/eval/internal/eval/suites/flatindexcardinality/schema.go
@@ -1,0 +1,6 @@
+package flatindexcardinality
+
+// ResultSchemaPath is the repository-relative JSON Schema for one
+// flat_index_cardinality suite record before the common framework envelope is
+// applied.
+const ResultSchemaPath = "cmd/eval/schemas/flat-index-cardinality-result.schema.json"

--- a/cmd/eval/internal/eval/suites/flatindexcardinality/suite.go
+++ b/cmd/eval/internal/eval/suites/flatindexcardinality/suite.go
@@ -105,6 +105,13 @@ func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *rea
 				if err != nil {
 					return err
 				}
+				if prover, ok := system.(readbench.MatrixProveSystem); ok {
+					proveElapsedNS, err := prover.MeasureProve(ctx, iteration, dataset, op)
+					if err != nil {
+						return err
+					}
+					result.ProveElapsedNS = proveElapsedNS
+				}
 				if err := env.WriteRecord(Name, result); err != nil {
 					return err
 				}
@@ -127,7 +134,7 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 	cfg := Config{
 		Systems:          []string{"maltflat", "flathamt"},
 		Dataset:          "flat-index-cardinality",
-		KeyCounts:        []int{1, 64, 256, 1024, 4096},
+		KeyCounts:        []int{1, 64, 256, 1024, 4096, 16384},
 		PathDepth:        4,
 		PathsPerKeyCount: 5,
 		CASLatencyMS:     []int{0, 25, 200},

--- a/cmd/eval/internal/eval/suites/flatindexcardinality/suite.go
+++ b/cmd/eval/internal/eval/suites/flatindexcardinality/suite.go
@@ -1,0 +1,226 @@
+package flatindexcardinality
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/readbench"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/configjson"
+)
+
+// Name is the fixed evaluation framework suite name.
+const Name = "flat_index_cardinality"
+
+// Suite adapts the flat full-path index cardinality benchmark to the unified
+// evaluation framework.
+type Suite struct{}
+
+// Config controls the flat_index_cardinality suite.
+type Config struct {
+	Systems          []string `json:"systems"`
+	Dataset          string   `json:"dataset"`
+	KeyCounts        []int    `json:"key_counts"`
+	PathDepth        int      `json:"path_depth"`
+	PathsPerKeyCount int      `json:"paths_per_key_count"`
+	CASLatencyMS     []int    `json:"cas_latency_ms"`
+	SmallBytes       int      `json:"small_bytes"`
+	Iterations       int      `json:"iterations"`
+}
+
+// Name returns the fixed suite name expected by framework plans.
+func (Suite) Name() string {
+	return Name
+}
+
+// Run executes the flat index cardinality suite and writes framework-enveloped
+// raw records plus a figure-facing aggregate CSV.
+func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) error {
+	log := env.Log()
+	cfg, err := parseConfig(raw)
+	if err != nil {
+		return err
+	}
+	systems, err := parseSystems(cfg.Systems)
+	if err != nil {
+		return err
+	}
+
+	total := 0
+	for _, keyCount := range cfg.KeyCounts {
+		total += cfg.Iterations * len(cfg.CASLatencyMS) * len(systems) * measuredPathCount(keyCount, cfg.PathsPerKeyCount)
+	}
+	count := 0
+	log("  systems=%v key_counts=%v path_depth=%d cas_latency_ms=%v paths_per_key_count=%d iterations=%d",
+		systems, cfg.KeyCounts, cfg.PathDepth, cfg.CASLatencyMS, cfg.PathsPerKeyCount, cfg.Iterations)
+
+	var results []readbench.Result
+	for _, keyCount := range cfg.KeyCounts {
+		dataset, err := readbench.NewMatrixDataset(readbench.MatrixDatasetConfig{
+			Name:          fmt.Sprintf("%s-n%d", cfg.Dataset, keyCount),
+			FileCount:     keyCount,
+			Depths:        []int{cfg.PathDepth},
+			PayloadBytes:  cfg.SmallBytes,
+			PathsPerDepth: measuredPathCount(keyCount, cfg.PathsPerKeyCount),
+		})
+		if err != nil {
+			return err
+		}
+		for _, latencyMS := range cfg.CASLatencyMS {
+			materialized := make([]readbench.MatrixSystem, 0, len(systems))
+			for _, system := range systems {
+				benchSystem, err := readbench.NewMatrixSystem(ctx, system, dataset, latencyMS)
+				if err != nil {
+					closeMatrixSystems(materialized)
+					return err
+				}
+				materialized = append(materialized, benchSystem)
+			}
+			if err := runDataset(ctx, env, cfg, dataset, materialized, total, &count, &results); err != nil {
+				closeMatrixSystems(materialized)
+				return err
+			}
+			if err := closeMatrixSystems(materialized); err != nil {
+				return err
+			}
+		}
+	}
+	return writeAggregateCSV(env, Name, aggregateResults(results))
+}
+
+func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *readbench.MatrixDataset, systems []readbench.MatrixSystem, total int, count *int, results *[]readbench.Result) error {
+	log := env.Log()
+	ops, err := readbench.MatrixOperations(dataset, cfg.PathDepth)
+	if err != nil {
+		return err
+	}
+	for iteration := 0; iteration < cfg.Iterations; iteration++ {
+		for _, system := range systems {
+			for _, op := range ops {
+				result, err := system.Measure(ctx, iteration, dataset, op)
+				if err != nil {
+					return err
+				}
+				if err := env.WriteRecord(Name, result); err != nil {
+					return err
+				}
+				if results != nil {
+					*results = append(*results, *result)
+				}
+				*count = *count + 1
+				if *count%25 == 0 || *count == total {
+					log("  [%d/%d] dataset=%s iter=%d system=%s file_count=%d cas_latency_ms=%d elapsed=%s",
+						*count, total, dataset.Name, iteration, system.Name(), dataset.FileCount, result.CASLatencyMS,
+						time.Duration(result.ElapsedNS).Round(time.Microsecond))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func parseConfig(raw json.RawMessage) (Config, error) {
+	cfg := Config{
+		Systems:          []string{"maltflat", "flathamt"},
+		Dataset:          "flat-index-cardinality",
+		KeyCounts:        []int{1, 64, 256, 1024, 4096},
+		PathDepth:        4,
+		PathsPerKeyCount: 5,
+		CASLatencyMS:     []int{0, 25, 200},
+		SmallBytes:       1024,
+		Iterations:       5,
+	}
+	if len(strings.TrimSpace(string(raw))) > 0 {
+		if err := configjson.Decode(raw, Name, &cfg); err != nil {
+			return Config{}, err
+		}
+	}
+	if strings.TrimSpace(cfg.Dataset) == "" {
+		return Config{}, fmt.Errorf("dataset must not be empty")
+	}
+	keyCounts, err := normalizeKeyCounts(cfg.KeyCounts)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.KeyCounts = keyCounts
+	if cfg.PathDepth < 1 {
+		return Config{}, fmt.Errorf("path_depth must be >= 1")
+	}
+	if cfg.PathsPerKeyCount <= 0 {
+		return Config{}, fmt.Errorf("paths_per_key_count must be positive")
+	}
+	if len(cfg.CASLatencyMS) == 0 {
+		return Config{}, fmt.Errorf("cas_latency_ms must not be empty")
+	}
+	for _, latencyMS := range cfg.CASLatencyMS {
+		if latencyMS < 0 {
+			return Config{}, fmt.Errorf("cas_latency_ms values must be non-negative")
+		}
+	}
+	if cfg.SmallBytes <= 0 {
+		return Config{}, fmt.Errorf("small_bytes must be positive")
+	}
+	if cfg.Iterations < 0 {
+		return Config{}, fmt.Errorf("iterations must be non-negative")
+	}
+	return cfg, nil
+}
+
+func parseSystems(values []string) ([]readbench.SystemName, error) {
+	if len(values) == 0 {
+		return []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemFlatHAMT}, nil
+	}
+	systems, err := readbench.ParseSystemsCSV(strings.Join(values, ","))
+	if err != nil {
+		return nil, err
+	}
+	for _, system := range systems {
+		switch system {
+		case readbench.SystemMALTFlat, readbench.SystemFlatHAMT:
+		default:
+			return nil, fmt.Errorf("system %q is not a flat-index baseline", system)
+		}
+	}
+	return systems, nil
+}
+
+func normalizeKeyCounts(keyCounts []int) ([]int, error) {
+	if len(keyCounts) == 0 {
+		return nil, fmt.Errorf("key_counts must not be empty")
+	}
+	out := append([]int(nil), keyCounts...)
+	slices.Sort(out)
+	out = slices.Compact(out)
+	for _, keyCount := range out {
+		if keyCount < 1 {
+			return nil, fmt.Errorf("key_counts values must be positive")
+		}
+	}
+	return out, nil
+}
+
+func measuredPathCount(keyCount int, pathsPerKeyCount int) int {
+	if keyCount < pathsPerKeyCount {
+		return keyCount
+	}
+	return pathsPerKeyCount
+}
+
+func closeMatrixSystems(systems []readbench.MatrixSystem) error {
+	var firstErr error
+	for _, system := range systems {
+		if system == nil {
+			continue
+		}
+		if err := system.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+var _ framework.Suite = Suite{}

--- a/cmd/eval/internal/eval/suites/flatindexcardinality/suite_test.go
+++ b/cmd/eval/internal/eval/suites/flatindexcardinality/suite_test.go
@@ -85,6 +85,16 @@ func TestRunWritesFlatIndexCardinalityMatrixAndAggregate(t *testing.T) {
 		if result.ContentBytes == nil || *result.ContentBytes != 64 {
 			t.Fatalf("content_bytes = %v, want 64", result.ContentBytes)
 		}
+		switch result.System {
+		case readbench.SystemMALTFlat:
+			if result.ProveElapsedNS == nil || *result.ProveElapsedNS <= 0 {
+				t.Fatalf("malt prove_elapsed_ns = %v, want positive proof/open generation latency", result.ProveElapsedNS)
+			}
+		case readbench.SystemFlatHAMT:
+			if result.ProveElapsedNS != nil {
+				t.Fatalf("flathamt prove_elapsed_ns = %v, want omitted", result.ProveElapsedNS)
+			}
+		}
 	}
 	for _, system := range []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemFlatHAMT} {
 		if !seenSystems[system] {
@@ -110,6 +120,19 @@ func TestRunWritesFlatIndexCardinalityMatrixAndAggregate(t *testing.T) {
 		}
 		if parseInt64Field(t, row, "p95_elapsed_ns") <= 0 {
 			t.Fatalf("p95_elapsed_ns should be positive in row %+v", row)
+		}
+		switch row["system"] {
+		case string(readbench.SystemMALTFlat):
+			if parseInt64Field(t, row, "median_prove_elapsed_ns") <= 0 {
+				t.Fatalf("median_prove_elapsed_ns should be positive for MALT in row %+v", row)
+			}
+			if parseInt64Field(t, row, "p95_prove_elapsed_ns") <= 0 {
+				t.Fatalf("p95_prove_elapsed_ns should be positive for MALT in row %+v", row)
+			}
+		case string(readbench.SystemFlatHAMT):
+			if row["median_prove_elapsed_ns"] != "0" || row["p95_prove_elapsed_ns"] != "0" {
+				t.Fatalf("proof elapsed aggregate should be zero for flat HAMT in row %+v", row)
+			}
 		}
 	}
 }

--- a/cmd/eval/internal/eval/suites/flatindexcardinality/suite_test.go
+++ b/cmd/eval/internal/eval/suites/flatindexcardinality/suite_test.go
@@ -1,0 +1,195 @@
+package flatindexcardinality
+
+import (
+	"bufio"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/readbench"
+)
+
+func TestSuiteNameIsFlatIndexCardinality(t *testing.T) {
+	if got := (Suite{}).Name(); got != Name {
+		t.Fatalf("Suite.Name() = %q, want %q", got, Name)
+	}
+}
+
+func TestParseConfigDefaultsUseFlatIndexSystems(t *testing.T) {
+	cfg, err := parseConfig(nil)
+	if err != nil {
+		t.Fatalf("parseConfig(nil) error = %v", err)
+	}
+	if want := []string{"maltflat", "flathamt"}; !reflect.DeepEqual(cfg.Systems, want) {
+		t.Fatalf("Systems = %v, want %v", cfg.Systems, want)
+	}
+	if cfg.PathDepth != 4 {
+		t.Fatalf("PathDepth = %d, want 4", cfg.PathDepth)
+	}
+	if cfg.PathsPerKeyCount != 5 {
+		t.Fatalf("PathsPerKeyCount = %d, want 5", cfg.PathsPerKeyCount)
+	}
+}
+
+func TestRunWritesFlatIndexCardinalityMatrixAndAggregate(t *testing.T) {
+	env := newSuiteTestEnv(t, "run-flat-index-cardinality")
+	raw := json.RawMessage(`{
+		"systems": ["maltflat", "flathamt"],
+		"dataset": "flat-index-unit",
+		"key_counts": [2, 4],
+		"path_depth": 3,
+		"paths_per_key_count": 2,
+		"small_bytes": 64,
+		"cas_latency_ms": [0, 1],
+		"iterations": 1
+	}`)
+
+	if err := (Suite{}).Run(context.Background(), env, raw); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	envelopes := readRawEnvelopes(t, env.RawPath(Name))
+	if len(envelopes) != 16 {
+		t.Fatalf("raw envelope count = %d, want 16", len(envelopes))
+	}
+	seenSystems := map[readbench.SystemName]bool{}
+	seenFileCounts := map[int]bool{}
+	for _, envelope := range envelopes {
+		if envelope.Suite != Name {
+			t.Fatalf("suite = %q, want %q", envelope.Suite, Name)
+		}
+		var result readbench.Result
+		if err := json.Unmarshal(envelope.Record, &result); err != nil {
+			t.Fatalf("decode result: %v", err)
+		}
+		seenSystems[result.System] = true
+		seenFileCounts[result.FileCount] = true
+		if result.PathDepth != 3 {
+			t.Fatalf("path_depth = %d, want 3", result.PathDepth)
+		}
+		if result.FileCount != 2 && result.FileCount != 4 {
+			t.Fatalf("file_count = %d, want 2 or 4", result.FileCount)
+		}
+		if result.OperationKind != readbench.OperationResolvePath {
+			t.Fatalf("operation_kind = %q, want resolve_path", result.OperationKind)
+		}
+		if result.Workload != readbench.WorkloadDeepPathLookup {
+			t.Fatalf("workload = %q, want deep_path_lookup", result.Workload)
+		}
+		if result.ContentBytes == nil || *result.ContentBytes != 64 {
+			t.Fatalf("content_bytes = %v, want 64", result.ContentBytes)
+		}
+	}
+	for _, system := range []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemFlatHAMT} {
+		if !seenSystems[system] {
+			t.Fatalf("missing system %q", system)
+		}
+	}
+	for _, fileCount := range []int{2, 4} {
+		if !seenFileCounts[fileCount] {
+			t.Fatalf("missing file_count %d", fileCount)
+		}
+	}
+
+	rows := readAggregateRows(t, aggregatePath(env, Name))
+	if len(rows) != 8 {
+		t.Fatalf("aggregate row count = %d, want 8", len(rows))
+	}
+	for _, row := range rows {
+		if row["samples"] != "2" {
+			t.Fatalf("aggregate samples = %q, want 2 in row %+v", row["samples"], row)
+		}
+		if parseInt64Field(t, row, "median_elapsed_ns") <= 0 {
+			t.Fatalf("median_elapsed_ns should be positive in row %+v", row)
+		}
+		if parseInt64Field(t, row, "p95_elapsed_ns") <= 0 {
+			t.Fatalf("p95_elapsed_ns should be positive in row %+v", row)
+		}
+	}
+}
+
+type recordEnvelope struct {
+	SchemaVersion string          `json:"schema_version"`
+	RunID         string          `json:"run_id"`
+	Suite         string          `json:"suite"`
+	EmittedAt     string          `json:"emitted_at"`
+	Record        json.RawMessage `json:"record"`
+}
+
+func newSuiteTestEnv(t *testing.T, runID string) framework.Env {
+	t.Helper()
+	tmp := t.TempDir()
+	resultDir := filepath.Join(tmp, "result")
+	if err := os.MkdirAll(filepath.Join(resultDir, "raw"), 0o755); err != nil {
+		t.Fatalf("create raw dir: %v", err)
+	}
+	return framework.Env{
+		RunID:     runID,
+		ResultDir: resultDir,
+	}
+}
+
+func readRawEnvelopes(t *testing.T, path string) []recordEnvelope {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open raw output: %v", err)
+	}
+	defer f.Close()
+
+	var out []recordEnvelope
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var envelope recordEnvelope
+		if err := json.Unmarshal(scanner.Bytes(), &envelope); err != nil {
+			t.Fatalf("decode envelope: %v", err)
+		}
+		out = append(out, envelope)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan raw output: %v", err)
+	}
+	return out
+}
+
+func readAggregateRows(t *testing.T, path string) []map[string]string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open aggregate output: %v", err)
+	}
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("read aggregate csv: %v", err)
+	}
+	if len(records) < 1 {
+		t.Fatal("aggregate csv missing header")
+	}
+	header := records[0]
+	out := make([]map[string]string, 0, len(records)-1)
+	for _, record := range records[1:] {
+		row := make(map[string]string, len(header))
+		for i, column := range header {
+			row[column] = record[i]
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+func parseInt64Field(t *testing.T, row map[string]string, field string) int64 {
+	t.Helper()
+	value, err := strconv.ParseInt(row[field], 10, 64)
+	if err != nil {
+		t.Fatalf("parse %s=%q: %v", field, row[field], err)
+	}
+	return value
+}

--- a/cmd/eval/internal/eval/suites/readmatrix/aggregate.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/aggregate.go
@@ -1,0 +1,274 @@
+package readmatrix
+
+import (
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/readbench"
+)
+
+type aggregateRow struct {
+	System                          readbench.SystemName
+	Workload                        readbench.WorkloadKind
+	PathDepth                       int
+	CASLatencyMS                    int
+	Samples                         int
+	MedianElapsedNS                 int64
+	P95ElapsedNS                    int64
+	MedianCASGetCount               uint64
+	P95CASGetCount                  uint64
+	MedianEvidenceItemCount         uint64
+	P95EvidenceItemCount            uint64
+	MedianProofListStepCount        uint64
+	P95ProofListStepCount           uint64
+	MedianArcTableBatchGetCount     uint64
+	P95ArcTableBatchGetCount        uint64
+	MedianArcTableBatchGetPathCount uint64
+	P95ArcTableBatchGetPathCount    uint64
+}
+
+type aggregateKey struct {
+	system       readbench.SystemName
+	workload     readbench.WorkloadKind
+	pathDepth    int
+	casLatencyMS int
+}
+
+func aggregateResults(results []readbench.Result) []aggregateRow {
+	groups := make(map[aggregateKey][]readbench.Result)
+	for _, result := range results {
+		key := aggregateKey{
+			system:       result.System,
+			workload:     result.Workload,
+			pathDepth:    result.PathDepth,
+			casLatencyMS: result.CASLatencyMS,
+		}
+		groups[key] = append(groups[key], result)
+	}
+
+	keys := make([]aggregateKey, 0, len(groups))
+	for key := range groups {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		a, b := keys[i], keys[j]
+		if a.system != b.system {
+			return a.system < b.system
+		}
+		if a.workload != b.workload {
+			return a.workload < b.workload
+		}
+		if a.pathDepth != b.pathDepth {
+			return a.pathDepth < b.pathDepth
+		}
+		return a.casLatencyMS < b.casLatencyMS
+	})
+
+	rows := make([]aggregateRow, 0, len(keys))
+	for _, key := range keys {
+		group := groups[key]
+		rows = append(rows, aggregateRow{
+			System:                          key.system,
+			Workload:                        key.workload,
+			PathDepth:                       key.pathDepth,
+			CASLatencyMS:                    key.casLatencyMS,
+			Samples:                         len(group),
+			MedianElapsedNS:                 medianInt64(mapElapsedNS(group)),
+			P95ElapsedNS:                    p95Int64(mapElapsedNS(group)),
+			MedianCASGetCount:               medianUint64(mapCASGetCount(group)),
+			P95CASGetCount:                  p95Uint64(mapCASGetCount(group)),
+			MedianEvidenceItemCount:         medianUint64(mapEvidenceItemCount(group)),
+			P95EvidenceItemCount:            p95Uint64(mapEvidenceItemCount(group)),
+			MedianProofListStepCount:        medianUint64(mapProofListStepCount(group)),
+			P95ProofListStepCount:           p95Uint64(mapProofListStepCount(group)),
+			MedianArcTableBatchGetCount:     medianUint64(mapArcTableBatchGetCount(group)),
+			P95ArcTableBatchGetCount:        p95Uint64(mapArcTableBatchGetCount(group)),
+			MedianArcTableBatchGetPathCount: medianUint64(mapArcTableBatchGetPathCount(group)),
+			P95ArcTableBatchGetPathCount:    p95Uint64(mapArcTableBatchGetPathCount(group)),
+		})
+	}
+	return rows
+}
+
+func writeAggregateCSV(env framework.Env, suite string, rows []aggregateRow) error {
+	path := aggregatePath(env, suite)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	header := []string{
+		"system",
+		"workload",
+		"path_depth",
+		"cas_latency_ms",
+		"samples",
+		"median_elapsed_ns",
+		"p95_elapsed_ns",
+		"median_cas_get_count",
+		"p95_cas_get_count",
+		"median_evidence_item_count",
+		"p95_evidence_item_count",
+		"median_prooflist_step_count",
+		"p95_prooflist_step_count",
+		"median_arctable_batch_get_count",
+		"p95_arctable_batch_get_count",
+		"median_arctable_batch_get_path_count",
+		"p95_arctable_batch_get_path_count",
+	}
+	if err := w.Write(header); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		record := []string{
+			string(row.System),
+			string(row.Workload),
+			strconv.Itoa(row.PathDepth),
+			strconv.Itoa(row.CASLatencyMS),
+			strconv.Itoa(row.Samples),
+			strconv.FormatInt(row.MedianElapsedNS, 10),
+			strconv.FormatInt(row.P95ElapsedNS, 10),
+			strconv.FormatUint(row.MedianCASGetCount, 10),
+			strconv.FormatUint(row.P95CASGetCount, 10),
+			strconv.FormatUint(row.MedianEvidenceItemCount, 10),
+			strconv.FormatUint(row.P95EvidenceItemCount, 10),
+			strconv.FormatUint(row.MedianProofListStepCount, 10),
+			strconv.FormatUint(row.P95ProofListStepCount, 10),
+			strconv.FormatUint(row.MedianArcTableBatchGetCount, 10),
+			strconv.FormatUint(row.P95ArcTableBatchGetCount, 10),
+			strconv.FormatUint(row.MedianArcTableBatchGetPathCount, 10),
+			strconv.FormatUint(row.P95ArcTableBatchGetPathCount, 10),
+		}
+		if err := w.Write(record); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func aggregatePath(env framework.Env, suite string) string {
+	base := env.ResultDir
+	if base == "" {
+		base = env.OutputDir
+	}
+	return filepath.Join(base, "aggregate", suite+".csv")
+}
+
+func mapElapsedNS(results []readbench.Result) []int64 {
+	out := make([]int64, len(results))
+	for i, result := range results {
+		out[i] = result.ElapsedNS
+	}
+	return out
+}
+
+func mapCASGetCount(results []readbench.Result) []uint64 {
+	out := make([]uint64, len(results))
+	for i, result := range results {
+		out[i] = result.CAS.GetCount
+	}
+	return out
+}
+
+func mapEvidenceItemCount(results []readbench.Result) []uint64 {
+	out := make([]uint64, len(results))
+	for i, result := range results {
+		out[i] = uint64(result.EvidenceItemCount)
+	}
+	return out
+}
+
+func mapProofListStepCount(results []readbench.Result) []uint64 {
+	out := make([]uint64, len(results))
+	for i, result := range results {
+		out[i] = uint64(result.ProofListStepCount)
+	}
+	return out
+}
+
+func mapArcTableBatchGetCount(results []readbench.Result) []uint64 {
+	out := make([]uint64, len(results))
+	for i, result := range results {
+		out[i] = result.ArcTable.BatchGetCount
+	}
+	return out
+}
+
+func mapArcTableBatchGetPathCount(results []readbench.Result) []uint64 {
+	out := make([]uint64, len(results))
+	for i, result := range results {
+		out[i] = result.ArcTable.BatchGetPathCount
+	}
+	return out
+}
+
+func medianInt64(values []int64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}
+
+func p95Int64(values []int64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted[percentileIndex(len(sorted), 95)]
+}
+
+func medianUint64(values []uint64) uint64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]uint64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}
+
+func p95Uint64(values []uint64) uint64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]uint64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted[percentileIndex(len(sorted), 95)]
+}
+
+func percentileIndex(length int, percentile int) int {
+	if length <= 0 {
+		return 0
+	}
+	index := ((percentile * length) + 99) / 100
+	if index < 1 {
+		index = 1
+	}
+	if index > length {
+		index = length
+	}
+	return index - 1
+}

--- a/cmd/eval/internal/eval/suites/readmatrix/doc.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/doc.go
@@ -1,3 +1,4 @@
-// Package readmatrix runs fair resolve-path benchmarks across MALT, Merkle DAG,
-// and HAMT using one shared logical source dataset.
+// Package readmatrix runs fair resolve-path benchmarks across flat MALT, UnixFS
+// Merkle DAG, UnixFS HAMT directories, and flat full-path HAMT using one shared
+// logical source dataset.
 package readmatrix

--- a/cmd/eval/internal/eval/suites/readmatrix/doc.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/doc.go
@@ -1,0 +1,3 @@
+// Package readmatrix runs fair core read benchmarks across MALT, Merkle DAG,
+// and HAMT using one shared logical source dataset.
+package readmatrix

--- a/cmd/eval/internal/eval/suites/readmatrix/doc.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/doc.go
@@ -1,3 +1,3 @@
-// Package readmatrix runs fair core read benchmarks across MALT, Merkle DAG,
+// Package readmatrix runs fair resolve-path benchmarks across MALT, Merkle DAG,
 // and HAMT using one shared logical source dataset.
 package readmatrix

--- a/cmd/eval/internal/eval/suites/readmatrix/schema.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/schema.go
@@ -1,0 +1,5 @@
+package readmatrix
+
+// ResultSchemaPath is the repository-relative JSON Schema for one read_matrix
+// suite record before the common framework envelope is applied.
+const ResultSchemaPath = "cmd/eval/schemas/read-matrix-result.schema.json"

--- a/cmd/eval/internal/eval/suites/readmatrix/suite.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/suite.go
@@ -1,0 +1,187 @@
+package readmatrix
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/readbench"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/suites/configjson"
+)
+
+// Name is the fixed evaluation framework suite name.
+const Name = "read_matrix"
+
+// Suite adapts the fair core read matrix to the unified evaluation framework.
+type Suite struct{}
+
+// Config controls the read_matrix suite.
+type Config struct {
+	Systems    []string `json:"systems"`
+	Dataset    string   `json:"dataset"`
+	FileCounts []int    `json:"file_counts"`
+	Depths     []int    `json:"depths"`
+	SmallBytes int      `json:"small_bytes"`
+	LargeBytes int      `json:"large_bytes"`
+	Range      string   `json:"range"`
+	Iterations int      `json:"iterations"`
+}
+
+// Name returns the fixed suite name expected by framework plans.
+func (Suite) Name() string {
+	return Name
+}
+
+// Run executes the read matrix suite and writes framework-enveloped records.
+func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) error {
+	log := env.Log()
+	cfg, err := parseConfig(raw)
+	if err != nil {
+		return err
+	}
+	systems, err := parseSystems(cfg.Systems)
+	if err != nil {
+		return err
+	}
+
+	total := cfg.Iterations * len(cfg.FileCounts) * len(systems) * len(cfg.Depths) * 3
+	count := 0
+	log("  systems=%v file_counts=%v depths=%v iterations=%d", systems, cfg.FileCounts, cfg.Depths, cfg.Iterations)
+
+	for _, fileCount := range cfg.FileCounts {
+		dataset, err := readbench.NewMatrixDataset(readbench.MatrixDatasetConfig{
+			Name:       cfg.Dataset,
+			FileCount:  fileCount,
+			Depths:     cfg.Depths,
+			SmallBytes: cfg.SmallBytes,
+			LargeBytes: cfg.LargeBytes,
+		})
+		if err != nil {
+			return err
+		}
+
+		materialized := make([]readbench.MatrixSystem, 0, len(systems))
+		for _, system := range systems {
+			benchSystem, err := readbench.NewMatrixSystem(ctx, system, dataset)
+			if err != nil {
+				closeMatrixSystems(materialized)
+				return err
+			}
+			materialized = append(materialized, benchSystem)
+		}
+
+		if err := runDataset(ctx, env, cfg, dataset, materialized, total, &count); err != nil {
+			closeMatrixSystems(materialized)
+			return err
+		}
+		if err := closeMatrixSystems(materialized); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *readbench.MatrixDataset, systems []readbench.MatrixSystem, total int, count *int) error {
+	log := env.Log()
+	for iteration := 0; iteration < cfg.Iterations; iteration++ {
+		for _, system := range systems {
+			for _, depth := range cfg.Depths {
+				ops, err := readbench.MatrixOperations(dataset, depth, cfg.Range)
+				if err != nil {
+					return err
+				}
+				for _, op := range ops {
+					result, err := system.Measure(ctx, iteration, dataset, op)
+					if err != nil {
+						return err
+					}
+					if err := env.WriteRecord(Name, result); err != nil {
+						return err
+					}
+					*count = *count + 1
+					if *count%25 == 0 || *count == total {
+						log("  [%d/%d] dataset=%s iter=%d system=%s depth=%d workload=%s elapsed=%s",
+							*count, total, dataset.Name, iteration, system.Name(), depth, op.Workload,
+							time.Duration(result.ElapsedNS).Round(time.Microsecond))
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func parseConfig(raw json.RawMessage) (Config, error) {
+	cfg := Config{
+		Systems:    []string{"maltflat", "merkledag", "hamt"},
+		Dataset:    "read-matrix",
+		FileCounts: []int{32, 128},
+		Depths:     []int{2, 4, 8},
+		SmallBytes: 1024,
+		LargeBytes: readbench.DefaultLargeFileBytes,
+		Range:      readbench.DefaultRangeHeader,
+		Iterations: 5,
+	}
+	if len(strings.TrimSpace(string(raw))) > 0 {
+		if err := configjson.Decode(raw, Name, &cfg); err != nil {
+			return Config{}, err
+		}
+	}
+	if strings.TrimSpace(cfg.Dataset) == "" {
+		return Config{}, fmt.Errorf("dataset must not be empty")
+	}
+	if len(cfg.FileCounts) == 0 {
+		return Config{}, fmt.Errorf("file_counts must not be empty")
+	}
+	for _, fileCount := range cfg.FileCounts {
+		if fileCount <= 0 {
+			return Config{}, fmt.Errorf("file_counts must be positive")
+		}
+	}
+	if len(cfg.Depths) == 0 {
+		return Config{}, fmt.Errorf("depths must not be empty")
+	}
+	for _, depth := range cfg.Depths {
+		if depth < 1 {
+			return Config{}, fmt.Errorf("depths must be >= 1")
+		}
+	}
+	if cfg.SmallBytes <= 0 {
+		return Config{}, fmt.Errorf("small_bytes must be positive")
+	}
+	if cfg.LargeBytes <= 0 {
+		return Config{}, fmt.Errorf("large_bytes must be positive")
+	}
+	if cfg.Iterations < 0 {
+		return Config{}, fmt.Errorf("iterations must be non-negative")
+	}
+	if strings.TrimSpace(cfg.Range) == "" {
+		cfg.Range = readbench.DefaultRangeHeader
+	}
+	return cfg, nil
+}
+
+func parseSystems(values []string) ([]readbench.SystemName, error) {
+	if len(values) == 0 {
+		return readbench.DefaultSystems(), nil
+	}
+	return readbench.ParseSystemsCSV(strings.Join(values, ","))
+}
+
+func closeMatrixSystems(systems []readbench.MatrixSystem) error {
+	var firstErr error
+	for _, system := range systems {
+		if system == nil {
+			continue
+		}
+		if err := system.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+var _ framework.Suite = Suite{}

--- a/cmd/eval/internal/eval/suites/readmatrix/suite.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/suite.go
@@ -20,14 +20,12 @@ type Suite struct{}
 
 // Config controls the read_matrix suite.
 type Config struct {
-	Systems    []string `json:"systems"`
-	Dataset    string   `json:"dataset"`
-	FileCounts []int    `json:"file_counts"`
-	Depths     []int    `json:"depths"`
-	SmallBytes int      `json:"small_bytes"`
-	LargeBytes int      `json:"large_bytes"`
-	Range      string   `json:"range"`
-	Iterations int      `json:"iterations"`
+	Systems      []string `json:"systems"`
+	Dataset      string   `json:"dataset"`
+	Depths       []int    `json:"depths"`
+	CASLatencyMS []int    `json:"cas_latency_ms"`
+	SmallBytes   int      `json:"small_bytes"`
+	Iterations   int      `json:"iterations"`
 }
 
 // Name returns the fixed suite name expected by framework plans.
@@ -47,25 +45,22 @@ func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) er
 		return err
 	}
 
-	total := cfg.Iterations * len(cfg.FileCounts) * len(systems) * len(cfg.Depths) * 3
+	total := cfg.Iterations * len(cfg.CASLatencyMS) * len(systems) * len(cfg.Depths)
 	count := 0
-	log("  systems=%v file_counts=%v depths=%v iterations=%d", systems, cfg.FileCounts, cfg.Depths, cfg.Iterations)
+	log("  systems=%v depths=%v cas_latency_ms=%v iterations=%d", systems, cfg.Depths, cfg.CASLatencyMS, cfg.Iterations)
 
-	for _, fileCount := range cfg.FileCounts {
-		dataset, err := readbench.NewMatrixDataset(readbench.MatrixDatasetConfig{
-			Name:       cfg.Dataset,
-			FileCount:  fileCount,
-			Depths:     cfg.Depths,
-			SmallBytes: cfg.SmallBytes,
-			LargeBytes: cfg.LargeBytes,
-		})
-		if err != nil {
-			return err
-		}
-
+	dataset, err := readbench.NewMatrixDataset(readbench.MatrixDatasetConfig{
+		Name:         cfg.Dataset,
+		Depths:       cfg.Depths,
+		PayloadBytes: cfg.SmallBytes,
+	})
+	if err != nil {
+		return err
+	}
+	for _, latencyMS := range cfg.CASLatencyMS {
 		materialized := make([]readbench.MatrixSystem, 0, len(systems))
 		for _, system := range systems {
-			benchSystem, err := readbench.NewMatrixSystem(ctx, system, dataset)
+			benchSystem, err := readbench.NewMatrixSystem(ctx, system, dataset, latencyMS)
 			if err != nil {
 				closeMatrixSystems(materialized)
 				return err
@@ -89,7 +84,7 @@ func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *rea
 	for iteration := 0; iteration < cfg.Iterations; iteration++ {
 		for _, system := range systems {
 			for _, depth := range cfg.Depths {
-				ops, err := readbench.MatrixOperations(dataset, depth, cfg.Range)
+				ops, err := readbench.MatrixOperations(dataset, depth)
 				if err != nil {
 					return err
 				}
@@ -103,8 +98,8 @@ func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *rea
 					}
 					*count = *count + 1
 					if *count%25 == 0 || *count == total {
-						log("  [%d/%d] dataset=%s iter=%d system=%s depth=%d workload=%s elapsed=%s",
-							*count, total, dataset.Name, iteration, system.Name(), depth, op.Workload,
+						log("  [%d/%d] dataset=%s iter=%d system=%s depth=%d cas_latency_ms=%d elapsed=%s",
+							*count, total, dataset.Name, iteration, system.Name(), depth, result.CASLatencyMS,
 							time.Duration(result.ElapsedNS).Round(time.Microsecond))
 					}
 				}
@@ -116,14 +111,12 @@ func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *rea
 
 func parseConfig(raw json.RawMessage) (Config, error) {
 	cfg := Config{
-		Systems:    []string{"maltflat", "merkledag", "hamt"},
-		Dataset:    "read-matrix",
-		FileCounts: []int{32, 128},
-		Depths:     []int{2, 4, 8},
-		SmallBytes: 1024,
-		LargeBytes: readbench.DefaultLargeFileBytes,
-		Range:      readbench.DefaultRangeHeader,
-		Iterations: 5,
+		Systems:      []string{"maltflat", "merkledag", "hamt"},
+		Dataset:      "read-matrix",
+		Depths:       []int{1, 2, 4, 8, 16},
+		CASLatencyMS: []int{0, 25, 50, 100, 200},
+		SmallBytes:   1024,
+		Iterations:   5,
 	}
 	if len(strings.TrimSpace(string(raw))) > 0 {
 		if err := configjson.Decode(raw, Name, &cfg); err != nil {
@@ -132,14 +125,6 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 	}
 	if strings.TrimSpace(cfg.Dataset) == "" {
 		return Config{}, fmt.Errorf("dataset must not be empty")
-	}
-	if len(cfg.FileCounts) == 0 {
-		return Config{}, fmt.Errorf("file_counts must not be empty")
-	}
-	for _, fileCount := range cfg.FileCounts {
-		if fileCount <= 0 {
-			return Config{}, fmt.Errorf("file_counts must be positive")
-		}
 	}
 	if len(cfg.Depths) == 0 {
 		return Config{}, fmt.Errorf("depths must not be empty")
@@ -152,14 +137,16 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 	if cfg.SmallBytes <= 0 {
 		return Config{}, fmt.Errorf("small_bytes must be positive")
 	}
-	if cfg.LargeBytes <= 0 {
-		return Config{}, fmt.Errorf("large_bytes must be positive")
+	if len(cfg.CASLatencyMS) == 0 {
+		return Config{}, fmt.Errorf("cas_latency_ms must not be empty")
+	}
+	for _, latencyMS := range cfg.CASLatencyMS {
+		if latencyMS < 0 {
+			return Config{}, fmt.Errorf("cas_latency_ms values must be non-negative")
+		}
 	}
 	if cfg.Iterations < 0 {
 		return Config{}, fmt.Errorf("iterations must be non-negative")
-	}
-	if strings.TrimSpace(cfg.Range) == "" {
-		cfg.Range = readbench.DefaultRangeHeader
 	}
 	return cfg, nil
 }

--- a/cmd/eval/internal/eval/suites/readmatrix/suite.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/suite.go
@@ -20,12 +20,13 @@ type Suite struct{}
 
 // Config controls the read_matrix suite.
 type Config struct {
-	Systems      []string `json:"systems"`
-	Dataset      string   `json:"dataset"`
-	Depths       []int    `json:"depths"`
-	CASLatencyMS []int    `json:"cas_latency_ms"`
-	SmallBytes   int      `json:"small_bytes"`
-	Iterations   int      `json:"iterations"`
+	Systems       []string `json:"systems"`
+	Dataset       string   `json:"dataset"`
+	Depths        []int    `json:"depths"`
+	CASLatencyMS  []int    `json:"cas_latency_ms"`
+	SmallBytes    int      `json:"small_bytes"`
+	PathsPerDepth int      `json:"paths_per_depth"`
+	Iterations    int      `json:"iterations"`
 }
 
 // Name returns the fixed suite name expected by framework plans.
@@ -45,18 +46,21 @@ func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) er
 		return err
 	}
 
-	total := cfg.Iterations * len(cfg.CASLatencyMS) * len(systems) * len(cfg.Depths)
+	total := cfg.Iterations * len(cfg.CASLatencyMS) * len(systems) * len(cfg.Depths) * cfg.PathsPerDepth
 	count := 0
-	log("  systems=%v depths=%v cas_latency_ms=%v iterations=%d", systems, cfg.Depths, cfg.CASLatencyMS, cfg.Iterations)
+	log("  systems=%v depths=%v cas_latency_ms=%v paths_per_depth=%d iterations=%d",
+		systems, cfg.Depths, cfg.CASLatencyMS, cfg.PathsPerDepth, cfg.Iterations)
 
 	dataset, err := readbench.NewMatrixDataset(readbench.MatrixDatasetConfig{
-		Name:         cfg.Dataset,
-		Depths:       cfg.Depths,
-		PayloadBytes: cfg.SmallBytes,
+		Name:          cfg.Dataset,
+		Depths:        cfg.Depths,
+		PayloadBytes:  cfg.SmallBytes,
+		PathsPerDepth: cfg.PathsPerDepth,
 	})
 	if err != nil {
 		return err
 	}
+	var results []readbench.Result
 	for _, latencyMS := range cfg.CASLatencyMS {
 		materialized := make([]readbench.MatrixSystem, 0, len(systems))
 		for _, system := range systems {
@@ -68,7 +72,7 @@ func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) er
 			materialized = append(materialized, benchSystem)
 		}
 
-		if err := runDataset(ctx, env, cfg, dataset, materialized, total, &count); err != nil {
+		if err := runDataset(ctx, env, cfg, dataset, materialized, total, &count, &results); err != nil {
 			closeMatrixSystems(materialized)
 			return err
 		}
@@ -76,10 +80,10 @@ func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) er
 			return err
 		}
 	}
-	return nil
+	return writeAggregateCSV(env, Name, aggregateResults(results))
 }
 
-func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *readbench.MatrixDataset, systems []readbench.MatrixSystem, total int, count *int) error {
+func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *readbench.MatrixDataset, systems []readbench.MatrixSystem, total int, count *int, results *[]readbench.Result) error {
 	log := env.Log()
 	for iteration := 0; iteration < cfg.Iterations; iteration++ {
 		for _, system := range systems {
@@ -96,6 +100,9 @@ func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *rea
 					if err := env.WriteRecord(Name, result); err != nil {
 						return err
 					}
+					if results != nil {
+						*results = append(*results, *result)
+					}
 					*count = *count + 1
 					if *count%25 == 0 || *count == total {
 						log("  [%d/%d] dataset=%s iter=%d system=%s depth=%d cas_latency_ms=%d elapsed=%s",
@@ -111,12 +118,13 @@ func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *rea
 
 func parseConfig(raw json.RawMessage) (Config, error) {
 	cfg := Config{
-		Systems:      []string{"maltflat", "merkledag", "hamt"},
-		Dataset:      "read-matrix",
-		Depths:       []int{1, 2, 3, 4, 5, 6},
-		CASLatencyMS: []int{0, 25, 50, 100, 200},
-		SmallBytes:   1024,
-		Iterations:   5,
+		Systems:       []string{"maltflat", "merkledag", "hamt", "flathamt"},
+		Dataset:       "read-matrix",
+		Depths:        []int{1, 2, 3, 4, 5, 6},
+		CASLatencyMS:  []int{0, 25, 50, 100, 200},
+		SmallBytes:    1024,
+		PathsPerDepth: 5,
+		Iterations:    5,
 	}
 	if len(strings.TrimSpace(string(raw))) > 0 {
 		if err := configjson.Decode(raw, Name, &cfg); err != nil {
@@ -137,6 +145,9 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 	if cfg.SmallBytes <= 0 {
 		return Config{}, fmt.Errorf("small_bytes must be positive")
 	}
+	if cfg.PathsPerDepth <= 0 {
+		return Config{}, fmt.Errorf("paths_per_depth must be positive")
+	}
 	if len(cfg.CASLatencyMS) == 0 {
 		return Config{}, fmt.Errorf("cas_latency_ms must not be empty")
 	}
@@ -153,7 +164,7 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 
 func parseSystems(values []string) ([]readbench.SystemName, error) {
 	if len(values) == 0 {
-		return readbench.DefaultSystems(), nil
+		return []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemMerkleDAG, readbench.SystemHAMT, readbench.SystemFlatHAMT}, nil
 	}
 	return readbench.ParseSystemsCSV(strings.Join(values, ","))
 }

--- a/cmd/eval/internal/eval/suites/readmatrix/suite.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/suite.go
@@ -113,7 +113,7 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 	cfg := Config{
 		Systems:      []string{"maltflat", "merkledag", "hamt"},
 		Dataset:      "read-matrix",
-		Depths:       []int{1, 2, 4, 8, 16},
+		Depths:       []int{1, 2, 3, 4, 5, 6},
 		CASLatencyMS: []int{0, 25, 50, 100, 200},
 		SmallBytes:   1024,
 		Iterations:   5,

--- a/cmd/eval/internal/eval/suites/readmatrix/suite.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/suite.go
@@ -118,7 +118,7 @@ func runDataset(ctx context.Context, env framework.Env, cfg Config, dataset *rea
 
 func parseConfig(raw json.RawMessage) (Config, error) {
 	cfg := Config{
-		Systems:       []string{"maltflat", "merkledag", "hamt", "flathamt"},
+		Systems:       []string{"maltflat", "merkledag"},
 		Dataset:       "read-matrix",
 		Depths:        []int{1, 2, 3, 4, 5, 6},
 		CASLatencyMS:  []int{0, 25, 50, 100, 200},
@@ -164,7 +164,7 @@ func parseConfig(raw json.RawMessage) (Config, error) {
 
 func parseSystems(values []string) ([]readbench.SystemName, error) {
 	if len(values) == 0 {
-		return []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemMerkleDAG, readbench.SystemHAMT, readbench.SystemFlatHAMT}, nil
+		return []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemMerkleDAG}, nil
 	}
 	return readbench.ParseSystemsCSV(strings.Join(values, ","))
 }

--- a/cmd/eval/internal/eval/suites/readmatrix/suite_test.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/suite_test.go
@@ -27,6 +27,10 @@ func TestParseConfigDefaultsUsePaperCASLatencyBuckets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseConfig(nil) error = %v", err)
 	}
+	wantSystems := []string{"maltflat", "merkledag"}
+	if !reflect.DeepEqual(cfg.Systems, wantSystems) {
+		t.Fatalf("Systems = %v, want %v", cfg.Systems, wantSystems)
+	}
 	wantDepths := []int{1, 2, 3, 4, 5, 6}
 	if !reflect.DeepEqual(cfg.Depths, wantDepths) {
 		t.Fatalf("Depths = %v, want %v", cfg.Depths, wantDepths)

--- a/cmd/eval/internal/eval/suites/readmatrix/suite_test.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/suite_test.go
@@ -3,14 +3,17 @@ package readmatrix
 import (
 	"bufio"
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/readbench"
+	"github.com/dewebprotocol/malt/runtime/metrics"
 )
 
 func TestSuiteNameIsReadMatrix(t *testing.T) {
@@ -32,17 +35,21 @@ func TestParseConfigDefaultsUsePaperCASLatencyBuckets(t *testing.T) {
 	if !reflect.DeepEqual(cfg.CASLatencyMS, wantLatencies) {
 		t.Fatalf("CASLatencyMS = %v, want %v", cfg.CASLatencyMS, wantLatencies)
 	}
+	if cfg.PathsPerDepth != 5 {
+		t.Fatalf("PathsPerDepth = %d, want 5", cfg.PathsPerDepth)
+	}
 }
 
 func TestRunWritesResolveOnlyDepthLatencyMatrix(t *testing.T) {
 	env := newSuiteTestEnv(t, "run-read-matrix")
 	raw := json.RawMessage(`{
-		"systems": ["maltflat", "merkledag"],
+		"systems": ["maltflat", "merkledag", "flathamt"],
 		"dataset": "matrix-unit",
 		"depths": [2, 4],
 		"small_bytes": 128,
 		"cas_latency_ms": [0, 1],
-		"iterations": 1
+		"iterations": 1,
+		"paths_per_depth": 2
 	}`)
 
 	if err := (Suite{}).Run(context.Background(), env, raw); err != nil {
@@ -50,8 +57,8 @@ func TestRunWritesResolveOnlyDepthLatencyMatrix(t *testing.T) {
 	}
 
 	envelopes := readRawEnvelopes(t, env.RawPath(Name))
-	if len(envelopes) != 8 {
-		t.Fatalf("envelope count = %d, want 8", len(envelopes))
+	if len(envelopes) != 24 {
+		t.Fatalf("envelope count = %d, want 24", len(envelopes))
 	}
 
 	seenSystems := map[readbench.SystemName]bool{}
@@ -81,8 +88,8 @@ func TestRunWritesResolveOnlyDepthLatencyMatrix(t *testing.T) {
 		if result.DatasetName != "matrix-unit-depth2-4" {
 			t.Fatalf("dataset = %q", result.DatasetName)
 		}
-		if result.FileCount != 2 {
-			t.Fatalf("file_count = %d, want one lookup file per depth", result.FileCount)
+		if result.FileCount != 4 {
+			t.Fatalf("file_count = %d, want one lookup file per depth sample", result.FileCount)
 		}
 		if result.DirectoryCount == 0 || result.PathCount == 0 {
 			t.Fatalf("directory/path counts should be populated: dirs=%d paths=%d", result.DirectoryCount, result.PathCount)
@@ -102,12 +109,16 @@ func TestRunWritesResolveOnlyDepthLatencyMatrix(t *testing.T) {
 			if result.ContentBytes != nil {
 				t.Fatalf("merkledag content_bytes = %v, want nil for path-resolution record", result.ContentBytes)
 			}
-			if result.CAS.GetCount < uint64(result.PathDepth+2) {
-				t.Fatalf("merkledag CAS get_count = %d, want at least depth+2 for root/directories/target", result.CAS.GetCount)
+			if result.CAS.GetCount < uint64(result.PathDepth+1) {
+				t.Fatalf("merkledag CAS get_count = %d, want at least depth+1 for root/path edges", result.CAS.GetCount)
+			}
+		case readbench.SystemFlatHAMT:
+			if result.ContentBytes == nil || *result.ContentBytes != 128 {
+				t.Fatalf("flathamt content_bytes = %v, want target blob size 128", result.ContentBytes)
 			}
 		}
 	}
-	for _, system := range []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemMerkleDAG} {
+	for _, system := range []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemMerkleDAG, readbench.SystemFlatHAMT} {
 		if !seenSystems[system] {
 			t.Fatalf("missing system %q", system)
 		}
@@ -122,6 +133,51 @@ func TestRunWritesResolveOnlyDepthLatencyMatrix(t *testing.T) {
 			t.Fatalf("missing cas latency %dms", latencyMS)
 		}
 	}
+
+	rows := readAggregateRows(t, aggregatePath(env, Name))
+	if len(rows) != 12 {
+		t.Fatalf("aggregate row count = %d, want 12", len(rows))
+	}
+	for _, row := range rows {
+		if row["samples"] != "2" {
+			t.Fatalf("aggregate samples = %q, want 2 in row %+v", row["samples"], row)
+		}
+		if parseInt64Field(t, row, "median_elapsed_ns") <= 0 {
+			t.Fatalf("median_elapsed_ns should be positive in row %+v", row)
+		}
+		if parseInt64Field(t, row, "p95_elapsed_ns") <= 0 {
+			t.Fatalf("p95_elapsed_ns should be positive in row %+v", row)
+		}
+	}
+}
+
+func TestAggregateResultsReportsMedianAndP95(t *testing.T) {
+	results := []readbench.Result{
+		{System: readbench.SystemMALTFlat, PathDepth: 2, CASLatencyMS: 50, ElapsedNS: 100, CAS: metricsCAS(1)},
+		{System: readbench.SystemMALTFlat, PathDepth: 2, CASLatencyMS: 50, ElapsedNS: 500, CAS: metricsCAS(5)},
+		{System: readbench.SystemMALTFlat, PathDepth: 2, CASLatencyMS: 50, ElapsedNS: 300, CAS: metricsCAS(3)},
+		{System: readbench.SystemMALTFlat, PathDepth: 2, CASLatencyMS: 50, ElapsedNS: 200, CAS: metricsCAS(2)},
+		{System: readbench.SystemMALTFlat, PathDepth: 2, CASLatencyMS: 50, ElapsedNS: 400, CAS: metricsCAS(4)},
+	}
+
+	rows := aggregateResults(results)
+	if len(rows) != 1 {
+		t.Fatalf("aggregate row count = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.Samples != 5 {
+		t.Fatalf("samples = %d, want 5", row.Samples)
+	}
+	if row.MedianElapsedNS != 300 || row.P95ElapsedNS != 500 {
+		t.Fatalf("elapsed aggregate = median %d p95 %d, want 300/500", row.MedianElapsedNS, row.P95ElapsedNS)
+	}
+	if row.MedianCASGetCount != 3 || row.P95CASGetCount != 5 {
+		t.Fatalf("cas aggregate = median %d p95 %d, want 3/5", row.MedianCASGetCount, row.P95CASGetCount)
+	}
+}
+
+func metricsCAS(getCount uint64) metrics.CASStats {
+	return metrics.CASStats{GetCount: getCount}
 }
 
 type recordEnvelope struct {
@@ -166,4 +222,40 @@ func readRawEnvelopes(t *testing.T, path string) []recordEnvelope {
 		t.Fatalf("scan raw output: %v", err)
 	}
 	return out
+}
+
+func readAggregateRows(t *testing.T, path string) []map[string]string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open aggregate output: %v", err)
+	}
+	defer f.Close()
+
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("read aggregate csv: %v", err)
+	}
+	if len(records) < 1 {
+		t.Fatal("aggregate csv missing header")
+	}
+	header := records[0]
+	out := make([]map[string]string, 0, len(records)-1)
+	for _, record := range records[1:] {
+		row := make(map[string]string, len(header))
+		for i, column := range header {
+			row[column] = record[i]
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+func parseInt64Field(t *testing.T, row map[string]string, field string) int64 {
+	t.Helper()
+	value, err := strconv.ParseInt(row[field], 10, 64)
+	if err != nil {
+		t.Fatalf("parse %s=%q: %v", field, row[field], err)
+	}
+	return value
 }

--- a/cmd/eval/internal/eval/suites/readmatrix/suite_test.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/suite_test.go
@@ -1,0 +1,145 @@
+package readmatrix
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/readbench"
+)
+
+func TestSuiteNameIsReadMatrix(t *testing.T) {
+	if got := (Suite{}).Name(); got != Name {
+		t.Fatalf("Suite.Name() = %q, want %q", got, Name)
+	}
+}
+
+func TestRunWritesMatrixRecordsWithDatasetMetadata(t *testing.T) {
+	env := newSuiteTestEnv(t, "run-read-matrix")
+	raw := json.RawMessage(`{
+		"systems": ["maltflat", "merkledag"],
+		"dataset": "matrix-unit",
+		"file_counts": [4],
+		"depths": [2, 4],
+		"small_bytes": 128,
+		"large_bytes": 262145,
+		"range": "bytes=7-18",
+		"iterations": 1
+	}`)
+
+	if err := (Suite{}).Run(context.Background(), env, raw); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	envelopes := readRawEnvelopes(t, env.RawPath(Name))
+	if len(envelopes) != 12 {
+		t.Fatalf("envelope count = %d, want 12", len(envelopes))
+	}
+
+	seenSystems := map[readbench.SystemName]bool{}
+	seenDepths := map[int]bool{}
+	seenWorkloads := map[readbench.WorkloadKind]bool{}
+	for _, envelope := range envelopes {
+		if envelope.Suite != Name {
+			t.Fatalf("suite = %q, want %q", envelope.Suite, Name)
+		}
+		var result readbench.Result
+		if err := json.Unmarshal(envelope.Record, &result); err != nil {
+			t.Fatalf("decode result: %v", err)
+		}
+		seenSystems[result.System] = true
+		seenDepths[result.PathDepth] = true
+		seenWorkloads[result.Workload] = true
+
+		if result.DatasetName != "matrix-unit-files4-depth2-4" {
+			t.Fatalf("dataset = %q", result.DatasetName)
+		}
+		if result.FileCount != 4 {
+			t.Fatalf("file_count = %d, want 4", result.FileCount)
+		}
+		if result.DirectoryCount == 0 || result.PathCount == 0 {
+			t.Fatalf("directory/path counts should be populated: dirs=%d paths=%d", result.DirectoryCount, result.PathCount)
+		}
+		if result.LogicalPayloadBytes <= 262145 {
+			t.Fatalf("logical_payload_bytes = %d, want dataset-level total > large file", result.LogicalPayloadBytes)
+		}
+		if result.SmallFileBytes != 128 || result.LargeFileBytes != 262145 {
+			t.Fatalf("file bytes = small %d large %d", result.SmallFileBytes, result.LargeFileBytes)
+		}
+		if result.OperationKind == readbench.OperationContentRange {
+			if result.RangeHeader != "bytes=7-18" {
+				t.Fatalf("range_header = %q, want bytes=7-18", result.RangeHeader)
+			}
+			if result.ContentBytes == nil || *result.ContentBytes != 12 {
+				t.Fatalf("content_bytes = %v, want 12", result.ContentBytes)
+			}
+		}
+	}
+	for _, system := range []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemMerkleDAG} {
+		if !seenSystems[system] {
+			t.Fatalf("missing system %q", system)
+		}
+	}
+	for _, depth := range []int{2, 4} {
+		if !seenDepths[depth] {
+			t.Fatalf("missing depth %d", depth)
+		}
+	}
+	for _, workload := range []readbench.WorkloadKind{
+		readbench.WorkloadDeepPathLookup,
+		readbench.WorkloadSmallFileRead,
+		readbench.WorkloadLargeFileRangeRead,
+	} {
+		if !seenWorkloads[workload] {
+			t.Fatalf("missing workload %q", workload)
+		}
+	}
+}
+
+type recordEnvelope struct {
+	SchemaVersion string          `json:"schema_version"`
+	RunID         string          `json:"run_id"`
+	Suite         string          `json:"suite"`
+	EmittedAt     string          `json:"emitted_at"`
+	Record        json.RawMessage `json:"record"`
+}
+
+func newSuiteTestEnv(t *testing.T, runID string) framework.Env {
+	t.Helper()
+	tmp := t.TempDir()
+	resultDir := filepath.Join(tmp, "result")
+	if err := os.MkdirAll(filepath.Join(resultDir, "raw"), 0o755); err != nil {
+		t.Fatalf("create raw dir: %v", err)
+	}
+	return framework.Env{
+		RunID:     runID,
+		ResultDir: resultDir,
+	}
+}
+
+func readRawEnvelopes(t *testing.T, path string) []recordEnvelope {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open raw output: %v", err)
+	}
+	defer f.Close()
+
+	var out []recordEnvelope
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var envelope recordEnvelope
+		if err := json.Unmarshal(scanner.Bytes(), &envelope); err != nil {
+			t.Fatalf("decode envelope: %v", err)
+		}
+		out = append(out, envelope)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan raw output: %v", err)
+	}
+	return out
+}

--- a/cmd/eval/internal/eval/suites/readmatrix/suite_test.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/suite_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
@@ -18,16 +19,25 @@ func TestSuiteNameIsReadMatrix(t *testing.T) {
 	}
 }
 
-func TestRunWritesMatrixRecordsWithDatasetMetadata(t *testing.T) {
+func TestParseConfigDefaultsUsePaperCASLatencyBuckets(t *testing.T) {
+	cfg, err := parseConfig(nil)
+	if err != nil {
+		t.Fatalf("parseConfig(nil) error = %v", err)
+	}
+	want := []int{0, 25, 50, 100, 200}
+	if !reflect.DeepEqual(cfg.CASLatencyMS, want) {
+		t.Fatalf("CASLatencyMS = %v, want %v", cfg.CASLatencyMS, want)
+	}
+}
+
+func TestRunWritesResolveOnlyDepthLatencyMatrix(t *testing.T) {
 	env := newSuiteTestEnv(t, "run-read-matrix")
 	raw := json.RawMessage(`{
 		"systems": ["maltflat", "merkledag"],
 		"dataset": "matrix-unit",
-		"file_counts": [4],
 		"depths": [2, 4],
 		"small_bytes": 128,
-		"large_bytes": 262145,
-		"range": "bytes=7-18",
+		"cas_latency_ms": [0, 1],
 		"iterations": 1
 	}`)
 
@@ -36,13 +46,13 @@ func TestRunWritesMatrixRecordsWithDatasetMetadata(t *testing.T) {
 	}
 
 	envelopes := readRawEnvelopes(t, env.RawPath(Name))
-	if len(envelopes) != 12 {
-		t.Fatalf("envelope count = %d, want 12", len(envelopes))
+	if len(envelopes) != 8 {
+		t.Fatalf("envelope count = %d, want 8", len(envelopes))
 	}
 
 	seenSystems := map[readbench.SystemName]bool{}
 	seenDepths := map[int]bool{}
-	seenWorkloads := map[readbench.WorkloadKind]bool{}
+	seenLatencies := map[int]bool{}
 	for _, envelope := range envelopes {
 		if envelope.Suite != Name {
 			t.Fatalf("suite = %q, want %q", envelope.Suite, Name)
@@ -53,30 +63,31 @@ func TestRunWritesMatrixRecordsWithDatasetMetadata(t *testing.T) {
 		}
 		seenSystems[result.System] = true
 		seenDepths[result.PathDepth] = true
-		seenWorkloads[result.Workload] = true
+		seenLatencies[result.CASLatencyMS] = true
 
-		if result.DatasetName != "matrix-unit-files4-depth2-4" {
+		if result.OperationKind != readbench.OperationResolvePath {
+			t.Fatalf("operation_kind = %q, want %q", result.OperationKind, readbench.OperationResolvePath)
+		}
+		if result.Workload != readbench.WorkloadDeepPathLookup {
+			t.Fatalf("workload = %q, want %q", result.Workload, readbench.WorkloadDeepPathLookup)
+		}
+		if result.RangeHeader != "" {
+			t.Fatalf("range_header = %q, want empty", result.RangeHeader)
+		}
+		if result.ContentBytes != nil {
+			t.Fatalf("content_bytes = %v, want nil for resolve-only matrix", result.ContentBytes)
+		}
+		if result.DatasetName != "matrix-unit-depth2-4" {
 			t.Fatalf("dataset = %q", result.DatasetName)
 		}
-		if result.FileCount != 4 {
-			t.Fatalf("file_count = %d, want 4", result.FileCount)
+		if result.FileCount != 2 {
+			t.Fatalf("file_count = %d, want one lookup file per depth", result.FileCount)
 		}
 		if result.DirectoryCount == 0 || result.PathCount == 0 {
 			t.Fatalf("directory/path counts should be populated: dirs=%d paths=%d", result.DirectoryCount, result.PathCount)
 		}
-		if result.LogicalPayloadBytes <= 262145 {
-			t.Fatalf("logical_payload_bytes = %d, want dataset-level total > large file", result.LogicalPayloadBytes)
-		}
-		if result.SmallFileBytes != 128 || result.LargeFileBytes != 262145 {
-			t.Fatalf("file bytes = small %d large %d", result.SmallFileBytes, result.LargeFileBytes)
-		}
-		if result.OperationKind == readbench.OperationContentRange {
-			if result.RangeHeader != "bytes=7-18" {
-				t.Fatalf("range_header = %q, want bytes=7-18", result.RangeHeader)
-			}
-			if result.ContentBytes == nil || *result.ContentBytes != 12 {
-				t.Fatalf("content_bytes = %v, want 12", result.ContentBytes)
-			}
+		if result.SmallFileBytes != 128 || result.LargeFileBytes != 0 {
+			t.Fatalf("file bytes = small %d large %d, want small 128 and no large/list payload", result.SmallFileBytes, result.LargeFileBytes)
 		}
 	}
 	for _, system := range []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemMerkleDAG} {
@@ -89,13 +100,9 @@ func TestRunWritesMatrixRecordsWithDatasetMetadata(t *testing.T) {
 			t.Fatalf("missing depth %d", depth)
 		}
 	}
-	for _, workload := range []readbench.WorkloadKind{
-		readbench.WorkloadDeepPathLookup,
-		readbench.WorkloadSmallFileRead,
-		readbench.WorkloadLargeFileRangeRead,
-	} {
-		if !seenWorkloads[workload] {
-			t.Fatalf("missing workload %q", workload)
+	for _, latencyMS := range []int{0, 1} {
+		if !seenLatencies[latencyMS] {
+			t.Fatalf("missing cas latency %dms", latencyMS)
 		}
 	}
 }

--- a/cmd/eval/internal/eval/suites/readmatrix/suite_test.go
+++ b/cmd/eval/internal/eval/suites/readmatrix/suite_test.go
@@ -24,9 +24,13 @@ func TestParseConfigDefaultsUsePaperCASLatencyBuckets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseConfig(nil) error = %v", err)
 	}
-	want := []int{0, 25, 50, 100, 200}
-	if !reflect.DeepEqual(cfg.CASLatencyMS, want) {
-		t.Fatalf("CASLatencyMS = %v, want %v", cfg.CASLatencyMS, want)
+	wantDepths := []int{1, 2, 3, 4, 5, 6}
+	if !reflect.DeepEqual(cfg.Depths, wantDepths) {
+		t.Fatalf("Depths = %v, want %v", cfg.Depths, wantDepths)
+	}
+	wantLatencies := []int{0, 25, 50, 100, 200}
+	if !reflect.DeepEqual(cfg.CASLatencyMS, wantLatencies) {
+		t.Fatalf("CASLatencyMS = %v, want %v", cfg.CASLatencyMS, wantLatencies)
 	}
 }
 
@@ -74,9 +78,6 @@ func TestRunWritesResolveOnlyDepthLatencyMatrix(t *testing.T) {
 		if result.RangeHeader != "" {
 			t.Fatalf("range_header = %q, want empty", result.RangeHeader)
 		}
-		if result.ContentBytes != nil {
-			t.Fatalf("content_bytes = %v, want nil for resolve-only matrix", result.ContentBytes)
-		}
 		if result.DatasetName != "matrix-unit-depth2-4" {
 			t.Fatalf("dataset = %q", result.DatasetName)
 		}
@@ -88,6 +89,22 @@ func TestRunWritesResolveOnlyDepthLatencyMatrix(t *testing.T) {
 		}
 		if result.SmallFileBytes != 128 || result.LargeFileBytes != 0 {
 			t.Fatalf("file bytes = small %d large %d, want small 128 and no large/list payload", result.SmallFileBytes, result.LargeFileBytes)
+		}
+		switch result.System {
+		case readbench.SystemMALTFlat:
+			if result.ContentBytes == nil || *result.ContentBytes != 128 {
+				t.Fatalf("malt content_bytes = %v, want target blob size 128", result.ContentBytes)
+			}
+			if result.CAS.GetCount != 1 {
+				t.Fatalf("malt CAS get_count = %d, want one target blob fetch", result.CAS.GetCount)
+			}
+		case readbench.SystemMerkleDAG:
+			if result.ContentBytes != nil {
+				t.Fatalf("merkledag content_bytes = %v, want nil for path-resolution record", result.ContentBytes)
+			}
+			if result.CAS.GetCount < uint64(result.PathDepth+2) {
+				t.Fatalf("merkledag CAS get_count = %d, want at least depth+2 for root/directories/target", result.CAS.GetCount)
+			}
 		}
 	}
 	for _, system := range []readbench.SystemName{readbench.SystemMALTFlat, readbench.SystemMerkleDAG} {

--- a/cmd/eval/internal/eval/suites/readquery/suite_test.go
+++ b/cmd/eval/internal/eval/suites/readquery/suite_test.go
@@ -114,8 +114,8 @@ func TestRunAllowsBaselineOnlyWithoutDaemonArcs(t *testing.T) {
 	}
 
 	envelopes := readRawEnvelopes(t, env.RawPath(Name))
-	if len(envelopes) != 2 {
-		t.Fatalf("envelope count = %d, want 2", len(envelopes))
+	if len(envelopes) != 3 {
+		t.Fatalf("envelope count = %d, want 3", len(envelopes))
 	}
 	for _, envelope := range envelopes {
 		result := decodeEnvelopeResult(t, envelope)
@@ -181,8 +181,8 @@ func TestFrameworkRunWritesEnvelopedReadQueryRecords(t *testing.T) {
 	}
 
 	envelopes := readRawEnvelopes(t, filepath.Join(plan.ResultDir, "raw", "read_query.jsonl"))
-	if len(envelopes) != 2 {
-		t.Fatalf("envelope count = %d, want 2", len(envelopes))
+	if len(envelopes) != 3 {
+		t.Fatalf("envelope count = %d, want 3", len(envelopes))
 	}
 
 	for _, envelope := range envelopes {
@@ -206,9 +206,17 @@ func TestFrameworkRunWritesEnvelopedReadQueryRecords(t *testing.T) {
 			t.Fatalf("CAS metrics not preserved in envelope record: %+v", result.CAS)
 		}
 	}
-	rangeResult := decodeEnvelopeResult(t, envelopes[1])
+	smallReadResult := decodeEnvelopeResult(t, envelopes[1])
+	if smallReadResult.OperationKind != readbench.OperationContentFull {
+		t.Fatalf("second operation = %q, want content_full", smallReadResult.OperationKind)
+	}
+	if smallReadResult.Workload != readbench.WorkloadSmallFileRead {
+		t.Fatalf("second workload = %q, want small_file_read", smallReadResult.Workload)
+	}
+
+	rangeResult := decodeEnvelopeResult(t, envelopes[2])
 	if rangeResult.OperationKind != readbench.OperationContentRange {
-		t.Fatalf("second operation = %q, want content_range", rangeResult.OperationKind)
+		t.Fatalf("third operation = %q, want content_range", rangeResult.OperationKind)
 	}
 	if rangeResult.RangeHeader != "bytes=3-6" {
 		t.Fatalf("range header = %q, want bytes=3-6", rangeResult.RangeHeader)

--- a/cmd/eval/internal/eval/summary/summary.go
+++ b/cmd/eval/internal/eval/summary/summary.go
@@ -17,6 +17,7 @@ var metadataColumns = []string{"schema_version", "run_id", "suite", "emitted_at"
 
 var figureNames = map[string]string{
 	"write_trace":      "figure_write_trace.csv",
+	"read_matrix":      "figure_read_matrix.csv",
 	"read_query":       "figure_read_query.csv",
 	"cas_model":        "figure_cas_model.csv",
 	"proof_overhead":   "figure_proof.csv",

--- a/cmd/eval/schemas/flat-index-cardinality-result.schema.json
+++ b/cmd/eval/schemas/flat-index-cardinality-result.schema.json
@@ -102,7 +102,7 @@
     "prove_elapsed_ns": {
       "type": "integer",
       "minimum": 0,
-      "description": "MALT proof/open generation latency for the canonical full-path key; omitted for flat HAMT."
+      "description": "MALT commitment open/prove latency for the canonical full-path key after radix slots have been loaded; omitted for flat HAMT."
     },
     "verify_elapsed_ns": {
       "type": "integer",

--- a/cmd/eval/schemas/flat-index-cardinality-result.schema.json
+++ b/cmd/eval/schemas/flat-index-cardinality-result.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/flat-index-cardinality-result.schema.json",
+  "title": "Flat index cardinality suite result",
+  "description": "One flat_index_cardinality suite record for a full-path-key lookup plus target fetch before the common framework envelope is applied.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "system",
+    "operation_kind",
+    "workload",
+    "iteration",
+    "fixture",
+    "path",
+    "cas_latency_ms",
+    "elapsed_ns",
+    "prooflist_step_count",
+    "evidence_item_count",
+    "cas",
+    "arctable",
+    "proof"
+  ],
+  "properties": {
+    "system": {
+      "type": "string",
+      "enum": ["maltflat", "flathamt"],
+      "description": "Evaluated flat full-path index implementation."
+    },
+    "operation_kind": {
+      "type": "string",
+      "enum": ["resolve_path"]
+    },
+    "workload": {
+      "type": "string",
+      "enum": ["deep_path_lookup"],
+      "description": "Full-path-key lookup workload represented by this operation."
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "fixture": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dataset": {
+      "type": "string",
+      "description": "Logical source dataset shared by both flat systems at this cardinality."
+    },
+    "file_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of canonical full-path keys in the flat index."
+    },
+    "directory_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "path_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "path_depth": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Fixed logical path depth used to generate canonical full-path strings; not the independent variable for this suite."
+    },
+    "path_sample": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "One-based lookup-key sample index within this key-count point."
+    },
+    "logical_payload_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "small_file_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "large_file_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "cas_latency_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Configured fixed per-CAS-Get latency for this matrix point in milliseconds."
+    },
+    "range_header": {
+      "type": "string",
+      "description": "Unused by flat_index_cardinality; present for compatibility with the shared read result shape."
+    },
+    "elapsed_ns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "verify_elapsed_ns": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional MALT client verification latency for returned ProofList evidence."
+    },
+    "content_bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Target blob bytes fetched after full-path index lookup."
+    },
+    "prooflist_step_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "evidence_item_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Comparable evidence count: ProofList steps for MALT, CAS block fetches for flat HAMT."
+    },
+    "target": {
+      "type": "string",
+      "description": "Resolved target CID for resolve_path records."
+    },
+    "cas": {
+      "$ref": "#/$defs/cas_stats"
+    },
+    "arctable": {
+      "$ref": "#/$defs/arctable_stats"
+    },
+    "proof": {
+      "$ref": "#/$defs/proof_stats"
+    }
+  },
+  "$defs": {
+    "counter": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cas_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["put_count", "get_count", "has_count", "bytes_put", "bytes_get"],
+      "properties": {
+        "put_count": { "$ref": "#/$defs/counter" },
+        "get_count": { "$ref": "#/$defs/counter" },
+        "has_count": { "$ref": "#/$defs/counter" },
+        "bytes_put": { "$ref": "#/$defs/counter" },
+        "bytes_get": { "$ref": "#/$defs/counter" }
+      }
+    },
+    "arctable_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "get_count",
+        "batch_get_count",
+        "batch_get_path_count",
+        "update_count",
+        "update_arc_count",
+        "snapshot_count",
+        "snapshot_arc_count",
+        "iterate_count"
+      ],
+      "properties": {
+        "get_count": { "$ref": "#/$defs/counter" },
+        "batch_get_count": { "$ref": "#/$defs/counter" },
+        "batch_get_path_count": { "$ref": "#/$defs/counter" },
+        "update_count": { "$ref": "#/$defs/counter" },
+        "update_arc_count": { "$ref": "#/$defs/counter" },
+        "snapshot_count": { "$ref": "#/$defs/counter" },
+        "snapshot_arc_count": { "$ref": "#/$defs/counter" },
+        "iterate_count": { "$ref": "#/$defs/counter" }
+      }
+    },
+    "proof_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "proof_list_count",
+        "step_count",
+        "evidence_bytes",
+        "proof_bytes",
+        "total_bytes"
+      ],
+      "properties": {
+        "proof_list_count": { "$ref": "#/$defs/counter" },
+        "step_count": { "$ref": "#/$defs/counter" },
+        "evidence_bytes": { "$ref": "#/$defs/counter" },
+        "proof_bytes": { "$ref": "#/$defs/counter" },
+        "total_bytes": { "$ref": "#/$defs/counter" }
+      }
+    }
+  }
+}

--- a/cmd/eval/schemas/flat-index-cardinality-result.schema.json
+++ b/cmd/eval/schemas/flat-index-cardinality-result.schema.json
@@ -99,6 +99,11 @@
       "type": "integer",
       "minimum": 0
     },
+    "prove_elapsed_ns": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "MALT proof/open generation latency for the canonical full-path key; omitted for flat HAMT."
+    },
     "verify_elapsed_ns": {
       "type": "integer",
       "minimum": 0,

--- a/cmd/eval/schemas/read-matrix-result.schema.json
+++ b/cmd/eval/schemas/read-matrix-result.schema.json
@@ -12,6 +12,7 @@
     "iteration",
     "fixture",
     "path",
+    "cas_latency_ms",
     "elapsed_ns",
     "prooflist_step_count",
     "evidence_item_count",
@@ -27,11 +28,11 @@
     },
     "operation_kind": {
       "type": "string",
-      "enum": ["resolve_path", "content_full", "content_range"]
+      "enum": ["resolve_path"]
     },
     "workload": {
       "type": "string",
-      "enum": ["deep_path_lookup", "small_file_read", "large_file_range_read"],
+      "enum": ["deep_path_lookup"],
       "description": "Paper-facing read workload represented by this operation."
     },
     "iteration": {
@@ -77,6 +78,11 @@
     "path": {
       "type": "string",
       "minLength": 1
+    },
+    "cas_latency_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Configured fixed per-CAS-Get latency for this matrix point in milliseconds."
     },
     "range_header": {
       "type": "string",

--- a/cmd/eval/schemas/read-matrix-result.schema.json
+++ b/cmd/eval/schemas/read-matrix-result.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/read-matrix-result.schema.json",
   "title": "Read matrix suite result",
-  "description": "One read_matrix suite record for a single measured read operation before the common framework envelope is applied.",
+  "description": "One read_matrix suite record for a resolve-path operation plus target fetch before the common framework envelope is applied.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -86,7 +86,7 @@
     },
     "range_header": {
       "type": "string",
-      "description": "HTTP Range header used for content_range records."
+      "description": "Unused by read_matrix; present for compatibility with the shared read result shape."
     },
     "elapsed_ns": {
       "type": "integer",
@@ -99,7 +99,8 @@
     },
     "content_bytes": {
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "description": "Target blob bytes fetched by MALT after flat path resolution; omitted by IPLD baseline path-resolution records."
     },
     "prooflist_step_count": {
       "type": "integer",

--- a/cmd/eval/schemas/read-matrix-result.schema.json
+++ b/cmd/eval/schemas/read-matrix-result.schema.json
@@ -97,6 +97,11 @@
       "type": "integer",
       "minimum": 0
     },
+    "prove_elapsed_ns": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "MALT proof/open generation latency for the requested full-path key; omitted when this suite does not measure it separately."
+    },
     "verify_elapsed_ns": {
       "type": "integer",
       "minimum": 0,

--- a/cmd/eval/schemas/read-matrix-result.schema.json
+++ b/cmd/eval/schemas/read-matrix-result.schema.json
@@ -100,7 +100,7 @@
     "prove_elapsed_ns": {
       "type": "integer",
       "minimum": 0,
-      "description": "MALT proof/open generation latency for the requested full-path key; omitted when this suite does not measure it separately."
+      "description": "MALT commitment open/prove latency after radix slots have been loaded; omitted when this suite does not measure it separately."
     },
     "verify_elapsed_ns": {
       "type": "integer",

--- a/cmd/eval/schemas/read-matrix-result.schema.json
+++ b/cmd/eval/schemas/read-matrix-result.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/read-query-result.schema.json",
-  "title": "Read query suite result",
-  "description": "One read_query suite record for a single measured read operation before the common framework envelope is applied.",
+  "$id": "https://github.com/dewebprotocol/malt/cmd/eval/schemas/read-matrix-result.schema.json",
+  "title": "Read matrix suite result",
+  "description": "One read_matrix suite record for a single measured read operation before the common framework envelope is applied.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -44,7 +44,7 @@
     },
     "dataset": {
       "type": "string",
-      "description": "Logical source dataset shared by read_matrix systems."
+      "description": "Logical source dataset shared by all systems in this matrix point."
     },
     "file_count": {
       "type": "integer",
@@ -89,7 +89,7 @@
     "verify_elapsed_ns": {
       "type": "integer",
       "minimum": 0,
-      "description": "MALT client verification latency for returned ProofList evidence; omitted for IPLD UnixFS baselines."
+      "description": "Optional MALT client verification latency for returned ProofList evidence."
     },
     "content_bytes": {
       "type": "integer",

--- a/cmd/eval/schemas/read-matrix-result.schema.json
+++ b/cmd/eval/schemas/read-matrix-result.schema.json
@@ -23,7 +23,7 @@
   "properties": {
     "system": {
       "type": "string",
-      "enum": ["maltflat", "merkledag", "hamt"],
+      "enum": ["maltflat", "merkledag", "hamt", "flathamt"],
       "description": "Evaluated read implementation."
     },
     "operation_kind": {
@@ -63,6 +63,11 @@
       "type": "integer",
       "minimum": 0
     },
+    "path_sample": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "One-based lookup-key sample index within this path depth."
+    },
     "logical_payload_bytes": {
       "type": "integer",
       "minimum": 0
@@ -100,7 +105,7 @@
     "content_bytes": {
       "type": "integer",
       "minimum": 0,
-      "description": "Target blob bytes fetched by MALT after flat path resolution; omitted by IPLD baseline path-resolution records."
+      "description": "Target blob bytes fetched by flat MALT and flat HAMT after path resolution; omitted by IPLD UnixFS path-resolution records."
     },
     "prooflist_step_count": {
       "type": "integer",

--- a/cmd/eval/schemas/read-query-result.schema.json
+++ b/cmd/eval/schemas/read-query-result.schema.json
@@ -63,6 +63,10 @@
       "type": "integer",
       "minimum": 0
     },
+    "path_sample": {
+      "type": "integer",
+      "minimum": 0
+    },
     "logical_payload_bytes": {
       "type": "integer",
       "minimum": 0

--- a/cmd/eval/schemas/read-query-result.schema.json
+++ b/cmd/eval/schemas/read-query-result.schema.json
@@ -8,6 +8,7 @@
   "required": [
     "system",
     "operation_kind",
+    "workload",
     "iteration",
     "fixture",
     "path",
@@ -26,7 +27,12 @@
     },
     "operation_kind": {
       "type": "string",
-      "enum": ["resolve_path", "content_range"]
+      "enum": ["resolve_path", "content_full", "content_range"]
+    },
+    "workload": {
+      "type": "string",
+      "enum": ["deep_path_lookup", "small_file_read", "large_file_range_read"],
+      "description": "Paper-facing read workload represented by this operation."
     },
     "iteration": {
       "type": "integer",
@@ -47,6 +53,11 @@
     "elapsed_ns": {
       "type": "integer",
       "minimum": 0
+    },
+    "verify_elapsed_ns": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "MALT client verification latency for returned ProofList evidence; omitted for IPLD UnixFS baselines."
     },
     "content_bytes": {
       "type": "integer",

--- a/cmd/eval/schemas/read-query-result.schema.json
+++ b/cmd/eval/schemas/read-query-result.schema.json
@@ -12,6 +12,7 @@
     "iteration",
     "fixture",
     "path",
+    "cas_latency_ms",
     "elapsed_ns",
     "prooflist_step_count",
     "evidence_item_count",
@@ -77,6 +78,11 @@
     "path": {
       "type": "string",
       "minLength": 1
+    },
+    "cas_latency_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Configured fixed per-CAS-Get latency for this read record in milliseconds; zero for read_query daemon runs."
     },
     "range_header": {
       "type": "string",

--- a/cmd/eval/schemas/read-query-result.schema.json
+++ b/cmd/eval/schemas/read-query-result.schema.json
@@ -96,6 +96,11 @@
       "type": "integer",
       "minimum": 0
     },
+    "prove_elapsed_ns": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "MALT proof/open generation latency for the requested full-path key; omitted when this suite does not measure it separately."
+    },
     "verify_elapsed_ns": {
       "type": "integer",
       "minimum": 0,

--- a/cmd/eval/schemas/read-query-result.schema.json
+++ b/cmd/eval/schemas/read-query-result.schema.json
@@ -99,7 +99,7 @@
     "prove_elapsed_ns": {
       "type": "integer",
       "minimum": 0,
-      "description": "MALT proof/open generation latency for the requested full-path key; omitted when this suite does not measure it separately."
+      "description": "MALT commitment open/prove latency after radix slots have been loaded; omitted when this suite does not measure it separately."
     },
     "verify_elapsed_ns": {
       "type": "integer",

--- a/cmd/eval/schemas/readbench-result.schema.json
+++ b/cmd/eval/schemas/readbench-result.schema.json
@@ -42,6 +42,38 @@
       "type": "string",
       "minLength": 1
     },
+    "dataset": {
+      "type": "string",
+      "description": "Logical source dataset shared by read_matrix systems."
+    },
+    "file_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "directory_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "path_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "path_depth": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "logical_payload_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "small_file_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "large_file_bytes": {
+      "type": "integer",
+      "minimum": 0
+    },
     "path": {
       "type": "string",
       "minLength": 1

--- a/cmd/eval/schemas/readbench-result.schema.json
+++ b/cmd/eval/schemas/readbench-result.schema.json
@@ -12,6 +12,7 @@
     "iteration",
     "fixture",
     "path",
+    "cas_latency_ms",
     "elapsed_ns",
     "prooflist_step_count",
     "evidence_item_count",
@@ -77,6 +78,11 @@
     "path": {
       "type": "string",
       "minLength": 1
+    },
+    "cas_latency_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Configured fixed per-CAS-Get latency for this read record in milliseconds; zero for runs without an explicit latency model."
     },
     "range_header": {
       "type": "string",

--- a/cmd/eval/schemas/readbench-result.schema.json
+++ b/cmd/eval/schemas/readbench-result.schema.json
@@ -8,6 +8,7 @@
   "required": [
     "system",
     "operation_kind",
+    "workload",
     "iteration",
     "fixture",
     "path",
@@ -26,7 +27,12 @@
     },
     "operation_kind": {
       "type": "string",
-      "enum": ["resolve_path", "content_range"]
+      "enum": ["resolve_path", "content_full", "content_range"]
+    },
+    "workload": {
+      "type": "string",
+      "enum": ["deep_path_lookup", "small_file_read", "large_file_range_read"],
+      "description": "Paper-facing read workload represented by this operation."
     },
     "iteration": {
       "type": "integer",
@@ -47,6 +53,11 @@
     "elapsed_ns": {
       "type": "integer",
       "minimum": 0
+    },
+    "verify_elapsed_ns": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "MALT client verification latency for returned ProofList evidence; omitted for IPLD UnixFS baselines."
     },
     "content_bytes": {
       "type": "integer",

--- a/cmd/eval/schemas/readbench-result.schema.json
+++ b/cmd/eval/schemas/readbench-result.schema.json
@@ -23,7 +23,7 @@
   "properties": {
     "system": {
       "type": "string",
-      "enum": ["maltflat", "merkledag", "hamt"],
+      "enum": ["maltflat", "merkledag", "hamt", "flathamt"],
       "description": "Evaluated read implementation."
     },
     "operation_kind": {
@@ -60,6 +60,10 @@
       "minimum": 0
     },
     "path_depth": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "path_sample": {
       "type": "integer",
       "minimum": 0
     },

--- a/cmd/eval/schemas/readbench-result.schema.json
+++ b/cmd/eval/schemas/readbench-result.schema.json
@@ -99,7 +99,7 @@
     "prove_elapsed_ns": {
       "type": "integer",
       "minimum": 0,
-      "description": "MALT proof/open generation latency for the requested full-path key; omitted for baselines and read modes that do not measure it separately."
+      "description": "MALT commitment open/prove latency after radix slots have been loaded; omitted for baselines and read modes that do not measure it separately."
     },
     "verify_elapsed_ns": {
       "type": "integer",

--- a/cmd/eval/schemas/readbench-result.schema.json
+++ b/cmd/eval/schemas/readbench-result.schema.json
@@ -96,6 +96,11 @@
       "type": "integer",
       "minimum": 0
     },
+    "prove_elapsed_ns": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "MALT proof/open generation latency for the requested full-path key; omitted for baselines and read modes that do not measure it separately."
+    },
     "verify_elapsed_ns": {
       "type": "integer",
       "minimum": 0,

--- a/cmd/eval/schemas/schemas.go
+++ b/cmd/eval/schemas/schemas.go
@@ -22,6 +22,7 @@ func Entries() []Entry {
 		{Name: "cas-model-result", Path: "cmd/eval/schemas/cas-model-result.schema.json"},
 		{Name: "common-record", Path: "cmd/eval/schemas/common-record.schema.json"},
 		{Name: "proof-overhead-result", Path: "cmd/eval/schemas/proof-overhead-result.schema.json"},
+		{Name: "read-matrix-result", Path: "cmd/eval/schemas/read-matrix-result.schema.json"},
 		{Name: "read-query-result", Path: "cmd/eval/schemas/read-query-result.schema.json"},
 		{Name: "readbench-result", Path: "cmd/eval/schemas/readbench-result.schema.json"},
 		{Name: "run-manifest", Path: "cmd/eval/schemas/run-manifest.schema.json"},

--- a/cmd/eval/schemas/schemas.go
+++ b/cmd/eval/schemas/schemas.go
@@ -21,6 +21,7 @@ func Entries() []Entry {
 	return []Entry{
 		{Name: "cas-model-result", Path: "cmd/eval/schemas/cas-model-result.schema.json"},
 		{Name: "common-record", Path: "cmd/eval/schemas/common-record.schema.json"},
+		{Name: "flat-index-cardinality-result", Path: "cmd/eval/schemas/flat-index-cardinality-result.schema.json"},
 		{Name: "proof-overhead-result", Path: "cmd/eval/schemas/proof-overhead-result.schema.json"},
 		{Name: "read-matrix-result", Path: "cmd/eval/schemas/read-matrix-result.schema.json"},
 		{Name: "read-query-result", Path: "cmd/eval/schemas/read-query-result.schema.json"},

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -63,13 +63,30 @@ writer receipt counts as correctness proofs. Receipts and metrics are
 operational accounting unless tied to verifier evidence.
 
 The `read_matrix` suite is the main paper-facing read comparison. It builds one
-deterministic logical lookup tree, materializes the same paths as flat MALT
-authenticated arcs, IPLD UnixFS MerkleDAG, and IPLD UnixFS HAMT, then emits one
-`resolve_path` record per system, path depth, configured CAS latency, and
-iteration. Use it to compare whether lookup latency grows with path depth under
-warm per-block CAS latency models. The MALT record includes flat path
-authentication plus one target blob fetch from CAS; the IPLD baselines include
-their serial directory traversal and terminal target-node fetches.
+deterministic logical lookup tree and materializes the same paths as:
+
+- `maltflat`: flat MALT authenticated arcs keyed by the complete logical path
+- `merkledag`: IPLD UnixFS basic directory traversal
+- `hamt`: IPLD UnixFS HAMT directory traversal
+- `flathamt`: one IPFS/Boxo HAMT map keyed by the complete logical path
+
+It emits one `resolve_path` record per system, path depth, path sample,
+configured CAS latency, and iteration. Use it to compare whether lookup latency
+grows with path depth under warm per-block CAS latency models. The `maltflat`
+and `flathamt` records include flat path lookup plus one target blob fetch from
+CAS; the IPLD UnixFS baselines include their serial directory traversal and
+terminal target-node fetches.
+
+In `read_matrix`, `path_depth` means the number of edges from the root directory
+to the target file. Therefore depth `1` is a file directly under the root,
+depth `2` is one directory plus a file, and so on. It is not the number of
+directory components.
+
+The suite writes raw records to `raw/read_matrix.jsonl` and a figure-facing
+aggregate to `aggregate/read_matrix.csv`. Use the aggregate's median and p95
+columns for plots; raw records remain the audit trail for per-sample behavior.
+Set `paths_per_depth` above `1` for the main paper run so that key-dependent
+radix/HAMT artifacts do not dominate a single depth point.
 
 Use depths `[1, 2, 3, 4, 5, 6]` for the main paper figure. A sweep up to depth
 10 is acceptable for a sensitivity appendix, but depth 16 should be treated as
@@ -86,11 +103,12 @@ steady-state latency.
 Report the read matrix from two views:
 
 - fixed CAS latency: plot path depth on the x-axis, total elapsed time on the
-  y-axis, and one line per system; use two or three latency scenarios such as
-  `25`, `200`, and optionally `2100` ms
+  y-axis, and one line per system; use median latency as the main line and p95
+  as optional error bars or a separate table; use two or three latency scenarios
+  such as `25`, `200`, and optionally `2100` ms
 - fixed path depth: hold depth at a representative value such as `4`, plot CAS
   latency on the x-axis, total elapsed time on the y-axis, and one line per
-  system
+  system; again report median first and p95 as tail latency
 
 The read matrix intentionally excludes full-content reads, range reads,
 list-backed payloads, and data-size/proof-generation sweeps. Dataset size effects

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -52,6 +52,7 @@ Paper-facing reports should keep these dimensions separate:
   path-depth matrix
 - configured per-CAS-Get latency (`cas_latency_ms`)
 - read-path latency (`elapsed_ns`)
+- MALT proof/open generation latency (`prove_elapsed_ns`)
 - MALT client ProofList verification latency (`verify_elapsed_ns`)
 - proof bytes
 - ProofList step counts
@@ -129,13 +130,19 @@ record per system, key-count point, lookup sample, configured CAS latency, and
 iteration. Use this benchmark to evaluate the claim that a flat HAMT's latency
 depends on the number of HAMT blocks touched, which grows with key cardinality
 and hash distribution, while flat MALT lookup remains independent of logical
-path depth. The fixed `path_depth` only shapes the canonical string used as the
-key; it is not the independent variable for this suite.
+path depth. For MALT records, `prove_elapsed_ns` separately measures semantic
+proof/open generation for the canonical full-path key without target blob fetch.
+This is the cost that should be compared against the expected MALT radix depth,
+approximately `log_256(key_count)` in the common case. The fixed `path_depth`
+only shapes the canonical string used as the key; it is not the independent
+variable for this suite.
 
 The suite writes raw records to `raw/flat_index_cardinality.jsonl` and a
 figure-facing aggregate to `aggregate/flat_index_cardinality.csv`. Plot
 `file_count` on the x-axis, total elapsed time on the y-axis, and one line per
 system. Use median latency for the main result and p95 to report tail behavior.
+For the MALT proof-cost figure, plot `median_prove_elapsed_ns` and
+`p95_prove_elapsed_ns` against `file_count` separately from read latency.
 
 `malt-eval read` and the `read_query` suite remain useful for daemon-oriented
 end-to-end checks. They exercise the HTTP daemon path for MALT and local IPLD

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -8,8 +8,8 @@ See also the evaluator code under `cmd/eval/`.
 
 `malt-eval` supports:
 
-- the `read_matrix` suite for paper-facing fair read comparisons over shared
-  logical datasets
+- the `read_matrix` suite for paper-facing fair resolve-path comparisons over
+  shared logical paths
 - `malt-eval read` for paper-facing read benchmark records
 - `malt-eval write` for write-trace replay records
 - `malt-eval run` for JSON run plans and durable run directories
@@ -45,8 +45,9 @@ Paper-facing reports should keep these dimensions separate:
 - payload bytes
 - read dataset metadata: `dataset`, `file_count`, `directory_count`,
   `path_count`, `path_depth`, and `logical_payload_bytes`
-- read workload labels: `deep_path_lookup`, `small_file_read`, and
-  `large_file_range_read`
+- read workload labels, with `deep_path_lookup` used for the main
+  path-depth matrix
+- configured per-CAS-Get latency (`cas_latency_ms`)
 - read-path latency (`elapsed_ns`)
 - MALT client ProofList verification latency (`verify_elapsed_ns`)
 - proof bytes
@@ -62,10 +63,23 @@ writer receipt counts as correctness proofs. Receipts and metrics are
 operational accounting unless tied to verifier evidence.
 
 The `read_matrix` suite is the main paper-facing read comparison. It builds one
-deterministic logical file tree per dataset point, materializes that same source
-dataset into MALT, IPLD UnixFS MerkleDAG, and IPLD UnixFS HAMT, then emits one
-record per system, dataset scale, path depth, workload, and iteration. Use it
-to compare how read latency changes as data scale and lookup depth increase.
+deterministic logical lookup tree, materializes the same paths as flat MALT
+authenticated arcs, IPLD UnixFS MerkleDAG, and IPLD UnixFS HAMT, then emits one
+`resolve_path` record per system, path depth, configured CAS latency, and
+iteration. Use it to compare whether lookup latency grows with path depth under
+warm per-block CAS latency models.
+
+Use `[0, 25, 50, 100, 200]` milliseconds as the primary
+`cas_latency_ms` sweep. These values model local execution, near-region managed
+CAS, low-latency public gateway access, typical public internet access, and
+poor/far public gateway access. A separate `2100` millisecond stress run can be
+used for cold IPFS DHT/provider-discovery behavior, but it should be reported
+separately from the main warm-CAS figure because it is not a normal per-block
+steady-state latency.
+
+The read matrix intentionally excludes full-content reads, range reads,
+list-backed payloads, and data-size/proof-generation sweeps. Dataset size effects
+on flat MALT proof generation belong in a separate microbenchmark.
 
 `malt-eval read` and the `read_query` suite remain useful for daemon-oriented
 end-to-end checks. They exercise the HTTP daemon path for MALT and local IPLD

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -8,7 +8,7 @@ See also the evaluator code under `cmd/eval/`.
 
 `malt-eval` supports:
 
-- `malt-eval read` for read-query records
+- `malt-eval read` for paper-facing read benchmark records
 - `malt-eval write` for write-trace replay records
 - `malt-eval run` for JSON run plans and durable run directories
 - `malt-eval summarize` for summary CSV regeneration
@@ -40,6 +40,10 @@ normalization tests in the same PR.
 Paper-facing reports should keep these dimensions separate:
 
 - payload bytes
+- read workload labels: `deep_path_lookup`, `small_file_read`, and
+  `large_file_range_read`
+- read-path latency (`elapsed_ns`)
+- MALT client ProofList verification latency (`verify_elapsed_ns`)
 - proof bytes
 - ProofList step counts
 - comparable baseline evidence items, such as CAS block fetches
@@ -51,6 +55,13 @@ Paper-facing reports should keep these dimensions separate:
 Do not count unverifiable helper metadata as proof evidence. Do not present
 writer receipt counts as correctness proofs. Receipts and metrics are
 operational accounting unless tied to verifier evidence.
+
+`malt-eval read` and the `read_query` suite compare MALT against IPLD UnixFS
+MerkleDAG and HAMT-style baselines. Each iteration emits one record per system
+for deep path lookup, small file read, and large file range read. For MALT
+records, `verify_elapsed_ns` measures client-side verification of returned
+ProofList evidence; baseline records omit it and use CAS block fetches as the
+comparable evidence-item count.
 
 Historical smoke artifacts that predate the current schemas should be labeled
 legacy rather than silently mixed into paper-facing aggregates.

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -52,7 +52,8 @@ Paper-facing reports should keep these dimensions separate:
   path-depth matrix
 - configured per-CAS-Get latency (`cas_latency_ms`)
 - read-path latency (`elapsed_ns`)
-- MALT proof/open generation latency (`prove_elapsed_ns`)
+- MALT commitment open/prove latency after ArcSet materialization
+  (`prove_elapsed_ns`)
 - MALT client ProofList verification latency (`verify_elapsed_ns`)
 - proof bytes
 - ProofList step counts
@@ -130,9 +131,11 @@ record per system, key-count point, lookup sample, configured CAS latency, and
 iteration. Use this benchmark to evaluate the claim that a flat HAMT's latency
 depends on the number of HAMT blocks touched, which grows with key cardinality
 and hash distribution, while flat MALT lookup remains independent of logical
-path depth. For MALT records, `prove_elapsed_ns` separately measures semantic
-proof/open generation for the canonical full-path key without target blob fetch.
-This is the cost that should be compared against the expected MALT radix depth,
+path depth. For MALT records, `prove_elapsed_ns` separately measures only the
+commitment open/prove calls for the canonical full-path key after radix slots
+have already been read from the ArcTable. It excludes target blob fetch,
+resolver longest-prefix lookup, and ArcSet/radix-slot materialization. This is
+the cost that should be compared against the expected MALT radix depth,
 approximately `log_256(key_count)` in the common case. The fixed `path_depth`
 only shapes the canonical string used as the key; it is not the independent
 variable for this suite.

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -8,6 +8,8 @@ See also the evaluator code under `cmd/eval/`.
 
 `malt-eval` supports:
 
+- the `read_matrix` suite for paper-facing fair read comparisons over shared
+  logical datasets
 - `malt-eval read` for paper-facing read benchmark records
 - `malt-eval write` for write-trace replay records
 - `malt-eval run` for JSON run plans and durable run directories
@@ -25,6 +27,7 @@ Current machine-readable schemas live in `cmd/eval/schemas`:
 - `run-plan.schema.json`
 - `run-manifest.schema.json`
 - `common-record.schema.json`
+- `read-matrix-result.schema.json`
 - `readbench-result.schema.json`
 - `read-query-result.schema.json`
 - `write-trace-result.schema.json`
@@ -40,6 +43,8 @@ normalization tests in the same PR.
 Paper-facing reports should keep these dimensions separate:
 
 - payload bytes
+- read dataset metadata: `dataset`, `file_count`, `directory_count`,
+  `path_count`, `path_depth`, and `logical_payload_bytes`
 - read workload labels: `deep_path_lookup`, `small_file_read`, and
   `large_file_range_read`
 - read-path latency (`elapsed_ns`)
@@ -56,12 +61,18 @@ Do not count unverifiable helper metadata as proof evidence. Do not present
 writer receipt counts as correctness proofs. Receipts and metrics are
 operational accounting unless tied to verifier evidence.
 
-`malt-eval read` and the `read_query` suite compare MALT against IPLD UnixFS
-MerkleDAG and HAMT-style baselines. Each iteration emits one record per system
-for deep path lookup, small file read, and large file range read. For MALT
-records, `verify_elapsed_ns` measures client-side verification of returned
-ProofList evidence; baseline records omit it and use CAS block fetches as the
-comparable evidence-item count.
+The `read_matrix` suite is the main paper-facing read comparison. It builds one
+deterministic logical file tree per dataset point, materializes that same source
+dataset into MALT, IPLD UnixFS MerkleDAG, and IPLD UnixFS HAMT, then emits one
+record per system, dataset scale, path depth, workload, and iteration. Use it
+to compare how read latency changes as data scale and lookup depth increase.
+
+`malt-eval read` and the `read_query` suite remain useful for daemon-oriented
+end-to-end checks. They exercise the HTTP daemon path for MALT and local IPLD
+baselines, so they should not be mixed into the same aggregate as `read_matrix`
+core benchmark results. For MALT records, `verify_elapsed_ns` measures
+client-side verification of returned ProofList evidence; baseline records omit
+it and use CAS block fetches as the comparable evidence-item count.
 
 Historical smoke artifacts that predate the current schemas should be labeled
 legacy rather than silently mixed into paper-facing aggregates.

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -10,6 +10,8 @@ See also the evaluator code under `cmd/eval/`.
 
 - the `read_matrix` suite for paper-facing fair resolve-path comparisons over
   shared logical paths
+- the `flat_index_cardinality` suite for flat full-path index comparisons over
+  increasing key counts
 - `malt-eval read` for paper-facing read benchmark records
 - `malt-eval write` for write-trace replay records
 - `malt-eval run` for JSON run plans and durable run directories
@@ -28,6 +30,7 @@ Current machine-readable schemas live in `cmd/eval/schemas`:
 - `run-manifest.schema.json`
 - `common-record.schema.json`
 - `read-matrix-result.schema.json`
+- `flat-index-cardinality-result.schema.json`
 - `readbench-result.schema.json`
 - `read-query-result.schema.json`
 - `write-trace-result.schema.json`
@@ -67,15 +70,16 @@ deterministic logical lookup tree and materializes the same paths as:
 
 - `maltflat`: flat MALT authenticated arcs keyed by the complete logical path
 - `merkledag`: IPLD UnixFS basic directory traversal
-- `hamt`: IPLD UnixFS HAMT directory traversal
-- `flathamt`: one IPFS/Boxo HAMT map keyed by the complete logical path
 
 It emits one `resolve_path` record per system, path depth, path sample,
 configured CAS latency, and iteration. Use it to compare whether lookup latency
 grows with path depth under warm per-block CAS latency models. The `maltflat`
-and `flathamt` records include flat path lookup plus one target blob fetch from
-CAS; the IPLD UnixFS baselines include their serial directory traversal and
-terminal target-node fetches.
+records include flat path lookup plus one target blob fetch from CAS; the
+Merkle DAG baseline includes its serial directory traversal and terminal
+target-node fetches. The suite still accepts `hamt` and `flathamt` as explicit
+diagnostic baselines, but they are not the default paper-facing path-depth
+comparison because HAMT's main variable is key cardinality rather than logical
+path depth.
 
 In `read_matrix`, `path_depth` means the number of edges from the root directory
 to the target file. Therefore depth `1` is a file directly under the root,
@@ -113,6 +117,25 @@ Report the read matrix from two views:
 The read matrix intentionally excludes full-content reads, range reads,
 list-backed payloads, and data-size/proof-generation sweeps. Dataset size effects
 on flat MALT proof generation belong in a separate microbenchmark.
+
+The `flat_index_cardinality` suite is the separate flat-structure comparison.
+It fixes logical path depth and materializes complete canonical paths as keys in:
+
+- `maltflat`: flat MALT authenticated arcs keyed by the complete logical path
+- `flathamt`: one IPFS/Boxo HAMT map keyed by the complete logical path
+
+It varies `key_counts` instead of path depth, then emits one `resolve_path`
+record per system, key-count point, lookup sample, configured CAS latency, and
+iteration. Use this benchmark to evaluate the claim that a flat HAMT's latency
+depends on the number of HAMT blocks touched, which grows with key cardinality
+and hash distribution, while flat MALT lookup remains independent of logical
+path depth. The fixed `path_depth` only shapes the canonical string used as the
+key; it is not the independent variable for this suite.
+
+The suite writes raw records to `raw/flat_index_cardinality.jsonl` and a
+figure-facing aggregate to `aggregate/flat_index_cardinality.csv`. Plot
+`file_count` on the x-axis, total elapsed time on the y-axis, and one line per
+system. Use median latency for the main result and p95 to report tail behavior.
 
 `malt-eval read` and the `read_query` suite remain useful for daemon-oriented
 end-to-end checks. They exercise the HTTP daemon path for MALT and local IPLD

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -67,7 +67,13 @@ deterministic logical lookup tree, materializes the same paths as flat MALT
 authenticated arcs, IPLD UnixFS MerkleDAG, and IPLD UnixFS HAMT, then emits one
 `resolve_path` record per system, path depth, configured CAS latency, and
 iteration. Use it to compare whether lookup latency grows with path depth under
-warm per-block CAS latency models.
+warm per-block CAS latency models. The MALT record includes flat path
+authentication plus one target blob fetch from CAS; the IPLD baselines include
+their serial directory traversal and terminal target-node fetches.
+
+Use depths `[1, 2, 3, 4, 5, 6]` for the main paper figure. A sweep up to depth
+10 is acceptable for a sensitivity appendix, but depth 16 should be treated as
+an artificial stress case rather than the default dataset shape.
 
 Use `[0, 25, 50, 100, 200]` milliseconds as the primary
 `cas_latency_ms` sweep. These values model local execution, near-region managed
@@ -76,6 +82,15 @@ poor/far public gateway access. A separate `2100` millisecond stress run can be
 used for cold IPFS DHT/provider-discovery behavior, but it should be reported
 separately from the main warm-CAS figure because it is not a normal per-block
 steady-state latency.
+
+Report the read matrix from two views:
+
+- fixed CAS latency: plot path depth on the x-axis, total elapsed time on the
+  y-axis, and one line per system; use two or three latency scenarios such as
+  `25`, `200`, and optionally `2100` ms
+- fixed path depth: hold depth at a representative value such as `4`, plot CAS
+  latency on the x-axis, total elapsed time on the y-axis, and one line per
+  system
 
 The read matrix intentionally excludes full-content reads, range reads,
 list-backed payloads, and data-size/proof-generation sweeps. Dataset size effects

--- a/examples/eval-paper-plan.json
+++ b/examples/eval-paper-plan.json
@@ -47,7 +47,7 @@
       "config": {
         "systems": ["maltflat", "merkledag", "hamt"],
         "dataset": "paper-read",
-        "depths": [1, 2, 4, 8, 16],
+        "depths": [1, 2, 3, 4, 5, 6],
         "cas_latency_ms": [0, 25, 50, 100, 200],
         "small_bytes": 1024,
         "iterations": 10

--- a/examples/eval-paper-plan.json
+++ b/examples/eval-paper-plan.json
@@ -47,11 +47,9 @@
       "config": {
         "systems": ["maltflat", "merkledag", "hamt"],
         "dataset": "paper-read",
-        "file_counts": [16, 64, 256],
-        "depths": [2, 4, 8, 16],
+        "depths": [1, 2, 4, 8, 16],
+        "cas_latency_ms": [0, 25, 50, 100, 200],
         "small_bytes": 1024,
-        "large_bytes": 1048576,
-        "range": "bytes=0-4095",
         "iterations": 10
       }
     }

--- a/examples/eval-paper-plan.json
+++ b/examples/eval-paper-plan.json
@@ -59,7 +59,7 @@
       "config": {
         "systems": ["maltflat", "flathamt"],
         "dataset": "paper-flat-index",
-        "key_counts": [1, 64, 256, 1024, 4096],
+        "key_counts": [1, 64, 256, 1024, 4096, 16384],
         "path_depth": 4,
         "cas_latency_ms": [0, 25, 200],
         "small_bytes": 1024,

--- a/examples/eval-paper-plan.json
+++ b/examples/eval-paper-plan.json
@@ -45,11 +45,12 @@
     {
       "name": "read_matrix",
       "config": {
-        "systems": ["maltflat", "merkledag", "hamt"],
+        "systems": ["maltflat", "merkledag", "hamt", "flathamt"],
         "dataset": "paper-read",
         "depths": [1, 2, 3, 4, 5, 6],
         "cas_latency_ms": [0, 25, 50, 100, 200],
         "small_bytes": 1024,
+        "paths_per_depth": 5,
         "iterations": 10
       }
     }

--- a/examples/eval-paper-plan.json
+++ b/examples/eval-paper-plan.json
@@ -43,23 +43,15 @@
       }
     },
     {
-      "name": "read_depth_sweep",
+      "name": "read_matrix",
       "config": {
         "systems": ["maltflat", "merkledag", "hamt"],
-        "depths": [3, 4, 5, 6],
-        "small_bytes": 256,
+        "dataset": "paper-read",
+        "file_counts": [16, 64, 256],
+        "depths": [2, 4, 8, 16],
+        "small_bytes": 1024,
         "large_bytes": 1048576,
-        "iterations": 10
-      }
-    },
-    {
-      "name": "read_latency_sweep",
-      "config": {
-        "systems": ["maltflat", "merkledag", "hamt"],
-        "depth": 6,
-        "cas_latency_ms": [0, 5, 10, 20, 50, 100],
-        "small_bytes": 256,
-        "large_bytes": 1048576,
+        "range": "bytes=0-4095",
         "iterations": 10
       }
     }

--- a/examples/eval-paper-plan.json
+++ b/examples/eval-paper-plan.json
@@ -45,12 +45,25 @@
     {
       "name": "read_matrix",
       "config": {
-        "systems": ["maltflat", "merkledag", "hamt", "flathamt"],
+        "systems": ["maltflat", "merkledag"],
         "dataset": "paper-read",
         "depths": [1, 2, 3, 4, 5, 6],
         "cas_latency_ms": [0, 25, 50, 100, 200],
         "small_bytes": 1024,
         "paths_per_depth": 5,
+        "iterations": 10
+      }
+    },
+    {
+      "name": "flat_index_cardinality",
+      "config": {
+        "systems": ["maltflat", "flathamt"],
+        "dataset": "paper-flat-index",
+        "key_counts": [1, 64, 256, 1024, 4096],
+        "path_depth": 4,
+        "cas_latency_ms": [0, 25, 200],
+        "small_bytes": 1024,
+        "paths_per_key_count": 5,
         "iterations": 10
       }
     }

--- a/examples/eval-read-dht-stress-plan.json
+++ b/examples/eval-read-dht-stress-plan.json
@@ -1,0 +1,16 @@
+{
+  "run_id": "read-dht-stress",
+  "suites": [
+    {
+      "name": "read_matrix",
+      "config": {
+        "systems": ["maltflat", "merkledag", "hamt"],
+        "dataset": "paper-read-cold-dht-stress",
+        "depths": [1, 2, 4, 8, 16],
+        "cas_latency_ms": [2100],
+        "small_bytes": 1024,
+        "iterations": 10
+      }
+    }
+  ]
+}

--- a/examples/eval-read-dht-stress-plan.json
+++ b/examples/eval-read-dht-stress-plan.json
@@ -4,7 +4,7 @@
     {
       "name": "read_matrix",
       "config": {
-        "systems": ["maltflat", "merkledag", "hamt", "flathamt"],
+        "systems": ["maltflat", "merkledag"],
         "dataset": "paper-read-cold-dht-stress",
         "depths": [1, 2, 3, 4, 5, 6],
         "cas_latency_ms": [2100],

--- a/examples/eval-read-dht-stress-plan.json
+++ b/examples/eval-read-dht-stress-plan.json
@@ -6,10 +6,10 @@
       "config": {
         "systems": ["maltflat", "merkledag", "hamt"],
         "dataset": "paper-read-cold-dht-stress",
-        "depths": [1, 2, 4, 8, 16],
+        "depths": [1, 2, 3, 4, 5, 6],
         "cas_latency_ms": [2100],
         "small_bytes": 1024,
-        "iterations": 10
+        "iterations": 1
       }
     }
   ]

--- a/examples/eval-read-dht-stress-plan.json
+++ b/examples/eval-read-dht-stress-plan.json
@@ -4,11 +4,12 @@
     {
       "name": "read_matrix",
       "config": {
-        "systems": ["maltflat", "merkledag", "hamt"],
+        "systems": ["maltflat", "merkledag", "hamt", "flathamt"],
         "dataset": "paper-read-cold-dht-stress",
         "depths": [1, 2, 3, 4, 5, 6],
         "cas_latency_ms": [2100],
         "small_bytes": 1024,
+        "paths_per_depth": 1,
         "iterations": 1
       }
     }

--- a/runtime/semantic/mapping/radix/radix.go
+++ b/runtime/semantic/mapping/radix/radix.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/auth/commitment"
@@ -35,6 +36,15 @@ const (
 type Map struct {
 	commitment *mapping.Commitment
 	arctable   arctable.ArcTable
+}
+
+// ProveTimings separates materialization from commitment-open cost for
+// benchmark reporting. LoadElapsedNS covers ArcTable reads and loaded-node
+// validation; OpenElapsedNS covers only commitment ProveSlot calls.
+type ProveTimings struct {
+	LoadElapsedNS int64
+	OpenElapsedNS int64
+	OpenCount     int
 }
 
 // ErrPathNotFound indicates that a requested radix map path is absent.
@@ -105,11 +115,20 @@ func (s *Map) Commit(ctx context.Context, namespace string, view mapping.View) (
 }
 
 func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arcset.Path) (mapping.Binding, structure.Proof, error) {
+	binding, proof, _, err := s.ProveWithTimings(ctx, namespace, root, key)
+	return binding, proof, err
+}
+
+// ProveWithTimings proves the existing binding for key and returns a timing
+// breakdown suitable for evaluation. The returned proof is identical to Prove;
+// timings do not change verifier semantics.
+func (s *Map) ProveWithTimings(ctx context.Context, namespace string, root cid.Cid, key arcset.Path) (mapping.Binding, structure.Proof, ProveTimings, error) {
+	var timings ProveTimings
 	if !root.Defined() {
-		return mapping.Binding{}, nil, fmt.Errorf("root is undefined")
+		return mapping.Binding{}, nil, timings, fmt.Errorf("root is undefined")
 	}
 	if key.IsEmpty() {
-		return mapping.Binding{}, nil, fmt.Errorf("key is empty")
+		return mapping.Binding{}, nil, timings, fmt.Errorf("key is empty")
 	}
 
 	digest := hashPath(key)
@@ -117,20 +136,25 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 	envelope := proofEnvelope{}
 
 	for depth := 0; depth < len(digest); depth++ {
+		loadStart := time.Now()
 		slots, err := s.loadValidatedNode(ctx, namespace, currentRoot)
+		timings.LoadElapsedNS += time.Since(loadStart).Nanoseconds()
 		if err != nil {
-			return mapping.Binding{}, nil, err
+			return mapping.Binding{}, nil, timings, err
 		}
 
 		slotIndex := digest[depth]
+		openStart := time.Now()
 		value, proof, err := s.commitment.ProveSlot(currentRoot, slots, uint64(slotIndex))
+		timings.OpenElapsedNS += time.Since(openStart).Nanoseconds()
+		timings.OpenCount++
 		if err != nil {
-			return mapping.Binding{}, nil, err
+			return mapping.Binding{}, nil, timings, err
 		}
 
 		slotCID, err := value.AsCID()
 		if err != nil {
-			return mapping.Binding{}, nil, err
+			return mapping.Binding{}, nil, timings, err
 		}
 		envelope.Steps = append(envelope.Steps, proofStep{
 			Slot:  cidBytes(slotCID),
@@ -138,34 +162,36 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 		})
 
 		if !slotCID.Defined() {
-			return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+			return mapping.Binding{}, nil, timings, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 		}
 
 		if leafPath, leafValue, ok, err := tryDecodeLeafMarker(slotCID); err != nil {
-			return mapping.Binding{}, nil, err
+			return mapping.Binding{}, nil, timings, err
 		} else if ok {
 			if leafPath != key {
-				return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+				return mapping.Binding{}, nil, timings, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 			}
 			proofBytes, err := json.Marshal(envelope)
 			if err != nil {
-				return mapping.Binding{}, nil, err
+				return mapping.Binding{}, nil, timings, err
 			}
-			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), nil
+			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), timings, nil
 		}
 
 		if bucketRoot, ok, err := tryDecodeBucketRef(slotCID); err != nil {
-			return mapping.Binding{}, nil, err
+			return mapping.Binding{}, nil, timings, err
 		} else if ok {
+			loadStart := time.Now()
 			markers, err := s.loadBucketEntries(ctx, namespace, bucketRoot)
+			timings.LoadElapsedNS += time.Since(loadStart).Nanoseconds()
 			if err != nil {
-				return mapping.Binding{}, nil, err
+				return mapping.Binding{}, nil, timings, err
 			}
 			index := -1
 			for i, marker := range markers {
 				leafPath, _, err := decodeLeafMarker(marker)
 				if err != nil {
-					return mapping.Binding{}, nil, err
+					return mapping.Binding{}, nil, timings, err
 				}
 				if leafPath == key {
 					index = i
@@ -173,29 +199,32 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 				}
 			}
 			if index < 0 {
-				return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+				return mapping.Binding{}, nil, timings, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 			}
 
+			openStart := time.Now()
 			value, proof, err := s.commitment.ProveSlot(bucketRoot, markers, uint64(index))
+			timings.OpenElapsedNS += time.Since(openStart).Nanoseconds()
+			timings.OpenCount++
 			if err != nil {
-				return mapping.Binding{}, nil, err
+				return mapping.Binding{}, nil, timings, err
 			}
 			_, leafValue, err := decodeLeafMarkerCID(value)
 			if err != nil {
-				return mapping.Binding{}, nil, err
+				return mapping.Binding{}, nil, timings, err
 			}
 			envelope.Bucket = &bucketWitness{Proof: proof}
 			proofBytes, err := json.Marshal(envelope)
 			if err != nil {
-				return mapping.Binding{}, nil, err
+				return mapping.Binding{}, nil, timings, err
 			}
-			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), nil
+			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), timings, nil
 		}
 
 		currentRoot = slotCID
 	}
 
-	return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+	return mapping.Binding{}, nil, timings, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 }
 
 func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, proof structure.Proof) (bool, error) {

--- a/runtime/semantic/mapping/radix/radix_test.go
+++ b/runtime/semantic/mapping/radix/radix_test.go
@@ -2,16 +2,22 @@ package radix_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/auth/commitment"
 	"github.com/dewebprotocol/malt/auth/commitment/ipa"
 	"github.com/dewebprotocol/malt/auth/commitment/kzg"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/runtime/arctable"
 	"github.com/dewebprotocol/malt/runtime/arctable/overwrite"
 	mappingradix "github.com/dewebprotocol/malt/runtime/semantic/mapping/radix"
 	kvmemory "github.com/dewebprotocol/malt/storage/kv/memory"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -110,6 +116,49 @@ func TestMapCommitProveVerify(t *testing.T) {
 	}
 }
 
+func TestProveWithTimingsExcludesArcSetLoadTime(t *testing.T) {
+	ctx := context.Background()
+	base, err := overwrite.NewArcTable(overwrite.WithKVStore(kvmemory.New()))
+	if err != nil {
+		t.Fatalf("overwrite.NewArcTable failed: %v", err)
+	}
+	loadDelay := 120 * time.Millisecond
+	openDelay := 5 * time.Millisecond
+	table := delayedArcTable{inner: base, delay: loadDelay}
+	semantic, err := mappingradix.NewMap(fakeTimingScheme{proveDelay: openDelay}, table)
+	if err != nil {
+		t.Fatalf("radix.NewMap failed: %v", err)
+	}
+	view := mapping.NewViewFrom(map[string]cid.Cid{
+		"a": fakeCID("value-a"),
+		"b": fakeCID("value-b"),
+	})
+	root, err := semantic.Commit(ctx, testNamespace+"-timing", view)
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	binding, proof, timings, err := semantic.ProveWithTimings(ctx, testNamespace+"-timing", root, arcset.CanonicalizePath("b"))
+	if err != nil {
+		t.Fatalf("ProveWithTimings failed: %v", err)
+	}
+	if !binding.Present || !binding.Value.Equals(fakeCID("value-b")) || len(proof) == 0 {
+		t.Fatalf("proof result = binding %+v proof bytes %d", binding, len(proof))
+	}
+	if timings.LoadElapsedNS < int64(loadDelay) {
+		t.Fatalf("LoadElapsedNS = %d, want at least injected load delay %s", timings.LoadElapsedNS, loadDelay)
+	}
+	if timings.OpenElapsedNS <= 0 {
+		t.Fatalf("OpenElapsedNS = %d, want positive open/prove time", timings.OpenElapsedNS)
+	}
+	if timings.OpenElapsedNS >= int64(loadDelay/2) {
+		t.Fatalf("OpenElapsedNS = %d includes too much load delay, want below %s", timings.OpenElapsedNS, loadDelay/2)
+	}
+	if timings.OpenCount != 1 {
+		t.Fatalf("OpenCount = %d, want one radix open at this cardinality", timings.OpenCount)
+	}
+}
+
 func TestMapUpdateReplaceInsertDelete(t *testing.T) {
 	ctx := context.Background()
 	initialEntries := map[string]cid.Cid{
@@ -203,6 +252,106 @@ func TestMapUpdateReplaceInsertDelete(t *testing.T) {
 			}
 		})
 	}
+}
+
+type delayedArcTable struct {
+	inner arctable.ArcTable
+	delay time.Duration
+}
+
+func (d delayedArcTable) Get(ctx context.Context, namespace string, root cid.Cid, path arcset.Path) (cid.Cid, error) {
+	time.Sleep(d.delay)
+	return d.inner.Get(ctx, namespace, root, path)
+}
+
+func (d delayedArcTable) BatchGet(ctx context.Context, namespace string, root cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error) {
+	time.Sleep(d.delay)
+	return d.inner.BatchGet(ctx, namespace, root, paths)
+}
+
+func (d delayedArcTable) Update(ctx context.Context, namespace string, newRoot, oldRoot cid.Cid, arcs arcset.ArcSet) error {
+	return d.inner.Update(ctx, namespace, newRoot, oldRoot, arcs)
+}
+
+func (d delayedArcTable) Snapshot(ctx context.Context, namespace string, root cid.Cid) (arcset.ArcSet, error) {
+	return d.inner.Snapshot(ctx, namespace, root)
+}
+
+func (d delayedArcTable) Iterate(ctx context.Context, namespace string, root cid.Cid) arcset.Iterator {
+	return d.inner.Iterate(ctx, namespace, root)
+}
+
+func (d delayedArcTable) Close() error {
+	return d.inner.Close()
+}
+
+type fakeTimingScheme struct {
+	proveDelay time.Duration
+}
+
+func (s fakeTimingScheme) MaxValues() int { return 256 }
+
+func (s fakeTimingScheme) Commit(values []commitment.Cell) (cid.Cid, error) {
+	return fakeCommitRoot(values)
+}
+
+func (s fakeTimingScheme) Prove(values []commitment.Cell, index uint64) (cid.Cid, commitment.Cell, []byte, error) {
+	time.Sleep(s.proveDelay)
+	if index >= uint64(len(values)) {
+		return cid.Undef, nil, nil, fmt.Errorf("index %d out of range", index)
+	}
+	root, err := s.Commit(values)
+	if err != nil {
+		return cid.Undef, nil, nil, err
+	}
+	return root, commitment.NewCell(values[index]), []byte("proof"), nil
+}
+
+func (s fakeTimingScheme) BatchProve(values []commitment.Cell, indices []uint64) (cid.Cid, []commitment.Cell, []byte, error) {
+	root, err := s.Commit(values)
+	if err != nil {
+		return cid.Undef, nil, nil, err
+	}
+	proved := make([]commitment.Cell, len(indices))
+	for i, index := range indices {
+		if index >= uint64(len(values)) {
+			return cid.Undef, nil, nil, fmt.Errorf("index %d out of range", index)
+		}
+		proved[i] = commitment.NewCell(values[index])
+	}
+	return root, proved, []byte("batch-proof"), nil
+}
+
+func (s fakeTimingScheme) VerifyIndex(cid.Cid, uint64, commitment.Cell, []byte) (bool, error) {
+	return true, nil
+}
+
+func (s fakeTimingScheme) BatchVerify(cid.Cid, []uint64, []commitment.Cell, []byte) (bool, error) {
+	return true, nil
+}
+
+func (s fakeTimingScheme) VerifyProof(cid.Cid, commitment.Cell, []byte) (bool, error) {
+	return true, nil
+}
+
+func (s fakeTimingScheme) Replace(values []commitment.Cell, index uint64, _, newValue commitment.Cell) (cid.Cid, error) {
+	next := commitment.CloneCells(values)
+	if index >= uint64(len(next)) {
+		return cid.Undef, fmt.Errorf("index %d out of range", index)
+	}
+	next[index] = commitment.NewCell(newValue)
+	return s.Commit(next)
+}
+
+func fakeCommitRoot(values []commitment.Cell) (cid.Cid, error) {
+	h := sha256.New()
+	var lenBuf [4]byte
+	for _, value := range values {
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(value)))
+		h.Write(lenBuf[:])
+		h.Write(value)
+	}
+	return maltcid.NewMapIPACid(h.Sum(nil))
 }
 
 func TestMapUpdateRejectsInconsistentOldValue(t *testing.T) {


### PR DESCRIPTION
## Summary
- refocus `read_matrix` on the paper-facing path-depth question: `resolve_path` plus target blob fetch, no range reads, and no list-backed payloads
- measure a practical `path_depth × cas_latency_ms` matrix for `maltflat`, `merkledag`, and `hamt`, with default depths `[1, 2, 3, 4, 5, 6]` and warm-CAS latency buckets `[0, 25, 50, 100, 200]`
- materialize MALT as flat authenticated arcs while MerkleDAG/HAMT traverse UnixFS directory blocks, and record `cas_latency_ms`, `path_depth`, CAS get counts, and existing evidence metrics
- document a separate `2100ms` cold-DHT stress plan and the two reporting views: fixed latency vs depth, and fixed depth vs latency

## Local benchmark
- main run: `bin/malt-eval run --plan eval/read-depth-latency-v2-20260627/plan.json`
- stress run: `bin/malt-eval run --plan eval/read-depth-dht-stress-v2-20260627/plan.json`
- saved locally under `eval/read-depth-latency-v2-20260627/` and `eval/read-depth-dht-stress-v2-20260627/`
- depth 4 result: MALT performs 1 CAS get; MerkleDAG/HAMT perform 6 CAS gets
- at 200ms CAS latency and depth 6, MALT is about 279ms while MerkleDAG/HAMT are about 1.6s
- at 2100ms cold-DHT latency and depth 6, MALT is about 2.18s while MerkleDAG/HAMT are about 16.8s

## Test Plan
- `gofmt -l cmd/eval/internal/eval/readbench cmd/eval/internal/eval/suites/readmatrix`
- `git diff --check`
- `env GOCACHE=/tmp/go-build-cache-read-matrix go test ./cmd/eval/internal/eval/readbench ./cmd/eval/internal/eval/suites/readmatrix ./cmd/eval/helper/evalschema ./cmd/eval/schemas`
- `env GOCACHE=/tmp/go-build-cache-read-matrix go test ./cmd/eval/internal/eval/... ./cmd/eval/helper/... ./cmd/eval/command ./cmd/eval/schemas`
- `env GOCACHE=/tmp/go-build-cache-read-matrix go test ./...`