### PR TITLE
[codex] core: define v0.0.3 boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Those deployment and product concerns belong in the separate
 
 ```mermaid
 flowchart TB
-  app["Applications / CLI / Go client"] --> api["Reference daemon / eval gateway HTTP API"]
+  app["Applications / CLI / Go client"] --> api["Reference daemon / evaluation HTTP API"]
   api --> rw["Resolver / Writer"]
   rw --> semantics["Authenticated list / map semantics"]
   semantics --> proofs["ProofList and commitment backends"]
@@ -98,7 +98,7 @@ change. It is not production-ready.
 Current in-tree capabilities:
 
 - root-centric `malt` CLI for local daemon lifecycle, add, resolve, and verify
-- reference/evaluation gateway surface for explicit-root HTTP reads and writes
+- reference/evaluation HTTP surface for explicit-root HTTP reads and writes
 - proof-bearing HTTP reads for file bytes, directory JSON, and byte ranges
 - pure MALT UnixFS-style layout built from map/list semantics and CAS-backed
   immutable payloads
@@ -114,8 +114,7 @@ Current experimental boundaries:
 - no tenant, quota, pinning, or garbage-collection policy
 - no production managed gateway or hosted service semantics
 - no stable public API compatibility guarantee yet
-- response-body binding for large-file byte ranges is still a ProofList-schema
-  design item
+- large-file byte-range response bodies must be bound to authenticated segment CIDs with layout/unixfs.VerifyRangeBody after ProofList verification
 
 ## Use Cases
 
@@ -262,7 +261,7 @@ graph/                         resolver and writer port definitions/adapters
 layout/unixfs/                 UnixFS-style layout over map/list semantics and CAS-backed payloads
 runtime/                       node, runtime graph composition, ArcTable, metrics
 sdk/client/                    Go daemon client facade
-server/                        reference daemon and eval-gateway HTTP server
+server/                        reference daemon and evaluation HTTP server
 storage/                       CAS and KV storage libraries
 wire/maltcid/                  MALT map/list root CID codecs
 docs/                          implementation docs: policy, evaluation, specs, and MIPs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,15 +13,15 @@ change. It is not production-ready.
 The near-term goal is to make the repository easier to understand, validate,
 and integrate experimentally while preserving honest boundaries around unstable
 schemas and deployment policy. The in-tree daemon/server remains a
-reference/evaluation gateway for explicit-root behavior, not the production
-managed gateway.
+reference/evaluation HTTP surface for explicit-root behavior, not the production
+managed gateway product.
 
 ## Near Term
 
 - Stabilize the public `malt` CLI around root-centric add, resolve, verify, and
   daemon lifecycle workflows.
 - Keep proof-bearing HTTP reads explicit and verifier-facing.
-- Document and test the reference/evaluation gateway boundary for
+- Document and test the reference/evaluation HTTP surface boundary for
   `Read(root, query) -> result + ProofList`.
 - Tighten `ProofList` verifier documentation for path resolution, terminal
   `@payload` binding, and list-backed byte-range evidence.
@@ -33,7 +33,7 @@ managed gateway.
 
 ## Active Research And Design Areas
 
-- Response-body binding for large-file byte ranges.
+- Range-body helper integration in clients and gateway.
 - Writer receipt semantics and accounting.
 - Benchmark-facing proof reporting.
 - Variable-size measured list evidence.
@@ -62,8 +62,13 @@ Before the first public release tag:
 - `malt-eval run --plan examples/eval-smoke-plan.json` writes a manifest and
   summaries.
 - Security reporting path is enabled in GitHub repository settings.
-- Release notes state experimental limits and any known ProofList verifier
-  contract TODOs.
+- Release notes state experimental limits and known ProofList verifier limits.
+- `/verify` still works through `graph/verifier`.
+- `malt resolve` returns ProofList evidence by default.
+- `malt verify` verifies a resolve output or bare ProofList.
+- Large-file byte-range body binding is documented through
+  `layout/unixfs.VerifyRangeBody`.
+- The writer core/compat split is documented in `docs/spec/writer-receipts.md`.
 - Public docs avoid claims that are not implemented in the current code.
 - Repository docs distinguish MALT core/reference evaluation surfaces from
   managed gateway product behavior in `DeWebProtocol/gateway`.

--- a/cmd/malt/add.go
+++ b/cmd/malt/add.go
@@ -26,7 +26,7 @@ var (
 
 func init() {
 	rootCmd.AddCommand(addCmd)
-	addCmd.Flags().StringVarP(&addPrefixFlag, "prefix", "p", "", "Prefix inside the current root")
+	addCmd.Flags().StringVarP(&addPrefixFlag, "prefix", "p", "", "Prefix inside the result tree")
 	addCmd.Flags().BoolVarP(&addWrapFlag, "wrap", "w", false, "Wrap all inputs under one directory")
 	addCmd.Flags().StringVar(&addWrapNameFlag, "wrap-name", "", "Wrapper directory name (required for multi-input --wrap)")
 	addCmd.Flags().StringVar(&addTargetFlag, "target", addTargetMALT, "Authenticated target substrate: malt or merkle-dag")
@@ -37,12 +37,12 @@ func init() {
 	addCmd.Flags().BoolVar(&addNoGitignoreFlag, "no-gitignore", false, "Do not read .gitignore files while adding directories")
 	addCmd.Flags().BoolVar(&addNoMaltignoreFlag, "no-maltignore", false, "Do not read .maltignore files while adding directories")
 	addCmd.Flags().StringArrayVar(&addIgnoreFileFlags, "ignore-file", nil, "Additional gitignore-style ignore file to apply while adding directories")
-	addCmd.Flags().StringVar(&addRootFlag, "root", "", "Root CID to add files under (creates a new root if empty)")
+	addCmd.Flags().StringVar(&addRootFlag, "root", "", "Base root CID to add files under (creates a new root if empty)")
 }
 
 var addCmd = &cobra.Command{
 	Use:   "add <local-path> [<local-path>...]",
-	Short: "Upload local files/directories and merge into the current root",
+	Short: "Upload local files/directories from a base root to a result root",
 	Args:  cobra.MinimumNArgs(1),
 	RunE:  runAdd,
 }

--- a/cmd/malt/main.go
+++ b/cmd/malt/main.go
@@ -24,7 +24,7 @@ Primary commands:
   status      Show the local MALT daemon status
   stop        Stop the managed local MALT daemon
   restart     Restart the managed local MALT daemon
-  add         Upload local files/directories to CAS and merge into the current root
+  add         Upload local files/directories to CAS from a base root and print a result root
   resolve     Resolve a path via the daemon
   verify      Verify a ProofList`,
 	Version: Version,

