### PR TITLE
Move ProofList list verification into auth

### DIFF
--- a/auth/verifier/list.go
+++ b/auth/verifier/list.go
@@ -1,0 +1,56 @@
+// Package verifier contains verifier-critical helpers for auth proof artifacts.
+package verifier
+
+import (
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	structure "github.com/dewebprotocol/malt/auth/semantic"
+	"github.com/dewebprotocol/malt/auth/semantic/list"
+	cid "github.com/ipfs/go-cid"
+)
+
+// VerifyProofListListStructure verifies list-backed ProofList structure steps
+// through the supplied list semantic backend.
+func VerifyProofListListStructure(lists list.Semantics, step prooflist.Step, stepIndex int) (bool, error) {
+	switch step.EvidenceBackend {
+	case "list":
+		if step.Index == nil {
+			return false, fmt.Errorf("prooflist step %d list index is missing", stepIndex)
+		}
+		if step.Length == nil {
+			return false, fmt.Errorf("prooflist step %d list length is missing", stepIndex)
+		}
+		return lists.Verify(step.From, *step.Index, list.Query{Key: step.Target, Length: *step.Length}, structure.Proof(step.Proof))
+	case "measured_list":
+		if !step.Target.Equals(step.From) {
+			return false, nil
+		}
+		if step.Start == nil {
+			return false, fmt.Errorf("prooflist step %d list range start is missing", stepIndex)
+		}
+		if step.ChildCount == nil {
+			return false, fmt.Errorf("prooflist step %d list range child count is missing", stepIndex)
+		}
+		if step.TotalSize == nil {
+			return false, fmt.Errorf("prooflist step %d list range total size is missing", stepIndex)
+		}
+		if step.ChunkSize == nil {
+			return false, fmt.Errorf("prooflist step %d list range chunk size is missing", stepIndex)
+		}
+		measured, ok := lists.(list.MeasuredSemantics)
+		if !ok {
+			return false, fmt.Errorf("prooflist step %d has measured list evidence but graph list semantic does not support measured ranges", stepIndex)
+		}
+		return measured.VerifyRange(step.From, *step.Start, step.End, list.RangeResult{
+			Metadata: list.RangeMetadata{
+				ChildCount: *step.ChildCount,
+				TotalSize:  *step.TotalSize,
+				ChunkSize:  *step.ChunkSize,
+			},
+			Segments: append([]cid.Cid(nil), step.Segments...),
+		}, structure.Proof(step.Proof))
+	default:
+		return false, fmt.Errorf("prooflist step %d has unsupported structure evidence backend %q", stepIndex, step.EvidenceBackend)
+	}
+}

