### PR TITLE
fix: reject malformed KZG verifier inputs

### DIFF
--- a/auth/commitment/kzg/kzg.go
+++ b/auth/commitment/kzg/kzg.go
@@ -116,9 +116,15 @@ func (s *Scheme) BatchProve(values []commitment.Cell, indices []uint64) (cid.Cid
 
 // VerifyIndex verifies a proof for a stable index without cache state.
 func (s *Scheme) VerifyIndex(comm cid.Cid, index uint64, value commitment.Cell, proof []byte) (bool, error) {
+	if index >= uint64(len(s.domainPoints)) {
+		return false, fmt.Errorf("index %d exceeds max %d", index, len(s.domainPoints)-1)
+	}
 	kzgProof, claimedValue, proofIndex, err := deserializeProof(proof)
 	if err != nil {
 		return false, err
+	}
+	if proofIndex >= uint64(len(s.domainPoints)) {
+		return false, fmt.Errorf("proof index %d exceeds max %d", proofIndex, len(s.domainPoints)-1)
 	}
 	if proofIndex != index {
 		return false, nil
@@ -248,8 +254,8 @@ func serializeProof(proof gokzg4844.KZGProof, claimedValue gokzg4844.Scalar, ind
 }
 
 func deserializeProof(data []byte) (gokzg4844.KZGProof, gokzg4844.Scalar, uint64, error) {
-	if len(data) < ProofSize {
-		return gokzg4844.KZGProof{}, gokzg4844.Scalar{}, 0, fmt.Errorf("proof too short: %d", len(data))
+	if len(data) != ProofSize {
+		return gokzg4844.KZGProof{}, gokzg4844.Scalar{}, 0, fmt.Errorf("proof has wrong size: expected %d, got %d", ProofSize, len(data))
 	}
 	var proof gokzg4844.KZGProof
 	var claimed gokzg4844.Scalar

--- a/auth/commitment/kzg/kzg_test.go
+++ b/auth/commitment/kzg/kzg_test.go
@@ -1,6 +1,7 @@
 package kzg_test
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/commitment"
@@ -97,4 +98,57 @@ func TestKZGBatchProveIsStateless(t *testing.T) {
 	if ok {
 		t.Fatal("expected wrong batch value verification to fail")
 	}
+}
+
+func TestKZGVerifyRejectsMalformedProofMetadata(t *testing.T) {
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme failed: %v", err)
+	}
+	values := []commitment.Cell{commitment.NewCell([]byte("slot0"))}
+	root, value, proof, err := scheme.Prove(values, 0)
+	if err != nil {
+		t.Fatalf("Prove failed: %v", err)
+	}
+
+	outOfRange := append([]byte(nil), proof...)
+	binary.BigEndian.PutUint32(outOfRange[80:84], uint32(kzg.MaxValues))
+	if ok, err := scheme.VerifyProof(root, value, outOfRange); err == nil || ok {
+		t.Fatalf("VerifyProof(out-of-range index) = %v, %v; want false, error", ok, err)
+	}
+	if ok, err := scheme.VerifyIndex(root, 0, value, outOfRange); err == nil || ok {
+		t.Fatalf("VerifyIndex(proof index out of range) = %v, %v; want false, error", ok, err)
+	}
+
+	if ok, err := scheme.VerifyIndex(root, kzg.MaxValues, value, proof); err == nil || ok {
+		t.Fatalf("VerifyIndex(out-of-range index) = %v, %v; want false, error", ok, err)
+	}
+
+	withTrailingData := append(append([]byte(nil), proof...), 0)
+	if ok, err := scheme.VerifyProof(root, value, withTrailingData); err == nil || ok {
+		t.Fatalf("VerifyProof(trailing data) = %v, %v; want false, error", ok, err)
+	}
+}
+
+func FuzzKZGVerifyProofDoesNotPanic(f *testing.F) {
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		f.Fatalf("NewScheme failed: %v", err)
+	}
+	values := []commitment.Cell{commitment.NewCell([]byte("slot0"))}
+	root, value, proof, err := scheme.Prove(values, 0)
+	if err != nil {
+		f.Fatalf("Prove failed: %v", err)
+	}
+
+	outOfRange := append([]byte(nil), proof...)
+	binary.BigEndian.PutUint32(outOfRange[80:84], uint32(kzg.MaxValues))
+	f.Add(proof)
+	f.Add(outOfRange)
+	f.Add(append(append([]byte(nil), proof...), 0))
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, candidate []byte) {
+		_, _ = scheme.VerifyProof(root, value, candidate)
+	})
 }

--- a/auth/verifier/portable_test.go
+++ b/auth/verifier/portable_test.go
@@ -18,6 +18,7 @@ import (
 	listtree "github.com/dewebprotocol/malt/runtime/semantic/list/tree"
 	mapradix "github.com/dewebprotocol/malt/runtime/semantic/mapping/radix"
 	kvmemory "github.com/dewebprotocol/malt/storage/kv/memory"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -79,6 +80,15 @@ func TestPortableVerifierAcceptsRuntimeRadixAndTreeProofs(t *testing.T) {
 					EvidenceKind: "structure", EvidenceBackend: "map", Proof: proof,
 				}}}
 				assertPortableValid(t, portable, pl)