--- a/cmd/malt/public_surface_test.go
+++ b/cmd/malt/public_surface_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -21,6 +22,23 @@ func TestRootCommandOnlyExposesProductCommands(t *testing.T) {
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("public commands = %v, want %v", got, want)
+	}
+}
+
+func TestAddCommandRootWordingIsRootRelative(t *testing.T) {
+	texts := map[string]string{
+		"root help":       rootCmd.Long,
+		"add short":       addCmd.Short,
+		"add prefix flag": addCmd.Flag("prefix").Usage,
+		"add root flag":   addCmd.Flag("root").Usage,
+	}
+	for name, text := range texts {
+		if strings.Contains(text, "current root") {
+			t.Fatalf("%s contains current-root wording: %q", name, text)
+		}
+	}
+	if !strings.Contains(addCmd.Short, "base root") || !strings.Contains(addCmd.Short, "result root") {
+		t.Fatalf("add short = %q, want base root and result root wording", addCmd.Short)
 	}
 }
 

--- a/docs/mips/mip-1010-data-authentication-core-boundary.md
+++ b/docs/mips/mip-1010-data-authentication-core-boundary.md
@@ -288,6 +288,25 @@ API responsibilities:
   ownership inside DTO packages
 - keep schema validation separate from cryptographic or semantic verification
 
+### Gateway Integration Contract
+
+A managed gateway should depend on MALT through core packages, not the
+reference server. The expected import surface is:
+
+- `auth/proof/prooflist` for verifier-facing proof artifacts
+- `graph/verifier` for reusable ProofList verification
+- `graph` resolver and writer contracts where a gateway exposes root-relative
+  core operations
+- `graph/writer` semantic mutation and receipt types
+- `layout/unixfs` only when the gateway intentionally reuses the reference UnixFS-style layout
+
+A managed gateway must not import `server` as its product API boundary. The
+gateway owns tenants, projects, API keys, authorization, root registry,
+latest-head publication, freshness and rollback policy, backend credentials,
+S3/Filecoin/IPFS orchestration, cache policy, quota, billing, pinning, garbage
+collection, abuse controls, and operations. Gateway roots are product metadata;
+they do not become MALT core state.
+
 ## Rationale
 
 Three layouts were considered.

