### PR TITLE
docs: add data authentication concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ wire formats, reference runtime, and core benchmark/evaluation framework. The
 managed product gateway lives outside this repository.
 
 [Documentation](./docs/README.md) · [Architecture](./ARCHITECTURE.md) ·
+[Concepts](./docs/concepts/README.md) ·
 [Threat Model](./docs/policy/threat-model.md) ·
 [Compatibility](./docs/policy/compatibility.md) · [Evaluation](./docs/evaluation.md) ·
 [MIPs](./docs/mips/README.md) ·
@@ -37,6 +38,10 @@ MALT also makes verifiable reads work over ordinary HTTP(S): content routes can
 return the application result in the response body and carry proof evidence in
 `X-Malt-ProofList`, so clients verify `root + path -> result` without trusting
 the gateway or downloading the Merkle-DAG traversal chain.
+
+For background on hashes, Merkle trees, Merkle DAGs, and MALT's data
+authentication model, see
+[Data authentication background](./docs/concepts/data-authentication.md).
 
 **Status:** Experimental reference implementation. Runnable end to end, not
 production-ready.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,12 @@ quota, cache policy, and operations, belongs in `DeWebProtocol/gateway` or
 private deployment overlays. This repository may keep a reference/evaluation
 gateway only to exercise MALT core end to end.
 
+## Concepts
+
+- [Concepts index](./concepts/README.md)
+- [Data authentication background](./concepts/data-authentication.md)
+- [Merkle DAG vs MALT](./concepts/merkle-dag-vs-malt.md)
+
 ## Policy
 
 - [Threat model](./policy/threat-model.md)
@@ -45,6 +51,7 @@ removed after migration. New implementation-bound MIP work should happen here.
 
 ## What Goes Where
 
+- `concepts/` for reader-facing background, comparisons, and orientation
 - `policy/` for stability, safety, and release policy
 - `releases/` for source-release candidate notes and validation checklists
 - `evaluation.md` for benchmark methods, headline results, and artifact rules

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,0 +1,31 @@
+# Concepts
+
+This folder gives reader-facing background for MALT. These documents explain
+why the project exists and how to compare it with hash, Merkle tree, and
+Merkle-DAG authentication models.
+
+Use these documents for orientation. Implementation-bound behavior, wire
+formats, proof fields, HTTP headers, and compatibility rules remain in
+[`docs/spec`](../spec/README.md) and [`docs/policy`](../policy/README.md).
+
+## Start Here
+
+- [Data authentication background](./data-authentication.md) explains how hash,
+  Merkle tree, and Merkle-DAG authentication work, then introduces MALT's data
+  authentication model.
+- [Merkle DAG vs MALT](./merkle-dag-vs-malt.md) compares object-chain proofs,
+  direct `root + path` reads, HTTP proof transport, and rewrite amplification.
+
+## Mechanism References
+
+After the conceptual overview, use the implementation-bound specs for exact
+mechanics:
+
+- [Semantic model](../spec/semantic.md) for map/list semantics, roots, payloads,
+  resolver, writer, and ArcTable boundaries.
+- [ProofList format](../spec/prooflist-format.md) for proof steps, ordering,
+  HTTP proof headers, and range evidence.
+- [HTTP API](../spec/http-api.md) for resolve, content, verify, and mutation
+  routes.
+- [Commitment model](../spec/commitment.md) for backend proof assumptions.
+- [CID and wire format](../spec/cid-and-wire-format.md) for root encoding.