+
+				if name == "kzg" {
+					malformedRoot := portableMalformedRoot(t, root)
+					malformed := pl
+					malformed.Root = malformedRoot
+					malformed.Steps = append([]prooflist.Step(nil), pl.Steps...)
+					malformed.Steps[0].From = malformedRoot
+					assertPortableRejected(t, portable, malformed)
+				}
 
 				pl.Steps[0].Target = portableTestCID(t, "forged-map-target")
 				assertPortableRejected(t, portable, pl)
@@ -201,4 +211,18 @@ func portableTestCID(t *testing.T, seed string) cid.Cid {
 		t.Fatalf("hash seed: %v", err)
 	}
 	return cid.NewCidV1(cid.Raw, sum)
+}
+
+func portableMalformedRoot(t *testing.T, root cid.Cid) cid.Cid {
+	t.Helper()
+	digest, err := maltcid.ExtractCommitment(root)
+	if err != nil {
+		t.Fatalf("ExtractCommitment: %v", err)
+	}
+	digest = append(append([]byte(nil), digest...), 0x42)
+	hash, err := mh.Encode(digest, mh.IDENTITY)
+	if err != nil {
+		t.Fatalf("encode malformed root: %v", err)
+	}
+	return cid.NewCidV1(root.Prefix().Codec, hash)
 }

--- a/wire/maltcid/codec.go
+++ b/wire/maltcid/codec.go
@@ -185,6 +185,21 @@ func ExtractCommitment(c cid.Cid) ([]byte, error) {
 	if decoded.Code != mh.IDENTITY {
 		return nil, fmt.Errorf("expected identity hash, got code=%x", decoded.Code)
 	}
+	expectedSize := 0
+	switch BackendKindOf(c) {
+	case BackendKindKZG:
+		expectedSize = KZGCommitmentSize
+	case BackendKindIPA:
+		expectedSize = IPACommitmentSize
+	default:
+		return nil, fmt.Errorf("unsupported MALT commitment backend for codec=%x", c.Prefix().Codec)
+	}
+	if len(decoded.Digest) != expectedSize {
+		return nil, fmt.Errorf(
+			"invalid %s commitment size: %d, expected %d",
+			CodecName(c.Prefix().Codec), len(decoded.Digest), expectedSize,
+		)
+	}
 	return decoded.Digest, nil
 }
 

--- a/wire/maltcid/codec_test.go
+++ b/wire/maltcid/codec_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
 )
 
 func TestNewKZGCid(t *testing.T) {
@@ -175,5 +176,42 @@ func TestExtractCommitmentNonMalt(t *testing.T) {
 	_, err := maltcid.ExtractCommitment(c)
 	if err == nil {
 		t.Error("Expected error for non-MALT CID")
+	}
+}
+
+func TestExtractCommitmentRejectsInvalidDigestSize(t *testing.T) {
+	tests := []struct {
+		codec uint64
+		size  int
+	}{
+		{codec: maltcid.CodecMaltMapKZG, size: maltcid.KZGCommitmentSize},
+		{codec: maltcid.CodecMaltListKZG, size: maltcid.KZGCommitmentSize},
+		{codec: maltcid.CodecMaltMapIPA, size: maltcid.IPACommitmentSize},
+		{codec: maltcid.CodecMaltListIPA, size: maltcid.IPACommitmentSize},
+	}
+
+	for _, test := range tests {
+		invalidSizes := []struct {
+			name string
+			size int
+		}{
+			{name: "short", size: test.size - 1},
+			{name: "long", size: test.size + 1},
+		}
+		for _, invalid := range invalidSizes {
+			name := maltcid.CodecName(test.codec) + "/" + invalid.name
+			t.Run(name, func(t *testing.T) {
+				invalidSize := invalid.size
+				digest := make([]byte, invalidSize)
+				hash, err := mh.Encode(digest, mh.IDENTITY)
+				if err != nil {
+					t.Fatalf("encode identity multihash: %v", err)
+				}
+				malformed := cid.NewCidV1(test.codec, hash)
+				if _, err := maltcid.ExtractCommitment(malformed); err == nil {
+					t.Fatalf("ExtractCommitment accepted %d-byte digest, want %d", invalidSize, test.size)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- require exact backend-specific commitment digest sizes when decoding typed MALT roots
- reject out-of-range KZG proof indices before domain lookup and require exact primitive proof length
- add typed-root, portable-verifier, negative-index, trailing-data, and fuzz regression coverage

## Why

The v0.0.3 release audit found two verifier fail-open/fail-unsafe cases:

1. a KZG typed CID with extra identity-digest bytes could reuse a valid proof because the verifier copied only the first 48 bytes
2. a proof-carried index at or above the KZG domain size could panic during verification

Both violate the portable authentication-kernel contract. This patch centralizes typed-root length validation and makes malformed proof metadata fail closed.

## Validation

- `go test ./wire/maltcid ./auth/commitment/kzg ./auth/verifier`
- `go test -race ./wire/maltcid ./auth/commitment/kzg ./auth/verifier`
- `go test ./auth/commitment/kzg -run '^$' -fuzz '^FuzzKZGVerifyProofDoesNotPanic$' -fuzztime 10s`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