--- a/docs/plans/v0.0.3-core-boundary.md
+++ b/docs/plans/v0.0.3-core-boundary.md
@@ -1,0 +1,185 @@
+# v0.0.3 Core Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Narrow the `malt` implementation boundary around reusable data-authentication core APIs, reference runtime behavior, and evaluation surfaces for the `v0.0.3-core-boundary` release.
+
+**Architecture:** Extract ProofList verification out of `server` into `graph/verifier`, split the stable mutation writer port from reference helper methods, add an explicit range-body verification helper, and update docs/CLI wording so MALT remains root-relative while gateway-owned product policy stays outside this repository. The reference server continues to expose the same HTTP behavior, but gateway integrations can depend on verifier and graph contracts without importing `server`.
+
+**Tech Stack:** Go modules, `auth/proof/prooflist`, `graph`, `graph/writer`, `layout/unixfs`, `server`, Cobra CLI, Markdown specs.
+
+---
+
+## Files
+
+- Create: `graph/verifier/verifier.go`
+- Create: `graph/verifier/verifier_test.go`
+- Create: `layout/unixfs/range_body.go`
+- Create: `layout/unixfs/range_body_test.go`
+- Modify: `server/routes_verify.go`
+- Modify: `server/service_verify.go`
+- Modify: `server/source_layout_test.go`
+- Modify: `graph/interfaces.go`
+- Modify: `graph/interfaces_test.go`
+- Modify: `runtime/graph/graph.go`
+- Modify: `server/service_graph.go`
+- Modify: `server/routes_write.go`
+- Modify: `cmd/malt/main.go`
+- Modify: `cmd/malt/add.go`
+- Modify: `README.md`
+- Modify: `ROADMAP.md`
+- Modify: `docs/spec/http-api.md`
+- Modify: `docs/spec/prooflist-format.md`
+- Modify: `docs/spec/writer-receipts.md`
+- Modify: `docs/mips/mip-1010-data-authentication-core-boundary.md`
+
+## Task 1: Extract ProofList Verifier Package
+
+- [ ] **Step 1: Write failing verifier package tests**
+  - Add `graph/verifier/verifier_test.go`.
+  - Cover valid map path verification, query mismatch rejection, traversal after terminal `@payload` rejection, measured-list/range step verification, and malformed ProofList rejection.
+  - Run: `env GOCACHE=/tmp/go-build-cache-core-boundary go test ./graph/verifier`
+  - Expected before implementation: fail because `graph/verifier` does not exist.
+
+- [ ] **Step 2: Move verifier implementation**
+  - Add `graph/verifier/verifier.go`.
+  - Define:
+    ```go
+    type Runtime interface {
+        Resolver() graph.Resolver
+        Semantic() mapping.Semantics
+        ListSemantic() list.Semantics
+    }
+
+    type Verifier struct {
+        runtime Runtime
+    }
+
+    func New(runtime Runtime) *Verifier
+    func (v *Verifier) VerifyProofList(ctx context.Context, pl prooflist.ProofList) (bool, error)
+    ```
+  - Move ordered traversal validation, query validation, explicit evidence verification, map proof verification, list proof verification, and measured-list proof verification out of `server/service_verify.go`.
+
+- [ ] **Step 3: Wire server to the public verifier**
+  - Update `server/routes_verify.go` to call `verifier.New(svc.runtime).VerifyProofList(...)`.
+  - Remove verifier implementation from `server/service_verify.go` or leave only server-specific code if required.
+  - Update `server/source_layout_test.go` so it no longer expects verifier internals in `server`.
+  - Run: `env GOCACHE=/tmp/go-build-cache-core-boundary go test ./graph/verifier ./server`
+  - Expected after implementation: pass.
+
+## Task 2: Split Writer Core Port From Reference Helpers
+
+- [ ] **Step 1: Write interface assertion test**
+  - Update `graph/interfaces_test.go` to assert `*writer.Writer` implements both a narrow `MutationWriter` and a reference helper interface.
+  - Run: `env GOCACHE=/tmp/go-build-cache-core-boundary go test ./graph`
+  - Expected before implementation: fail because the split interfaces do not exist.
+
+- [ ] **Step 2: Split interfaces**
+  - In `graph/interfaces.go`, introduce:
+    ```go
+    type MutationWriter interface {
+        Apply(ctx context.Context, namespace string, mut writer.SemanticMutation) (writer.WriteReceipt, error)
+    }
+
+    type CompatWriter interface {
+        CreateStructure(ctx context.Context, namespace string, arcs arcset.ArcSet) (cid.Cid, error)
+        UpdateArc(ctx context.Context, namespace string, root cid.Cid, path string, newTarget cid.Cid) (*writer.UpdateResult, error)
+        BatchUpdateArcs(ctx context.Context, namespace string, root cid.Cid, updates map[string]cid.Cid) (*writer.BatchUpdateResult, error)
+        GetArc(ctx context.Context, namespace string, root cid.Cid, path string) (cid.Cid, error)
+        GetSnapshot(ctx context.Context, namespace string, root cid.Cid) (arcset.ArcSet, error)
+    }
+
+    type Writer interface {
+        MutationWriter
+        CompatWriter
+    }
+    ```
+  - Update comments to mark `MutationWriter` as the stable core mutation port and `CompatWriter` as reference-runtime helper surface.
+
+- [ ] **Step 3: Make helper dependencies explicit where useful**
+  - Keep `RuntimeGraph.Writer()` returning `graph.Writer` for reference compatibility unless compile errors show a narrower return is practical.
+  - Update server comments and helper names where routes use compat methods.
+  - Run: `env GOCACHE=/tmp/go-build-cache-core-boundary go test ./graph ./runtime/graph ./server`
+  - Expected after implementation: pass.
+
+## Task 3: Add Range Body Binding Helper
+
+- [ ] **Step 1: Write failing range body tests**
+  - Add `layout/unixfs/range_body_test.go`.
+  - Cover accepted body assembled from verified segment CIDs, tampered bytes rejection, shifted range rejection, and segment CID mismatch rejection.
+  - Run: `env GOCACHE=/tmp/go-build-cache-core-boundary go test ./layout/unixfs -run RangeBody`
+  - Expected before implementation: fail because `VerifyRangeBody` does not exist.
+
+- [ ] **Step 2: Implement helper**
+  - Add `layout/unixfs/range_body.go`.
+  - Implement:
+    ```go
+    func VerifyRangeBody(pl prooflist.ProofList, body []byte, start, end uint64, fetch func(cid.Cid) ([]byte, error)) error
+    ```
+  - Require a matching `KindListRange` step with identical `Start` and `End`.
+  - Fetch each segment CID, concatenate segment bytes, slice the requested range relative to `start` and `end`, and compare to `body`.
+  - Return descriptive errors for missing range proof, invalid metadata, fetch failure, short segment data, and byte mismatch.
+
+- [ ] **Step 3: Document helper contract**
+  - Update `docs/spec/prooflist-format.md` and `docs/spec/http-api.md`.
+  - State that the ProofList authenticates range metadata and segment CIDs, and callers accepting HTTP range bytes must call `layout/unixfs.VerifyRangeBody` or equivalent body binding before trusting returned bytes.
+  - Run: `env GOCACHE=/tmp/go-build-cache-core-boundary go test ./layout/unixfs`
+  - Expected after implementation: pass.
+
+## Task 4: Root-Relative Wording Cleanup
+
+- [ ] **Step 1: Write or update wording tests when the command text is executable**
+  - Inspect existing `cmd/malt` tests for help/add output snapshots.
+  - If a relevant test exists, update it first so old "current root" wording fails.
+  - Run targeted command tests before changing command text.
+
+- [ ] **Step 2: Update CLI and docs wording**
+  - Replace ambiguous "current root" and product-gateway wording in `cmd/malt/main.go`, `cmd/malt/add.go`, `README.md`, `docs/spec/http-api.md`, `docs/spec/writer-receipts.md`, `ROADMAP.md`, and MIP-1010.
+  - Use "base root", "result root", "reference daemon", and "reference/evaluation HTTP surface".
+  - State that MALT does not publish authoritative latest heads.
+
+- [ ] **Step 3: Scan for stale terms**
+  - Run:
+    ```bash
+    rg -n "current root|latest root|managed gateway|authoritative head|publish heads|head publication" README.md ROADMAP.md docs cmd/malt server graph runtime
+    ```
+  - Review each hit; keep only explicit gateway-owned or limitation language.
+
+## Task 5: Gateway Integration Contract And Release Readiness Docs
+
+- [ ] **Step 1: Update integration docs**
+  - Update `docs/mips/mip-1010-data-authentication-core-boundary.md` and relevant specs with an integration sketch:
+    - gateway may import `auth/proof/prooflist`, `graph/verifier`, graph resolver/writer contracts, writer mutation types, and `layout/unixfs` only when reusing the reference layout.
+    - gateway must not depend on `server`.
+    - gateway owns tenants, API keys, root registry, latest-head publication, freshness, backend credentials, quotas, billing, pinning, GC, and operations.
+
+- [ ] **Step 2: Add release checklist**
+  - Update `ROADMAP.md` or `docs/policy/releasing.md` with `v0.0.3-core-boundary` readiness checks:
+    - `go test ./...`
+    - `go vet ./...`
+    - `/verify` still uses extracted verifier
+    - `malt resolve` returns ProofList
+    - `malt verify` verifies resolve output
+    - range body binding helper or limitation is documented
+    - writer core/compat split is documented
+
+## Task 6: GitHub Tracking
+
+- [ ] **Step 1: Create release milestone and labels**
+  - Use `gh api` against `DeWebProtocol/malt` to create or verify milestone `v0.0.3-core-boundary`.
+  - Create or verify labels: `core-boundary`, `verifier`, `writer-api`, `prooflist`, `reference-runtime`, `gateway-split`, `release-blocker`.
+
+- [ ] **Step 2: Create implementation issues**
+  - Create issues matching the plan's issue list, with target repo, touched packages, acceptance criteria, and test plan.
+  - Add the milestone and labels to each issue.
+
+## Final Verification
+
+- [ ] Run `gofmt -w` on changed Go files.
+- [ ] Run `git diff --check`.
+- [ ] Run `env GOCACHE=/tmp/go-build-cache-core-boundary go test ./...`.
+- [ ] Run `env GOCACHE=/tmp/go-build-cache-core-boundary go vet ./...`.
+- [ ] Review `git diff` for unintended unrelated changes.
+- [ ] Commit with a focused message.
+- [ ] Push `codex/core-boundary-v003`.
+- [ ] Open a PR to `main`.

--- a/docs/spec/http-api.md
+++ b/docs/spec/http-api.md
@@ -1,6 +1,6 @@
 # HTTP API
 
-This document describes the current root-centric daemon HTTP surface and DTO
+This document describes the root-relative reference/evaluation HTTP surface and DTO
 boundaries. It is a reference for implementation docs, not a stable public API
 contract.
 
@@ -57,7 +57,11 @@ Range content reads use standard byte range headers where supported:
 - response: `Accept-Ranges: bytes`
 - partial response: `Content-Range: bytes start-end/total`
 
-See [ProofList format](./prooflist-format.md) for proof semantics.
+See [ProofList format](./prooflist-format.md) for proof semantics. For
+large-file range responses, `/verify` authenticates the ProofList metadata and
+segment CIDs. Clients that trust the returned body bytes must first verify the
+ProofList and then call `layout/unixfs.VerifyRangeBody` or an equivalent
+segment-byte binding check.
 
 ## Main DTOs
 