--- a/docs/concepts/data-authentication.md
+++ b/docs/concepts/data-authentication.md
@@ -1,0 +1,116 @@
+# Data Authentication Background
+
+MALT is a data authentication layer. It helps a client check that application
+data returned by a gateway, cache, storage service, or local index matches a
+trusted root.
+
+This page explains the progression from hashes to Merkle DAGs, then shows where
+MALT changes the model.
+
+## Hashes Authenticate One Object
+
+A cryptographic hash authenticates one byte string.
+
+```text
+bytes -> hash(bytes) -> content identifier
+```
+
+If a client already trusts the expected hash, it can fetch the bytes from an
+untrusted location, hash them again, and compare the result. A mismatch means
+the bytes were corrupted, substituted, or not the expected object.
+
+This works well for a single immutable object. It does not by itself describe
+how to authenticate relationships among many objects, such as a directory tree,
+an application manifest, an agent-memory namespace, or an ordered log.
+
+## Merkle Trees Authenticate a Set
+
+A Merkle tree authenticates many leaves by hashing them into parent nodes until
+there is one root hash.
+
+```text
+        root
+       /    \
+   node      node
+   /  \      /  \
+ leaf leaf  leaf leaf
+```
+
+To verify one leaf, the client needs the leaf bytes and the sibling hashes along
+the path to the root. The client recomputes each parent hash and checks that the
+final value equals the trusted root.
+
+Merkle trees are efficient for membership proofs over ordered or indexed sets.
+They also make the root change whenever a leaf or intermediate node changes.
+
+## Merkle DAGs Authenticate Linked Objects
+
+A Merkle DAG generalizes this idea to content-addressed objects that may link to
+other content-addressed objects. A parent object contains child references, and
+the parent's CID commits to both its own content and those references.
+
+```text
+root CID
+   |
+ parent object
+   |
+ child object
+   |
+ target object
+```
+
+This prevents tampering because every object is addressed by its hash. To
+verify a traversal from a trusted root CID to a target object, the client checks
+that each fetched object hashes to its CID and that each parent object contains
+the next child reference.
+
+That model is powerful for immutable content-addressed structures, but it also
+couples several things to the object boundary:
+
+- the object payload
+- the links used for traversal
+- the proof material needed to verify traversal
+- the cost of reference updates
+- the data layout exposed to readers
+
+If a child reference changes, the parent object's CID changes. That change can
+propagate toward the root. If a client wants to verify a path without trusting a
+gateway, the linked objects along the traversal path are also part of the
+evidence the client needs.
+
+## MALT Authenticates Mutable Relationships Separately
+
+MALT is a Merkle-DAG alternative for authenticating mutable application data.
+It keeps payload bytes in ordinary content-addressed storage, but moves mutable
+relationships into authenticated map/list semantics under independent structure
+roots.
+
+```text
+trusted MALT root + path
+        |
+        v
+result + ProofList
+```
+
+The client verifies `root + path -> result` with a dedicated `ProofList`.
+Payload objects remain ordinary CAS data. They are not the proof carrier for
+the application path.
+
+This separation gives MALT four core advantages:
+
+- **Dedicated proof material:** verification uses `ProofList` evidence instead
+  of the Merkle-DAG traversal object chain.
+- **Direct application reads:** clients can ask for `root + path` instead of
+  walking object links themselves.
+- **HTTP-native verification:** content reads can return normal HTTP bodies
+  with proof evidence in `X-Malt-ProofList`.
+- **Lower rewrite amplification:** relationship updates advance MALT structure
+  roots without rewriting unrelated payload objects.
+
+## Where To Go Next
+
+- For a direct comparison, read [Merkle DAG vs MALT](./merkle-dag-vs-malt.md).
+- For exact proof fields and HTTP transport rules, read
+  [ProofList format](../spec/prooflist-format.md).
+- For the current resolver and writer model, read
+  [Semantic model](../spec/semantic.md).

