### PR TITLE
[codex] docs: prepare core boundary release notes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,3 +72,6 @@ Before the first public release tag:
 - Public docs avoid claims that are not implemented in the current code.
 - Repository docs distinguish MALT core/reference evaluation surfaces from
   managed gateway product behavior in `DeWebProtocol/gateway`.
+
+The current release-candidate checklist lives in
+[`docs/releases/v0.0.3-core-boundary.md`](docs/releases/v0.0.3-core-boundary.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ gateway only to exercise MALT core end to end.
 - [Threat model](./policy/threat-model.md)
 - [Compatibility policy](./policy/compatibility.md)
 - [Release process](./policy/releasing.md)
+- [Release notes](./releases/v0.0.3-core-boundary.md)
 
 ## Evaluation
 
@@ -45,6 +46,7 @@ removed after migration. New implementation-bound MIP work should happen here.
 ## What Goes Where
 
 - `policy/` for stability, safety, and release policy
+- `releases/` for source-release candidate notes and validation checklists
 - `evaluation.md` for benchmark methods, headline results, and artifact rules
 - `spec/` for formal protocol and schema documents
 - `mips/` for design proposals and process records

--- a/docs/mips/README.md
+++ b/docs/mips/README.md
@@ -76,8 +76,8 @@ not become the only copy of a schema or specification.
 | [MIP-1](mip-1.md) | Living | Meta | Process | Define the MALT Improvement Proposal process and document format. |
 | [MIP-1001](mip-1001-semantic-object-and-arc-terminology.md) | Draft | Standards Track | Core | Define graph root, semantic object, payload, outgoing arc, map relation, and list child-reference terminology. |
 | [MIP-1002](mip-1002-writer-receipt-accounting.md) | Draft | Standards Track | Interface | Decide how writer receipts support storage, indexing, accounting, and benchmark reporting. |
-| [MIP-1003](mip-1003-prooflist-verification-schema.md) | Draft | Standards Track | Core | Formalize ProofList verifier contract, body/header binding, omission behavior, and range-body verification. |
-| [MIP-1004](mip-1004-resolve-prooflist-artifact-schema.md) | Draft | Standards Track | Interface | Decide whether `malt resolve` JSON and bare ProofList JSON need stable named schemas. |
+| [MIP-1003](mip-1003-prooflist-verification-schema.md) | Review | Standards Track | Core | Formalize ProofList verifier contract, body/header binding, omission behavior, and range-body verification. |
+| [MIP-1004](mip-1004-resolve-prooflist-artifact-schema.md) | Review | Standards Track | Interface | Decide whether `malt resolve` JSON and bare ProofList JSON need stable named schemas. |
 | [MIP-1005](mip-1005-kzg-map-label-domain.md) | Final | Standards Track | Core | Record the canonical binding-CID slot model for storage-free map commitment primitives. |
 | [MIP-1006](mip-1006-variable-size-measured-list-evidence.md) | Draft | Standards Track | Core | Specify a future range-addressable list model for variable-size children. |
 | [MIP-1007](mip-1007-incremental-add-root-optimization.md) | Draft | Standards Track | Tooling | Explore path-local incremental add for very large existing roots. |

--- a/docs/mips/mip-1003-prooflist-verification-schema.md
+++ b/docs/mips/mip-1003-prooflist-verification-schema.md
@@ -3,7 +3,7 @@ mip: 1003
 title: ProofList Verification Contract
 description: Formalize ProofList step semantics, body/header binding, proof omission, and range-body verification.
 author: MALT maintainers
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2026-05-25
@@ -13,68 +13,84 @@ replaces: none
 
 ## Abstract
 
-This MIP proposes formalizing the verifier contract described in
+This MIP formalizes the verifier contract described in
 [`docs/spec/prooflist-format.md`](../spec/prooflist-format.md), including map
 traversal, terminal `@payload`, blob binding, measured-list `list_range`
 evidence, proof omission, and returned-body binding.
 
 ## Motivation
 
-The implementation emits and verifies ProofList evidence, but the paper-facing
-contract remains incomplete. The main remaining gap is binding returned HTTP
-bytes to the requested byte range and proved segment contents.
+The implementation emits and verifies ProofList evidence through a reusable
+`graph/verifier` package. The paper-facing contract still needs a clear review
+boundary so readers can distinguish ProofList verification from HTTP body-byte
+binding and from JSON shape validation.
 
 ## Specification
 
 The current ProofList reference lives in
-[`docs/spec/prooflist-format.md`](../spec/prooflist-format.md). This MIP should
-decide which parts of that reference are ready to become accepted verifier
-contract:
+[`docs/spec/prooflist-format.md`](../spec/prooflist-format.md). For the
+`v0.0.3-core-boundary` candidate, the review boundary is:
 
-- ordered path traversal
-- terminal `@payload` binding
-- raw blob binding
-- measured-list `list_range` step semantics
-- optional proof omission via query/header
-- `X-Malt-ProofList` header semantics
-- returned byte range binding to proved segment contents
+- ordered path traversal is verifier-facing and implemented by
+  `graph/verifier`;
+- terminal `@payload` binding is a terminal proof step and must not be followed
+  by later traversal steps;
+- map, list-index, and measured-list `list_range` structure evidence is
+  verified through the runtime semantic backends;
+- proof omission via query/header is a transport option and does not change the
+  verifier contract for artifacts that are returned;
+- `X-Malt-ProofList` carries base64url-encoded ProofList JSON for content reads;
+- returned byte-range body bytes are not authenticated by `/verify` alone and
+  must be bound with `layout/unixfs.VerifyRangeBody` or an equivalent segment
+  byte check after ProofList verification.
 
-The last item remains the main open design issue. The reference document states
-the current implementation boundary and the gap.
+This MIP does not promote ProofList JSON to a stable cross-release schema. It
+records the current verifier contract for review before a stable API line.
 
 ## Rationale
 
 Current code evidence:
 
 - `auth/proof/prooflist/prooflist.go` defines ProofList shape.
-- `server/service_verify.go` verifies map, list, and measured-list
-  structure evidence.
+- `graph/verifier/verifier.go` verifies ordered traversal, query binding, map
+  evidence, list evidence, and measured-list range evidence.
+- `server/routes_verify.go` projects the reusable verifier through `/verify`.
 - `server/routes_content.go` sends proof-bearing content responses in
   `X-Malt-ProofList`.
 - `layout/unixfs/prooflist.go` emits map, payload, list-index, and
   `list_range` evidence.
+- `layout/unixfs/range_body.go` binds returned range bytes to authenticated
+  segment CIDs.
 
 ## Backwards Compatibility
 
-The first accepted version may be documentation-only. If fields or verifier
-behavior change, existing CLI and API compatibility must be handled in the
-implementation plan.
+The `v0.0.3-core-boundary` contract remains experimental. If field names,
+evidence labels, or verifier behavior change before a stable release, the same
+change must update `docs/spec/prooflist-format.md`, tests, CLI/HTTP examples,
+and release notes.
 
 ## Security Considerations
 
 This MIP is security-sensitive because it defines what a client actually
-verifies. It must reject forged paths, malformed list metadata, branch jumps,
-and mismatches between returned bytes and proved segment contents.
+verifies. ProofList verification must reject forged paths, malformed list
+metadata, branch jumps, and traversal after terminal payload bindings. Range
+body acceptance must also reject shifted ranges, segment CID mismatches, short
+segment data, and tampered returned bytes.
 
 ## Implementation Plan
 
-No implementation work is approved while this MIP is Draft. If accepted, a
-phase plan should include reference docs, verifier tests, CLI validation, and
-benchmark artifact validation.
+For the current review pass:
+
+- keep the durable field reference in `docs/spec/prooflist-format.md`;
+- keep reusable verifier code in `graph/verifier`;
+- keep range body-byte binding in `layout/unixfs.VerifyRangeBody`;
+- run verifier, server, UnixFS, CLI, and full Go validation before tagging.
 
 ## History
 
 - 2026-05-25: Created from the previous open TODO list.
 - 2026-06-25: Moved current ProofList shape and transport rules to
-  `docs/spec/prooflist-format.md`; this MIP now tracks formal acceptance and
-  remaining body-binding work.
+  `docs/spec/prooflist-format.md`; this MIP tracks formal acceptance of the
+  verifier contract.
+- 2026-07-06: Updated for `graph/verifier` extraction and
+  `layout/unixfs.VerifyRangeBody`; moved to Review for maintainer judgment.

--- a/docs/mips/mip-1004-resolve-prooflist-artifact-schema.md
+++ b/docs/mips/mip-1004-resolve-prooflist-artifact-schema.md
@@ -3,7 +3,7 @@ mip: 1004
 title: Resolve And ProofList Artifact Schema
 description: Decide whether exported resolve JSON and bare ProofList JSON need stable named schemas.
 author: MALT maintainers
-status: Draft
+status: Review
 type: Standards Track
 category: Interface
 created: 2026-05-25
@@ -13,29 +13,37 @@ replaces: none
 
 ## Abstract
 
-This MIP decides whether the artifact surfaces described in
-[`docs/spec/artifacts.md`](../spec/artifacts.md) should become stable named
-schemas.
+This MIP records the current decision boundary for the artifact surfaces
+described in [`docs/spec/artifacts.md`](../spec/artifacts.md): what is
+documented for `v0.0.3-core-boundary`, and what is deferred until a stable
+schema line.
 
 ## Motivation
 
 `malt resolve` currently prints JSON containing `target` plus optional
 `prooflist`, and `malt verify --prooflist` accepts both bare ProofList JSON and
-resolve JSON containing a `prooflist` field. Benchmark and paper artifacts may
-need a stronger schema contract.
+resolve JSON containing a `prooflist` field. Benchmark and paper artifacts need
+the current shape documented, but premature stable named schemas would imply a
+compatibility commitment the repository has not yet made.
 
 ## Specification
 
 The current artifact reference lives in
-[`docs/spec/artifacts.md`](../spec/artifacts.md). This MIP should decide
-whether to add stable named schemas for:
+[`docs/spec/artifacts.md`](../spec/artifacts.md). For
+`v0.0.3-core-boundary`:
 
-- resolve response JSON
-- bare ProofList JSON
-- proof-bearing content response metadata
+- `malt resolve` JSON is documented as `api/http.ResolveResponse`;
+- bare ProofList JSON is documented as `auth/proof/prooflist.ProofList`;
+- proof-bearing content response metadata is documented as
+  `X-Malt-ProofList` plus `X-Malt-ProofList-Encoding`;
+- evaluator record schemas remain the only checked-in machine-readable JSON
+  schemas;
+- resolve JSON and bare ProofList JSON remain experimental and do not get
+  stable named schema files in this release candidate.
 
-If accepted, it should also choose schema paths, compatibility expectations,
-schema listing behavior, and CLI help wording.
+A later stable-schema proposal may add named schema files, CLI schema listing,
+and compatibility rules, but that work should happen in a separate issue or PR
+after the verifier contract has settled.
 
 ## Rationale
 
@@ -47,11 +55,15 @@ Current code evidence:
 - `auth/proof/prooflist/prooflist.go` defines bare ProofList.
 - `cmd/eval/schemas` has evaluator schemas but no stable resolve or
   bare ProofList schema.
+- `docs/spec/artifacts.md` records the current artifact surfaces and explains
+  that schema validation is separate from proof verification.
 
 ## Backwards Compatibility
 
-Adding schemas should not change current runtime output unless the accepted MIP
-explicitly introduces a versioned artifact contract.
+The review decision is intentionally non-breaking: document the current shapes,
+do not add stable named schemas, and do not change runtime output. Adding named
+schemas later must not be presented as proof verification and must document any
+compatibility commitment it introduces.
 
 ## Security Considerations
 
@@ -60,12 +72,20 @@ validation separate from cryptographic or semantic verification.
 
 ## Implementation Plan
 
-No implementation work is approved while this MIP is Draft. If accepted, a
-phase plan should cover schema files, CLI tests, docs, and optional schema
-listing integration.
+For the current review pass:
+
+- keep the durable artifact reference in `docs/spec/artifacts.md`;
+- do not add stable resolve or ProofList JSON Schema files for
+  `v0.0.3-core-boundary`;
+- keep evaluator schema listing scoped to `cmd/eval/schemas`;
+- revisit named schemas when the repository is ready to commit to a stable
+  artifact compatibility policy.
 
 ## History
 
 - 2026-05-25: Created from the previous open TODO list.
 - 2026-06-25: Moved current artifact boundaries to `docs/spec/artifacts.md`;
   this MIP now tracks whether those artifacts need stable named schemas.
+- 2026-07-06: Recorded the `v0.0.3-core-boundary` decision to document current
+  shapes without adding stable named resolve or ProofList JSON schemas; moved
+  to Review for maintainer judgment.

--- a/docs/policy/releasing.md
+++ b/docs/policy/releasing.md
@@ -37,6 +37,11 @@ Review:
 - `SECURITY.md` reporting path is still accurate.
 - `cmd/eval/schemas` match current evaluator outputs.
 
+For the current core-boundary release candidate, use
+[`docs/releases/v0.0.3-core-boundary.md`](../releases/v0.0.3-core-boundary.md)
+as the release-note and validation checklist. That candidate is still
+experimental and should be tagged only after maintainer approval.
+
 ## Tagging
 
 After checks pass:

--- a/docs/releases/v0.0.3-core-boundary.md
+++ b/docs/releases/v0.0.3-core-boundary.md
@@ -1,0 +1,89 @@
+# v0.0.3-core-boundary Release Notes
+
+Status: release candidate checklist
+
+This release candidate records the current MALT core boundary after PR #146 and
+the full write-trace replay hardening after PR #148. It is still an
+experimental source release candidate, not a stable API line.
+
+## Summary
+
+- `graph/verifier` is the reusable ProofList verifier package. The reference
+  HTTP `/verify` route delegates to it instead of carrying server-local verifier
+  logic.
+- `graph.MutationWriter` is the narrow core mutation port. `graph.CompatWriter`
+  keeps reference-runtime helper methods separate from the stable mutation
+  boundary.
+- `layout/unixfs.VerifyRangeBody` binds returned byte-range response bodies to
+  authenticated list-range segment CIDs after ProofList verification.
+- CLI and docs use explicit base-root/result-root wording. MALT core does not
+  publish authoritative latest heads.
+- The managed gateway boundary is documented as product-layer behavior owned
+  outside this repository.
+- The `write_trace` evaluation suite can run full first-parent Git histories
+  with Badger-backed persistent state, per-task checkpoints, raw-output repair,
+  and `--resume`.
+
+## Experimental Limits
+
+- ProofList, resolve JSON, HTTP DTOs, and evaluator schemas remain
+  implementation-bound and may change before a stable release.
+- `malt resolve` JSON and bare ProofList JSON do not yet have stable named JSON
+  Schema files. Their current shapes are defined by Go DTOs and reference docs.
+- `/verify` verifies ProofList structure and semantic evidence. For large-file
+  range reads, callers must also bind returned body bytes with
+  `layout/unixfs.VerifyRangeBody` or an equivalent segment-byte check.
+- The reference daemon and CLI are local development/evaluation surfaces, not a
+  production managed gateway API.
+- Head publication, freshness, authorization, tenancy, quota, backend
+  orchestration, pinning, GC, and billing remain gateway or deployment policy.
+- Variable-size measured-list evidence remains future work; current range
+  evidence is fixed-width measured-list evidence.
+
+## Required Validation Before Tagging
+
+Run from the repository root:
+
+```bash
+git diff --check
+go test ./...
+go vet ./...
+mkdir -p bin
+go build -buildvcs=false -o bin/cas ./cmd/cas
+go build -buildvcs=false -o bin/malt ./cmd/malt
+go build -buildvcs=false -o bin/malt-eval ./cmd/eval/malt-eval
+bin/malt-eval run --plan examples/eval-smoke-plan.json --run-id v0.0.3-core-boundary-smoke
+```
+
+Run a CLI proof smoke:
+
+```bash
+bin/cas start
+bin/malt init --non-interactive
+bin/malt start
+printf 'hello malt\n' >/tmp/malt-v003-hello.txt
+ROOT=$(bin/malt add /tmp/malt-v003-hello.txt | awk '/Result root:/ {print $3}')
+bin/malt resolve "$ROOT" malt-v003-hello.txt >/tmp/malt-v003-resolve.json
+bin/malt verify --prooflist /tmp/malt-v003-resolve.json
+bin/malt stop
+```
+
+If a local daemon is already running, reuse it or stop it cleanly before running
+the smoke. Record any skipped manual step in the GitHub release notes.
+
+## Tagging
+
+Tag only after the required validation passes and the maintainer approves the
+source release:
+
+```bash
+git tag -a v0.0.3-core-boundary -m "MALT v0.0.3 core boundary"
+git push origin v0.0.3-core-boundary
+```
+
+## Tracking
+
+- Milestone: `v0.0.3-core-boundary`
+- Release blocker: GitHub issue #142
+- Core boundary implementation: PR #146
+- Full write-trace replay hardening: PR #148

--- a/docs/releases/v0.0.3-core-boundary.md
+++ b/docs/releases/v0.0.3-core-boundary.md
@@ -58,18 +58,35 @@ bin/malt-eval run --plan examples/eval-smoke-plan.json --run-id v0.0.3-core-boun
 Run a CLI proof smoke:
 
 ```bash
-bin/cas start
-bin/malt init --non-interactive
-bin/malt start
-printf 'hello malt\n' >/tmp/malt-v003-hello.txt
-ROOT=$(bin/malt add /tmp/malt-v003-hello.txt | awk '/Result root:/ {print $3}')
-bin/malt resolve "$ROOT" malt-v003-hello.txt >/tmp/malt-v003-resolve.json
-bin/malt verify --prooflist /tmp/malt-v003-resolve.json
-bin/malt stop
+set -euo pipefail
+
+SMOKE_DIR=$(mktemp -d)
+MALT_CONFIG="$SMOKE_DIR/malt.json"
+MALT_STATE="$SMOKE_DIR/malt-state"
+CAS_CONFIG="$SMOKE_DIR/cas/settings.json"
+CAS_DATA="$SMOKE_DIR/cas/data"
+
+cleanup() {
+  bin/malt --config "$MALT_CONFIG" stop >/dev/null 2>&1 || true
+  bin/cas --config "$CAS_CONFIG" stop >/dev/null 2>&1 || true
+  rm -rf "$SMOKE_DIR"
+}
+trap cleanup EXIT
+
+bin/cas --config "$CAS_CONFIG" init --non-interactive --force --data-dir "$CAS_DATA"
+bin/cas --config "$CAS_CONFIG" start
+bin/malt --config "$MALT_CONFIG" init --non-interactive --force --state-root "$MALT_STATE"
+bin/malt --config "$MALT_CONFIG" start
+printf 'hello malt\n' >"$SMOKE_DIR/malt-v003-hello.txt"
+ROOT=$(bin/malt --config "$MALT_CONFIG" add "$SMOKE_DIR/malt-v003-hello.txt" | awk '/Result root:/ {print $3}')
+bin/malt --config "$MALT_CONFIG" resolve "$ROOT" malt-v003-hello.txt >"$SMOKE_DIR/malt-v003-resolve.json"
+bin/malt --config "$MALT_CONFIG" verify --prooflist "$SMOKE_DIR/malt-v003-resolve.json"
 ```
 
-If a local daemon is already running, reuse it or stop it cleanly before running
-the smoke. Record any skipped manual step in the GitHub release notes.
+If a local daemon is already running, reuse it deliberately or stop it cleanly
+before running the smoke. The snippet owns the temporary MALT config/state and
+CAS settings/data paths it creates; record any skipped manual step in the GitHub
+release notes.
 
 ## Tagging
 

--- a/docs/releases/v0.0.3-core-boundary.md
+++ b/docs/releases/v0.0.3-core-boundary.md
@@ -35,6 +35,8 @@ experimental source release candidate, not a stable API line.
   `layout/unixfs.VerifyRangeBody` or an equivalent segment-byte check.
 - The reference daemon and CLI are local development/evaluation surfaces, not a
   production managed gateway API.
+- Validation smoke uses the local `cmd/cas` mock CAS, not a production storage
+  backend.
 - Head publication, freshness, authorization, tenancy, quota, backend
   orchestration, pinning, GC, and billing remain gateway or deployment policy.
 - Variable-size measured-list evidence remains future work; current range
@@ -63,19 +65,28 @@ set -euo pipefail
 SMOKE_DIR=$(mktemp -d)
 MALT_CONFIG="$SMOKE_DIR/malt.json"
 MALT_STATE="$SMOKE_DIR/malt-state"
+MALT_LISTEN="${MALT_LISTEN:-127.0.0.1:14317}"
+CAS_HOME="$SMOKE_DIR/cas-home"
 CAS_CONFIG="$SMOKE_DIR/cas/settings.json"
 CAS_DATA="$SMOKE_DIR/cas/data"
+CAS_LISTEN="${CAS_LISTEN:-127.0.0.1:14318}"
 
 cleanup() {
   bin/malt --config "$MALT_CONFIG" stop >/dev/null 2>&1 || true
-  bin/cas --config "$CAS_CONFIG" stop >/dev/null 2>&1 || true
+  HOME="$CAS_HOME" bin/cas --config "$CAS_CONFIG" stop >/dev/null 2>&1 || true
   rm -rf "$SMOKE_DIR"
 }
 trap cleanup EXIT
 
-bin/cas --config "$CAS_CONFIG" init --non-interactive --force --data-dir "$CAS_DATA"
-bin/cas --config "$CAS_CONFIG" start
-bin/malt --config "$MALT_CONFIG" init --non-interactive --force --state-root "$MALT_STATE"
+mkdir -p "$CAS_HOME"
+HOME="$CAS_HOME" bin/cas --config "$CAS_CONFIG" init --non-interactive --force \
+  --listen "$CAS_LISTEN" \
+  --data-dir "$CAS_DATA"
+HOME="$CAS_HOME" bin/cas --config "$CAS_CONFIG" start
+bin/malt --config "$MALT_CONFIG" init --non-interactive --force \
+  --state-root "$MALT_STATE" \
+  --listen "$MALT_LISTEN" \
+  --cas-base-url "http://$CAS_LISTEN"
 bin/malt --config "$MALT_CONFIG" start
 printf 'hello malt\n' >"$SMOKE_DIR/malt-v003-hello.txt"
 ROOT=$(bin/malt --config "$MALT_CONFIG" add "$SMOKE_DIR/malt-v003-hello.txt" | awk '/Result root:/ {print $3}')
@@ -84,9 +95,10 @@ bin/malt --config "$MALT_CONFIG" verify --prooflist "$SMOKE_DIR/malt-v003-resolv
 ```
 
 If a local daemon is already running, reuse it deliberately or stop it cleanly
-before running the smoke. The snippet owns the temporary MALT config/state and
-CAS settings/data paths it creates; record any skipped manual step in the GitHub
-release notes.
+before running the smoke. The snippet owns the temporary MALT config/state, CAS
+settings/data, and CAS managed state/log paths it creates. Override
+`MALT_LISTEN` or `CAS_LISTEN` if either default smoke port is occupied, and
+record any skipped manual step in the GitHub release notes.
 
 ## Tagging
 

--- a/docs/spec/artifacts.md
+++ b/docs/spec/artifacts.md
@@ -6,7 +6,9 @@ JSON, content-proof headers, and evaluator schemas.
 ## Status
 
 Experimental and implementation-bound. Only evaluator schemas currently have
-machine-readable JSON Schema files in the repository.
+machine-readable JSON Schema files in the repository. For
+`v0.0.3-core-boundary`, resolve JSON and bare ProofList JSON remain documented
+Go DTO artifacts rather than stable named JSON schemas.
 
 ## Current Artifact Surfaces
 
@@ -53,6 +55,11 @@ Clients must decode the header before running ProofList verification.
 Evaluator JSON schemas live under `cmd/eval/schemas` and are embedded in the
 `malt-eval schema` command. Resolve JSON and bare ProofList JSON do not yet have
 stable named schema files.
+
+The current release-candidate decision is to keep that boundary: document
+resolve and ProofList shapes, but avoid stable named schema files until the
+project is ready to commit to artifact compatibility. JSON shape validation is
+still separate from ProofList verification through `graph/verifier`.
 
 If resolve or ProofList artifacts are promoted to stable named schemas, the
 same change should:


### PR DESCRIPTION
## Summary

- Add `docs/releases/v0.0.3-core-boundary.md` with the release-candidate notes, experimental limits, validation checklist, CLI proof smoke, and source tag instructions.
- Move MIP-1003 and MIP-1004 to Review and align them with the current `graph/verifier`, `layout/unixfs.VerifyRangeBody`, and artifact-schema boundary.
- Update docs indexes and artifact docs to keep resolve JSON and bare ProofList JSON documented but not promoted to stable named schemas for this release candidate.

Closes #142.

## Validation

- `git diff --check`
- `env GOCACHE=/tmp/go-build-cache-release-artifact go vet ./...`
- `env GOCACHE=/tmp/go-build-cache-release-artifact go test ./...`
- `go build -buildvcs=false -o bin/cas ./cmd/cas`
- `go build -buildvcs=false -o bin/malt ./cmd/malt`
- `go build -buildvcs=false -o bin/malt-eval ./cmd/eval/malt-eval`
- `bin/malt-eval run --plan examples/eval-smoke-plan.json --run-id v0.0.3-core-boundary-smoke --result-dir /tmp/malt-release-artifact-result --output-dir /tmp/malt-release-artifact-output`
- CLI proof smoke using isolated `/tmp/malt-v003-cli-smoke` config and ports `127.0.0.1:54317/54318`: `malt add` -> `malt resolve` -> `malt verify` returned `valid: true`.