--- a/auth/verifier/list_test.go
+++ b/auth/verifier/list_test.go
@@ -1,0 +1,175 @@
+package verifier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	structure "github.com/dewebprotocol/malt/auth/semantic"
+	"github.com/dewebprotocol/malt/auth/semantic/list"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestVerifyProofListListStructureVerifiesListIndexStep(t *testing.T) {
+	root := testCID(t, "list-root")
+	target := testCID(t, "segment")
+	index := uint64(3)
+	length := uint64(9)
+	lists := &fakeListSemantics{valid: true}
+
+	valid, err := VerifyProofListListStructure(lists, prooflist.Step{
+		From:            root,
+		Index:           &index,
+		Length:          &length,
+		Target:          target,
+		EvidenceBackend: "list",
+		Proof:           []byte("index-proof"),
+	}, 2)
+	if err != nil {
+		t.Fatalf("VerifyProofListListStructure returned error: %v", err)
+	}
+	if !valid {
+		t.Fatal("VerifyProofListListStructure returned invalid for a valid list index step")
+	}
+	if got, want := len(lists.verifyCalls), 1; got != want {
+		t.Fatalf("Verify calls = %d, want %d", got, want)
+	}
+	call := lists.verifyCalls[0]
+	if !call.root.Equals(root) {
+		t.Fatalf("Verify root = %s, want %s", call.root, root)
+	}
+	if call.index != index {
+		t.Fatalf("Verify index = %d, want %d", call.index, index)
+	}
+	if !call.expected.Key.Equals(target) || call.expected.Length != length {
+		t.Fatalf("Verify expected = %+v, want target %s length %d", call.expected, target, length)
+	}
+}
+
+func TestVerifyProofListListStructureVerifiesMeasuredListRangeStep(t *testing.T) {
+	root := testCID(t, "list-root")
+	segA := testCID(t, "segment-a")
+	segB := testCID(t, "segment-b")
+	start := uint64(4)
+	end := uint64(12)
+	childCount := uint64(2)
+	totalSize := uint64(16)
+	chunkSize := uint64(8)
+	lists := &fakeListSemantics{valid: true}
+
+	valid, err := VerifyProofListListStructure(lists, prooflist.Step{
+		From:            root,
+		Target:          root,
+		Start:           &start,
+		End:             &end,
+		ChildCount:      &childCount,
+		TotalSize:       &totalSize,
+		ChunkSize:       &chunkSize,
+		Segments:        []cid.Cid{segA, segB},
+		EvidenceBackend: "measured_list",
+		Proof:           []byte("range-proof"),
+	}, 5)
+	if err != nil {
+		t.Fatalf("VerifyProofListListStructure returned error: %v", err)
+	}
+	if !valid {
+		t.Fatal("VerifyProofListListStructure returned invalid for a valid measured-list range step")
+	}
+	if got, want := len(lists.verifyRangeCalls), 1; got != want {
+		t.Fatalf("VerifyRange calls = %d, want %d", got, want)
+	}
+	call := lists.verifyRangeCalls[0]
+	if !call.root.Equals(root) {
+		t.Fatalf("VerifyRange root = %s, want %s", call.root, root)
+	}
+	if call.start != start || call.end == nil || *call.end != end {
+		t.Fatalf("VerifyRange bounds = [%d,%v), want [%d,%d)", call.start, call.end, start, end)
+	}
+	if call.expected.Metadata.ChildCount != childCount || call.expected.Metadata.TotalSize != totalSize || call.expected.Metadata.ChunkSize != chunkSize {
+		t.Fatalf("VerifyRange metadata = %+v, want child_count=%d total_size=%d chunk_size=%d", call.expected.Metadata, childCount, totalSize, chunkSize)
+	}
+	if got, want := len(call.expected.Segments), 2; got != want {
+		t.Fatalf("VerifyRange segments = %d, want %d", got, want)
+	}
+}
+
+type listVerifyCall struct {
+	root     cid.Cid
+	index    uint64
+	expected list.Query
+	proof    structure.Proof
+}
+
+type rangeVerifyCall struct {
+	root     cid.Cid
+	start    uint64
+	end      *uint64
+	expected list.RangeResult
+	proof    structure.Proof
+}
+
+type fakeListSemantics struct {
+	valid            bool
+	err              error
+	verifyCalls      []listVerifyCall
+	verifyRangeCalls []rangeVerifyCall
+}
+
+func (l *fakeListSemantics) Commitment() *list.Commitment {
+	return nil
+}
+
+func (l *fakeListSemantics) Commit(context.Context, string, list.View) (cid.Cid, error) {
+	return cid.Undef, nil
+}
+
+func (l *fakeListSemantics) Prove(context.Context, string, cid.Cid, uint64) (list.Query, structure.Proof, error) {
+	return list.Query{}, nil, nil
+}
+
+func (l *fakeListSemantics) Verify(root cid.Cid, index uint64, expected list.Query, proof structure.Proof) (bool, error) {
+	l.verifyCalls = append(l.verifyCalls, listVerifyCall{
+		root:     root,
+		index:    index,
+		expected: expected,
+		proof:    proof,
+	})
+	return l.valid, l.err
+}
+
+func (l *fakeListSemantics) Replace(context.Context, string, cid.Cid, uint64, cid.Cid, cid.Cid) (cid.Cid, error) {
+	return cid.Undef, nil
+}
+
+func (l *fakeListSemantics) Append(context.Context, string, cid.Cid, cid.Cid) (cid.Cid, uint64, error) {
+	return cid.Undef, 0, nil
+}
+
+func (l *fakeListSemantics) Truncate(context.Context, string, cid.Cid, uint64) (cid.Cid, error) {
+	return cid.Undef, nil
+}
+
+func (l *fakeListSemantics) ProveRange(context.Context, string, cid.Cid, uint64, *uint64) (list.RangeResult, structure.Proof, error) {
+	return list.RangeResult{}, nil, nil
+}
+
+func (l *fakeListSemantics) VerifyRange(root cid.Cid, start uint64, end *uint64, expected list.RangeResult, proof structure.Proof) (bool, error) {
+	l.verifyRangeCalls = append(l.verifyRangeCalls, rangeVerifyCall{
+		root:     root,
+		start:    start,
+		end:      end,
+		expected: expected,
+		proof:    proof,
+	})
+	return l.valid, l.err
+}
+
+func testCID(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	sum, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("hash seed: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}

--- a/docs/mips/mip-1003-prooflist-verification-schema.md
+++ b/docs/mips/mip-1003-prooflist-verification-schema.md
@@ -52,8 +52,10 @@ records the current verifier contract for review before a stable API line.
 Current code evidence:
 
 - `auth/proof/prooflist/prooflist.go` defines ProofList shape.
-- `graph/verifier/verifier.go` verifies ordered traversal, query binding, map
-  evidence, list evidence, and measured-list range evidence.
+- `graph/verifier/verifier.go` verifies ordered traversal, query binding, and
+  map evidence.
+- `auth/verifier/list.go` verifies list evidence and measured-list range
+  evidence against the runtime semantic backends.
 - `server/routes_verify.go` projects the reusable verifier through `/verify`.
 - `server/routes_content.go` sends proof-bearing content responses in
   `X-Malt-ProofList`.
@@ -82,7 +84,8 @@ segment data, and tampered returned bytes.
 For the current review pass:
 
 - keep the durable field reference in `docs/spec/prooflist-format.md`;
-- keep reusable verifier code in `graph/verifier`;
+- keep reusable verifier orchestration in `graph/verifier`;
+- keep verifier-critical list-step helpers in `auth/verifier`;
 - keep range body-byte binding in `layout/unixfs.VerifyRangeBody`;
 - run verifier, server, UnixFS, CLI, and full Go validation before tagging.
 

--- a/docs/mips/mip-1010-data-authentication-core-boundary.md
+++ b/docs/mips/mip-1010-data-authentication-core-boundary.md
@@ -151,6 +151,7 @@ auth/
   semantic/
     list/
     mapping/
+  verifier/
 
 wire/
   maltcid/

--- a/graph/verifier/import_boundary_test.go
+++ b/graph/verifier/import_boundary_test.go
@@ -1,0 +1,36 @@
+package verifier
+
+import (
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestVerifierPackageDoesNotImportLayoutPackages(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob Go files: %v", err)
+	}
+	fset := token.NewFileSet()
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		parsed, err := parser.ParseFile(fset, file, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		for _, spec := range parsed.Imports {
+			path, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				t.Fatalf("unquote import in %s: %v", file, err)
+			}
+			if strings.HasPrefix(path, "github.com/dewebprotocol/malt/layout/") {
+				t.Fatalf("graph/verifier must not import layout packages; %s imports %s", file, path)
+			}
+		}
+	}
+}

--- a/graph/verifier/verifier.go
+++ b/graph/verifier/verifier.go
@@ -13,10 +13,10 @@ import (
 	structure "github.com/dewebprotocol/malt/auth/semantic"
 	"github.com/dewebprotocol/malt/auth/semantic/list"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	authverifier "github.com/dewebprotocol/malt/auth/verifier"
 	"github.com/dewebprotocol/malt/graph"
 	"github.com/dewebprotocol/malt/graph/querypath"
 	"github.com/dewebprotocol/malt/graph/resolver"
-	"github.com/dewebprotocol/malt/layout/unixfs"
 )
 
 // Runtime is the minimal graph runtime surface needed to verify ProofList
@@ -143,7 +143,7 @@ func (v *Verifier) verifyStep(ctx context.Context, index int, step prooflist.Ste
 			key := arcset.CanonicalizePath(step.Path)
 			return v.runtime.Semantic().Verify(step.From, key, mapping.Binding{Value: step.Target, Present: true}, structure.Proof(step.Proof))
 		case "list", "measured_list":
-			return unixfs.VerifyProofListListStructure(v.runtime.ListSemantic(), step, index)
+			return authverifier.VerifyProofListListStructure(v.runtime.ListSemantic(), step, index)
 		default:
 			return false, fmt.Errorf("prooflist step %d has unsupported structure evidence backend %q", index, step.EvidenceBackend)
 		}

--- a/layout/unixfs/prooflist.go
+++ b/layout/unixfs/prooflist.go
@@ -122,52 +122,6 @@ func AppendListRangeStep(pl *prooflist.ProofList, queriedPath string, root cid.C
 	return nil
 }
 
-// VerifyProofListListStructure verifies list-backed ProofList structure steps
-// emitted by the UnixFS layout. Server-side ProofList verification owns the
-// ordered traversal policy; UnixFS owns the list/index/range proof semantics.
-func VerifyProofListListStructure(lists list.Semantics, step prooflist.Step, stepIndex int) (bool, error) {
-	switch step.EvidenceBackend {
-	case "list":
-		if step.Index == nil {
-			return false, fmt.Errorf("prooflist step %d list index is missing", stepIndex)
-		}
-		if step.Length == nil {
-			return false, fmt.Errorf("prooflist step %d list length is missing", stepIndex)
-		}
-		return lists.Verify(step.From, *step.Index, list.Query{Key: step.Target, Length: *step.Length}, structure.Proof(step.Proof))
-	case "measured_list":
-		if !step.Target.Equals(step.From) {
-			return false, nil
-		}
-		if step.Start == nil {
-			return false, fmt.Errorf("prooflist step %d list range start is missing", stepIndex)
-		}
-		if step.ChildCount == nil {
-			return false, fmt.Errorf("prooflist step %d list range child count is missing", stepIndex)
-		}
-		if step.TotalSize == nil {
-			return false, fmt.Errorf("prooflist step %d list range total size is missing", stepIndex)
-		}
-		if step.ChunkSize == nil {
-			return false, fmt.Errorf("prooflist step %d list range chunk size is missing", stepIndex)
-		}
-		measured, ok := lists.(list.MeasuredSemantics)
-		if !ok {
-			return false, fmt.Errorf("prooflist step %d has measured list evidence but graph list semantic does not support measured ranges", stepIndex)
-		}
-		return measured.VerifyRange(step.From, *step.Start, step.End, list.RangeResult{
-			Metadata: list.RangeMetadata{
-				ChildCount: *step.ChildCount,
-				TotalSize:  *step.TotalSize,
-				ChunkSize:  *step.ChunkSize,
-			},
-			Segments: append([]cid.Cid(nil), step.Segments...),
-		}, structure.Proof(step.Proof))
-	default:
-		return false, fmt.Errorf("prooflist step %d has unsupported structure evidence backend %q", stepIndex, step.EvidenceBackend)
-	}
-}
-
 // AppendListPayloadRangeProof appends proof evidence for a byte range in a
 // fixed-width list payload. It prefers the measured-list range proof and falls
 // back to composed list-index proof steps when the measured proof is not


### PR DESCRIPTION
## Summary
- Add `auth/verifier` for verifier-critical ProofList list and measured-list step validation.
- Update `graph/verifier` to call the auth helper instead of importing `layout/unixfs`.
- Remove the old UnixFS list-structure verifier helper and add an import-boundary regression test.
- Update MIP boundary docs to reflect the new helper ownership.

## Why
`graph/verifier` is part of the reusable core verification path. Importing `layout/unixfs` inverted the intended dependency direction and pulled layout-level dependencies into verifier compilation. The list-step helper only needs ProofList schema plus auth list semantics, so it belongs under `auth`.

## Validation
- `env GOCACHE=/tmp/go-build-cache-auth-prooflist go test ./auth/verifier ./graph/verifier ./layout/unixfs ./server ./cmd/malt`
- `env GOCACHE=/tmp/go-build-cache-auth-prooflist go vet ./auth/verifier ./graph/verifier ./layout/unixfs`
- `gofmt -l auth/verifier/list.go auth/verifier/list_test.go graph/verifier/verifier.go graph/verifier/import_boundary_test.go layout/unixfs/prooflist.go`
- `git diff --check`
- `env GOCACHE=/tmp/go-build-cache-auth-prooflist go test ./...`