### PR TITLE
[codex] eval: log write trace commit progress

### DIFF
--- a/cmd/eval/helper/git/trace.go
+++ b/cmd/eval/helper/git/trace.go
@@ -87,6 +87,24 @@ func (s Source) Walk(ctx context.Context, fn func(replay.CommitMutation) error) 
 	return nil
 }
 
+// CommitCount returns the number of commits Source.Walk would visit after
+// applying ref, first-parent, and limit settings.
+func (s Source) CommitCount(ctx context.Context) (int, error) {
+	sourceRepo, err := s.repositoryPath(ctx)
+	if err != nil {
+		return 0, err
+	}
+	ref := strings.TrimSpace(s.Ref)
+	if ref == "" {
+		ref = "HEAD"
+	}
+	commits, err := s.revList(ctx, sourceRepo, ref)
+	if err != nil {
+		return 0, err
+	}
+	return len(commits), nil
+}
+
 func (s Source) repositoryPath(ctx context.Context) (string, error) {
 	if strings.TrimSpace(s.RepoPath) != "" {
 		return filepath.Abs(s.RepoPath)

--- a/cmd/eval/helper/git/trace_test.go
+++ b/cmd/eval/helper/git/trace_test.go
@@ -134,6 +134,27 @@ func TestSourceWalkLimitKeepsEarliestReplayPrefix(t *testing.T) {
 	}
 }
 
+func TestSourceCommitCountMatchesLimitedReplayPrefix(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	repo := initTraceRepo(t)
+
+	source := gittrace.Source{
+		RepoPath: repo,
+		Ref:      "HEAD",
+		Limit:    2,
+	}
+	count, err := source.CommitCount(ctx)
+	if err != nil {
+		t.Fatalf("CommitCount: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("CommitCount = %d, want 2", count)
+	}
+}
+
 func TestSourceWalkReadsCommittedBlobWhenCheckoutIsDirty(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git binary not available")

--- a/cmd/eval/internal/eval/suites/writetrace/config.go
+++ b/cmd/eval/internal/eval/suites/writetrace/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	FirstParent       bool       `json:"first_parent"`
 	Jobs              int        `json:"jobs,omitempty"`
 	Resume            bool       `json:"resume,omitempty"`
+	// ProgressIntervalCommits controls write-trace progress logging. A value of
+	// zero disables commit progress logs.
+	ProgressIntervalCommits int `json:"progress_interval_commits,omitempty"`
 }
 
 // RepositoryTarget is one repository-level replay target resolved from a repo
@@ -55,12 +58,13 @@ func init() {
 // DefaultConfig returns framework-managed write-trace replay defaults.
 func DefaultConfig() Config {
 	return Config{
-		RepoURLs:     defaultBenchmarkRepos,
-		StoreMode:    string(evalstore.StoreModeIsolated),
-		StoreBackend: string(evalstore.StoreBackendMemory),
-		Systems:      SystemList{"maltflat", "merkledag", "hamt"},
-		FirstParent:  true,
-		Jobs:         1,
+		RepoURLs:                defaultBenchmarkRepos,
+		StoreMode:               string(evalstore.StoreModeIsolated),
+		StoreBackend:            string(evalstore.StoreBackendMemory),
+		Systems:                 SystemList{"maltflat", "merkledag", "hamt"},
+		FirstParent:             true,
+		Jobs:                    1,
+		ProgressIntervalCommits: 1000,
 	}
 }
 
@@ -97,6 +101,9 @@ func (c Config) RepositoryTargets() ([]RepositoryTarget, error) {
 	}
 	if c.Jobs < 1 {
 		return nil, fmt.Errorf("jobs must be at least 1")
+	}
+	if c.ProgressIntervalCommits < 0 {
+		return nil, fmt.Errorf("progress_interval_commits must be non-negative")
 	}
 	urls := c.RepoURLs
 	if len(urls) == 0 && strings.TrimSpace(c.RepoURLsFile) != "" {

--- a/cmd/eval/internal/eval/suites/writetrace/progress.go
+++ b/cmd/eval/internal/eval/suites/writetrace/progress.go
@@ -1,0 +1,54 @@
+package writetrace
+
+import "strings"
+
+type commitProgressConfig struct {
+	repo     string
+	systems  []string
+	total    int
+	interval int
+	logf     func(string, ...any)
+}
+
+type commitProgressLogger struct {
+	cfg        commitProgressConfig
+	lastLogged int
+}
+
+func newCommitProgressLogger(cfg commitProgressConfig) *commitProgressLogger {
+	return &commitProgressLogger{cfg: cfg}
+}
+
+func (p *commitProgressLogger) Observe(replayed int) {
+	if p == nil || p.cfg.interval <= 0 || p.cfg.total <= 0 || p.cfg.logf == nil {
+		return
+	}
+	if replayed < p.cfg.total && replayed%p.cfg.interval != 0 {
+		return
+	}
+	p.log(replayed)
+}
+
+func (p *commitProgressLogger) Complete() {
+	if p == nil || p.cfg.interval <= 0 || p.cfg.total <= 0 || p.cfg.logf == nil {
+		return
+	}
+	p.log(p.cfg.total)
+}
+
+func (p *commitProgressLogger) log(replayed int) {
+	if replayed <= p.lastLogged {
+		return
+	}
+	if replayed > p.cfg.total {
+		replayed = p.cfg.total
+	}
+	percent := float64(replayed) / float64(p.cfg.total) * 100
+	p.cfg.logf("  progress repository=%s systems=%s replayed=%d/%d percent=%.2f%%",
+		p.cfg.repo,
+		strings.Join(p.cfg.systems, ","),
+		replayed,
+		p.cfg.total,
+		percent)
+	p.lastLogged = replayed
+}

--- a/cmd/eval/internal/eval/suites/writetrace/progress_test.go
+++ b/cmd/eval/internal/eval/suites/writetrace/progress_test.go
@@ -1,0 +1,55 @@
+package writetrace
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestCommitProgressLoggerLogsAtIntervalAndCompletion(t *testing.T) {
+	var logs []string
+	progress := newCommitProgressLogger(commitProgressConfig{
+		repo:     "github.com/ipfs/kubo",
+		systems:  []string{"maltflat", "hamt"},
+		total:    5,
+		interval: 2,
+		logf: func(format string, args ...any) {
+			logs = append(logs, fmt.Sprintf(format, args...))
+		},
+	})
+
+	for replayed := 1; replayed <= 5; replayed++ {
+		progress.Observe(replayed)
+	}
+	progress.Complete()
+
+	want := []string{
+		"  progress repository=github.com/ipfs/kubo systems=maltflat,hamt replayed=2/5 percent=40.00%",
+		"  progress repository=github.com/ipfs/kubo systems=maltflat,hamt replayed=4/5 percent=80.00%",
+		"  progress repository=github.com/ipfs/kubo systems=maltflat,hamt replayed=5/5 percent=100.00%",
+	}
+	if !reflect.DeepEqual(logs, want) {
+		t.Fatalf("progress logs = %#v, want %#v", logs, want)
+	}
+}
+
+func TestCommitProgressLoggerCanBeDisabled(t *testing.T) {
+	var logs []string
+	progress := newCommitProgressLogger(commitProgressConfig{
+		repo:     "github.com/ipfs/kubo",
+		systems:  []string{"maltflat"},
+		total:    3,
+		interval: 0,
+		logf: func(format string, args ...any) {
+			logs = append(logs, fmt.Sprintf(format, args...))
+		},
+	})
+
+	progress.Observe(1)
+	progress.Observe(3)
+	progress.Complete()
+
+	if len(logs) != 0 {
+		t.Fatalf("progress logs = %#v, want disabled logger to stay silent", logs)
+	}
+}

--- a/cmd/eval/internal/eval/suites/writetrace/suite.go
+++ b/cmd/eval/internal/eval/suites/writetrace/suite.go
@@ -210,6 +210,17 @@ func runRepoTask(ctx context.Context, env framework.Env, cfg Config, task repoRe
 		Limit:       cfg.MaxCommitsPerRepo,
 		FirstParent: cfg.FirstParent,
 	}
+	totalCommits, err := source.CommitCount(ctx)
+	if err != nil {
+		return err
+	}
+	progressLog := newCommitProgressLogger(commitProgressConfig{
+		repo:     task.repo.RepoID,
+		systems:  task.systems,
+		total:    totalCommits,
+		interval: cfg.ProgressIntervalCommits,
+		logf:     log,
+	})
 	err = source.Walk(ctx, func(commit replay.CommitMutation) error {
 		commit.Repo = task.repo.RepoID
 		for _, system := range systems {
@@ -244,11 +255,13 @@ func runRepoTask(ctx context.Context, env framework.Env, cfg Config, task repoRe
 				return err
 			}
 		}
+		progressLog.Observe(commit.Index + 1)
 		return nil
 	})
 	if err != nil {
 		return err
 	}
+	progressLog.Complete()
 	for _, system := range systems {
 		name := system.Name()
 		last := progresses[name]

--- a/cmd/eval/internal/eval/suites/writetrace/suite_test.go
+++ b/cmd/eval/internal/eval/suites/writetrace/suite_test.go
@@ -2,6 +2,7 @@ package writetrace_test
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/csv"
 	"encoding/json"
@@ -33,7 +34,8 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 		"systems": ["maltflat", "hamt"],
 		"first_parent": false,
 		"jobs": 3,
-		"resume": true
+		"resume": true,
+		"progress_interval_commits": 2
 	}`))
 	if err != nil {
 		t.Fatalf("ParseConfig: %v", err)
@@ -50,6 +52,9 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	if cfg.Jobs != 3 || !cfg.Resume {
 		t.Fatalf("execution config = %+v, want jobs=3 resume=true", cfg)
 	}
+	if cfg.ProgressIntervalCommits != 2 {
+		t.Fatalf("progress interval = %d, want JSON override 2", cfg.ProgressIntervalCommits)
+	}
 	if got := cfg.SystemsCSV(); got != "maltflat,hamt" {
 		t.Fatalf("systems CSV = %q, want maltflat,hamt", got)
 	}
@@ -63,6 +68,9 @@ func TestParseConfigAppliesWriteCommandDefaultsAndJSONOverrides(t *testing.T) {
 	}
 	if defaults.Jobs != 1 || defaults.Resume {
 		t.Fatalf("execution defaults = %+v, want jobs=1 resume=false", defaults)
+	}
+	if defaults.ProgressIntervalCommits != 1000 {
+		t.Fatalf("progress interval default = %d, want 1000", defaults.ProgressIntervalCommits)
 	}
 	if got := defaults.SystemsCSV(); got != "maltflat,merkledag,hamt" {
 		t.Fatalf("default systems = %q, want maltflat,merkledag,hamt", got)
@@ -267,6 +275,49 @@ func TestSuiteRunWritesFrameworkEnvelopedReplayRecords(t *testing.T) {
 	}
 	if row["canonical_delta_persisted_bytes"] == "" {
 		t.Fatalf("aggregate missing canonical delta breakdown field: %+v", row)
+	}
+}
+
+func TestSuiteRunLogsCommitProgress(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	ctx := context.Background()
+	sourceBase := filepath.Join(t.TempDir(), "github.com")
+	initWriteTraceRepoAt(t, filepath.Join(sourceBase, "ipfs", "kubo.git"))
+	installGitHubInsteadOf(t, sourceBase)
+	tmp := t.TempDir()
+	var log bytes.Buffer
+
+	reg := framework.NewRegistry()
+	if err := reg.Register(writetrace.Suite{}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	plan := framework.Plan{
+		RunID:     "run-write-trace-progress",
+		OutputDir: filepath.Join(tmp, "output"),
+		ResultDir: filepath.Join(tmp, "result"),
+		Suites: []framework.SuitePlan{{
+			Name: "write_trace",
+			Config: json.RawMessage(`{
+				"repo_urls": [` + strconvQuote(githubRepoURL("ipfs", "kubo")) + `],
+				"max_commits_per_repo": 3,
+				"store_backend": "memory",
+				"systems": ["maltflat"],
+				"progress_interval_commits": 2
+			}`),
+		}},
+	}
+
+	if err := framework.Run(ctx, plan, reg, framework.RunOptions{Stderr: &log}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	logText := log.String()
+	if !strings.Contains(logText, "progress repository=github.com/ipfs/kubo systems=maltflat replayed=2/3 percent=66.67%") {
+		t.Fatalf("progress log = %q, want 2/3 progress", logText)
+	}
+	if !strings.Contains(logText, "progress repository=github.com/ipfs/kubo systems=maltflat replayed=3/3 percent=100.00%") {
+		t.Fatalf("progress log = %q, want completion progress", logText)
 	}
 }
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -93,6 +93,9 @@ plans use the Badger store backend so replay state does not have to remain in
 process memory. The suite runs each `repository + system` pair as an independent
 task, writes per-task checkpoints under `output/<run_id>/write-checkpoints/`,
 and can resume an interrupted run without duplicating existing raw records.
+Progress logs include `replayed/total` commit counts per repository; set
+`progress_interval_commits` in the `write_trace` suite config to control the
+commit interval, or set it to `0` to disable commit progress logs.
 `jobs` controls task parallelism; the checked-in plans keep `jobs: 1` to minimize
 memory pressure during full-history replay.
 

--- a/examples/eval-paper-plan.json
+++ b/examples/eval-paper-plan.json
@@ -41,7 +41,8 @@
         "store_backend": "badger",
         "first_parent": true,
         "jobs": 1,
-        "resume": true
+        "resume": true,
+        "progress_interval_commits": 1000
       }
     },
     {

--- a/examples/eval-write-trace-plan.json
+++ b/examples/eval-write-trace-plan.json
@@ -12,7 +12,8 @@
         "store_backend": "badger",
         "first_parent": true,
         "jobs": 1,
-        "resume": true
+        "resume": true,
+        "progress_interval_commits": 1000
       }
     }
   ]


### PR DESCRIPTION
## Summary

- add configurable `write_trace` commit progress logging with `replayed/total` counts per repository
- expose `progress_interval_commits` in write-trace config, defaulting to `1000` and allowing `0` to disable logs
- add `git.Source.CommitCount` so write-trace can report total replay commits
- document the new progress logging option and make the checked-in write-trace plans explicit

## Notes

This does not affect an already-running `malt-eval` process. New progress output appears after rebuilding and starting a new eval binary/run.

Example log line:

```text
progress repository=github.com/ipfs/kubo systems=maltflat,merkledag,hamt replayed=1000/5086 percent=19.66%
```

## Validation

- `git diff --check`
- `gofmt -l cmd/eval/helper/git/trace.go cmd/eval/helper/git/trace_test.go cmd/eval/internal/eval/suites/writetrace/config.go cmd/eval/internal/eval/suites/writetrace/suite.go cmd/eval/internal/eval/suites/writetrace/suite_test.go cmd/eval/internal/eval/suites/writetrace/progress.go cmd/eval/internal/eval/suites/writetrace/progress_test.go`
- `env GOCACHE=/tmp/go-build-cache-eval-progress go test ./cmd/eval/internal/eval/suites/writetrace ./cmd/eval/helper/git`
- `env GOCACHE=/tmp/go-build-cache-eval-progress go test ./...`
- `env GOCACHE=/tmp/go-build-cache-eval-progress go vet ./...`
