### PR TITLE
[codex] replay write traces incrementally

### DIFF
--- a/cmd/eval/helper/adapters/hamt/adapter.go
+++ b/cmd/eval/helper/adapters/hamt/adapter.go
@@ -10,7 +10,8 @@ import (
 // New creates an IPLD UnixFS + HAMT adapter.
 func New(system *evalstore.System) *merkledag.Adapter {
 	return merkledag.New(system, merkledag.Options{
-		Name:      "hamt",
-		DirLayout: merkledagimport.DirLayoutHAMT,
+		Name:        "hamt",
+		DirLayout:   merkledagimport.DirLayoutHAMT,
+		RawFileLeaf: true,
 	})
 }

--- a/cmd/eval/helper/adapters/maltflat/adapter.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter.go
@@ -3,8 +3,8 @@ package maltflat
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/dewebprotocol/malt/auth/commitment"
@@ -40,7 +40,10 @@ const (
 	CommitmentBackendKZG CommitmentBackend = "kzg"
 )
 
-const MaterializationStrategyLiveSnapshotRebuild = "live_snapshot_rebuild"
+const (
+	MaterializationStrategyLiveSnapshotRebuild = "live_snapshot_rebuild"
+	MaterializationStrategyIncrementalDelta    = "incremental_delta"
+)
 
 // Options configures the MALT-flat adapter.
 type Options struct {
@@ -54,6 +57,7 @@ type Options struct {
 type Adapter struct {
 	system *evalstore.System
 	layout *unixfs.Layout
+	root   cid.Cid
 }
 
 // DefaultOptions returns the paper-aligned MALT-flat evaluation configuration.
@@ -108,44 +112,84 @@ func (a *Adapter) Name() string {
 	return "maltflat"
 }
 
-// Apply materializes the object-backed live snapshot for this commit.
-// Rebuilding from the live trace keeps delete/rename semantics correct even
-// before the UnixFS layout exposes a delete primitive.
+// Apply incrementally applies the commit mutation set to the previous root.
 func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (replay.ApplyResult, error) {
 	if commit.Snapshot == nil {
 		return replay.ApplyResult{}, fmt.Errorf("snapshot reader is nil")
 	}
-	files := append([]replay.LiveFile(nil), commit.LiveFiles...)
-	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
-
-	root := cid.Undef
-	var err error
-	if len(files) == 0 {
+	before := a.system.Meter.Snapshot()
+	root := a.root
+	if !root.Defined() {
+		var err error
 		root, err = a.layout.EmptyDirectory(ctx)
 		if err != nil {
 			return replay.ApplyResult{}, err
 		}
 	}
-	for _, file := range files {
-		data, err := commit.Snapshot.ReadBlob(ctx, file.Hash)
-		if err != nil {
-			return replay.ApplyResult{}, fmt.Errorf("read blob for %s: %w", file.Path, err)
+	materializedPaths := 0
+	for _, mutation := range commit.Mutations {
+		var err error
+		switch mutation.Kind {
+		case replay.MutationAdd, replay.MutationModify:
+			if mutationHasBlob(mutation) {
+				root, err = a.addMutationFile(ctx, root, commit.Snapshot, mutation)
+				materializedPaths++
+			}
+		case replay.MutationDelete:
+			root, err = a.removeMutationPath(ctx, root, mutation.Path)
+		case replay.MutationRename:
+			root, err = a.removeMutationPath(ctx, root, mutation.OldPath)
+			if err == nil && mutationHasBlob(mutation) {
+				root, err = a.addMutationFile(ctx, root, commit.Snapshot, mutation)
+				materializedPaths++
+			}
+		default:
+			if mutationHasBlob(mutation) {
+				root, err = a.addMutationFile(ctx, root, commit.Snapshot, mutation)
+				materializedPaths++
+			}
 		}
-		root, err = a.layout.AddFile(ctx, root, file.Path, data)
 		if err != nil {
-			return replay.ApplyResult{}, fmt.Errorf("materialize %s: %w", file.Path, err)
+			return replay.ApplyResult{}, fmt.Errorf("apply %s %s: %w", mutation.Kind, mutation.Path, err)
 		}
 	}
-	if root.Defined() {
-		a.system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(root.String()))
-	}
+	a.root = root
+	a.system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(root.String()))
+	after := a.system.Meter.Snapshot()
 	return replay.ApplyResult{
 		Root:                    root.String(),
 		AppliedMutations:        len(commit.Mutations),
-		MaterializedPaths:       len(files),
-		MaterializationStrategy: MaterializationStrategyLiveSnapshotRebuild,
-		Accounting:              a.system.Meter.Snapshot(),
+		MaterializedPaths:       materializedPaths,
+		MaterializationStrategy: MaterializationStrategyIncrementalDelta,
+		Accounting:              after,
+		AccountingDelta:         evalstore.Delta(after, before),
 	}, nil
+}
+
+func (a *Adapter) addMutationFile(ctx context.Context, root cid.Cid, snapshot replay.SnapshotReader, mutation replay.FileMutation) (cid.Cid, error) {
+	if strings.TrimSpace(mutation.Hash) == "" {
+		return cid.Undef, fmt.Errorf("blob hash is empty")
+	}
+	data, err := snapshot.ReadBlob(ctx, mutation.Hash)
+	if err != nil {
+		return cid.Undef, fmt.Errorf("read blob: %w", err)
+	}
+	return a.layout.AddFile(ctx, root, mutation.Path, data)
+}
+
+func mutationHasBlob(mutation replay.FileMutation) bool {
+	return strings.TrimSpace(mutation.Hash) != ""
+}
+
+func (a *Adapter) removeMutationPath(ctx context.Context, root cid.Cid, path string) (cid.Cid, error) {
+	nextRoot, err := a.layout.RemovePath(ctx, root, path)
+	if err != nil {
+		if errors.Is(err, unixfs.ErrNotFound) {
+			return root, nil
+		}
+		return cid.Undef, err
+	}
+	return nextRoot, nil
 }
 
 var _ replay.SystemAdapter = (*Adapter)(nil)

--- a/cmd/eval/helper/adapters/maltflat/adapter.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter.go
@@ -14,17 +14,18 @@ import (
 	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
 	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
 	"github.com/dewebprotocol/malt/layout/unixfs"
-	"github.com/dewebprotocol/malt/runtime/arctable"
 	"github.com/dewebprotocol/malt/runtime/arctable/overwrite"
-	"github.com/dewebprotocol/malt/runtime/arctable/versioned"
 	mappingradix "github.com/dewebprotocol/malt/runtime/semantic/mapping/radix"
-	"github.com/dewebprotocol/malt/storage/kv"
+	kvmemory "github.com/dewebprotocol/malt/storage/kv/memory"
 	cid "github.com/ipfs/go-cid"
 )
 
 const defaultNamespace = "eval-maltflat"
 
-// ArcTableMode selects the ArcTable persistence strategy used by MALT-flat.
+// ArcTableMode selects the ArcTable materialization mode requested by callers.
+// Write-trace canonical accounting uses an unmetered derived cache regardless
+// of this value, but the option is retained and validated for compatibility
+// with older plans.
 type ArcTableMode string
 
 const (
@@ -78,9 +79,14 @@ func New(system *evalstore.System, opts Options) (*Adapter, error) {
 		return nil, fmt.Errorf("system store is nil")
 	}
 	opts = applyDefaults(opts)
-	arcs, err := newArcTable(system.StateKV, opts.ArcTableMode)
+	if err := validateArcTableMode(opts.ArcTableMode); err != nil {
+		return nil, err
+	}
+	// The radix ArcTable is a proof-serving cache in write_trace. Canonical
+	// durable state is accounted separately as path-to-CID deltas.
+	arcs, err := overwrite.NewArcTable(overwrite.WithKVStore(kvmemory.New()))
 	if err != nil {
-		return nil, fmt.Errorf("create arctable: %w", err)
+		return nil, fmt.Errorf("create cache arctable: %w", err)
 	}
 	scheme, err := newCommitmentBackend(opts.CommitmentBackend)
 	if err != nil {
@@ -111,6 +117,7 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 		return replay.ApplyResult{}, fmt.Errorf("snapshot reader is nil")
 	}
 	before := a.system.Meter.Snapshot()
+	parentRoot := a.root
 	root := a.root
 	if !root.Defined() {
 		var err error
@@ -154,6 +161,7 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 		if err != nil {
 			return replay.ApplyResult{}, err
 		}
+		a.recordCanonicalDelta(parentRoot, updates)
 	}
 	a.root = root
 	a.entries = nextEntries
@@ -237,6 +245,23 @@ func sameCID(a, b cid.Cid) bool {
 	return a.Equals(b)
 }
 
+func (a *Adapter) recordCanonicalDelta(parent cid.Cid, updates []semanticmapping.BatchUpdate) {
+	if parent.Defined() {
+		a.system.Meter.RecordLogicalBytes(evalstore.CategoryCanonicalDelta, len(parent.Bytes()))
+	}
+	for _, update := range updates {
+		a.system.Meter.RecordLogicalBytes(evalstore.CategoryCanonicalDelta, canonicalDeltaEntryBytes(update))
+	}
+}
+
+func canonicalDeltaEntryBytes(update semanticmapping.BatchUpdate) int {
+	bytes := 1 + len(update.Key.String())
+	if update.NewValue.Defined() {
+		bytes += len(update.NewValue.Bytes())
+	}
+	return bytes
+}
+
 func applyDefaults(opts Options) Options {
 	defaults := DefaultOptions()
 	if opts.Namespace == "" {
@@ -254,14 +279,12 @@ func applyDefaults(opts Options) Options {
 	return opts
 }
 
-func newArcTable(kv kvstore.KVStore, mode ArcTableMode) (arctable.ArcTable, error) {
+func validateArcTableMode(mode ArcTableMode) error {
 	switch ArcTableMode(strings.ToLower(string(mode))) {
-	case ArcTableModeOverwrite, "simple":
-		return overwrite.NewArcTable(overwrite.WithKVStore(kv))
-	case ArcTableModeVersioned:
-		return versioned.NewArcTable(versioned.WithKVStore(kv))
+	case ArcTableModeOverwrite, ArcTableModeVersioned, "simple":
+		return nil
 	default:
-		return nil, fmt.Errorf("unknown ArcTable mode %q", mode)
+		return fmt.Errorf("unknown ArcTable mode %q", mode)
 	}
 }
 

--- a/cmd/eval/helper/adapters/maltflat/adapter.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter.go
@@ -1,22 +1,22 @@
-// Package maltflat replays Git snapshots into the MALT-flat UnixFS layout.
+// Package maltflat replays Git mutations into a flat MALT path-to-blob map.
 package maltflat
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/auth/commitment"
 	"github.com/dewebprotocol/malt/auth/commitment/ipa"
 	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	semanticmapping "github.com/dewebprotocol/malt/auth/semantic/mapping"
 	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
 	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
 	"github.com/dewebprotocol/malt/layout/unixfs"
 	"github.com/dewebprotocol/malt/runtime/arctable"
 	"github.com/dewebprotocol/malt/runtime/arctable/overwrite"
 	"github.com/dewebprotocol/malt/runtime/arctable/versioned"
-	"github.com/dewebprotocol/malt/runtime/semantic/list/tree"
 	mappingradix "github.com/dewebprotocol/malt/runtime/semantic/mapping/radix"
 	"github.com/dewebprotocol/malt/storage/kv"
 	cid "github.com/ipfs/go-cid"
@@ -53,11 +53,13 @@ type Options struct {
 	CommitmentBackend CommitmentBackend
 }
 
-// Adapter materializes each commit snapshot as a MALT-flat UnixFS root.
+// Adapter materializes each commit mutation set as a MALT-flat map root.
 type Adapter struct {
-	system *evalstore.System
-	layout *unixfs.Layout
-	root   cid.Cid
+	system    *evalstore.System
+	maps      *mappingradix.Map
+	namespace string
+	root      cid.Cid
+	entries   map[arcset.Path]cid.Cid
 }
 
 // DefaultOptions returns the paper-aligned MALT-flat evaluation configuration.
@@ -88,21 +90,12 @@ func New(system *evalstore.System, opts Options) (*Adapter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create map semantics: %w", err)
 	}
-	lists, err := tree.NewList(scheme, arcs)
-	if err != nil {
-		return nil, fmt.Errorf("create list semantics: %w", err)
-	}
-	layout, err := unixfs.New(unixfs.Options{
-		Namespace: opts.Namespace,
-		ChunkSize: opts.ChunkSize,
-		Map:       maps,
-		List:      lists,
-		Blocks:    system.CAS,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &Adapter{system: system, layout: layout}, nil
+	return &Adapter{
+		system:    system,
+		maps:      maps,
+		namespace: opts.Namespace,
+		entries:   make(map[arcset.Path]cid.Cid),
+	}, nil
 }
 
 func (a *Adapter) Name() string {
@@ -121,31 +114,33 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 	root := a.root
 	if !root.Defined() {
 		var err error
-		root, err = a.layout.EmptyDirectory(ctx)
+		root, err = a.maps.Commit(ctx, a.namespace, semanticmapping.NewViewFromPaths(nil))
 		if err != nil {
 			return replay.ApplyResult{}, err
 		}
 	}
+	nextEntries := cloneEntries(a.entries)
+	updates := make([]semanticmapping.BatchUpdate, 0, len(commit.Mutations))
 	materializedPaths := 0
 	for _, mutation := range commit.Mutations {
 		var err error
 		switch mutation.Kind {
 		case replay.MutationAdd, replay.MutationModify:
 			if mutationHasBlob(mutation) {
-				root, err = a.addMutationFile(ctx, root, commit.Snapshot, mutation)
+				err = a.queuePutMutationFile(ctx, commit.Snapshot, nextEntries, &updates, mutation)
 				materializedPaths++
 			}
 		case replay.MutationDelete:
-			root, err = a.removeMutationPath(ctx, root, mutation.Path)
+			err = a.queueRemoveMutationPath(nextEntries, &updates, mutation.Path)
 		case replay.MutationRename:
-			root, err = a.removeMutationPath(ctx, root, mutation.OldPath)
+			err = a.queueRemoveMutationPath(nextEntries, &updates, mutation.OldPath)
 			if err == nil && mutationHasBlob(mutation) {
-				root, err = a.addMutationFile(ctx, root, commit.Snapshot, mutation)
+				err = a.queuePutMutationFile(ctx, commit.Snapshot, nextEntries, &updates, mutation)
 				materializedPaths++
 			}
 		default:
 			if mutationHasBlob(mutation) {
-				root, err = a.addMutationFile(ctx, root, commit.Snapshot, mutation)
+				err = a.queuePutMutationFile(ctx, commit.Snapshot, nextEntries, &updates, mutation)
 				materializedPaths++
 			}
 		}
@@ -153,7 +148,15 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 			return replay.ApplyResult{}, fmt.Errorf("apply %s %s: %w", mutation.Kind, mutation.Path, err)
 		}
 	}
+	if len(updates) > 0 {
+		var err error
+		root, err = a.maps.BatchUpdate(ctx, a.namespace, root, updates)
+		if err != nil {
+			return replay.ApplyResult{}, err
+		}
+	}
 	a.root = root
+	a.entries = nextEntries
 	a.system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(root.String()))
 	after := a.system.Meter.Snapshot()
 	return replay.ApplyResult{
@@ -166,33 +169,73 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 	}, nil
 }
 
-func (a *Adapter) addMutationFile(ctx context.Context, root cid.Cid, snapshot replay.SnapshotReader, mutation replay.FileMutation) (cid.Cid, error) {
+func (a *Adapter) queuePutMutationFile(ctx context.Context, snapshot replay.SnapshotReader, entries map[arcset.Path]cid.Cid, updates *[]semanticmapping.BatchUpdate, mutation replay.FileMutation) error {
 	if strings.TrimSpace(mutation.Hash) == "" {
-		return cid.Undef, fmt.Errorf("blob hash is empty")
+		return fmt.Errorf("blob hash is empty")
+	}
+	key, err := arcset.NewPath(mutation.Path)
+	if err != nil {
+		return err
 	}
 	data, err := snapshot.ReadBlob(ctx, mutation.Hash)
 	if err != nil {
-		return cid.Undef, fmt.Errorf("read blob: %w", err)
+		return fmt.Errorf("read blob: %w", err)
 	}
-	return a.layout.AddFile(ctx, root, mutation.Path, data)
+	target, err := a.system.CAS.Put(ctx, data)
+	if err != nil {
+		return err
+	}
+	oldValue := entries[key]
+	if sameCID(oldValue, target) {
+		return nil
+	}
+	*updates = append(*updates, semanticmapping.BatchUpdate{
+		Key:      key,
+		OldValue: oldValue,
+		NewValue: target,
+	})
+	entries[key] = target
+	return nil
 }
 
 func mutationHasBlob(mutation replay.FileMutation) bool {
 	return strings.TrimSpace(mutation.Hash) != ""
 }
 
-func (a *Adapter) removeMutationPath(ctx context.Context, root cid.Cid, path string) (cid.Cid, error) {
-	nextRoot, err := a.layout.RemovePath(ctx, root, path)
+func (a *Adapter) queueRemoveMutationPath(entries map[arcset.Path]cid.Cid, updates *[]semanticmapping.BatchUpdate, path string) error {
+	key, err := arcset.NewPath(path)
 	if err != nil {
-		if errors.Is(err, unixfs.ErrNotFound) {
-			return root, nil
-		}
-		return cid.Undef, err
+		return err
 	}
-	return nextRoot, nil
+	oldValue := entries[key]
+	if !oldValue.Defined() {
+		return nil
+	}
+	*updates = append(*updates, semanticmapping.BatchUpdate{
+		Key:      key,
+		OldValue: oldValue,
+		NewValue: cid.Undef,
+	})
+	delete(entries, key)
+	return nil
 }
 
 var _ replay.SystemAdapter = (*Adapter)(nil)
+
+func cloneEntries(entries map[arcset.Path]cid.Cid) map[arcset.Path]cid.Cid {
+	out := make(map[arcset.Path]cid.Cid, len(entries))
+	for key, value := range entries {
+		out[key] = value
+	}
+	return out
+}
+
+func sameCID(a, b cid.Cid) bool {
+	if !a.Defined() && !b.Defined() {
+		return true
+	}
+	return a.Equals(b)
+}
 
 func applyDefaults(opts Options) Options {
 	defaults := DefaultOptions()

--- a/cmd/eval/helper/adapters/maltflat/adapter_test.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter_test.go
@@ -56,8 +56,132 @@ func TestAdapterMaterializesLiveSnapshotWithIndependentStoreAccounting(t *testin
 	if rootHead.NewPersistedBytes != uint64(len(result.Root)) {
 		t.Fatalf("root/head bytes = %d, want emitted root string length %d", rootHead.NewPersistedBytes, len(result.Root))
 	}
-	if result.MaterializationStrategy != maltflat.MaterializationStrategyLiveSnapshotRebuild {
-		t.Fatalf("materialization strategy = %q, want %q", result.MaterializationStrategy, maltflat.MaterializationStrategyLiveSnapshotRebuild)
+	if result.MaterializationStrategy != maltflat.MaterializationStrategyIncrementalDelta {
+		t.Fatalf("materialization strategy = %q, want %q", result.MaterializationStrategy, maltflat.MaterializationStrategyIncrementalDelta)
+	}
+	if result.AccountingDelta.Categories[evalstore.CategoryArcTable].NewObjectCount == 0 {
+		t.Fatal("expected MALT-flat to report per-commit ArcTable delta")
+	}
+}
+
+func TestAdapterAppliesOnlyChangedMutationBlobs(t *testing.T) {
+	ctx := context.Background()
+
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	system, err := factory.NewSystem(ctx, "maltflat")
+	if err != nil {
+		t.Fatalf("NewSystem: %v", err)
+	}
+	adapter, err := maltflat.New(system, maltflat.Options{Namespace: "test-maltflat-delta", ChunkSize: 4})
+	if err != nil {
+		t.Fatalf("New adapter: %v", err)
+	}
+
+	_, err = adapter.Apply(ctx, replay.CommitMutation{
+		Repo:     "repo",
+		Commit:   "c1",
+		Snapshot: fakeSnapshot{"a-v1": []byte("a1"), "b-v1": []byte("b1")},
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationAdd, Path: "a.txt", Size: int64(len("a1")), Hash: "a-v1"},
+			{Kind: replay.MutationAdd, Path: "b.txt", Size: int64(len("b1")), Hash: "b-v1"},
+		},
+		LiveFiles: []replay.LiveFile{
+			{Path: "a.txt", Size: int64(len("a1")), Hash: "a-v1"},
+			{Path: "b.txt", Size: int64(len("b1")), Hash: "b-v1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply initial commit: %v", err)
+	}
+
+	result, err := adapter.Apply(ctx, replay.CommitMutation{
+		Repo:     "repo",
+		Commit:   "c2",
+		Parent:   "c1",
+		Snapshot: fakeSnapshot{"a-v2": []byte("a2")},
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationModify, Path: "a.txt", Size: int64(len("a2")), Hash: "a-v2"},
+		},
+		LiveFiles: []replay.LiveFile{
+			{Path: "a.txt", Size: int64(len("a2")), Hash: "a-v2"},
+			{Path: "b.txt", Size: int64(len("b1")), Hash: "b-v1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply modify commit should not reread unchanged b.txt: %v", err)
+	}
+	if result.MaterializedPaths != 1 {
+		t.Fatalf("materialized paths = %d, want only the changed path", result.MaterializedPaths)
+	}
+}
+
+func TestAdapterAppliesRenameAndDeleteMutations(t *testing.T) {
+	ctx := context.Background()
+
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	system, err := factory.NewSystem(ctx, "maltflat")
+	if err != nil {
+		t.Fatalf("NewSystem: %v", err)
+	}
+	adapter, err := maltflat.New(system, maltflat.Options{Namespace: "test-maltflat-rename-delete", ChunkSize: 4})
+	if err != nil {
+		t.Fatalf("New adapter: %v", err)
+	}
+
+	_, err = adapter.Apply(ctx, replay.CommitMutation{
+		Repo:     "repo",
+		Commit:   "c1",
+		Snapshot: fakeSnapshot{"readme-v1": []byte("hello")},
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationAdd, Path: "README.md", Size: int64(len("hello")), Hash: "readme-v1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply initial commit: %v", err)
+	}
+	result, err := adapter.Apply(ctx, replay.CommitMutation{
+		Repo:     "repo",
+		Commit:   "c2",
+		Parent:   "c1",
+		Snapshot: fakeSnapshot{"readme-v1": []byte("hello")},
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationRename, OldPath: "README.md", Path: "docs/README.md", Size: int64(len("hello")), Hash: "readme-v1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply rename commit: %v", err)
+	}
+	if result.MaterializedPaths != 1 {
+		t.Fatalf("rename materialized paths = %d, want 1", result.MaterializedPaths)
+	}
+	result, err = adapter.Apply(ctx, replay.CommitMutation{
+		Repo:   "repo",
+		Commit: "c3",
+		Parent: "c2",
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationDelete, Path: "docs/README.md"},
+		},
+		Snapshot: fakeSnapshot{},
+	})
+	if err != nil {
+		t.Fatalf("Apply delete commit: %v", err)
+	}
+	if result.MaterializedPaths != 0 {
+		t.Fatalf("delete materialized paths = %d, want 0", result.MaterializedPaths)
 	}
 }
 

--- a/cmd/eval/helper/adapters/maltflat/adapter_test.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter_test.go
@@ -49,8 +49,11 @@ func TestAdapterMaterializesLiveSnapshotWithIndependentStoreAccounting(t *testin
 	if result.AppliedMutations != 1 || result.MaterializedPaths != 1 {
 		t.Fatalf("applied/materialized = %d/%d, want 1/1", result.AppliedMutations, result.MaterializedPaths)
 	}
-	if result.Accounting.Categories[evalstore.CategoryArcTable].NewObjectCount == 0 {
-		t.Fatal("expected MALT-flat to charge ArcTable records")
+	if result.Accounting.Categories[evalstore.CategoryCanonicalDelta].NewObjectCount == 0 {
+		t.Fatal("expected MALT-flat to charge canonical delta records")
+	}
+	if result.Accounting.Categories[evalstore.CategoryArcTable].NewObjectCount != 0 {
+		t.Fatalf("ArcTable records should be derived cache only: %+v", result.Accounting.Categories[evalstore.CategoryArcTable])
 	}
 	rootHead := result.Accounting.Categories[evalstore.CategoryRootHead]
 	if rootHead.NewPersistedBytes != uint64(len(result.Root)) {
@@ -59,8 +62,8 @@ func TestAdapterMaterializesLiveSnapshotWithIndependentStoreAccounting(t *testin
 	if result.MaterializationStrategy != maltflat.MaterializationStrategyIncrementalDelta {
 		t.Fatalf("materialization strategy = %q, want %q", result.MaterializationStrategy, maltflat.MaterializationStrategyIncrementalDelta)
 	}
-	if result.AccountingDelta.Categories[evalstore.CategoryArcTable].NewObjectCount == 0 {
-		t.Fatal("expected MALT-flat to report per-commit ArcTable delta")
+	if result.AccountingDelta.Categories[evalstore.CategoryCanonicalDelta].NewObjectCount == 0 {
+		t.Fatal("expected MALT-flat to report per-commit canonical delta")
 	}
 }
 
@@ -167,9 +170,13 @@ func TestAdapterUpdatesFlatPathBindingForModifiedFile(t *testing.T) {
 		t.Fatalf("Apply modify commit: %v", err)
 	}
 
+	canonicalDelta := result.AccountingDelta.Categories[evalstore.CategoryCanonicalDelta]
+	if canonicalDelta.ChangedRecordCount != 2 {
+		t.Fatalf("changed canonical delta records = %d, want parent root plus one flat path binding update", canonicalDelta.ChangedRecordCount)
+	}
 	arctable := result.AccountingDelta.Categories[evalstore.CategoryArcTable]
-	if arctable.ChangedRecordCount != 1 {
-		t.Fatalf("changed ArcTable records = %d, want one flat path binding update", arctable.ChangedRecordCount)
+	if arctable.ChangedRecordCount != 0 {
+		t.Fatalf("ArcTable changed records = %d, want derived cache excluded from canonical writes", arctable.ChangedRecordCount)
 	}
 }
 

--- a/cmd/eval/helper/adapters/maltflat/adapter_test.go
+++ b/cmd/eval/helper/adapters/maltflat/adapter_test.go
@@ -122,6 +122,57 @@ func TestAdapterAppliesOnlyChangedMutationBlobs(t *testing.T) {
 	}
 }
 
+func TestAdapterUpdatesFlatPathBindingForModifiedFile(t *testing.T) {
+	ctx := context.Background()
+
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	system, err := factory.NewSystem(ctx, "maltflat")
+	if err != nil {
+		t.Fatalf("NewSystem: %v", err)
+	}
+	adapter, err := maltflat.New(system, maltflat.Options{Namespace: "test-maltflat-flat-path", ChunkSize: 4})
+	if err != nil {
+		t.Fatalf("New adapter: %v", err)
+	}
+
+	_, err = adapter.Apply(ctx, replay.CommitMutation{
+		Repo:     "repo",
+		Commit:   "c1",
+		Snapshot: fakeSnapshot{"a-v1": []byte("a1")},
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationAdd, Path: "docs/a.txt", Size: int64(len("a1")), Hash: "a-v1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply initial commit: %v", err)
+	}
+
+	result, err := adapter.Apply(ctx, replay.CommitMutation{
+		Repo:     "repo",
+		Commit:   "c2",
+		Parent:   "c1",
+		Snapshot: fakeSnapshot{"a-v2": []byte("a2")},
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationModify, Path: "docs/a.txt", Size: int64(len("a2")), Hash: "a-v2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply modify commit: %v", err)
+	}
+
+	arctable := result.AccountingDelta.Categories[evalstore.CategoryArcTable]
+	if arctable.ChangedRecordCount != 1 {
+		t.Fatalf("changed ArcTable records = %d, want one flat path binding update", arctable.ChangedRecordCount)
+	}
+}
+
 func TestAdapterAppliesRenameAndDeleteMutations(t *testing.T) {
 	ctx := context.Background()
 

--- a/cmd/eval/helper/adapters/merkledag/adapter.go
+++ b/cmd/eval/helper/adapters/merkledag/adapter.go
@@ -3,9 +3,11 @@ package merkledag
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
-	"sort"
+	"os"
+	"strings"
 
 	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
 	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
@@ -26,6 +28,7 @@ type Options struct {
 type Adapter struct {
 	system *evalstore.System
 	opts   Options
+	editor *merkledagimport.Editor
 }
 
 // New creates a Merkle DAG adapter.
@@ -46,7 +49,7 @@ func (a *Adapter) Name() string {
 	return "merkledag"
 }
 
-// Apply imports only the files listed in the trace's live snapshot.
+// Apply incrementally applies only the commit mutation set.
 func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (replay.ApplyResult, error) {
 	if a.system == nil {
 		return replay.ApplyResult{}, fmt.Errorf("system store is nil")
@@ -54,38 +57,84 @@ func (a *Adapter) Apply(ctx context.Context, commit replay.CommitMutation) (repl
 	if commit.Snapshot == nil {
 		return replay.ApplyResult{}, fmt.Errorf("snapshot reader is nil")
 	}
-	files := append([]replay.LiveFile(nil), commit.LiveFiles...)
-	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
-	importFiles := make([]merkledagimport.File, 0, len(files))
-	for _, file := range files {
-		data, err := commit.Snapshot.ReadBlob(ctx, file.Hash)
-		if err != nil {
-			return replay.ApplyResult{}, fmt.Errorf("read blob for %s: %w", file.Path, err)
-		}
-		importFiles = append(importFiles, merkledagimport.File{
-			Path: file.Path,
-			Data: data,
-			Mode: gitFileMode(file.Mode),
+	if a.editor == nil {
+		editor, err := merkledagimport.NewEditor(a.system.CAS, merkledagimport.Options{
+			Model:       merkledagimport.ModelUnixFS,
+			FileLayout:  a.opts.FileLayout,
+			DirLayout:   a.opts.DirLayout,
+			ChunkSize:   a.opts.ChunkSize,
+			HAMTFanout:  a.opts.HAMTFanout,
+			RawFileLeaf: a.opts.RawFileLeaf,
 		})
+		if err != nil {
+			return replay.ApplyResult{}, err
+		}
+		a.editor = editor
 	}
-	result, err := merkledagimport.ImportFiles(ctx, a.system.CAS, importFiles, merkledagimport.Options{
-		Model:       merkledagimport.ModelUnixFS,
-		FileLayout:  a.opts.FileLayout,
-		DirLayout:   a.opts.DirLayout,
-		ChunkSize:   a.opts.ChunkSize,
-		HAMTFanout:  a.opts.HAMTFanout,
-		RawFileLeaf: a.opts.RawFileLeaf,
-	})
-	if err != nil {
-		return replay.ApplyResult{}, err
+	before := a.system.Meter.Snapshot()
+	materializedPaths := 0
+	for _, mutation := range commit.Mutations {
+		var err error
+		switch mutation.Kind {
+		case replay.MutationAdd, replay.MutationModify:
+			if mutationHasBlob(mutation) {
+				err = a.putMutationFile(ctx, commit.Snapshot, mutation)
+				materializedPaths++
+			}
+		case replay.MutationDelete:
+			err = a.removeMutationPath(ctx, mutation.Path)
+		case replay.MutationRename:
+			err = a.removeMutationPath(ctx, mutation.OldPath)
+			if err == nil && mutationHasBlob(mutation) {
+				err = a.putMutationFile(ctx, commit.Snapshot, mutation)
+				materializedPaths++
+			}
+		default:
+			if mutationHasBlob(mutation) {
+				err = a.putMutationFile(ctx, commit.Snapshot, mutation)
+				materializedPaths++
+			}
+		}
+		if err != nil {
+			return replay.ApplyResult{}, fmt.Errorf("apply %s %s: %w", mutation.Kind, mutation.Path, err)
+		}
 	}
-	a.system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(result.Root))
+	root := a.editor.Root()
+	a.system.Meter.RecordLogicalBytes(evalstore.CategoryRootHead, len(root))
+	after := a.system.Meter.Snapshot()
 	return replay.ApplyResult{
-		Root:              result.Root,
-		AppliedMutations:  len(commit.Mutations),
-		MaterializedPaths: len(commit.LiveFiles),
-		Accounting:        a.system.Meter.Snapshot(),
+		Root:                    root,
+		AppliedMutations:        len(commit.Mutations),
+		MaterializedPaths:       materializedPaths,
+		MaterializationStrategy: "incremental_delta",
+		Accounting:              after,
+		AccountingDelta:         evalstore.Delta(after, before),
 	}, nil
+}
+
+func (a *Adapter) putMutationFile(ctx context.Context, snapshot replay.SnapshotReader, mutation replay.FileMutation) error {
+	if strings.TrimSpace(mutation.Hash) == "" {
+		return fmt.Errorf("blob hash is empty")
+	}
+	data, err := snapshot.ReadBlob(ctx, mutation.Hash)
+	if err != nil {
+		return fmt.Errorf("read blob: %w", err)
+	}
+	return a.editor.PutFile(ctx, mutation.Path, data, gitFileMode(mutation.Mode))
+}
+
+func mutationHasBlob(mutation replay.FileMutation) bool {
+	return strings.TrimSpace(mutation.Hash) != ""
+}
+
+func (a *Adapter) removeMutationPath(ctx context.Context, path string) error {
+	if err := a.editor.RemoveFile(ctx, path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func gitFileMode(mode string) fs.FileMode {

--- a/cmd/eval/helper/adapters/merkledag/adapter_test.go
+++ b/cmd/eval/helper/adapters/merkledag/adapter_test.go
@@ -59,6 +59,127 @@ func TestAdapterImportsOnlyTraceLiveFilesFromSnapshot(t *testing.T) {
 	}
 }
 
+func TestAdapterAppliesOnlyChangedMutationBlobs(t *testing.T) {
+	ctx := context.Background()
+
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	system, err := factory.NewSystem(ctx, "merkledag")
+	if err != nil {
+		t.Fatalf("NewSystem: %v", err)
+	}
+	adapter := merkledag.New(system, merkledag.Options{
+		Name:      "merkledag",
+		DirLayout: merkledagimport.DirLayoutBasic,
+	})
+
+	_, err = adapter.Apply(ctx, replay.CommitMutation{
+		Repo:     "repo",
+		Commit:   "c1",
+		Snapshot: fakeSnapshot{"a-v1": []byte("a1"), "b-v1": []byte("b1")},
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationAdd, Path: "a.txt", Size: int64(len("a1")), Hash: "a-v1"},
+			{Kind: replay.MutationAdd, Path: "b.txt", Size: int64(len("b1")), Hash: "b-v1"},
+		},
+		LiveFiles: []replay.LiveFile{
+			{Path: "a.txt", Size: int64(len("a1")), Hash: "a-v1"},
+			{Path: "b.txt", Size: int64(len("b1")), Hash: "b-v1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply initial commit: %v", err)
+	}
+
+	result, err := adapter.Apply(ctx, replay.CommitMutation{
+		Repo:     "repo",
+		Commit:   "c2",
+		Parent:   "c1",
+		Snapshot: fakeSnapshot{"a-v2": []byte("a2")},
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationModify, Path: "a.txt", Size: int64(len("a2")), Hash: "a-v2"},
+		},
+		LiveFiles: []replay.LiveFile{
+			{Path: "a.txt", Size: int64(len("a2")), Hash: "a-v2"},
+			{Path: "b.txt", Size: int64(len("b1")), Hash: "b-v1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply modify commit should not reread unchanged b.txt: %v", err)
+	}
+	if result.MaterializedPaths != 1 {
+		t.Fatalf("materialized paths = %d, want only the changed path", result.MaterializedPaths)
+	}
+}
+
+func TestAdapterAppliesRenameAndDeleteMutations(t *testing.T) {
+	ctx := context.Background()
+
+	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
+		Mode:    evalstore.StoreModeIsolated,
+		Backend: evalstore.StoreBackendMemory,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+	system, err := factory.NewSystem(ctx, "merkledag")
+	if err != nil {
+		t.Fatalf("NewSystem: %v", err)
+	}
+	adapter := merkledag.New(system, merkledag.Options{
+		Name:      "merkledag",
+		DirLayout: merkledagimport.DirLayoutBasic,
+	})
+
+	_, err = adapter.Apply(ctx, replay.CommitMutation{
+		Repo:     "repo",
+		Commit:   "c1",
+		Snapshot: fakeSnapshot{"readme-v1": []byte("hello")},
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationAdd, Path: "README.md", Size: int64(len("hello")), Hash: "readme-v1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply initial commit: %v", err)
+	}
+	result, err := adapter.Apply(ctx, replay.CommitMutation{
+		Repo:     "repo",
+		Commit:   "c2",
+		Parent:   "c1",
+		Snapshot: fakeSnapshot{"readme-v1": []byte("hello")},
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationRename, OldPath: "README.md", Path: "docs/README.md", Size: int64(len("hello")), Hash: "readme-v1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply rename commit: %v", err)
+	}
+	if result.MaterializedPaths != 1 {
+		t.Fatalf("rename materialized paths = %d, want 1", result.MaterializedPaths)
+	}
+	result, err = adapter.Apply(ctx, replay.CommitMutation{
+		Repo:   "repo",
+		Commit: "c3",
+		Parent: "c2",
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationDelete, Path: "docs/README.md"},
+		},
+		Snapshot: fakeSnapshot{},
+	})
+	if err != nil {
+		t.Fatalf("Apply delete commit: %v", err)
+	}
+	if result.MaterializedPaths != 0 {
+		t.Fatalf("delete materialized paths = %d, want 0", result.MaterializedPaths)
+	}
+}
+
 type fakeSnapshot map[string][]byte
 
 func (s fakeSnapshot) ReadBlob(_ context.Context, hash string) ([]byte, error) {

--- a/cmd/eval/helper/evalwrite/command.go
+++ b/cmd/eval/helper/evalwrite/command.go
@@ -132,8 +132,9 @@ func BuildSystems(ctx context.Context, factory *evalstore.Factory, csv string) (
 			systems = append(systems, adapter)
 		case "merkledag":
 			systems = append(systems, merkledag.New(system, merkledag.Options{
-				Name:      "merkledag",
-				DirLayout: merkledagimport.DirLayoutBasic,
+				Name:        "merkledag",
+				DirLayout:   merkledagimport.DirLayoutBasic,
+				RawFileLeaf: true,
 			}))
 		case "hamt":
 			systems = append(systems, hamt.New(system))

--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -104,7 +104,7 @@ func CloneForReplay(ctx context.Context, repoURL, baseDir string) (string, error
 }
 
 func (s Source) revList(ctx context.Context, repo, ref string) ([]string, error) {
-	args := revListArgs(ref, s.Limit, s.FirstParent)
+	args := revListArgs(ref, s.FirstParent)
 	out, err := gitOutput(ctx, repo, args...)
 	if err != nil {
 		return nil, err
@@ -113,16 +113,16 @@ func (s Source) revList(ctx context.Context, repo, ref string) ([]string, error)
 	if len(lines) == 0 {
 		return nil, fmt.Errorf("no commits found for ref %q", ref)
 	}
+	if s.Limit > 0 && len(lines) > s.Limit {
+		lines = lines[:s.Limit]
+	}
 	return lines, nil
 }
 
-func revListArgs(ref string, limit int, firstParent bool) []string {
+func revListArgs(ref string, firstParent bool) []string {
 	args := []string{"rev-list", "--topo-order", "--reverse"}
 	if firstParent {
 		args = append(args, "--first-parent")
-	}
-	if limit > 0 {
-		args = append(args, "-n", strconv.Itoa(limit))
 	}
 	return append(args, ref)
 }

--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -158,6 +158,10 @@ func mutationsForCommit(ctx context.Context, repo, parent, commit string) ([]rep
 	if err != nil {
 		return nil, err
 	}
+	renamedContent, err := renamedContentChanges(ctx, repo, parent, commit)
+	if err != nil {
+		return nil, err
+	}
 	var mutations []replay.FileMutation
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		if strings.TrimSpace(line) == "" {
@@ -179,16 +183,52 @@ func mutationsForCommit(ctx context.Context, repo, parent, commit string) ([]rep
 			if len(fields) < 3 {
 				return nil, fmt.Errorf("invalid rename line %q", line)
 			}
+			oldPath := filepath.ToSlash(fields[1])
+			path := filepath.ToSlash(fields[2])
 			mutations = append(mutations, replay.FileMutation{
-				Kind:    replay.MutationRename,
-				OldPath: filepath.ToSlash(fields[1]),
-				Path:    filepath.ToSlash(fields[2]),
+				Kind:           replay.MutationRename,
+				OldPath:        oldPath,
+				Path:           path,
+				ContentChanged: renamedContent[renameKey{oldPath: oldPath, path: path}],
 			})
 		default:
 			mutations = append(mutations, replay.FileMutation{Kind: replay.MutationModify, Path: filepath.ToSlash(fields[len(fields)-1])})
 		}
 	}
 	return mutations, nil
+}
+
+type renameKey struct {
+	oldPath string
+	path    string
+}
+
+func renamedContentChanges(ctx context.Context, repo, parent, commit string) (map[renameKey]bool, error) {
+	out, err := gitOutput(ctx, repo, "diff-tree", "--no-commit-id", "--raw", "-r", "-M", parent, commit)
+	if err != nil {
+		return nil, err
+	}
+	changed := make(map[renameKey]bool)
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("invalid git diff-tree raw line %q", line)
+		}
+		meta := strings.Fields(fields[0])
+		if len(meta) < 5 || !strings.HasPrefix(meta[4], "R") {
+			continue
+		}
+		if len(fields) < 3 {
+			return nil, fmt.Errorf("invalid rename raw line %q", line)
+		}
+		oldPath := filepath.ToSlash(fields[1])
+		path := filepath.ToSlash(fields[2])
+		changed[renameKey{oldPath: oldPath, path: path}] = meta[2] != meta[3]
+	}
+	return changed, nil
 }
 
 func scanSnapshot(ctx context.Context, repo, commit string) ([]replay.LiveFile, replay.LiveStats, replay.SkipStats, error) {
@@ -269,6 +309,9 @@ func enrichMutations(mutations []replay.FileMutation, files []replay.LiveFile) {
 	for i := range mutations {
 		file, ok := byPath[mutations[i].Path]
 		if !ok {
+			if mutations[i].Kind == replay.MutationModify {
+				mutations[i].Kind = replay.MutationDelete
+			}
 			continue
 		}
 		mutations[i].Mode = file.Mode

--- a/cmd/eval/helper/git/trace_internal_test.go
+++ b/cmd/eval/helper/git/trace_internal_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRevListArgsUseTopoOrder(t *testing.T) {
-	args := revListArgs("HEAD", 10, true)
+	args := revListArgs("HEAD", true)
 	if !slices.Contains(args, "--topo-order") {
 		t.Fatalf("rev-list args = %v, want --topo-order", args)
 	}

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -100,6 +100,37 @@ func TestSourceWalkUsesGitObjectSnapshotWithoutReplayWorktree(t *testing.T) {
 	}
 }
 
+func TestSourceWalkLimitKeepsEarliestReplayPrefix(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	repo := initTraceRepo(t)
+
+	source := gittrace.Source{
+		RepoPath: repo,
+		Ref:      "HEAD",
+		Limit:    1,
+	}
+	var commits []replay.CommitMutation
+	if err := source.Walk(ctx, func(commit replay.CommitMutation) error {
+		commits = append(commits, commit)
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	if len(commits) != 1 {
+		t.Fatalf("commit count = %d, want 1", len(commits))
+	}
+	if commits[0].Parent != "" {
+		t.Fatalf("limited replay starts at parent %q, want initial commit", commits[0].Parent)
+	}
+	if len(commits[0].Mutations) != 1 || commits[0].Mutations[0].Kind != replay.MutationAdd || commits[0].Mutations[0].Path != "README.md" {
+		t.Fatalf("limited first mutation = %+v, want initial README add", commits[0].Mutations)
+	}
+}
+
 func TestSourceWalkReadsCommittedBlobWhenCheckoutIsDirty(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git binary not available")

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -51,6 +51,9 @@ func TestSourceWalkEmitsFirstParentCommitMutationsAndLiveStats(t *testing.T) {
 	if commits[2].Mutations[0].Kind != replay.MutationRename || commits[2].Mutations[0].OldPath != "README.md" || commits[2].Mutations[0].Path != "docs/README.md" {
 		t.Fatalf("third mutation = %+v, want rename README.md -> docs/README.md", commits[2].Mutations[0])
 	}
+	if commits[2].Mutations[0].ContentChanged {
+		t.Fatalf("third mutation = %+v, want pure rename without content_changed", commits[2].Mutations[0])
+	}
 	if commits[2].LiveStats.FileCount != 1 || commits[2].LiveStats.LivePayloadBytes != int64(len("hello world\n")) {
 		t.Fatalf("third live stats = %+v, want one renamed file with current bytes", commits[2].LiveStats)
 	}
@@ -166,6 +169,86 @@ func TestSourceWalkReadsCommittedBlobWhenCheckoutIsDirty(t *testing.T) {
 	}
 	if branch := currentBranch(t, repo); branch != "main" {
 		t.Fatalf("source repo branch = %q, want main", branch)
+	}
+}
+
+func TestSourceWalkTreatsRegularFileToSymlinkAsDelete(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	repo := initSingleFileRepo(t, "a.txt", "regular\n")
+	if err := os.Remove(filepath.Join(repo, "a.txt")); err != nil {
+		t.Fatalf("remove regular file: %v", err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(repo, "a.txt")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	runGit(t, repo, "add", "-A")
+	runGit(t, repo, "commit", "-m", "turn file into symlink")
+
+	source := gittrace.Source{
+		RepoPath: repo,
+		Ref:      "HEAD",
+		Limit:    2,
+	}
+	var commits []replay.CommitMutation
+	if err := source.Walk(ctx, func(commit replay.CommitMutation) error {
+		commits = append(commits, commit)
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(commits) != 2 {
+		t.Fatalf("commit count = %d, want 2", len(commits))
+	}
+	got := commits[1].Mutations
+	if len(got) != 1 || got[0].Kind != replay.MutationDelete || got[0].Path != "a.txt" || got[0].Hash != "" {
+		t.Fatalf("type-change mutations = %+v, want delete a.txt without hash", got)
+	}
+	if commits[1].LiveStats.FileCount != 0 || len(commits[1].LiveFiles) != 0 || commits[1].Skipped.SymlinkCount != 1 {
+		t.Fatalf("type-change live/skipped = files %+v stats %+v skipped %+v, want symlink skipped and no live files",
+			commits[1].LiveFiles, commits[1].LiveStats, commits[1].Skipped)
+	}
+}
+
+func TestSourceWalkMarksRenameWithContentChange(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	repo := initSingleFileRepo(t, "old.txt", strings.Repeat("same\n", 20))
+	if err := os.Rename(filepath.Join(repo, "old.txt"), filepath.Join(repo, "new.txt")); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	writeFile(t, repo, "new.txt", strings.Repeat("same\n", 20)+"changed\n")
+	runGit(t, repo, "add", "-A")
+	runGit(t, repo, "commit", "-m", "rename and edit")
+
+	source := gittrace.Source{
+		RepoPath: repo,
+		Ref:      "HEAD",
+		Limit:    2,
+	}
+	var commits []replay.CommitMutation
+	if err := source.Walk(ctx, func(commit replay.CommitMutation) error {
+		commits = append(commits, commit)
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(commits) != 2 {
+		t.Fatalf("commit count = %d, want 2", len(commits))
+	}
+	got := commits[1].Mutations
+	if len(got) != 1 || got[0].Kind != replay.MutationRename || got[0].OldPath != "old.txt" || got[0].Path != "new.txt" {
+		t.Fatalf("rename-with-edit mutation = %+v, want old.txt -> new.txt rename", got)
+	}
+	if !got[0].ContentChanged {
+		t.Fatalf("rename-with-edit mutation = %+v, want content_changed", got[0])
+	}
+	if got[0].Size != int64(len(strings.Repeat("same\n", 20)+"changed\n")) || got[0].Hash == "" {
+		t.Fatalf("rename-with-edit mutation = %+v, want new blob metadata", got[0])
 	}
 }
 

--- a/cmd/eval/helper/replay/runner.go
+++ b/cmd/eval/helper/replay/runner.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
 )
 
 // RunJSONL replays commits across systems and writes one JSON record per
@@ -56,21 +58,57 @@ func RunCommitRecords(ctx context.Context, commit CommitMutation, systems []Syst
 		if err != nil {
 			return fmt.Errorf("%s apply commit %s: %w", system.Name(), commit.Commit, err)
 		}
+		logicalChangedPayloadBytes := LogicalChangedPayloadBytes(commit.Mutations)
+		physicalPersistedBytes := result.AccountingDelta.Total.NewPersistedBytes
+		physicalPayloadBytes := result.AccountingDelta.Categories[evalstore.CategoryCASPayload].NewPersistedBytes
+		physicalMetadataBytes := physicalPersistedBytes
+		if physicalMetadataBytes >= physicalPayloadBytes {
+			physicalMetadataBytes -= physicalPayloadBytes
+		} else {
+			physicalMetadataBytes = 0
+		}
+		var writeAmplification *float64
+		if logicalChangedPayloadBytes > 0 {
+			value := float64(physicalPersistedBytes) / float64(logicalChangedPayloadBytes)
+			writeAmplification = &value
+		}
 		record := ResultRecord{
-			Repo:        commit.Repo,
-			System:      system.Name(),
-			Commit:      commit.Commit,
-			Parent:      commit.Parent,
-			Index:       commit.Index,
-			LiveStats:   commit.LiveStats,
-			MutationSet: commit.Mutations,
-			Skipped:     commit.Skipped,
-			Result:      result,
-			Accounting:  result.Accounting,
+			Repo:                       commit.Repo,
+			System:                     system.Name(),
+			Commit:                     commit.Commit,
+			Parent:                     commit.Parent,
+			Index:                      commit.Index,
+			LiveStats:                  commit.LiveStats,
+			MutationSet:                commit.Mutations,
+			Skipped:                    commit.Skipped,
+			Result:                     result,
+			Accounting:                 result.Accounting,
+			AccountingDelta:            result.AccountingDelta,
+			LogicalChangedPayloadBytes: logicalChangedPayloadBytes,
+			PhysicalPersistedBytes:     physicalPersistedBytes,
+			PhysicalPayloadBytes:       physicalPayloadBytes,
+			PhysicalMetadataBytes:      physicalMetadataBytes,
+			WriteAmplification:         writeAmplification,
 		}
 		if err := emit(record); err != nil {
 			return fmt.Errorf("emit %s commit %s: %w", system.Name(), commit.Commit, err)
 		}
 	}
 	return nil
+}
+
+// LogicalChangedPayloadBytes returns the payload bytes logically written by a
+// commit. Renames and deletes are structural changes, so they are excluded from
+// the byte denominator used for write-amplification ratios.
+func LogicalChangedPayloadBytes(mutations []FileMutation) int64 {
+	var total int64
+	for _, mutation := range mutations {
+		switch mutation.Kind {
+		case MutationAdd, MutationModify:
+			if mutation.Size > 0 {
+				total += mutation.Size
+			}
+		}
+	}
+	return total
 }

--- a/cmd/eval/helper/replay/runner.go
+++ b/cmd/eval/helper/replay/runner.go
@@ -98,14 +98,18 @@ func RunCommitRecords(ctx context.Context, commit CommitMutation, systems []Syst
 }
 
 // LogicalChangedPayloadBytes returns the payload bytes logically written by a
-// commit. Renames and deletes are structural changes, so they are excluded from
-// the byte denominator used for write-amplification ratios.
+// commit. Pure renames and deletes are structural changes, but Git can report
+// rename-with-edit as one rename mutation; those count the new payload size.
 func LogicalChangedPayloadBytes(mutations []FileMutation) int64 {
 	var total int64
 	for _, mutation := range mutations {
 		switch mutation.Kind {
 		case MutationAdd, MutationModify:
 			if mutation.Size > 0 {
+				total += mutation.Size
+			}
+		case MutationRename:
+			if mutation.ContentChanged && mutation.Size > 0 {
 				total += mutation.Size
 			}
 		}

--- a/cmd/eval/helper/replay/runner_test.go
+++ b/cmd/eval/helper/replay/runner_test.go
@@ -164,6 +164,7 @@ func TestRunCommitRecordsReportsWriteAmplificationInputs(t *testing.T) {
 		Mutations: []replay.FileMutation{
 			{Kind: replay.MutationModify, Path: "a.txt", Size: 10},
 			{Kind: replay.MutationRename, OldPath: "b.txt", Path: "c.txt", Size: 99},
+			{Kind: replay.MutationRename, OldPath: "edited-old.txt", Path: "edited-new.txt", Size: 20, ContentChanged: true},
 			{Kind: replay.MutationDelete, Path: "d.txt"},
 		},
 	}
@@ -182,14 +183,14 @@ func TestRunCommitRecordsReportsWriteAmplificationInputs(t *testing.T) {
 		t.Fatalf("record count = %d, want 1", len(records))
 	}
 	record := records[0]
-	if record.LogicalChangedPayloadBytes != 10 {
-		t.Fatalf("logical changed payload bytes = %d, want modify bytes only", record.LogicalChangedPayloadBytes)
+	if record.LogicalChangedPayloadBytes != 30 {
+		t.Fatalf("logical changed payload bytes = %d, want modify plus edited rename bytes", record.LogicalChangedPayloadBytes)
 	}
 	if record.PhysicalPersistedBytes != 30 || record.PhysicalPayloadBytes != 10 || record.PhysicalMetadataBytes != 20 {
 		t.Fatalf("physical byte split = total %d payload %d metadata %d, want 30/10/20",
 			record.PhysicalPersistedBytes, record.PhysicalPayloadBytes, record.PhysicalMetadataBytes)
 	}
-	if record.WriteAmplification == nil || *record.WriteAmplification != 3 {
-		t.Fatalf("write amplification = %v, want 3", record.WriteAmplification)
+	if record.WriteAmplification == nil || *record.WriteAmplification != 1 {
+		t.Fatalf("write amplification = %v, want 1", record.WriteAmplification)
 	}
 }

--- a/cmd/eval/helper/replay/runner_test.go
+++ b/cmd/eval/helper/replay/runner_test.go
@@ -130,3 +130,66 @@ func TestRunCommitRecordsEmitsStructuredRecords(t *testing.T) {
 		t.Fatalf("top-level accounting = %+v, want result accounting %+v", record.Accounting, record.Result.Accounting)
 	}
 }
+
+type accountingAdapter struct {
+	name string
+}
+
+func (a accountingAdapter) Name() string {
+	return a.name
+}
+
+func (a accountingAdapter) Apply(context.Context, replay.CommitMutation) (replay.ApplyResult, error) {
+	accounting := evalstore.Snapshot{
+		Total: evalstore.Counter{NewPersistedBytes: 30},
+		Categories: map[evalstore.Category]evalstore.Counter{
+			evalstore.CategoryCASPayload: {NewPersistedBytes: 10},
+			evalstore.CategoryArcTable:   {NewPersistedBytes: 20},
+		},
+	}
+	return replay.ApplyResult{
+		Root:             a.name + "-root",
+		AppliedMutations: 1,
+		Accounting:       accounting,
+		AccountingDelta:  accounting,
+	}, nil
+}
+
+func TestRunCommitRecordsReportsWriteAmplificationInputs(t *testing.T) {
+	ctx := context.Background()
+	commit := replay.CommitMutation{
+		Repo:   "example",
+		Commit: "c1",
+		Index:  0,
+		Mutations: []replay.FileMutation{
+			{Kind: replay.MutationModify, Path: "a.txt", Size: 10},
+			{Kind: replay.MutationRename, OldPath: "b.txt", Path: "c.txt", Size: 99},
+			{Kind: replay.MutationDelete, Path: "d.txt"},
+		},
+	}
+
+	var records []replay.ResultRecord
+	err := replay.RunCommitRecords(ctx, commit, []replay.SystemAdapter{
+		accountingAdapter{name: "maltflat"},
+	}, func(record replay.ResultRecord) error {
+		records = append(records, record)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunCommitRecords: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("record count = %d, want 1", len(records))
+	}
+	record := records[0]
+	if record.LogicalChangedPayloadBytes != 10 {
+		t.Fatalf("logical changed payload bytes = %d, want modify bytes only", record.LogicalChangedPayloadBytes)
+	}
+	if record.PhysicalPersistedBytes != 30 || record.PhysicalPayloadBytes != 10 || record.PhysicalMetadataBytes != 20 {
+		t.Fatalf("physical byte split = total %d payload %d metadata %d, want 30/10/20",
+			record.PhysicalPersistedBytes, record.PhysicalPayloadBytes, record.PhysicalMetadataBytes)
+	}
+	if record.WriteAmplification == nil || *record.WriteAmplification != 3 {
+		t.Fatalf("write amplification = %v, want 3", record.WriteAmplification)
+	}
+}

--- a/cmd/eval/helper/replay/types.go
+++ b/cmd/eval/helper/replay/types.go
@@ -76,20 +76,27 @@ type ApplyResult struct {
 	MaterializedPaths       int                `json:"materialized_paths"`
 	MaterializationStrategy string             `json:"materialization_strategy,omitempty"`
 	Accounting              evalstore.Snapshot `json:"accounting"`
+	AccountingDelta         evalstore.Snapshot `json:"accounting_delta"`
 }
 
 // ResultRecord is one JSONL measurement point for one system at one commit.
 type ResultRecord struct {
-	Repo        string             `json:"repo"`
-	System      string             `json:"system"`
-	Commit      string             `json:"commit"`
-	Parent      string             `json:"parent,omitempty"`
-	Index       int                `json:"index"`
-	LiveStats   LiveStats          `json:"live_stats"`
-	MutationSet []FileMutation     `json:"mutations"`
-	Skipped     SkipStats          `json:"skipped,omitempty"`
-	Result      ApplyResult        `json:"result"`
-	Accounting  evalstore.Snapshot `json:"accounting"`
+	Repo                       string             `json:"repo"`
+	System                     string             `json:"system"`
+	Commit                     string             `json:"commit"`
+	Parent                     string             `json:"parent,omitempty"`
+	Index                      int                `json:"index"`
+	LiveStats                  LiveStats          `json:"live_stats"`
+	MutationSet                []FileMutation     `json:"mutations"`
+	Skipped                    SkipStats          `json:"skipped,omitempty"`
+	Result                     ApplyResult        `json:"result"`
+	Accounting                 evalstore.Snapshot `json:"accounting"`
+	AccountingDelta            evalstore.Snapshot `json:"accounting_delta"`
+	LogicalChangedPayloadBytes int64              `json:"logical_changed_payload_bytes"`
+	PhysicalPersistedBytes     uint64             `json:"physical_persisted_bytes"`
+	PhysicalPayloadBytes       uint64             `json:"physical_payload_bytes"`
+	PhysicalMetadataBytes      uint64             `json:"physical_metadata_bytes"`
+	WriteAmplification         *float64           `json:"write_amplification,omitempty"`
 }
 
 // SystemAdapter consumes source-domain commit mutations for one representation.

--- a/cmd/eval/helper/replay/types.go
+++ b/cmd/eval/helper/replay/types.go
@@ -19,12 +19,13 @@ const (
 
 // FileMutation is one logical file mutation extracted from a Git commit.
 type FileMutation struct {
-	Kind    MutationKind `json:"kind"`
-	Path    string       `json:"path"`
-	OldPath string       `json:"old_path,omitempty"`
-	Mode    string       `json:"mode,omitempty"`
-	Size    int64        `json:"size,omitempty"`
-	Hash    string       `json:"hash,omitempty"`
+	Kind           MutationKind `json:"kind"`
+	Path           string       `json:"path"`
+	OldPath        string       `json:"old_path,omitempty"`
+	ContentChanged bool         `json:"content_changed,omitempty"`
+	Mode           string       `json:"mode,omitempty"`
+	Size           int64        `json:"size,omitempty"`
+	Hash           string       `json:"hash,omitempty"`
 }
 
 // LiveFile describes a regular file present in the commit snapshot.

--- a/cmd/eval/helper/store/accounting.go
+++ b/cmd/eval/helper/store/accounting.go
@@ -7,11 +7,12 @@ import "sync"
 type Category string
 
 const (
-	CategoryCASPayload  Category = "cas_payload"
-	CategoryCASMetadata Category = "cas_metadata"
-	CategoryArcTable    Category = "arctable"
-	CategoryCommitment  Category = "commitment"
-	CategoryRootHead    Category = "root_head"
+	CategoryCASPayload     Category = "cas_payload"
+	CategoryCASMetadata    Category = "cas_metadata"
+	CategoryCanonicalDelta Category = "canonical_delta"
+	CategoryArcTable       Category = "arctable"
+	CategoryCommitment     Category = "commitment"
+	CategoryRootHead       Category = "root_head"
 )
 
 // Counter captures attempted writes and newly persisted writes for one class.

--- a/cmd/eval/helper/store/accounting.go
+++ b/cmd/eval/helper/store/accounting.go
@@ -63,7 +63,9 @@ func (m *Meter) RecordCASPut(category Category, bytes int, isNew bool) {
 
 // RecordChangedRecord records a KV-style changed record. KV writes are charged
 // on every successful put because overwrite and delta stores still persist a
-// changed record for the evaluated commit.
+// changed record for the evaluated commit. Byte counts are logical value bytes;
+// backend key bytes are excluded to keep this metric comparable with CAS object
+// byte accounting.
 func (m *Meter) RecordChangedRecord(category Category, keyBytes, valueBytes int) {
 	if m == nil {
 		return

--- a/cmd/eval/helper/store/accounting.go
+++ b/cmd/eval/helper/store/accounting.go
@@ -123,3 +123,38 @@ func (m *Meter) Snapshot() Snapshot {
 	}
 	return out
 }
+
+// Delta returns the non-negative counter difference between after and before.
+// Missing categories are treated as zero-valued counters.
+func Delta(after, before Snapshot) Snapshot {
+	out := Snapshot{
+		Total:      counterDelta(after.Total, before.Total),
+		Categories: make(map[Category]Counter),
+	}
+	for category, afterCounter := range after.Categories {
+		out.Categories[category] = counterDelta(afterCounter, before.Categories[category])
+	}
+	for category := range before.Categories {
+		if _, ok := out.Categories[category]; !ok {
+			out.Categories[category] = Counter{}
+		}
+	}
+	return out
+}
+
+func counterDelta(after, before Counter) Counter {
+	return Counter{
+		AttemptedPutCount:  saturatedSub(after.AttemptedPutCount, before.AttemptedPutCount),
+		AttemptedPutBytes:  saturatedSub(after.AttemptedPutBytes, before.AttemptedPutBytes),
+		NewObjectCount:     saturatedSub(after.NewObjectCount, before.NewObjectCount),
+		NewPersistedBytes:  saturatedSub(after.NewPersistedBytes, before.NewPersistedBytes),
+		ChangedRecordCount: saturatedSub(after.ChangedRecordCount, before.ChangedRecordCount),
+	}
+}
+
+func saturatedSub(after, before uint64) uint64 {
+	if after < before {
+		return 0
+	}
+	return after - before
+}

--- a/cmd/eval/helper/store/accounting_test.go
+++ b/cmd/eval/helper/store/accounting_test.go
@@ -85,7 +85,7 @@ func TestSharedSystemsExposeCrossSystemCASDedupAsDiagnosticMode(t *testing.T) {
 	}
 }
 
-func TestMeteredKVCountsEveryChangedRecord(t *testing.T) {
+func TestMeteredKVCountsEveryChangedRecordValueBytes(t *testing.T) {
 	ctx := context.Background()
 	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
 		Mode:    evalstore.StoreModeIsolated,
@@ -111,8 +111,8 @@ func TestMeteredKVCountsEveryChangedRecord(t *testing.T) {
 	if arctable.NewObjectCount != 2 {
 		t.Fatalf("changed records = %d, want 2", arctable.NewObjectCount)
 	}
-	if arctable.NewPersistedBytes != uint64(len("root")+len("v1")+len("root")+len("v2")) {
-		t.Fatalf("changed bytes = %d, want key+value bytes for both writes", arctable.NewPersistedBytes)
+	if arctable.NewPersistedBytes != uint64(len("v1")+len("v2")) {
+		t.Fatalf("changed bytes = %d, want value bytes for both writes", arctable.NewPersistedBytes)
 	}
 }
 

--- a/cmd/eval/helper/store/accounting_test.go
+++ b/cmd/eval/helper/store/accounting_test.go
@@ -116,6 +116,63 @@ func TestMeteredKVCountsEveryChangedRecord(t *testing.T) {
 	}
 }
 
+func TestSnapshotDeltaSubtractsCountersByCategory(t *testing.T) {
+	before := evalstore.Snapshot{
+		Total: evalstore.Counter{
+			AttemptedPutCount: 5,
+			AttemptedPutBytes: 50,
+			NewObjectCount:    3,
+			NewPersistedBytes: 30,
+		},
+		Categories: map[evalstore.Category]evalstore.Counter{
+			evalstore.CategoryCASPayload: {
+				AttemptedPutCount: 2,
+				AttemptedPutBytes: 20,
+				NewObjectCount:    1,
+				NewPersistedBytes: 10,
+			},
+		},
+	}
+	after := evalstore.Snapshot{
+		Total: evalstore.Counter{
+			AttemptedPutCount: 8,
+			AttemptedPutBytes: 90,
+			NewObjectCount:    5,
+			NewPersistedBytes: 70,
+		},
+		Categories: map[evalstore.Category]evalstore.Counter{
+			evalstore.CategoryCASPayload: {
+				AttemptedPutCount: 3,
+				AttemptedPutBytes: 25,
+				NewObjectCount:    1,
+				NewPersistedBytes: 10,
+			},
+			evalstore.CategoryArcTable: {
+				AttemptedPutCount: 2,
+				AttemptedPutBytes: 35,
+				NewObjectCount:    2,
+				NewPersistedBytes: 35,
+			},
+		},
+	}
+
+	delta := evalstore.Delta(after, before)
+
+	if delta.Total.AttemptedPutCount != 3 || delta.Total.AttemptedPutBytes != 40 ||
+		delta.Total.NewObjectCount != 2 || delta.Total.NewPersistedBytes != 40 {
+		t.Fatalf("total delta = %+v, want count/bytes 3/40 and new 2/40", delta.Total)
+	}
+	payload := delta.Categories[evalstore.CategoryCASPayload]
+	if payload.AttemptedPutCount != 1 || payload.AttemptedPutBytes != 5 ||
+		payload.NewObjectCount != 0 || payload.NewPersistedBytes != 0 {
+		t.Fatalf("payload delta = %+v, want attempted 1/5 and no new persisted bytes", payload)
+	}
+	arctable := delta.Categories[evalstore.CategoryArcTable]
+	if arctable.AttemptedPutCount != 2 || arctable.NewPersistedBytes != 35 {
+		t.Fatalf("arctable delta = %+v, want new category delta", arctable)
+	}
+}
+
 func TestMeteredCASPutBatchReportsStoredAlreadyPresentAndDuplicate(t *testing.T) {
 	ctx := context.Background()
 	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{

--- a/cmd/eval/helper/store/kv_meter.go
+++ b/cmd/eval/helper/store/kv_meter.go
@@ -7,6 +7,8 @@ import (
 )
 
 // MeteredKV wraps a KVStore and charges every successful put as a changed record.
+// The byte counter measures persisted record values, not backend addressing
+// keys, to match CAS object-byte accounting.
 type MeteredKV struct {
 	base     kvstore.KVStore
 	meter    *Meter
@@ -30,7 +32,7 @@ func (m *MeteredKV) Put(ctx context.Context, key, value []byte) error {
 	if err := m.base.Put(ctx, key, value); err != nil {
 		return err
 	}
-	m.meter.RecordChangedRecord(m.category, len(key), len(value))
+	m.meter.RecordChangedRecord(m.category, 0, len(value))
 	return nil
 }
 
@@ -38,7 +40,7 @@ func (m *MeteredKV) Delete(ctx context.Context, key []byte) error {
 	if err := m.base.Delete(ctx, key); err != nil {
 		return err
 	}
-	m.meter.RecordChangedRecord(m.category, len(key), 0)
+	m.meter.RecordChangedRecord(m.category, 0, 0)
 	return nil
 }
 
@@ -70,7 +72,6 @@ type meteredBatch struct {
 }
 
 type meteredBatchPut struct {
-	keyBytes   int
 	valueBytes int
 }
 
@@ -78,7 +79,7 @@ func (b *meteredBatch) Put(key, value []byte) error {
 	if err := b.base.Put(key, value); err != nil {
 		return err
 	}
-	b.puts = append(b.puts, meteredBatchPut{keyBytes: len(key), valueBytes: len(value)})
+	b.puts = append(b.puts, meteredBatchPut{valueBytes: len(value)})
 	return nil
 }
 
@@ -86,7 +87,7 @@ func (b *meteredBatch) Delete(key []byte) error {
 	if err := b.base.Delete(key); err != nil {
 		return err
 	}
-	b.puts = append(b.puts, meteredBatchPut{keyBytes: len(key)})
+	b.puts = append(b.puts, meteredBatchPut{})
 	return nil
 }
 
@@ -95,7 +96,7 @@ func (b *meteredBatch) Commit(ctx context.Context) error {
 		return err
 	}
 	for _, put := range b.puts {
-		b.meter.RecordChangedRecord(b.category, put.keyBytes, put.valueBytes)
+		b.meter.RecordChangedRecord(b.category, 0, put.valueBytes)
 	}
 	return nil
 }

--- a/cmd/eval/internal/eval/suites/writetrace/aggregate.go
+++ b/cmd/eval/internal/eval/suites/writetrace/aggregate.go
@@ -15,25 +15,26 @@ import (
 )
 
 type aggregateRow struct {
-	Repo                       string
-	System                     string
-	Commits                    int
-	FinalLivePayloadBytes      int64
-	LogicalChangedPayloadBytes int64
-	PhysicalPersistedBytes     uint64
-	PhysicalPayloadBytes       uint64
-	PhysicalMetadataBytes      uint64
-	ArcTablePersistedBytes     uint64
-	CASMetadataPersistedBytes  uint64
-	RootHeadPersistedBytes     uint64
-	CommitmentPersistedBytes   uint64
-	CumulativeWriteAmp         float64
-	MedianWriteAmp             float64
-	P95WriteAmp                float64
-	AddCount                   int
-	ModifyCount                int
-	DeleteCount                int
-	RenameCount                int
+	Repo                         string
+	System                       string
+	Commits                      int
+	FinalLivePayloadBytes        int64
+	LogicalChangedPayloadBytes   int64
+	PhysicalPersistedBytes       uint64
+	PhysicalPayloadBytes         uint64
+	PhysicalMetadataBytes        uint64
+	CanonicalDeltaPersistedBytes uint64
+	ArcTablePersistedBytes       uint64
+	CASMetadataPersistedBytes    uint64
+	RootHeadPersistedBytes       uint64
+	CommitmentPersistedBytes     uint64
+	CumulativeWriteAmp           float64
+	MedianWriteAmp               float64
+	P95WriteAmp                  float64
+	AddCount                     int
+	ModifyCount                  int
+	DeleteCount                  int
+	RenameCount                  int
 }
 
 type aggregateKey struct {
@@ -71,6 +72,7 @@ func aggregateRecords(records []replay.ResultRecord) []aggregateRow {
 		acc.row.PhysicalPersistedBytes += record.PhysicalPersistedBytes
 		acc.row.PhysicalPayloadBytes += record.PhysicalPayloadBytes
 		acc.row.PhysicalMetadataBytes += record.PhysicalMetadataBytes
+		acc.row.CanonicalDeltaPersistedBytes += persistedBytes(record, evalstore.CategoryCanonicalDelta)
 		acc.row.ArcTablePersistedBytes += persistedBytes(record, evalstore.CategoryArcTable)
 		acc.row.CASMetadataPersistedBytes += persistedBytes(record, evalstore.CategoryCASMetadata)
 		acc.row.RootHeadPersistedBytes += persistedBytes(record, evalstore.CategoryRootHead)
@@ -137,6 +139,7 @@ func writeAggregateCSV(env framework.Env, rows []aggregateRow) error {
 		"physical_persisted_bytes",
 		"physical_payload_bytes",
 		"physical_metadata_bytes",
+		"canonical_delta_persisted_bytes",
 		"arctable_persisted_bytes",
 		"cas_metadata_persisted_bytes",
 		"root_head_persisted_bytes",
@@ -162,6 +165,7 @@ func writeAggregateCSV(env framework.Env, rows []aggregateRow) error {
 			strconv.FormatUint(row.PhysicalPersistedBytes, 10),
 			strconv.FormatUint(row.PhysicalPayloadBytes, 10),
 			strconv.FormatUint(row.PhysicalMetadataBytes, 10),
+			strconv.FormatUint(row.CanonicalDeltaPersistedBytes, 10),
 			strconv.FormatUint(row.ArcTablePersistedBytes, 10),
 			strconv.FormatUint(row.CASMetadataPersistedBytes, 10),
 			strconv.FormatUint(row.RootHeadPersistedBytes, 10),

--- a/cmd/eval/internal/eval/suites/writetrace/aggregate.go
+++ b/cmd/eval/internal/eval/suites/writetrace/aggregate.go
@@ -1,0 +1,193 @@
+package writetrace
+
+import (
+	"encoding/csv"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+
+	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
+)
+
+type aggregateRow struct {
+	Repo                       string
+	System                     string
+	Commits                    int
+	FinalLivePayloadBytes      int64
+	LogicalChangedPayloadBytes int64
+	PhysicalPersistedBytes     uint64
+	PhysicalPayloadBytes       uint64
+	PhysicalMetadataBytes      uint64
+	CumulativeWriteAmp         float64
+	MedianWriteAmp             float64
+	P95WriteAmp                float64
+	AddCount                   int
+	ModifyCount                int
+	DeleteCount                int
+	RenameCount                int
+}
+
+type aggregateKey struct {
+	repo   string
+	system string
+}
+
+type aggregateAccumulator struct {
+	row       aggregateRow
+	waSamples []float64
+	seen      map[string]struct{}
+}
+
+func aggregateRecords(records []replay.ResultRecord) []aggregateRow {
+	groups := make(map[aggregateKey]*aggregateAccumulator)
+	for _, record := range records {
+		key := aggregateKey{repo: record.Repo, system: record.System}
+		acc := groups[key]
+		if acc == nil {
+			acc = &aggregateAccumulator{
+				row: aggregateRow{
+					Repo:   record.Repo,
+					System: record.System,
+				},
+				seen: make(map[string]struct{}),
+			}
+			groups[key] = acc
+		}
+		if _, ok := acc.seen[record.Commit]; !ok {
+			acc.seen[record.Commit] = struct{}{}
+			acc.row.Commits++
+		}
+		acc.row.FinalLivePayloadBytes = record.LiveStats.LivePayloadBytes
+		acc.row.LogicalChangedPayloadBytes += record.LogicalChangedPayloadBytes
+		acc.row.PhysicalPersistedBytes += record.PhysicalPersistedBytes
+		acc.row.PhysicalPayloadBytes += record.PhysicalPayloadBytes
+		acc.row.PhysicalMetadataBytes += record.PhysicalMetadataBytes
+		if record.WriteAmplification != nil {
+			acc.waSamples = append(acc.waSamples, *record.WriteAmplification)
+		}
+		for _, mutation := range record.MutationSet {
+			switch mutation.Kind {
+			case replay.MutationAdd:
+				acc.row.AddCount++
+			case replay.MutationModify:
+				acc.row.ModifyCount++
+			case replay.MutationDelete:
+				acc.row.DeleteCount++
+			case replay.MutationRename:
+				acc.row.RenameCount++
+			}
+		}
+	}
+
+	keys := make([]aggregateKey, 0, len(groups))
+	for key := range groups {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].repo != keys[j].repo {
+			return keys[i].repo < keys[j].repo
+		}
+		return keys[i].system < keys[j].system
+	})
+
+	rows := make([]aggregateRow, 0, len(keys))
+	for _, key := range keys {
+		acc := groups[key]
+		if acc.row.LogicalChangedPayloadBytes > 0 {
+			acc.row.CumulativeWriteAmp = float64(acc.row.PhysicalPersistedBytes) / float64(acc.row.LogicalChangedPayloadBytes)
+		}
+		acc.row.MedianWriteAmp = percentile(acc.waSamples, 0.50)
+		acc.row.P95WriteAmp = percentile(acc.waSamples, 0.95)
+		rows = append(rows, acc.row)
+	}
+	return rows
+}
+
+func writeAggregateCSV(env framework.Env, rows []aggregateRow) error {
+	path := aggregatePath(env)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create aggregate dir: %w", err)
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create aggregate csv: %w", err)
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	header := []string{
+		"repo",
+		"system",
+		"commits",
+		"final_live_payload_bytes",
+		"logical_changed_payload_bytes",
+		"physical_persisted_bytes",
+		"physical_payload_bytes",
+		"physical_metadata_bytes",
+		"cumulative_write_amplification",
+		"median_write_amplification",
+		"p95_write_amplification",
+		"add_count",
+		"modify_count",
+		"delete_count",
+		"rename_count",
+	}
+	if err := writer.Write(header); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		record := []string{
+			row.Repo,
+			row.System,
+			strconv.Itoa(row.Commits),
+			strconv.FormatInt(row.FinalLivePayloadBytes, 10),
+			strconv.FormatInt(row.LogicalChangedPayloadBytes, 10),
+			strconv.FormatUint(row.PhysicalPersistedBytes, 10),
+			strconv.FormatUint(row.PhysicalPayloadBytes, 10),
+			strconv.FormatUint(row.PhysicalMetadataBytes, 10),
+			formatFloat(row.CumulativeWriteAmp),
+			formatFloat(row.MedianWriteAmp),
+			formatFloat(row.P95WriteAmp),
+			strconv.Itoa(row.AddCount),
+			strconv.Itoa(row.ModifyCount),
+			strconv.Itoa(row.DeleteCount),
+			strconv.Itoa(row.RenameCount),
+		}
+		if err := writer.Write(record); err != nil {
+			return err
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return fmt.Errorf("write aggregate csv: %w", err)
+	}
+	return nil
+}
+
+func aggregatePath(env framework.Env) string {
+	return filepath.Join(env.ResultDir, "aggregate", SuiteName+".csv")
+}
+
+func percentile(values []float64, q float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	index := int(math.Ceil(q*float64(len(sorted)))) - 1
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(sorted) {
+		index = len(sorted) - 1
+	}
+	return sorted[index]
+}
+
+func formatFloat(value float64) string {
+	return strconv.FormatFloat(value, 'f', 6, 64)
+}

--- a/cmd/eval/internal/eval/suites/writetrace/aggregate.go
+++ b/cmd/eval/internal/eval/suites/writetrace/aggregate.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/dewebprotocol/malt/cmd/eval/helper/replay"
+	evalstore "github.com/dewebprotocol/malt/cmd/eval/helper/store"
 	"github.com/dewebprotocol/malt/cmd/eval/internal/eval/framework"
 )
 
@@ -22,6 +23,10 @@ type aggregateRow struct {
 	PhysicalPersistedBytes     uint64
 	PhysicalPayloadBytes       uint64
 	PhysicalMetadataBytes      uint64
+	ArcTablePersistedBytes     uint64
+	CASMetadataPersistedBytes  uint64
+	RootHeadPersistedBytes     uint64
+	CommitmentPersistedBytes   uint64
 	CumulativeWriteAmp         float64
 	MedianWriteAmp             float64
 	P95WriteAmp                float64
@@ -66,6 +71,10 @@ func aggregateRecords(records []replay.ResultRecord) []aggregateRow {
 		acc.row.PhysicalPersistedBytes += record.PhysicalPersistedBytes
 		acc.row.PhysicalPayloadBytes += record.PhysicalPayloadBytes
 		acc.row.PhysicalMetadataBytes += record.PhysicalMetadataBytes
+		acc.row.ArcTablePersistedBytes += persistedBytes(record, evalstore.CategoryArcTable)
+		acc.row.CASMetadataPersistedBytes += persistedBytes(record, evalstore.CategoryCASMetadata)
+		acc.row.RootHeadPersistedBytes += persistedBytes(record, evalstore.CategoryRootHead)
+		acc.row.CommitmentPersistedBytes += persistedBytes(record, evalstore.CategoryCommitment)
 		if record.WriteAmplification != nil {
 			acc.waSamples = append(acc.waSamples, *record.WriteAmplification)
 		}
@@ -128,6 +137,10 @@ func writeAggregateCSV(env framework.Env, rows []aggregateRow) error {
 		"physical_persisted_bytes",
 		"physical_payload_bytes",
 		"physical_metadata_bytes",
+		"arctable_persisted_bytes",
+		"cas_metadata_persisted_bytes",
+		"root_head_persisted_bytes",
+		"commitment_persisted_bytes",
 		"cumulative_write_amplification",
 		"median_write_amplification",
 		"p95_write_amplification",
@@ -149,6 +162,10 @@ func writeAggregateCSV(env framework.Env, rows []aggregateRow) error {
 			strconv.FormatUint(row.PhysicalPersistedBytes, 10),
 			strconv.FormatUint(row.PhysicalPayloadBytes, 10),
 			strconv.FormatUint(row.PhysicalMetadataBytes, 10),
+			strconv.FormatUint(row.ArcTablePersistedBytes, 10),
+			strconv.FormatUint(row.CASMetadataPersistedBytes, 10),
+			strconv.FormatUint(row.RootHeadPersistedBytes, 10),
+			strconv.FormatUint(row.CommitmentPersistedBytes, 10),
 			formatFloat(row.CumulativeWriteAmp),
 			formatFloat(row.MedianWriteAmp),
 			formatFloat(row.P95WriteAmp),
@@ -170,6 +187,10 @@ func writeAggregateCSV(env framework.Env, rows []aggregateRow) error {
 
 func aggregatePath(env framework.Env) string {
 	return filepath.Join(env.ResultDir, "aggregate", SuiteName+".csv")
+}
+
+func persistedBytes(record replay.ResultRecord, category evalstore.Category) uint64 {
+	return record.AccountingDelta.Categories[category].NewPersistedBytes
 }
 
 func percentile(values []float64, q float64) float64 {

--- a/cmd/eval/internal/eval/suites/writetrace/suite.go
+++ b/cmd/eval/internal/eval/suites/writetrace/suite.go
@@ -34,23 +34,26 @@ func (Suite) Run(ctx context.Context, env framework.Env, raw json.RawMessage) (e
 	}
 
 	log("  repositories=%d systems=%s", len(repositories), cfg.SystemsCSV())
+	var allRecords []replay.ResultRecord
 	for i, repo := range repositories {
 		log("  [%d/%d] repository=%s", i+1, len(repositories), repo.RepoID)
-		if err := runRepository(ctx, env, cfg, repo, i, len(repositories)); err != nil {
+		records, err := runRepository(ctx, env, cfg, repo, i, len(repositories))
+		if err != nil {
 			return err
 		}
+		allRecords = append(allRecords, records...)
 	}
-	return nil
+	return writeAggregateCSV(env, aggregateRecords(allRecords))
 }
 
-func runRepository(ctx context.Context, env framework.Env, cfg Config, repo RepositoryTarget, index, repoCount int) (err error) {
+func runRepository(ctx context.Context, env framework.Env, cfg Config, repo RepositoryTarget, index, repoCount int) (records []replay.ResultRecord, err error) {
 	factory, err := evalstore.NewFactory(evalstore.FactoryConfig{
 		Mode:    evalstore.StoreMode(cfg.StoreMode),
 		Backend: evalstore.StoreBackend(cfg.StoreBackend),
 		RootDir: storeDirForRepository(env.WorkPath("write-stores"), repo, index, repoCount),
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		if closeErr := factory.Close(); err == nil {
@@ -60,7 +63,7 @@ func runRepository(ctx context.Context, env framework.Env, cfg Config, repo Repo
 
 	systems, err := evalwrite.BuildSystems(ctx, factory, cfg.SystemsCSV())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	source := gittrace.Source{
@@ -70,12 +73,14 @@ func runRepository(ctx context.Context, env framework.Env, cfg Config, repo Repo
 		Limit:        cfg.MaxCommitsPerRepo,
 		FirstParent:  cfg.FirstParent,
 	}
-	return source.Walk(ctx, func(commit replay.CommitMutation) error {
+	err = source.Walk(ctx, func(commit replay.CommitMutation) error {
 		commit.Repo = repo.RepoID
 		return replay.RunCommitRecords(ctx, commit, systems, func(record replay.ResultRecord) error {
+			records = append(records, record)
 			return env.WriteRecord(SuiteName, record)
 		})
 	})
+	return records, err
 }
 
 var _ framework.Suite = Suite{}

--- a/cmd/eval/internal/eval/suites/writetrace/suite_test.go
+++ b/cmd/eval/internal/eval/suites/writetrace/suite_test.go
@@ -253,6 +253,9 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 	if row["logical_changed_payload_bytes"] == "" || row["physical_persisted_bytes"] == "" || row["cumulative_write_amplification"] == "" {
 		t.Fatalf("aggregate missing write amplification fields: %+v", row)
 	}
+	if row["arctable_persisted_bytes"] == "" {
+		t.Fatalf("aggregate missing ArcTable breakdown field: %+v", row)
+	}
 }
 
 func TestSuiteRunReplaysRepoURLListWithCanonicalRepoLabels(t *testing.T) {

--- a/cmd/eval/internal/eval/suites/writetrace/suite_test.go
+++ b/cmd/eval/internal/eval/suites/writetrace/suite_test.go
@@ -3,6 +3,7 @@ package writetrace_test
 import (
 	"bufio"
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"net/url"
 	"os"
@@ -230,12 +231,27 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 		if record.Commit == "" {
 			t.Fatalf("record %d commit is empty", i)
 		}
-		if record.Result.MaterializationStrategy != maltflat.MaterializationStrategyLiveSnapshotRebuild {
-			t.Fatalf("record %d materialization strategy = %q, want %q", i, record.Result.MaterializationStrategy, maltflat.MaterializationStrategyLiveSnapshotRebuild)
+		if record.Result.MaterializationStrategy != maltflat.MaterializationStrategyIncrementalDelta {
+			t.Fatalf("record %d materialization strategy = %q, want %q", i, record.Result.MaterializationStrategy, maltflat.MaterializationStrategyIncrementalDelta)
 		}
 		if record.Result.Accounting.Categories == nil || record.Accounting.Categories == nil {
 			t.Fatalf("record %d accounting missing: %+v", i, record)
 		}
+		if record.AccountingDelta.Categories == nil {
+			t.Fatalf("record %d accounting delta missing: %+v", i, record)
+		}
+	}
+
+	aggregateRows := readAggregateRows(t, filepath.Join(resultDir, "aggregate", "write_trace.csv"))
+	if len(aggregateRows) != 1 {
+		t.Fatalf("aggregate row count = %d, want 1", len(aggregateRows))
+	}
+	row := aggregateRows[0]
+	if row["repo"] != "github.com/ipfs/kubo" || row["system"] != "maltflat" || row["commits"] != "3" {
+		t.Fatalf("aggregate identity = %+v, want repo/system/3 commits", row)
+	}
+	if row["logical_changed_payload_bytes"] == "" || row["physical_persisted_bytes"] == "" || row["cumulative_write_amplification"] == "" {
+		t.Fatalf("aggregate missing write amplification fields: %+v", row)
 	}
 }
 
@@ -366,6 +382,34 @@ func readWriteTraceEnvelopes(t *testing.T, path string) []framework.RecordEnvelo
 		t.Fatalf("scan envelopes: %v", err)
 	}
 	return envelopes
+}
+
+func readAggregateRows(t *testing.T, path string) []map[string]string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open aggregate %s: %v", path, err)
+	}
+	defer f.Close()
+	rows, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("read aggregate csv: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("aggregate csv missing header")
+	}
+	header := rows[0]
+	out := make([]map[string]string, 0, len(rows)-1)
+	for _, row := range rows[1:] {
+		mapped := make(map[string]string, len(header))
+		for i, key := range header {
+			if i < len(row) {
+				mapped[key] = row[i]
+			}
+		}
+		out = append(out, mapped)
+	}
+	return out
 }
 
 func writeFile(t *testing.T, repo, rel, content string) {

--- a/cmd/eval/internal/eval/suites/writetrace/suite_test.go
+++ b/cmd/eval/internal/eval/suites/writetrace/suite_test.go
@@ -256,6 +256,9 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 	if row["arctable_persisted_bytes"] == "" {
 		t.Fatalf("aggregate missing ArcTable breakdown field: %+v", row)
 	}
+	if row["canonical_delta_persisted_bytes"] == "" {
+		t.Fatalf("aggregate missing canonical delta breakdown field: %+v", row)
+	}
 }
 
 func TestSuiteRunReplaysRepoURLListWithCanonicalRepoLabels(t *testing.T) {

--- a/cmd/eval/schemas/write-trace-result.schema.json
+++ b/cmd/eval/schemas/write-trace-result.schema.json
@@ -13,7 +13,12 @@
     "live_stats",
     "mutations",
     "result",
-    "accounting"
+    "accounting",
+    "accounting_delta",
+    "logical_changed_payload_bytes",
+    "physical_persisted_bytes",
+    "physical_payload_bytes",
+    "physical_metadata_bytes"
   ],
   "properties": {
     "repo": {
@@ -52,6 +57,25 @@
     },
     "accounting": {
       "$ref": "#/$defs/accounting_snapshot"
+    },
+    "accounting_delta": {
+      "$ref": "#/$defs/accounting_snapshot"
+    },
+    "logical_changed_payload_bytes": {
+      "$ref": "#/$defs/counter"
+    },
+    "physical_persisted_bytes": {
+      "$ref": "#/$defs/counter"
+    },
+    "physical_payload_bytes": {
+      "$ref": "#/$defs/counter"
+    },
+    "physical_metadata_bytes": {
+      "$ref": "#/$defs/counter"
+    },
+    "write_amplification": {
+      "type": "number",
+      "minimum": 0
     }
   },
   "$defs": {
@@ -123,7 +147,8 @@
       "required": [
         "applied_mutations",
         "materialized_paths",
-        "accounting"
+        "accounting",
+        "accounting_delta"
       ],
       "properties": {
         "root": {
@@ -133,9 +158,12 @@
         "materialized_paths": { "$ref": "#/$defs/counter" },
         "materialization_strategy": {
           "type": "string",
-          "enum": ["live_snapshot_rebuild"]
+          "enum": ["live_snapshot_rebuild", "incremental_delta"]
         },
         "accounting": {
+          "$ref": "#/$defs/accounting_snapshot"
+        },
+        "accounting_delta": {
           "$ref": "#/$defs/accounting_snapshot"
         }
       }

--- a/cmd/eval/schemas/write-trace-result.schema.json
+++ b/cmd/eval/schemas/write-trace-result.schema.json
@@ -122,6 +122,9 @@
         "old_path": {
           "type": "string"
         },
+        "content_changed": {
+          "type": "boolean"
+        },
         "mode": {
           "type": "string"
         },

--- a/cmd/internal/merkledagimport/editor.go
+++ b/cmd/internal/merkledagimport/editor.go
@@ -1,0 +1,238 @@
+package merkledagimport
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+	"time"
+
+	mdag "github.com/ipfs/boxo/ipld/merkledag"
+	unixfsio "github.com/ipfs/boxo/ipld/unixfs/io"
+	cid "github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// Editor incrementally mutates a UnixFS directory DAG backed by Store.
+type Editor struct {
+	dag   ipld.DAGService
+	opts  Options
+	build cid.Prefix
+	root  ipld.Node
+}
+
+// NewEditor creates an incremental UnixFS DAG editor.
+func NewEditor(store Store, opts Options) (*Editor, error) {
+	if store == nil {
+		return nil, fmt.Errorf("store is nil")
+	}
+	opts = normalizeOptions(opts)
+	if err := validateOptions(opts); err != nil {
+		return nil, err
+	}
+	editor := &Editor{
+		dag:   NewDAGService(store),
+		opts:  opts,
+		build: cid.Prefix{Version: 1, Codec: cid.DagProtobuf, MhType: mh.SHA2_256, MhLength: -1},
+	}
+	return editor, nil
+}
+
+// Root returns the current root CID string, or an empty string before the first
+// materialized directory.
+func (e *Editor) Root() string {
+	if e == nil || e.root == nil {
+		return ""
+	}
+	return e.root.Cid().String()
+}
+
+// PutFile writes or replaces one file in the current DAG.
+func (e *Editor) PutFile(ctx context.Context, filePath string, data []byte, mode fs.FileMode) error {
+	clean, parts, err := cleanPathParts(filePath)
+	if err != nil {
+		return err
+	}
+	importer := pathImporter{
+		dag:   e.dag,
+		opts:  e.opts,
+		seen:  make(map[string]struct{}),
+		build: e.build,
+	}
+	fileNode, err := importer.importFileReader(ctx, clean, bytes.NewReader(data), virtualFileMode(mode), time.Time{})
+	if err != nil {
+		return err
+	}
+	root, err := e.putFile(ctx, e.root, parts, fileNode)
+	if err != nil {
+		return err
+	}
+	e.root = root
+	return nil
+}
+
+// RemoveFile removes one file from the current DAG and prunes empty parent
+// directories.
+func (e *Editor) RemoveFile(ctx context.Context, filePath string) error {
+	_, parts, err := cleanPathParts(filePath)
+	if err != nil {
+		return err
+	}
+	if e.root == nil {
+		return fmt.Errorf("remove %s: %w", filePath, os.ErrNotExist)
+	}
+	root, _, err := e.removeFile(ctx, e.root, parts)
+	if err != nil {
+		return err
+	}
+	e.root = root
+	return nil
+}
+
+func (e *Editor) putFile(ctx context.Context, node ipld.Node, parts []string, fileNode ipld.Node) (ipld.Node, error) {
+	dir, err := e.directoryForNode(node)
+	if err != nil {
+		return nil, err
+	}
+	name := parts[0]
+	if len(parts) == 1 {
+		if err := dir.AddChild(ctx, name, fileNode); err != nil {
+			return nil, err
+		}
+		return e.storeDirectory(ctx, dir)
+	}
+	child, err := dir.Find(ctx, name)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		child = nil
+	}
+	nextChild, err := e.putFile(ctx, child, parts[1:], fileNode)
+	if err != nil {
+		return nil, err
+	}
+	if err := dir.AddChild(ctx, name, nextChild); err != nil {
+		return nil, err
+	}
+	return e.storeDirectory(ctx, dir)
+}
+
+func (e *Editor) removeFile(ctx context.Context, node ipld.Node, parts []string) (ipld.Node, bool, error) {
+	dir, err := e.directoryForNode(node)
+	if err != nil {
+		return nil, false, err
+	}
+	name := parts[0]
+	if len(parts) == 1 {
+		if err := dir.RemoveChild(ctx, name); err != nil {
+			return nil, false, err
+		}
+		next, err := e.storeDirectory(ctx, dir)
+		if err != nil {
+			return nil, false, err
+		}
+		empty, err := directoryIsEmpty(ctx, dir)
+		return next, empty, err
+	}
+	child, err := dir.Find(ctx, name)
+	if err != nil {
+		return nil, false, err
+	}
+	nextChild, removeChild, err := e.removeFile(ctx, child, parts[1:])
+	if err != nil {
+		return nil, false, err
+	}
+	if removeChild {
+		if err := dir.RemoveChild(ctx, name); err != nil {
+			return nil, false, err
+		}
+	} else {
+		if err := dir.AddChild(ctx, name, nextChild); err != nil {
+			return nil, false, err
+		}
+	}
+	next, err := e.storeDirectory(ctx, dir)
+	if err != nil {
+		return nil, false, err
+	}
+	empty, err := directoryIsEmpty(ctx, dir)
+	return next, empty, err
+}
+
+func (e *Editor) directoryForNode(node ipld.Node) (unixfsio.Directory, error) {
+	if node == nil {
+		return e.newDirectory()
+	}
+	switch e.opts.DirLayout {
+	case DirLayoutBasic:
+		protoNode, ok := node.(*mdag.ProtoNode)
+		if !ok {
+			return nil, fmt.Errorf("basic directory root %s is not dag-pb", node.Cid())
+		}
+		dir := unixfsio.NewBasicDirectoryFromNode(e.dag, protoNode.Copy().(*mdag.ProtoNode))
+		dir.SetCidBuilder(e.build)
+		return dir, nil
+	case DirLayoutHAMT:
+		dir, err := unixfsio.NewHAMTDirectoryFromNode(e.dag, node)
+		if err != nil {
+			return nil, err
+		}
+		dir.SetCidBuilder(e.build)
+		return dir, nil
+	case DirLayoutAdaptive:
+		dir, err := unixfsio.NewDirectoryFromNode(e.dag, node)
+		if err != nil {
+			return nil, err
+		}
+		dir.SetCidBuilder(e.build)
+		return dir, nil
+	default:
+		return nil, fmt.Errorf("unsupported merkle-dag unixfs directory layout %q", e.opts.DirLayout)
+	}
+}
+
+func (e *Editor) newDirectory() (unixfsio.Directory, error) {
+	importer := pathImporter{
+		dag:   e.dag,
+		opts:  e.opts,
+		seen:  make(map[string]struct{}),
+		build: e.build,
+	}
+	return importer.newDirectory()
+}
+
+func (e *Editor) storeDirectory(ctx context.Context, dir unixfsio.Directory) (ipld.Node, error) {
+	node, err := dir.GetNode()
+	if err != nil {
+		return nil, err
+	}
+	if err := e.dag.Add(ctx, node); err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+func directoryIsEmpty(ctx context.Context, dir unixfsio.Directory) (bool, error) {
+	links, err := dir.Links(ctx)
+	if err != nil {
+		return false, err
+	}
+	return len(links) == 0, nil
+}
+
+func cleanPathParts(raw string) (string, []string, error) {
+	clean, err := cleanVirtualPath(raw)
+	if err != nil {
+		return "", nil, err
+	}
+	parts := strings.Split(clean, "/")
+	if len(parts) == 0 || parts[0] == "" {
+		return "", nil, fmt.Errorf("invalid virtual file path %q", raw)
+	}
+	return clean, parts, nil
+}

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -168,7 +168,12 @@ commits.
 The MALT baseline is flat: `maltflat` stores file payloads in CAS and updates a
 single authenticated map from the canonical complete path to the payload CID. It
 does not materialize UnixFS directory/file nodes for the MALT side of this
-write-amplification comparison.
+write-amplification comparison. For this suite, MALT durable state is charged as
+canonical deltas: a parent-root link plus the changed canonical path-to-target
+CID bindings. Radix nodes and commitment calculation nodes are treated as
+derived latest-root cache material. They may be useful for serving proofs, but
+they are not counted as canonical write-amplification state because they can be
+rebuilt from the committed deltas.
 
 The Merkle DAG and HAMT write baselines use raw file leaves so payload bytes and
 directory/index metadata bytes are visible as separate accounting categories.
@@ -182,11 +187,14 @@ aggregate to `aggregate/write_trace.csv`. Use
 `cumulative_write_amplification` as the main paper number and
 `median_write_amplification` / `p95_write_amplification` as supporting
 per-commit statistics. The aggregate also exposes
-`arctable_persisted_bytes`, `cas_metadata_persisted_bytes`,
-`root_head_persisted_bytes`, and `commitment_persisted_bytes` so metadata can be
-attributed without treating `physical_metadata_bytes` as an ArcTable-only
-number. Small commits can have high per-commit ratios, so the cumulative ratio
-is the more stable repo-level comparison.
+`canonical_delta_persisted_bytes`, `arctable_persisted_bytes`,
+`cas_metadata_persisted_bytes`, `root_head_persisted_bytes`, and
+`commitment_persisted_bytes` so metadata can be attributed without treating
+`physical_metadata_bytes` as an ArcTable-only number. For `maltflat` write-trace
+records, `arctable_persisted_bytes` should remain zero under the canonical-delta
+accounting model; ArcTable materialization belongs to the derived cache or to a
+separate storage-backend experiment. Small commits can have high per-commit
+ratios, so the cumulative ratio is the more stable repo-level comparison.
 
 `malt-eval read` and the `read_query` suite remain useful for daemon-oriented
 end-to-end checks. They exercise the HTTP daemon path for MALT and local IPLD

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -147,6 +147,34 @@ system. Use median latency for the main result and p95 to report tail behavior.
 For the MALT proof-cost figure, plot `median_prove_elapsed_ns` and
 `p95_prove_elapsed_ns` against `file_count` separately from read latency.
 
+The `write_trace` suite is the paper-facing write-amplification comparison. It
+extracts a first-parent Git commit trace and applies the same regular-file
+mutation stream to:
+
+- `maltflat`
+- `merkledag`
+- `hamt`
+
+Unlike early smoke versions, `write_trace` is incremental: after the initial
+root is materialized, each later commit applies only that commit's
+add/modify/delete/rename mutations. It does not rebuild the complete live
+snapshot for every commit. The raw record keeps cumulative storage accounting in
+`accounting` and the current commit's accounting delta in `accounting_delta`.
+Use `physical_persisted_bytes` and `logical_changed_payload_bytes` for per-commit
+write-amplification analysis. `write_amplification` is omitted for structural
+commits with zero logical changed payload bytes, such as pure delete or rename
+commits.
+
+The Merkle DAG and HAMT write baselines use raw file leaves so payload bytes and
+directory/index metadata bytes are visible as separate accounting categories.
+
+The suite writes raw records to `raw/write_trace.jsonl` and a repo/system
+aggregate to `aggregate/write_trace.csv`. Use
+`cumulative_write_amplification` as the main paper number and
+`median_write_amplification` / `p95_write_amplification` as supporting
+per-commit statistics. Small commits can have high per-commit ratios, so the
+cumulative ratio is the more stable repo-level comparison.
+
 `malt-eval read` and the `read_query` suite remain useful for daemon-oriented
 end-to-end checks. They exercise the HTTP daemon path for MALT and local IPLD
 baselines, so they should not be mixed into the same aggregate as `read_matrix`

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -165,15 +165,28 @@ write-amplification analysis. `write_amplification` is omitted for structural
 commits with zero logical changed payload bytes, such as pure delete or rename
 commits.
 
+The MALT baseline is flat: `maltflat` stores file payloads in CAS and updates a
+single authenticated map from the canonical complete path to the payload CID. It
+does not materialize UnixFS directory/file nodes for the MALT side of this
+write-amplification comparison.
+
 The Merkle DAG and HAMT write baselines use raw file leaves so payload bytes and
 directory/index metadata bytes are visible as separate accounting categories.
+Write accounting reports logical persisted object/value bytes. It intentionally
+does not include backend addressing keys such as BadgerDB keys or CAS CID lookup
+keys; backend-specific physical footprint should be measured as a separate
+storage-backend experiment.
 
 The suite writes raw records to `raw/write_trace.jsonl` and a repo/system
 aggregate to `aggregate/write_trace.csv`. Use
 `cumulative_write_amplification` as the main paper number and
 `median_write_amplification` / `p95_write_amplification` as supporting
-per-commit statistics. Small commits can have high per-commit ratios, so the
-cumulative ratio is the more stable repo-level comparison.
+per-commit statistics. The aggregate also exposes
+`arctable_persisted_bytes`, `cas_metadata_persisted_bytes`,
+`root_head_persisted_bytes`, and `commitment_persisted_bytes` so metadata can be
+attributed without treating `physical_metadata_bytes` as an ArcTable-only
+number. Small commits can have high per-commit ratios, so the cumulative ratio
+is the more stable repo-level comparison.
 
 `malt-eval read` and the `read_query` suite remain useful for daemon-oriented
 end-to-end checks. They exercise the HTTP daemon path for MALT and local IPLD

--- a/docs/mips/mip-1009-benchmark-proof-reporting.md
+++ b/docs/mips/mip-1009-benchmark-proof-reporting.md
@@ -16,7 +16,7 @@ replaces: none
 This MIP proposes stabilizing the benchmark-facing reporting rules summarized
 in [`docs/evaluation/README.md`](../evaluation/README.md), including proof
 bytes, evidence items, writer receipts, CAS counters, ArcTable counters, and
-summary CSV fields.
+write-amplification summary CSV fields.
 
 ## Motivation
 
@@ -35,6 +35,8 @@ which reporting rules must become stable for paper-facing figures:
 - writer receipt fields
 - CAS operation counters
 - ArcTable operation counters
+- write-amplification accounting categories, including canonical delta bytes
+  and derived-cache bytes
 - summary CSV fields used in paper figures
 
 ## Rationale

--- a/examples/eval-write-trace-plan.json
+++ b/examples/eval-write-trace-plan.json
@@ -6,7 +6,11 @@
     {
       "name": "write_trace",
       "config": {
-        "max_commits_per_repo": 200
+        "max_commits_per_repo": 200,
+        "systems": ["maltflat", "merkledag", "hamt"],
+        "store_mode": "isolated",
+        "store_backend": "memory",
+        "first_parent": true
       }
     }
   ]

--- a/layout/unixfs/layout.go
+++ b/layout/unixfs/layout.go
@@ -207,6 +207,23 @@ func (l *Layout) AddFileStream(ctx context.Context, root cid.Cid, path string, r
 	return l.AddFile(ctx, root, path, data)
 }
 
+// RemovePath removes a file path from the UnixFS tree and prunes empty parent
+// directories created solely to hold that path.
+func (l *Layout) RemovePath(ctx context.Context, root cid.Cid, path string) (cid.Cid, error) {
+	if !root.Defined() {
+		return cid.Undef, fmt.Errorf("root is undefined")
+	}
+	segments, err := splitRelativePath(path)
+	if err != nil {
+		return cid.Undef, err
+	}
+	if len(segments) == 0 {
+		return cid.Undef, fmt.Errorf("file path is empty")
+	}
+	nextRoot, _, err := l.removePath(ctx, root, segments)
+	return nextRoot, err
+}
+
 // Resolve traverses directory arcs and materializes the terminal @payload.
 func (l *Layout) Resolve(ctx context.Context, root cid.Cid, path string) (*Resolution, error) {
 	nodeRoot, steps, err := l.resolveNode(ctx, root, path)
@@ -398,6 +415,58 @@ func (l *Layout) addFile(ctx context.Context, root cid.Cid, segments []string, d
 		return cid.Undef, err
 	}
 	return l.setChild(ctx, root, key, oldChild, nextChild)
+}
+
+func (l *Layout) removePath(ctx context.Context, root cid.Cid, segments []string) (cid.Cid, bool, error) {
+	key := arcset.CanonicalizePath(segments[0])
+	child, _, ok, err := l.lookup(ctx, root, key)
+	if err != nil {
+		return cid.Undef, false, err
+	}
+	if !ok {
+		return cid.Undef, false, fmt.Errorf("%w: %s", ErrNotFound, strings.Join(segments, "/"))
+	}
+
+	kind, err := l.nodeType(ctx, child)
+	if err != nil {
+		return cid.Undef, false, err
+	}
+	if len(segments) == 1 {
+		if kind == typeDirectory {
+			return cid.Undef, false, fmt.Errorf("%w: %s", ErrNotFile, key.String())
+		}
+		nextRoot, err := l.deleteChild(ctx, root, key, child)
+		if err != nil {
+			return cid.Undef, false, err
+		}
+		empty, err := l.directoryIsEmpty(ctx, nextRoot)
+		if err != nil {
+			return cid.Undef, false, err
+		}
+		return nextRoot, empty, nil
+	}
+
+	if kind != typeDirectory {
+		return cid.Undef, false, fmt.Errorf("%w: %s", ErrNotDirectory, key.String())
+	}
+	nextChild, removeChild, err := l.removePath(ctx, child, segments[1:])
+	if err != nil {
+		return cid.Undef, false, err
+	}
+	var nextRoot cid.Cid
+	if removeChild {
+		nextRoot, err = l.deleteChild(ctx, root, key, child)
+	} else {
+		nextRoot, err = l.maps.Update(ctx, l.namespace, root, key, child, nextChild)
+	}
+	if err != nil {
+		return cid.Undef, false, err
+	}
+	empty, err := l.directoryIsEmpty(ctx, nextRoot)
+	if err != nil {
+		return cid.Undef, false, err
+	}
+	return nextRoot, empty, nil
 }
 
 func (l *Layout) commitFile(ctx context.Context, data []byte) (cid.Cid, error) {
@@ -708,6 +777,14 @@ func (l *Layout) setChild(ctx context.Context, root cid.Cid, key arcset.Path, ol
 	return l.addDirectoryEntry(ctx, nextRoot, key.String())
 }
 
+func (l *Layout) deleteChild(ctx context.Context, root cid.Cid, key arcset.Path, oldValue cid.Cid) (cid.Cid, error) {
+	nextRoot, err := l.maps.Update(ctx, l.namespace, root, key, oldValue, cid.Undef)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return l.removeDirectoryEntry(ctx, nextRoot, key.String())
+}
+
 func (l *Layout) addDirectoryEntry(ctx context.Context, root cid.Cid, name string) (cid.Cid, error) {
 	payload, _, ok, err := l.lookup(ctx, root, payloadPath)
 	if err != nil {
@@ -729,6 +806,52 @@ func (l *Layout) addDirectoryEntry(ctx context.Context, root cid.Cid, name strin
 		return cid.Undef, err
 	}
 	return l.set(ctx, root, payloadPath, payload, nextPayload)
+}
+
+func (l *Layout) removeDirectoryEntry(ctx context.Context, root cid.Cid, name string) (cid.Cid, error) {
+	payload, _, ok, err := l.lookup(ctx, root, payloadPath)
+	if err != nil {
+		return cid.Undef, err
+	}
+	if !ok {
+		return cid.Undef, fmt.Errorf("%w: missing directory @payload", ErrNotFound)
+	}
+	entries, err := l.loadDirectoryManifest(ctx, payload)
+	if err != nil {
+		return cid.Undef, err
+	}
+	nextEntries := entries[:0]
+	removed := false
+	for _, entry := range entries {
+		if entry == name {
+			removed = true
+			continue
+		}
+		nextEntries = append(nextEntries, entry)
+	}
+	if !removed {
+		return root, nil
+	}
+	nextPayload, err := l.commitDirectoryManifest(ctx, nextEntries)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return l.maps.Update(ctx, l.namespace, root, payloadPath, payload, nextPayload)
+}
+
+func (l *Layout) directoryIsEmpty(ctx context.Context, root cid.Cid) (bool, error) {
+	payload, _, ok, err := l.lookup(ctx, root, payloadPath)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, fmt.Errorf("%w: missing directory @payload", ErrNotFound)
+	}
+	entries, err := l.loadDirectoryManifest(ctx, payload)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
 }
 
 func (l *Layout) commitDirectoryManifest(ctx context.Context, entries []string) (cid.Cid, error) {

--- a/layout/unixfs/layout_test.go
+++ b/layout/unixfs/layout_test.go
@@ -3,6 +3,7 @@ package unixfs_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -258,5 +259,37 @@ func TestRejectsReservedPathSegment(t *testing.T) {
 
 	if _, err := layout.AddFile(ctx, cid.Undef, "dir/@payload", []byte("bad")); err == nil {
 		t.Fatal("expected AddFile to reject reserved path segment")
+	}
+}
+
+func TestRemovePathDeletesFileAndPrunesEmptyDirectories(t *testing.T) {
+	ctx := context.Background()
+	layout := newLayout(t, 4)
+
+	root, err := layout.AddFile(ctx, cid.Undef, "docs/a.txt", []byte("a"))
+	if err != nil {
+		t.Fatalf("AddFile(a) failed: %v", err)
+	}
+	root, err = layout.AddFile(ctx, root, "keep.txt", []byte("keep"))
+	if err != nil {
+		t.Fatalf("AddFile(keep) failed: %v", err)
+	}
+
+	root, err = layout.RemovePath(ctx, root, "docs/a.txt")
+	if err != nil {
+		t.Fatalf("RemovePath failed: %v", err)
+	}
+	if _, err := layout.Stat(ctx, root, "docs/a.txt"); !errors.Is(err, unixfs.ErrNotFound) {
+		t.Fatalf("removed file Stat error = %v, want ErrNotFound", err)
+	}
+	if _, err := layout.Stat(ctx, root, "docs"); !errors.Is(err, unixfs.ErrNotFound) {
+		t.Fatalf("empty parent Stat error = %v, want ErrNotFound", err)
+	}
+	got, err := layout.ReadFile(ctx, root, "keep.txt")
+	if err != nil {
+		t.Fatalf("ReadFile(keep) failed: %v", err)
+	}
+	if string(got) != "keep" {
+		t.Fatalf("keep.txt = %q, want keep", got)
 	}
 }


### PR DESCRIPTION
## Summary

- change `write_trace` from live-snapshot rebuilds to incremental Git mutation replay
- add per-commit accounting deltas, logical changed payload bytes, physical byte splits, and write-amplification fields
- add incremental MerkleDAG/HAMT editing plus MALT UnixFS delete support for rename/delete replay
- write `aggregate/write_trace.csv` for repo/system-level cumulative and per-commit WA summaries
- document the new write-trace semantics and update the example plan

## Validation

- `go test ./...`
- `go run ./cmd/eval/malt-eval schema --name write-trace-result >/tmp/write-trace-schema.json && python3 -m json.tool /tmp/write-trace-schema.json >/dev/null`
- `git diff --check`
- bounded eval run saved locally under `eval/write-trace-incremental-20260628-rawleaf/`

## Eval Notes

The local bounded eval used 3 GitHub repos, first 50 first-parent commits each, and all three systems. Weighted cumulative WA across the run:

- `merkledag`: 1.274669
- `hamt`: 1.301580
- `maltflat`: 3.040695

The higher current MALT write amplification is dominated by ArcTable/commitment metadata writes, which is now visible in the aggregate CSV.