--- a/docs/spec/prooflist-format.md
+++ b/docs/spec/prooflist-format.md
@@ -103,14 +103,21 @@ The `list_range` step carries fixed chunk metadata, covered segment CIDs, and
 metadata/index proof bytes. Verifiers must reject range proofs that shift byte
 boundaries, omit covered segment bindings, or mismatch the measured metadata.
 
-Full response-body binding for returned range bytes remains an open
-verifier-contract design item. The current proof authenticates the range
-metadata and segment CIDs; clients must still validate fetched payload bytes
-against their CIDs.
+The `list_range` step authenticates range metadata and segment CIDs, not raw
+HTTP body bytes by itself. A verifier that accepts returned range body bytes
+must:
+
+1. verify the ProofList against the trusted root,
+2. fetch or otherwise resolve each authenticated segment CID, and
+3. call `layout/unixfs.VerifyRangeBody(pl, body, start, end, fetch)` or an
+   equivalent byte-binding check before trusting the body.
+
+`VerifyRangeBody` rejects shifted ranges, missing range evidence, segment CID
+mismatches, short segment data, and tampered returned bytes.
 
 ## Related Proposals
 
-- [MIP-1003](../mips/mip-1003-prooflist-verification-schema.md) tracks the
-  remaining formalization work and body-binding decision.
+- [MIP-1003](../mips/mip-1003-prooflist-verification-schema.md) tracks verifier-contract
+  formalization and range-body helper integration.
 - [MIP-1006](../mips/mip-1006-variable-size-measured-list-evidence.md) tracks a
   future variable-size measured-list model.

--- a/docs/spec/semantic.md
+++ b/docs/spec/semantic.md
@@ -71,7 +71,8 @@ The `graph` package is a small port/composition surface, not a separate
 semantic owner.
 
 - resolver is the read/proof port: `(root, query) -> result + ProofList`
-- writer is the mutation port: `(baseRoot, semantic mutation) -> newRoot + receipt`
+- writer is the mutation port: `graph.MutationWriter.Apply(baseRoot, semantic mutation) -> newRoot + receipt`
+- `graph.CompatWriter` contains reference-runtime helper methods and is not the gateway product API
 
 Resolver traversal lives under `graph/resolver`. Mutation application lives
 under `graph/writer`. Layouts translate source-domain data into semantic

--- a/docs/spec/writer-receipts.md
+++ b/docs/spec/writer-receipts.md
@@ -21,7 +21,21 @@ stable release.
 | `ArcCount` | Number of canonical arc changes applied. |
 
 The writer does not publish authoritative heads, choose freshness, or merge
-concurrent roots. Applications decide whether a produced root becomes current.
+concurrent roots. Applications decide whether to publish or select a produced result root.
+
+## Writer Ports
+
+`graph.MutationWriter` is the stable core mutation boundary. It exposes
+`Apply(ctx, namespace, writer.SemanticMutation)` and returns a
+`writer.WriteReceipt` with the caller-supplied base root and produced result
+root.
+
+`graph.CompatWriter` groups reference-runtime helper methods such as
+`CreateStructure`, `UpdateArc`, `BatchUpdateArcs`, `GetArc`, and
+`GetSnapshot`. These helpers remain available to the local reference runtime,
+CLI, and tests, but they are not the gateway product API. New integrations
+should prefer semantic mutations through `MutationWriter` unless they
+intentionally need reference compatibility helpers.
 
 ## HTTP Projection
 

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -16,12 +16,26 @@ type Resolver interface {
 	VerifyTranscript(ctx context.Context, root cid.Cid, transcript *resolver.Transcript) (bool, error)
 }
 