--- a/docs/concepts/merkle-dag-vs-malt.md
+++ b/docs/concepts/merkle-dag-vs-malt.md
@@ -1,0 +1,98 @@
+# Merkle DAG vs MALT
+
+MALT keeps the useful part of content-addressed storage: immutable payload bytes
+can still live in CAS blocks with ordinary CIDs. The difference is that MALT
+does not use the Merkle-DAG object chain as the application proof path.
+
+## Short Version
+
+| Concern | Merkle DAG | MALT |
+| --- | --- | --- |
+| Payload storage | Immutable content-addressed objects | Ordinary immutable CAS payloads |
+| Relationship authentication | Links embedded in parent object content | Typed map/list semantics under structure roots |
+| Read shape | Traverse linked objects from a root CID | Query `root + path` |
+| Proof material | Traversal objects and sibling or linked evidence | Dedicated `ProofList` evidence |
+| HTTP content reads | HTTP can transport blocks or gateway responses | Body can be ordinary HTTP content, proof can ride in `X-Malt-ProofList` |
+| Update cost | Child-reference changes can propagate rootward | Structure roots advance without rewriting unrelated payload objects |
+
+## Proof Material
+
+In a Merkle DAG, each object CID commits to that object's bytes, including its
+links. To verify a path, a client usually needs the linked object chain from
+the trusted root to the target. Those intermediate objects are not just
+payload; they are evidence for the traversal.
+
+MALT separates the proof from the payload object chain. The verifier checks a
+`ProofList` against a trusted MALT root, query, and result:
+
+```text
+VerifyRead(root, query, result, ProofList) -> valid / invalid
+```
+
+For flat MALT lookups, proof material for each semantic lookup is fixed-size
+under the selected commitment backend. A response that intentionally combines
+multiple semantic lookups or range segments carries the corresponding proof
+steps, but the proof is still a dedicated verifier artifact rather than the
+Merkle-DAG traversal objects themselves.
+
+## Direct Root And Path Reads
+
+Merkle-DAG readers normally traverse from object to object. A gateway can hide
+that traversal, but then the client must either trust the gateway's answer or
+fetch enough evidence to verify the traversal.
+
+MALT's read contract is root-relative:
+
+```text
+Read(root, path) -> result + ProofList
+```
+
+The application can request the object it wants by path, and the verifier checks
+the result against the trusted root.
+
+## HTTP Proof Transport
+
+Merkle DAGs can be transported over HTTP. The difference is what the client
+must receive to verify the answer.
+
+MALT content routes can return application data as ordinary HTTP response
+bodies and place verification evidence in headers:
+
+```text
+GET /{root}/{path}
+
+200 OK
+X-Malt-ProofList: <base64url-json>
+X-Malt-ProofList-Encoding: base64url-json
+
+<application bytes or directory JSON>
+```
+
+That means a gateway, CDN, or cache can serve normal content responses while
+the client still verifies `root + path -> result` without trusting that
+intermediary.
+
+The exact header behavior is implementation-bound and documented in
+[ProofList format](../spec/prooflist-format.md) and
+[HTTP API](../spec/http-api.md).
+
+## Rewrite Amplification
+
+In a Merkle DAG, changing a child reference changes the parent object's CID.
+If that parent is linked from another parent, the change can propagate toward
+the root. This is not a bug; it is how content-addressed identity authenticates
+embedded links.
+
+MALT moves mutable relationships into authenticated structure roots. Updating a
+relationship advances the relevant MALT root, but unrelated payload objects can
+keep their original CIDs.
+
+MALT does not claim that updates are free. It replaces implicit
+ancestor-rewrite cost with explicit, verifiable structure maintenance.
+
+## What MALT Does Not Replace
+
+MALT is not a replacement for IPFS, Filecoin, Kubo, S3, or object storage. It
+can run above those systems. They provide payload storage and transport; MALT
+provides authenticated mutable structure, proof generation, and verification
+above payload objects.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -6,6 +6,10 @@ These documents stay aligned with code, tests, and MIPs in this repository.
 They are the reference layer for current behavior; MIPs propose or record
 changes to this layer.
 
+For reader-facing background on hash authentication, Merkle DAGs, and MALT's
+positioning, start with [Concepts](../concepts/README.md). Keep normative
+behavior, wire formats, and proof semantics in this folder.
+
 ## Documents
 
 - [Semantic model](./semantic.md)


### PR DESCRIPTION
## Summary

- Add `docs/concepts/` as a reader-facing concept layer for data-authentication background and Merkle-DAG-vs-MALT comparison.
- Explain hashes, Merkle trees, Merkle DAG verification, object-chain proof material, direct `root + path` reads, HTTP proof headers, and rewrite amplification.
- Link README and docs indexes to the concept layer while keeping exact mechanism references in `docs/spec/`.

## Validation

- `git diff --cached --check`
- Markdown internal link check across `README.md` and `docs/**/*.md` (`checked 33 markdown files`)
- `go test -run '^$' ./...`