-// Writer is the graph mutation port.
-type Writer interface {
+// MutationWriter is the stable graph mutation port. Callers supply an explicit
+// base root through writer.SemanticMutation and receive a result root in the
+// write receipt; this interface does not publish heads or arbitrate freshness.
+type MutationWriter interface {
 	Apply(ctx context.Context, namespace string, mut writer.SemanticMutation) (writer.WriteReceipt, error)
+}
+
+// CompatWriter exposes reference-runtime helper methods used by the local
+// server, CLI, and tests. These helpers are not the gateway product API.
+type CompatWriter interface {
 	CreateStructure(ctx context.Context, namespace string, arcs arcset.ArcSet) (cid.Cid, error)
 	UpdateArc(ctx context.Context, namespace string, root cid.Cid, path string, newTarget cid.Cid) (*writer.UpdateResult, error)
 	BatchUpdateArcs(ctx context.Context, namespace string, root cid.Cid, updates map[string]cid.Cid) (*writer.BatchUpdateResult, error)
 	GetArc(ctx context.Context, namespace string, root cid.Cid, path string) (cid.Cid, error)
 	GetSnapshot(ctx context.Context, namespace string, root cid.Cid) (arcset.ArcSet, error)
+}
+
+// Writer is the reference-runtime write surface. New core integrations should
+// prefer MutationWriter unless they intentionally need compatibility helpers.
+type Writer interface {
+	MutationWriter
+	CompatWriter
 }

--- a/graph/interfaces_test.go
+++ b/graph/interfaces_test.go
@@ -9,5 +9,7 @@ import (
 
 func TestResolverAndWriterImplementGraphPorts(t *testing.T) {
 	var _ Resolver = (*resolver.Resolver)(nil)
+	var _ MutationWriter = (*writer.Writer)(nil)
+	var _ CompatWriter = (*writer.Writer)(nil)
 	var _ Writer = (*writer.Writer)(nil)
 }

--- a/graph/querypath/path.go
+++ b/graph/querypath/path.go
@@ -1,7 +1,7 @@
 // Package querypath implements locked path canonicalization for stat and content APIs.
 //
 // Rules:
-//   - empty or omitted path means current root
+//   - empty or omitted path means the caller-supplied root
 //   - leading "/" is accepted and removed
 //   - ".", "..", empty interior segments, and NUL bytes are rejected
 package querypath

--- a/graph/verifier/verifier.go
+++ b/graph/verifier/verifier.go
@@ -1,4 +1,6 @@
-package server
+// Package verifier verifies verifier-facing ProofList artifacts against a
+// caller-supplied graph runtime.
+package verifier
 
 import (
 	"context"
@@ -8,15 +10,33 @@ import (
 	"github.com/dewebprotocol/malt/auth/arcset"
 	"github.com/dewebprotocol/malt/auth/proof/evidence"
 	"github.com/dewebprotocol/malt/auth/proof/prooflist"
-	"github.com/dewebprotocol/malt/auth/semantic"
+	structure "github.com/dewebprotocol/malt/auth/semantic"
+	"github.com/dewebprotocol/malt/auth/semantic/list"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/graph"
 	"github.com/dewebprotocol/malt/graph/querypath"
 	"github.com/dewebprotocol/malt/graph/resolver"
 	"github.com/dewebprotocol/malt/layout/unixfs"
 )
 
-type proofVerifier struct {
-	runtime runtimeGraph
+// Runtime is the minimal graph runtime surface needed to verify ProofList
+// evidence. It deliberately excludes server, daemon, head-publication, and
+// gateway policy concerns.
+type Runtime interface {
+	Resolver() graph.Resolver
+	Semantic() mapping.Semantics
+	ListSemantic() list.Semantics
+}
+
+// Verifier verifies ProofList evidence against a runtime's resolver and
+// semantic implementations.
+type Verifier struct {
+	runtime Runtime
+}
+
+// New creates a verifier over runtime.
+func New(runtime Runtime) *Verifier {
+	return &Verifier{runtime: runtime}
 }
 
 type proofListVerifiedPath struct {
@@ -44,7 +64,12 @@ func (p proofListVerifiedPath) logicalQueryPath() string {
 	return strings.Join(p.parts, "/")
 }
 
-func (v proofVerifier) VerifyProofList(ctx context.Context, pl prooflist.ProofList) (bool, error) {
+// VerifyProofList verifies the ordered ProofList structure, query binding, and
+// per-step evidence against the verifier runtime.
+func (v *Verifier) VerifyProofList(ctx context.Context, pl prooflist.ProofList) (bool, error) {
+	if v == nil || v.runtime == nil {
+		return false, fmt.Errorf("verifier runtime is nil")
+	}
 	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
 		return false, err
 	}
@@ -98,7 +123,7 @@ func validateProofListQuery(pl prooflist.ProofList, verifiedPath proofListVerifi
 	return fmt.Errorf("prooflist query %q does not match ordered traversal path %q", want, got)
 }
 
-func (v proofVerifier) verifyStep(ctx context.Context, index int, step prooflist.Step) (bool, error) {
+func (v *Verifier) verifyStep(ctx context.Context, index int, step prooflist.Step) (bool, error) {
 	switch step.EvidenceKind {
 	case "explicit":
 		ev, err := decodeEvidence(step.EvidenceKind, step.Evidence)

--- a/graph/verifier/verifier_test.go
+++ b/graph/verifier/verifier_test.go
@@ -1,0 +1,336 @@
+package verifier
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	structure "github.com/dewebprotocol/malt/auth/semantic"
+	"github.com/dewebprotocol/malt/auth/semantic/list"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/graph"
+	"github.com/dewebprotocol/malt/graph/resolver"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestVerifyProofListAcceptsValidMapPath(t *testing.T) {
+	root := testCID(t, "root")
+	dir := testCID(t, "dir")
+	file := testCID(t, "file")
+	rt := newFakeRuntime()
+	pl := prooflist.ProofList{
+		Root:  root,
+		Query: "dir/file",
+		Steps: []prooflist.Step{
+			mapStep(root, "dir", dir),
+			mapStep(dir, "file", file),
+		},
+	}
+
+	valid, err := New(rt).VerifyProofList(context.Background(), pl)
+	if err != nil {
+		t.Fatalf("VerifyProofList returned error: %v", err)
+	}
+	if !valid {
+		t.Fatal("VerifyProofList returned invalid for a valid map path")
+	}
+	if got, want := len(rt.maps.verifyCalls), 2; got != want {
+		t.Fatalf("map verify calls = %d, want %d", got, want)
+	}
+	if got := rt.maps.verifyCalls[0].key.String(); got != "dir" {
+		t.Fatalf("first verified key = %q, want dir", got)
+	}
+	if got := rt.maps.verifyCalls[1].key.String(); got != "file" {
+		t.Fatalf("second verified key = %q, want file", got)
+	}
+}
+
+func TestVerifyProofListRejectsQueryMismatch(t *testing.T) {
+	root := testCID(t, "root")
+	target := testCID(t, "target")
+	pl := prooflist.ProofList{
+		Root:  root,
+		Query: "other",
+		Steps: []prooflist.Step{
+			mapStep(root, "name", target),
+		},
+	}
+
+	valid, err := New(newFakeRuntime()).VerifyProofList(context.Background(), pl)
+	if err == nil {
+		t.Fatal("VerifyProofList returned nil error for a query mismatch")
+	}
+	if valid {
+		t.Fatal("VerifyProofList returned valid for a query mismatch")
+	}
+	if !strings.Contains(err.Error(), "does not match ordered traversal path") {
+		t.Fatalf("query mismatch error = %q, want traversal path error", err.Error())
+	}
+}
+
+func TestVerifyProofListRejectsTraversalAfterPayloadBinding(t *testing.T) {
+	root := testCID(t, "root")
+	payload := testCID(t, "payload")
+	child := testCID(t, "child")
+	pl := prooflist.ProofList{
+		Root:  root,
+		Query: "@payload/child",
+		Steps: []prooflist.Step{
+			{
+				Kind:            prooflist.KindPayloadBinding,
+				From:            root,
+				Path:            "@payload",
+				Target:          payload,
+				EvidenceKind:    "structure",
+				EvidenceBackend: "map",
+				Proof:           []byte("payload-proof"),
+			},
+			mapStep(payload, "child", child),
+		},
+	}
+
+	valid, err := New(newFakeRuntime()).VerifyProofList(context.Background(), pl)
+	if err == nil {
+		t.Fatal("VerifyProofList returned nil error for traversal after @payload")
+	}
+	if valid {
+		t.Fatal("VerifyProofList returned valid for traversal after @payload")
+	}
+	if !strings.Contains(err.Error(), "appears after terminal @payload binding") {
+		t.Fatalf("payload traversal error = %q, want terminal binding error", err.Error())
+	}
+}
+
+func TestVerifyProofListVerifiesMeasuredListStep(t *testing.T) {
+	root := testCID(t, "list-root")
+	segA := testCID(t, "segment-a")
+	segB := testCID(t, "segment-b")
+	start := uint64(2)
+	end := uint64(10)
+	childCount := uint64(2)
+	totalSize := uint64(16)
+	chunkSize := uint64(8)
+	rt := newFakeRuntime()
+	pl := prooflist.ProofList{
+		Root: root,
+		Steps: []prooflist.Step{
+			{
+				Kind:            prooflist.KindListRange,
+				From:            root,
+				Target:          root,
+				Start:           &start,
+				End:             &end,
+				ChildCount:      &childCount,
+				TotalSize:       &totalSize,
+				ChunkSize:       &chunkSize,
+				Segments:        []cid.Cid{segA, segB},
+				EvidenceKind:    "structure",
+				EvidenceBackend: "measured_list",
+				Proof:           []byte("range-proof"),
+			},
+		},
+	}
+
+	valid, err := New(rt).VerifyProofList(context.Background(), pl)
+	if err != nil {
+		t.Fatalf("VerifyProofList returned error: %v", err)
+	}
+	if !valid {
+		t.Fatal("VerifyProofList returned invalid for a measured-list range step")
+	}
+	if got, want := len(rt.lists.verifyRangeCalls), 1; got != want {
+		t.Fatalf("range verify calls = %d, want %d", got, want)
+	}
+	call := rt.lists.verifyRangeCalls[0]
+	if call.start != start || call.end == nil || *call.end != end {
+		t.Fatalf("range verify bounds = [%d,%v), want [%d,%d)", call.start, call.end, start, end)
+	}
+	if got := len(call.expected.Segments); got != 2 {
+		t.Fatalf("range verify segments = %d, want 2", got)
+	}
+}
+
+func TestVerifyProofListRejectsMalformedProofList(t *testing.T) {
+	pl := prooflist.ProofList{
+		Root: testCID(t, "root"),
+	}
+
+	valid, err := New(newFakeRuntime()).VerifyProofList(context.Background(), pl)
+	if err == nil {
+		t.Fatal("VerifyProofList returned nil error for an empty ProofList")
+	}
+	if valid {
+		t.Fatal("VerifyProofList returned valid for an empty ProofList")
+	}
+	if !strings.Contains(err.Error(), "steps are empty") {
+		t.Fatalf("malformed prooflist error = %q, want empty steps error", err.Error())
+	}
+}
+
+func mapStep(from cid.Cid, path string, target cid.Cid) prooflist.Step {
+	return prooflist.Step{
+		Kind:            prooflist.KindMapStep,
+		From:            from,
+		Path:            path,
+		Target:          target,
+		EvidenceKind:    "structure",
+		EvidenceBackend: "map",
+		Proof:           []byte("map-proof"),
+	}
+}
+
+func testCID(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("hash seed: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}
+
+type fakeRuntime struct {
+	resolver *fakeResolver
+	maps     *fakeMapSemantics
+	lists    *fakeListSemantics
+}
+
+func newFakeRuntime() *fakeRuntime {
+	return &fakeRuntime{
+		resolver: &fakeResolver{valid: true},
+		maps:     &fakeMapSemantics{valid: true},
+		lists:    &fakeListSemantics{valid: true},
+	}
+}
+
+func (r *fakeRuntime) Resolver() graph.Resolver {
+	return r.resolver
+}
+
+func (r *fakeRuntime) Semantic() mapping.Semantics {
+	return r.maps
+}
+
+func (r *fakeRuntime) ListSemantic() list.Semantics {
+	return r.lists
+}
+
+type fakeResolver struct {
+	valid bool
+	err   error
+}
+
+func (r *fakeResolver) ResolveKey(context.Context, cid.Cid, string) (*resolver.ResolveResult, error) {
+	return nil, errors.New("ResolveKey should not be called")
+}
+
+func (r *fakeResolver) Resolve(context.Context, cid.Cid, string) (*resolver.ResolveResult, error) {
+	return nil, errors.New("Resolve should not be called")
+}
+
+func (r *fakeResolver) VerifyTranscript(context.Context, cid.Cid, *resolver.Transcript) (bool, error) {
+	return r.valid, r.err
+}
+
+type mapVerifyCall struct {
+	root     cid.Cid
+	key      arcset.Path
+	expected mapping.Binding
+	proof    structure.Proof
+}
+
+type fakeMapSemantics struct {
+	valid       bool
+	err         error
+	verifyCalls []mapVerifyCall
+}
+
+func (m *fakeMapSemantics) Commitment() *mapping.Commitment {
+	return nil
+}
+
+func (m *fakeMapSemantics) Commit(context.Context, string, mapping.View) (cid.Cid, error) {
+	return cid.Undef, errors.New("Commit should not be called")
+}
+
+func (m *fakeMapSemantics) Prove(context.Context, string, cid.Cid, arcset.Path) (mapping.Binding, structure.Proof, error) {
+	return mapping.Binding{}, nil, errors.New("Prove should not be called")
+}
+
+func (m *fakeMapSemantics) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, proof structure.Proof) (bool, error) {
+	m.verifyCalls = append(m.verifyCalls, mapVerifyCall{
+		root:     root,
+		key:      key,
+		expected: expected,
+		proof:    proof,
+	})
+	return m.valid, m.err
+}
+
+func (m *fakeMapSemantics) Update(context.Context, string, cid.Cid, arcset.Path, cid.Cid, cid.Cid) (cid.Cid, error) {
+	return cid.Undef, errors.New("Update should not be called")
+}
+
+func (m *fakeMapSemantics) BatchUpdate(context.Context, string, cid.Cid, []mapping.BatchUpdate) (cid.Cid, error) {
+	return cid.Undef, errors.New("BatchUpdate should not be called")
+}
+
+type rangeVerifyCall struct {
+	root     cid.Cid
+	start    uint64
+	end      *uint64
+	expected list.RangeResult
+	proof    structure.Proof
+}
+
+type fakeListSemantics struct {
+	valid            bool
+	err              error
+	verifyRangeCalls []rangeVerifyCall
+}
+
+func (l *fakeListSemantics) Commitment() *list.Commitment {
+	return nil
+}
+
+func (l *fakeListSemantics) Commit(context.Context, string, list.View) (cid.Cid, error) {
+	return cid.Undef, errors.New("Commit should not be called")
+}
+
+func (l *fakeListSemantics) Prove(context.Context, string, cid.Cid, uint64) (list.Query, structure.Proof, error) {
+	return list.Query{}, nil, errors.New("Prove should not be called")
+}
+
+func (l *fakeListSemantics) Verify(cid.Cid, uint64, list.Query, structure.Proof) (bool, error) {
+	return l.valid, l.err
+}
+
+func (l *fakeListSemantics) Replace(context.Context, string, cid.Cid, uint64, cid.Cid, cid.Cid) (cid.Cid, error) {
+	return cid.Undef, errors.New("Replace should not be called")
+}
+
+func (l *fakeListSemantics) Append(context.Context, string, cid.Cid, cid.Cid) (cid.Cid, uint64, error) {
+	return cid.Undef, 0, errors.New("Append should not be called")
+}
+
+func (l *fakeListSemantics) Truncate(context.Context, string, cid.Cid, uint64) (cid.Cid, error) {
+	return cid.Undef, errors.New("Truncate should not be called")
+}
+
+func (l *fakeListSemantics) ProveRange(context.Context, string, cid.Cid, uint64, *uint64) (list.RangeResult, structure.Proof, error) {
+	return list.RangeResult{}, nil, errors.New("ProveRange should not be called")
+}
+
+func (l *fakeListSemantics) VerifyRange(root cid.Cid, start uint64, end *uint64, expected list.RangeResult, proof structure.Proof) (bool, error) {
+	l.verifyRangeCalls = append(l.verifyRangeCalls, rangeVerifyCall{
+		root:     root,
+		start:    start,
+		end:      end,
+		expected: expected,
+		proof:    proof,
+	})
+	return l.valid, l.err
+}

--- a/layout/unixfs/range_body.go
+++ b/layout/unixfs/range_body.go
@@ -1,0 +1,85 @@
+package unixfs
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	cid "github.com/ipfs/go-cid"
+)
+
+// VerifyRangeBody verifies that body is the byte range [start, end) assembled
+// from the segment CIDs authenticated by a matching list_range ProofList step.
+//
+// This helper does not replace ProofList verification. Callers should first
+// verify the ProofList against the trusted root, then use this helper before
+// trusting HTTP range body bytes.
+func VerifyRangeBody(pl prooflist.ProofList, body []byte, start, end uint64, fetch func(cid.Cid) ([]byte, error)) error {
+	if fetch == nil {
+		return fmt.Errorf("range body segment fetcher is nil")
+	}
+	if start > end {
+		return fmt.Errorf("range start %d is after end %d", start, end)
+	}
+	if err := pl.ValidateShape(prooflist.RequireSteps()); err != nil {
+		return err
+	}
+	step, ok := matchingRangeStep(pl, start, end)
+	if !ok {
+		return fmt.Errorf("no matching list_range proof for byte range [%d,%d)", start, end)
+	}
+	if step.TotalSize == nil {
+		return fmt.Errorf("matching list_range proof is missing total size")
+	}
+	if step.ChunkSize == nil || *step.ChunkSize == 0 {
+		return fmt.Errorf("matching list_range proof has invalid chunk size")
+	}
+	if end > *step.TotalSize {
+		return fmt.Errorf("range end %d exceeds authenticated total size %d", end, *step.TotalSize)
+	}
+	wantLen := end - start
+	if uint64(len(body)) != wantLen {
+		return fmt.Errorf("range body length %d does not match requested length %d", len(body), wantLen)
+	}
+
+	assembled := make([]byte, 0, len(body))
+	for i, segment := range step.Segments {
+		data, err := fetch(segment)
+		if err != nil {
+			return fmt.Errorf("fetching authenticated segment %d %s: %w", i, segment.String(), err)
+		}
+		computed, err := segment.Prefix().Sum(data)
+		if err != nil {
+			return fmt.Errorf("computing fetched segment %d CID: %w", i, err)
+		}
+		if !computed.Equals(segment) {
+			return fmt.Errorf("fetched segment %d does not match authenticated segment CID %s", i, segment.String())
+		}
+		assembled = append(assembled, data...)
+	}
+
+	offset := start % *step.ChunkSize
+	limit := offset + wantLen
+	if uint64(len(assembled)) < limit {
+		return fmt.Errorf("authenticated segments provide %d bytes from range offset %d, need %d", len(assembled), offset, limit)
+	}
+	if !bytes.Equal(body, assembled[offset:limit]) {
+		return fmt.Errorf("range body does not match authenticated segments")
+	}
+	return nil
+}
+
+func matchingRangeStep(pl prooflist.ProofList, start, end uint64) (prooflist.Step, bool) {
+	for _, step := range pl.Steps {
+		if step.Kind != prooflist.KindListRange {
+			continue
+		}
+		if step.Start == nil || step.End == nil {
+			continue
+		}
+		if *step.Start == start && *step.End == end {
+			return step, true
+		}
+	}
+	return prooflist.Step{}, false
+}

--- a/layout/unixfs/range_body_test.go
+++ b/layout/unixfs/range_body_test.go
@@ -1,0 +1,151 @@
+package unixfs
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestVerifyRangeBodyAcceptsBytesBoundToSegments(t *testing.T) {
+	pl, segments := rangeBodyProofList(t)
+
+	err := VerifyRangeBody(pl, []byte("cdefghi"), 2, 9, segmentFetcher(segments))
+	if err != nil {
+		t.Fatalf("VerifyRangeBody returned error: %v", err)
+	}
+}
+
+func TestVerifyRangeBodyRejectsTamperedBytes(t *testing.T) {
+	pl, segments := rangeBodyProofList(t)
+
+	err := VerifyRangeBody(pl, []byte("cdefghX"), 2, 9, segmentFetcher(segments))
+	if err == nil {
+		t.Fatal("VerifyRangeBody accepted tampered bytes")
+	}
+	if !strings.Contains(err.Error(), "range body does not match authenticated segments") {
+		t.Fatalf("tampered body error = %q, want body mismatch error", err.Error())
+	}
+}
+
+func TestVerifyRangeBodyRejectsShiftedRange(t *testing.T) {
+	pl, segments := rangeBodyProofList(t)
+
+	err := VerifyRangeBody(pl, []byte("defghij"), 3, 10, segmentFetcher(segments))
+	if err == nil {
+		t.Fatal("VerifyRangeBody accepted bytes for a shifted range")
+	}
+	if !strings.Contains(err.Error(), "no matching list_range proof") {
+		t.Fatalf("shifted range error = %q, want missing range proof error", err.Error())
+	}
+}
+
+func TestVerifyRangeBodyRejectsSegmentCIDMismatch(t *testing.T) {
+	pl, segments := rangeBodyProofList(t)
+	for i := range pl.Steps {
+		if pl.Steps[i].Kind == prooflist.KindListRange {
+			pl.Steps[i].Segments[1] = rangeBodyCID(t, "wrong-segment")
+			segments[pl.Steps[i].Segments[1].String()] = []byte("XXXX")
+			break
+		}
+	}
+
+	err := VerifyRangeBody(pl, []byte("cdefghi"), 2, 9, segmentFetcher(segments))
+	if err == nil {
+		t.Fatal("VerifyRangeBody accepted bytes with a mismatched segment CID")
+	}
+	if !strings.Contains(err.Error(), "does not match authenticated segment CID") {
+		t.Fatalf("segment mismatch error = %q, want CID mismatch error", err.Error())
+	}
+}
+
+func TestVerifyRangeBodyRejectsFetcherBytesThatDoNotMatchSegmentCID(t *testing.T) {
+	pl, segments := rangeBodyProofList(t)
+	for i := range pl.Steps {
+		if pl.Steps[i].Kind == prooflist.KindListRange {
+			wrong := rangeBodyCID(t, "wrong-segment-cid")
+			pl.Steps[i].Segments[1] = wrong
+			segments[wrong.String()] = []byte("efgh")
+			break
+		}
+	}
+
+	err := VerifyRangeBody(pl, []byte("cdefghi"), 2, 9, segmentFetcher(segments))
+	if err == nil {
+		t.Fatal("VerifyRangeBody accepted bytes fetched for a CID they do not match")
+	}
+	if !strings.Contains(err.Error(), "does not match authenticated segment CID") {
+		t.Fatalf("segment CID validation error = %q, want CID mismatch error", err.Error())
+	}
+}
+
+func rangeBodyProofList(t *testing.T) (prooflist.ProofList, map[string][]byte) {
+	t.Helper()
+	root := rangeBodyCID(t, "list-root")
+	segAData := []byte("abcd")
+	segBData := []byte("efgh")
+	segCData := []byte("ij")
+	segA := rangeBodyCIDForBytes(t, segAData)
+	segB := rangeBodyCIDForBytes(t, segBData)
+	segC := rangeBodyCIDForBytes(t, segCData)
+	start := uint64(2)
+	end := uint64(9)
+	childCount := uint64(3)
+	totalSize := uint64(10)
+	chunkSize := uint64(4)
+	return prooflist.ProofList{
+			Root:  root,
+			Query: "large.bin[2:9]",
+			Steps: []prooflist.Step{
+				{
+					Kind:            prooflist.KindListRange,
+					From:            root,
+					Target:          root,
+					Start:           &start,
+					End:             &end,
+					ChildCount:      &childCount,
+					TotalSize:       &totalSize,
+					ChunkSize:       &chunkSize,
+					Segments:        []cid.Cid{segA, segB, segC},
+					EvidenceKind:    "structure",
+					EvidenceBackend: "measured_list",
+					Proof:           []byte("range-proof"),
+				},
+			},
+		}, map[string][]byte{
+			segA.String(): segAData,
+			segB.String(): segBData,
+			segC.String(): segCData,
+		}
+}
+
+func segmentFetcher(segments map[string][]byte) func(cid.Cid) ([]byte, error) {
+	return func(id cid.Cid) ([]byte, error) {
+		data, ok := segments[id.String()]
+		if !ok {
+			return nil, errors.New("segment not found")
+		}
+		return append([]byte(nil), data...), nil
+	}
+}
+
+func rangeBodyCIDForBytes(t *testing.T, data []byte) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum(data, mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("hash bytes: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}
+
+func rangeBodyCID(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("hash seed: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}

--- a/runtime/graph/manager.go
+++ b/runtime/graph/manager.go
@@ -1,6 +1,6 @@
 // Package runtimegraph provides graph lifecycle management for MALT.
 // A graph is runtime metadata for reopening a namespace with a compatible
-// backend profile. It does not own a current root or freshness policy.
+// backend profile. It does not own an authoritative result root or freshness policy.
 // The current daemon path creates an ad hoc default Graph instead of exposing
 // this lifecycle manager as a public API.
 // This file contains the Store and Manager types.

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -206,7 +206,7 @@ func (s *Server) prepareUnixFSRoot(ctx context.Context, g runtimeGraph, layout *
 func (s *Server) applyUnixFSLayoutMutation(ctx context.Context, g runtimeGraph, layout *unixfs.Layout, oldRoot cid.Cid, newRoot cid.Cid) (writer.WriteReceipt, error) {
 	if oldRoot.Defined() && oldRoot.Equals(newRoot) {
 		if maltcid.SemanticKindOf(newRoot) != maltcid.SemanticKindMap {
-			return writer.WriteReceipt{}, fmt.Errorf("unixfs mutation result must be a map current root")
+			return writer.WriteReceipt{}, fmt.Errorf("unixfs mutation result must be a map result root")
 		}
 		return writer.WriteReceipt{
 			BaseRoot: oldRoot,
@@ -224,7 +224,7 @@ func (s *Server) applyUnixFSLayoutMutation(ctx context.Context, g runtimeGraph, 
 		return writer.WriteReceipt{}, err
 	}
 	if maltcid.SemanticKindOf(receipt.NewRoot) != maltcid.SemanticKindMap {
-		return writer.WriteReceipt{}, fmt.Errorf("unixfs mutation result must be a map current root")
+		return writer.WriteReceipt{}, fmt.Errorf("unixfs mutation result must be a map result root")
 	}
 	return receipt, nil
 }

--- a/server/routes_verify.go
+++ b/server/routes_verify.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/dewebprotocol/malt/api/http"
+	"github.com/dewebprotocol/malt/graph/verifier"
 )
 
 func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
@@ -18,7 +19,7 @@ func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
 		writeBodyDecodeError(w, err)
 		return
 	}
-	valid, err := (proofVerifier{runtime: svc.runtime}).VerifyProofList(r.Context(), req.ProofList)
+	valid, err := verifier.New(svc.runtime).VerifyProofList(r.Context(), req.ProofList)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/server/source_layout_test.go
+++ b/server/source_layout_test.go
@@ -13,11 +13,10 @@ func TestServerRoutesAreSplitByGraphPort(t *testing.T) {
 		symbols []string
 	}{
 		{"service_graph.go", []string{"type graphService struct", "func (s *Server) graphService", "func (svc graphService) ResolveKey", "func (svc graphService) ApplyMutation"}},
-		{"service_verify.go", []string{"type proofVerifier struct", "func (v proofVerifier) VerifyProofList"}},
 		{"routes_write.go", []string{"func (s *Server) handleSemanticMutation", "func (s *Server) handleCreateStructure"}},
 		{"routes_unixfs_compat.go", []string{"func (s *Server) handleWrite", "UnixFSWriteResponse"}},
 		{"routes_resolve.go", []string{"func (s *Server) handleResolve", "func (s *Server) serveResolve"}},
-		{"routes_verify.go", []string{"func (s *Server) handleVerify"}},
+		{"routes_verify.go", []string{"func (s *Server) handleVerify", "verifier.New(svc.runtime).VerifyProofList"}},
 		{"routes_content.go", []string{"func (s *Server) handleContent", "func (s *Server) readContentPayload"}},
 		{"routes_admin.go", []string{"func (s *Server) handleHealth", "func (s *Server) handleMetrics"}},
 	}


### PR DESCRIPTION
## Summary

- Extract ProofList verification into `graph/verifier` so gateway code can reuse verifier logic without importing `server`.
- Split `graph.MutationWriter` from reference helper methods via `graph.CompatWriter`, keeping the existing combined `graph.Writer` for runtime compatibility.
- Add `layout/unixfs.VerifyRangeBody` to bind large-file range response bytes to authenticated segment CIDs after ProofList verification.
- Tighten CLI/docs wording around base roots, result roots, reference/evaluation HTTP surfaces, and the gateway-owned product boundary.

## Impact

`server` keeps the same `/verify` behavior while delegating to the reusable verifier package. Writer helpers remain available for the reference runtime, but new integrations have a narrower mutation port to depend on. Range callers now have a concrete helper for body-byte binding instead of an open-ended limitation.

Closes #136.
Closes #137.
Closes #139.
Closes #140.
Closes #141.
Closes #143.
Closes #144.
Closes #145.
Contributes to #142.

## Validation

- `git diff --check`
- `gofmt -l cmd/malt/add.go cmd/malt/main.go cmd/malt/public_surface_test.go graph/interfaces.go graph/interfaces_test.go graph/querypath/path.go graph/verifier/verifier.go graph/verifier/verifier_test.go layout/unixfs/range_body.go layout/unixfs/range_body_test.go runtime/graph/manager.go server/handlers.go server/routes_verify.go server/source_layout_test.go`
- `env GOCACHE=/tmp/go-build-cache-core-boundary go vet ./...`
- `env GOCACHE=/tmp/go-build-cache-core-boundary go test ./...`