### PR TITLE
docs: finalize v0.0.3 release record

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,10 +85,11 @@ advertise that request-header variance with `Vary: X-Malt-Proof`. Large-file
 byte-range reads include path/`@payload` proof plus one measured-list
 `list_range` step. That step carries authenticated fixed chunk metadata, the
 covered segment CIDs, and a proof payload composed from the metadata slot proof
-and the required index proofs. Response-body range binding is still a
-ProofList verifier-contract TODO. File routes are reference/evaluation surfaces
-around the same root-centric mutation namespace. They are not a production
-multi-tenant gateway contract.
+and the required index proofs. Portable ProofList verification authenticates
+that metadata and those segment CIDs; UnixFS callers bind the returned HTTP
+body with `layout/unixfs.VerifyRangeBody` or an equivalent segment-byte check.
+File routes are reference/evaluation surfaces around the same root-centric
+mutation namespace. They are not a production multi-tenant gateway contract.
 
 ### List Semantic
 
@@ -531,12 +532,10 @@ Metrics:
 
 Open proposal-stage MIPs for the next discussion:
 
-- review the portable arc-authentication contract in MIP-1011 and its
-  `v0alpha1` artifact profile
 - decide whether writer receipts in `docs/spec/writer-receipts.md` become a
   stable API and evaluation accounting contract
-- accept the current ProofList verifier contract in
-  `docs/spec/prooflist-format.md`, especially response-body range binding
+- stabilize the current `v0alpha1` ProofList verifier contract and add
+  versioned cross-language conformance vectors
 - decide whether resolve JSON and bare ProofList JSON need stable named schemas
   beyond the artifact reference in `docs/spec/artifacts.md`
 - decide whether list needs a future variable-size or compact range-proof API;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.3] - 2026-07-12
+
 ### Added
-- Open-source readiness: CODE_OF_CONDUCT.md, CHANGELOG.md, license badge.
+
+- Module-root `malt` facade with typed `Query`, `ReadRequest`, `ReadResult`,
+  `Engine.Read`, `Engine.Apply`, and `Engine.VerifyRead` contracts.
+- Portable `auth/verifier` support for runtime-generated KZG and IPA map,
+  list-index, and measured-range ProofList evidence without runtime, ArcTable,
+  CAS, layout, server, daemon, or network dependencies.
+- Separate UnixFS Reader and Writer facades with explicit CAS capabilities.
+- MIP-1011 and the experimental `v0alpha1` typed read/result and ProofList
+  binding profile.
+- Resumable full write-trace replay and expanded read/evaluation workloads.
 
 ### Changed
-- Minimum Go version raised to 1.25.7.
-- Upgraded `go-ipld-prime` from 0.22.0 to 0.24.0 (strict DAG-CBOR decode defaults).
-- Upgraded `go.uber.org/zap` from 1.27.1 to 1.28.0.
-- Upgraded `golang.org/x/sync` from 0.19.0 to 0.20.0.
-- Upgraded `bits-and-blooms/bitset` from 1.7.0 to 1.24.4.
+
+- Generic maps may omit or delete the reserved `@payload` coordinate; UnixFS
+  continues to require it as a layout invariant.
+- `graph/verifier` is now a thin reference-runtime adapter over the portable
+  authentication kernel.
+- Graph resolver/writer code consumes narrow ArcTable interfaces, and
+  `runtimegraph.NewGraph` no longer accepts an unused CAS argument.
+- Upgraded Badger from 4.9.2 to 4.9.4, `go-ipld-format` from 0.6.3
+  to 0.6.4, and `golang.org/x/sync` from 0.21.0 to 0.22.0.
 
 ### Fixed
-- Windows daemon no longer terminates when the parent console closes (#92).
+
+- Portable verification now preserves all generic canonical map coordinates
+  and maps semantic absence to the public `ErrQueryNotFound` facade error.
+- Typed MALT roots reject backend-invalid commitment lengths instead of
+  truncating extra digest bytes during verification.
+- KZG verification rejects out-of-range proof indices and non-canonical proof
+  lengths instead of allowing malformed input to panic or reuse a commitment.
+
+[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/DeWebProtocol/malt/compare/v0.0.2...v0.0.3

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ managed product gateway lives outside this repository.
 [Threat Model](./docs/policy/threat-model.md) ·
 [Compatibility](./docs/policy/compatibility.md) · [Evaluation](./docs/evaluation.md) ·
 [MIPs](./docs/mips/README.md) ·
+[v0.0.3 Release](./docs/releases/v0.0.3.md) ·
 [Roadmap](./ROADMAP.md) · [Security](./SECURITY.md) ·
 [Contributing](./CONTRIBUTING.md)
 
@@ -139,9 +140,16 @@ Current experimental boundaries:
 - no stable public API compatibility guarantee yet
 - large-file byte-range response bodies must be bound to authenticated segment CIDs with layout/unixfs.VerifyRangeBody after ProofList verification
 
-The core facade and ProofList binding rules introduced for `v0.0.3` use the
-experimental `v0alpha1` profile. The first candidate is `v0.0.3-rc.1`; after
-release validation the final tag must be exactly `v0.0.3`.
+The `v0.0.3` source release introduces the core facade and ProofList binding
+rules as the experimental `v0alpha1` profile. Integrators should pin the exact
+release and review the compatibility notes before upgrading:
+
+```bash
+go get github.com/dewebprotocol/malt@v0.0.3
+```
+
+See the [release notes](./docs/releases/v0.0.3.md) and the
+[GitHub Release](https://github.com/DeWebProtocol/malt/releases/tag/v0.0.3).
 
 ## Use Cases
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,43 +10,35 @@ MALT is an experimental reference implementation. It is runnable end to end, but
 its public APIs, ProofList schemas, wire formats, and deployment policies may
 change. It is not production-ready.
 
-The near-term goal is `v0.0.3`: make MALT's application-neutral,
-arc-granularity authentication contract usable without importing the reference
-server or treating UnixFS as the core abstraction. The in-tree daemon/server
-remains a reference/evaluation HTTP surface, not the production managed gateway
-product.
+`v0.0.3` established the application-neutral, arc-granularity authentication
+baseline. The post-release focus is to consume that tagged core from product
+and application layers without importing the reference server or treating
+UnixFS as the core abstraction.
 
 ## Near Term
 
-- Review MIP-1011 and validate the module-root `malt` facade: typed `Query`,
-  `ReadRequest`, `ReadResult`, and `Engine.Read`/`Apply`/`VerifyRead`.
-- Keep the portable `auth/verifier` free of runtime, ArcTable, CAS, layout,
-  server, and daemon dependencies.
-- Validate one non-UnixFS, relation-only map path so generic maps remain valid
-  without `@payload`.
-- Keep `@payload` reserved and optional in generic map semantics while enforcing
-  it as a UnixFS layout invariant.
-- Stabilize the public `malt` CLI around root-centric add, resolve, verify, and
-  daemon lifecycle workflows.
-- Keep proof-bearing HTTP reads explicit and verifier-facing.
-- Document and test the reference/evaluation HTTP surface boundary for
-  `Read(root, query) -> result + ProofList`.
-- Document the experimental ProofList and typed read binding profile as
-  `v0alpha1`, without claiming a stable cross-release JSON schema.
-- Keep `malt-eval` schemas, raw envelopes, manifests, and summary outputs stable
-  enough for repeatable research runs.
-- Preserve clear package boundaries among `auth`, `graph`, `runtime`,
-  `layout/unixfs`, `server`, `storage`, and `cmd/eval/internal`.
-- Build and test a gateway/external consumer against the public facade without
-  importing `server` or concrete runtime packages as its API boundary.
+- Wire `DeWebProtocol/gateway` to the tagged root `malt` facade and portable
+  verifier through a typed backend, with product-level end-to-end tests.
+- Define the standalone client daemon/CLI boundary: local root selection,
+  upload/synchronization, proof verification, and gateway interaction.
+- Add versioned conformance fixtures and test vectors for the experimental
+  `v0alpha1` typed read/result and ProofList profile before cross-language SDKs
+  depend on it.
+- Demonstrate at least one non-UnixFS layout, such as a PoDs-style personal
+  datastore or agent-memory relation model.
+- Refresh paper-grade evaluation artifacts with locked workloads, repeated
+  runs, backend/config labels, and explicit aggregation policy.
+- Keep `auth/verifier` free of runtime, storage, layout, server, daemon, and
+  network dependencies as integrations expand.
 
 ## Active Research And Design Areas
 
-- Range-body helper integration in clients and gateway.
+- Portable range-body helper integration in clients and gateway.
 - Writer receipt semantics and accounting.
 - Benchmark-facing proof reporting.
 - Variable-size measured list evidence.
 - Incremental `malt add --root` optimization.
+- Native KZG multi-opening proofs instead of concatenated single-index proofs.
 - Additional layouts for Pods, protocols, agent memory, and application data.
 - Head publication, freshness, and multi-writer policy as application or
   deployment concerns.
@@ -62,38 +54,18 @@ product.
 - Stable API compatibility across releases.
 - A full replacement for Kubo, IPFS, or any CAS implementation.
 
-## v0.0.3 Release Readiness Checklist
+## v0.0.3 Released Baseline
 
-Before `v0.0.3-rc.1`:
+The `v0.0.3` source release was completed on 2026-07-12. It includes:
 
-- `go test ./...` passes on CI.
-- `go vet ./...` passes on CI.
-- `cmd/cas`, `cmd/malt`, and `cmd/eval/malt-eval` build from a clean checkout.
-- `README.md` quick start works from a clean checkout.
-- `malt-eval run --plan examples/eval-smoke-plan.json` writes a manifest and
-  summaries.
-- Portable `auth/verifier` tests cover proof tampering and root, query, target,
-  and range-result mismatches without runtime or storage access.
-- Import-boundary tests keep ArcTable and concrete runtime/storage dependencies
-  outside the trusted auth kernel.
-- A generic relation-only map test passes without `@payload`, while UnixFS
-  payload-binding tests still pass.
-- An external consumer compiles against the root `malt` facade.
-- Release notes state `v0alpha1` compatibility limits and known ProofList
-  verifier limits.
-- `/verify` still works through the portable verifier adapter.
-- `malt resolve` returns ProofList evidence by default.
-- `malt verify` verifies a resolve output or bare ProofList.
-- Large-file byte-range body binding is documented through
-  `layout/unixfs.VerifyRangeBody`.
-- The writer core/compat split is documented in `docs/spec/writer-receipts.md`.
-- Public docs avoid claims that are not implemented in the current code.
-- Repository docs distinguish MALT core/reference evaluation surfaces from
-  managed gateway product behavior in `DeWebProtocol/gateway`.
+- the module-root typed `malt` facade
+- portable KZG/IPA ProofList verification under `auth/verifier`
+- generic relation-only maps without mandatory `@payload`
+- explicit UnixFS Reader/Writer and range-body verification boundaries
+- narrow graph/runtime dependency ports and import guards
+- malformed typed-root and KZG proof fail-closed hardening
+- source-release validation through full tests, vet, command builds, evaluator
+  smoke, external-consumer import, and isolated CLI proof verification
 
-Tag the validated candidate as exactly `v0.0.3-rc.1`. After candidate and
-external-consumer validation, tag the final source release as exactly
-`v0.0.3`; do not use `v0.0.3-core-boundary` as the final version.
-
-The current release checklist lives in
+The validation record and compatibility limits live in
 [`docs/releases/v0.0.3.md`](docs/releases/v0.0.3.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,15 @@ persistence.
 
 ## Supported Versions
 
-Until the first tagged release, security review applies to the `main` branch.
-After releases begin, this file will name supported release lines.
+| Version | Security support |
+| --- | --- |
+| `main` | Best-effort review of current integration code |
+| `v0.0.3` | Current supported experimental source release |
+| `v0.0.2` and earlier | Not supported |
+
+MALT remains pre-`v1.0.0` and experimental. Security fixes may require
+breaking API, proof, root, or wire-format changes. Reproducible consumers
+should pin `v0.0.3` rather than depend on `main`.
 
 ## Reporting a Vulnerability
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,14 +49,14 @@ the reference docs under `spec/` or `evaluation.md`, with MIPs linking to them.
 The previous `documents/MIPs` mirror in the research-paper workspace was
 removed after migration. New implementation-bound MIP work should happen here.
 
-The current public-core proposal is
+The current public-core contract is
 [MIP-1011: Arc Authentication Core Contract](./mips/mip-1011-arc-authentication-core-contract.md).
 
 ## What Goes Where
 
 - `concepts/` for reader-facing background, comparisons, and orientation
 - `policy/` for stability, safety, and release policy
-- `releases/` for source-release candidate notes and validation checklists
+- `releases/` for source-release notes and validation records
 - `evaluation.md` for benchmark methods, headline results, and artifact rules
 - `spec/` for formal protocol and schema documents
 - `mips/` for design proposals and process records

--- a/docs/mips/README.md
+++ b/docs/mips/README.md
@@ -84,7 +84,7 @@ not become the only copy of a schema or specification.
 | [MIP-1008](mip-1008-semantic-reachability-demo.md) | Draft | Informational | Evaluation | Define a small demo for reverse, cross-object, and multi-view relations. |
 | [MIP-1009](mip-1009-benchmark-proof-reporting.md) | Draft | Standards Track | Evaluation | Define paper-facing proof, receipt, and metrics reporting across benchmark suites. |
 | [MIP-1010](mip-1010-data-authentication-core-boundary.md) | Final | Standards Track | Core | Record the completed package-ownership split among authentication, graph ports, layouts, runtime, storage, SDK, and transport code. |
-| [MIP-1011](mip-1011-arc-authentication-core-contract.md) | Review | Standards Track | Core | Define the portable arc-level `Read`/`Apply`/`VerifyRead` contract targeted by `v0.0.3`. |
+| [MIP-1011](mip-1011-arc-authentication-core-contract.md) | Final | Standards Track | Core | Define the portable arc-level `Read`/`Apply`/`VerifyRead` contract introduced in `v0.0.3`. |
 
 ## Promotion Protocol
 

--- a/docs/mips/mip-1003-prooflist-verification-schema.md
+++ b/docs/mips/mip-1003-prooflist-verification-schema.md
@@ -29,8 +29,8 @@ validation.
 ## Specification
 
 The current ProofList reference lives in
-[`docs/spec/prooflist-format.md`](../spec/prooflist-format.md). For the
-`v0.0.3` candidate, the review boundary is:
+[`docs/spec/prooflist-format.md`](../spec/prooflist-format.md). The `v0.0.3`
+source release records this review boundary:
 
 - ordered path traversal is verifier-facing and implemented by
   `auth/verifier`;

--- a/docs/mips/mip-1004-resolve-prooflist-artifact-schema.md
+++ b/docs/mips/mip-1004-resolve-prooflist-artifact-schema.md
@@ -38,7 +38,7 @@ The current artifact reference lives in
 - evaluator record schemas remain the only checked-in machine-readable JSON
   schemas;
 - resolve JSON and bare ProofList JSON remain experimental and do not get
-  stable named schema files in this release candidate.
+  stable named schema files in the `v0.0.3` source release.
 
 A later stable-schema proposal may add named schema files, CLI schema listing,
 and compatibility rules, but that work should happen in a separate issue or PR

--- a/docs/mips/mip-1011-arc-authentication-core-contract.md
+++ b/docs/mips/mip-1011-arc-authentication-core-contract.md
@@ -3,7 +3,7 @@ mip: 1011
 title: Arc Authentication Core Contract
 description: Define MALT as a portable arc-granularity graph data-authentication system with typed read, mutation, and verification contracts.
 author: MALT maintainers
-status: Review
+status: Final
 type: Standards Track
 category: Core
 created: 2026-07-11
@@ -19,7 +19,7 @@ remain ordinary immutable objects in content-addressed storage (CAS), while
 vector-commitment (VC) backends commit to and prove typed relations. UnixFS is
 one layout over this core; it is not the definition of MALT.
 
-This MIP defines the public core contract targeted by `v0.0.3`: a portable,
+This MIP defines the public core contract introduced in `v0.0.3`: a portable,
 trusted authentication kernel; an untrusted execution engine; typed
 `Read`/`Apply`/`VerifyRead` operations in the module-root `malt` package; and an
 experimental ProofList artifact profile named `v0alpha1`.
@@ -248,11 +248,11 @@ MIP-1010 remains the historical record of the repository package split. This
 MIP defines the subsequent public arc-authentication contract; it does not
 reverse the ownership boundaries established by MIP-1010.
 
-## Release Plan
+## Release Record
 
-The first candidate for this contract must be tagged `v0.0.3-rc.1`. After the
-candidate passes the repository validation and an external-consumer smoke test,
-the final release tag must be exactly `v0.0.3`.
+This contract was validated first as `v0.0.3-rc.1`, then published from the
+same approved source commit as `v0.0.3` after repository, external-consumer,
+evaluator, and CLI proof smokes passed.
 
 `v0.0.3-core-boundary` may remain in historical milestone or planning text, but
 it is not a valid final release tag for this contract.
@@ -271,6 +271,13 @@ it is not a valid final release tag for this contract.
   are rejected.
 - Full tests, vet, command builds, evaluator smoke, and an external consumer
   compile/run smoke pass before tagging.
+
+## History
+
+- 2026-07-11: Implemented the portable facade and authentication kernel in PR
+  #159.
+- 2026-07-12: Hardened typed-root and malformed KZG proof handling in PR #160,
+  completed release validation, and finalized the contract for `v0.0.3`.
 
 ## References
 

--- a/docs/plans/v0.0.3-core-boundary.md
+++ b/docs/plans/v0.0.3-core-boundary.md
@@ -2,8 +2,9 @@
 
 > **Historical plan:** this file records the precursor package-boundary work.
 > The current portable arc-authentication contract is MIP-1011 and the release
-> checklist is [`docs/releases/v0.0.3.md`](../releases/v0.0.3.md). The final
-> release tag is `v0.0.3`, not the historical milestone name used below.
+> validation record is [`docs/releases/v0.0.3.md`](../releases/v0.0.3.md).
+> The work completed in the `v0.0.3` source release on 2026-07-12; the
+> historical milestone name used below was not used as a release tag.
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 

--- a/docs/policy/compatibility.md
+++ b/docs/policy/compatibility.md
@@ -66,7 +66,7 @@ compatibility surfaces.
 
 ## Release Notes
 
-When releases begin, release notes should call out changes to:
+Release notes must call out changes to:
 
 - CLI workflows
 - daemon API routes and DTOs

--- a/docs/policy/releasing.md
+++ b/docs/policy/releasing.md
@@ -38,24 +38,27 @@ Review:
 - `SECURITY.md` reporting path is still accurate.
 - `cmd/eval/schemas` match current evaluator outputs.
 
-For the current release candidate, use
-[`docs/releases/v0.0.3.md`](../releases/v0.0.3.md) as the release-note and
-validation checklist. It requires a portable-verifier smoke, a relation-only
-map test, import-boundary checks, and an external-consumer compile test in
-addition to the repository-wide commands.
+The completed `v0.0.3` validation record lives in
+[`docs/releases/v0.0.3.md`](../releases/v0.0.3.md). It includes a
+portable-verifier smoke, a relation-only map test, import-boundary checks, an
+external-consumer compile test, evaluator smoke, and isolated CLI proof smoke.
+Future releases should add a new release-note file with equivalent gates rather
+than editing the historical `v0.0.3` record.
 
 ## Tagging
 
-For `v0.0.3`, tag the validated candidate first:
+For a new release, tag the validated candidate first using a standard
+prerelease suffix:
 
 ```bash
-git tag -a v0.0.3-rc.1 -m "MALT v0.0.3-rc.1"
-git push origin v0.0.3-rc.1
+git tag -a vX.Y.Z-rc.1 -m "MALT vX.Y.Z-rc.1"
+git push origin vX.Y.Z-rc.1
 ```
 
 After candidate and external-consumer validation, tag the exact same approved
-release commit as `v0.0.3`, or rerun validation if the commit changes. Do not
-use `v0.0.3-core-boundary` as the final tag.
+release commit as `vX.Y.Z`, or rerun validation if the commit changes. The
+`v0.0.3` release followed this process with `v0.0.3-rc.1` and `v0.0.3`; the
+historical `v0.0.3-core-boundary` milestone was not used as a tag.
 
 Create GitHub release notes with:
 

--- a/docs/policy/threat-model.md
+++ b/docs/policy/threat-model.md
@@ -51,8 +51,10 @@ For an accepted root and query, MALT aims to provide:
 
 For HTTP content reads, the daemon returns body bytes together with
 `X-Malt-ProofList` evidence by default. Large-file byte-range reads include
-measured-list range evidence; full response-body binding for large-file ranges
-remains a ProofList schema design item.
+measured-list range evidence that authenticates layout metadata and segment
+CIDs. Portable ProofList verification does not by itself hash the returned HTTP
+body; UnixFS callers must additionally use `layout/unixfs.VerifyRangeBody` or
+an equivalent segment-byte binding before accepting those bytes.
 
 ## Not Guaranteed By Core MALT
 

--- a/docs/releases/v0.0.3.md
+++ b/docs/releases/v0.0.3.md
@@ -1,14 +1,14 @@
 # MALT v0.0.3
 
-Status: release-candidate preparation
+Status: released on 2026-07-12
 
 `v0.0.3` packages MALT as a general arc-granularity graph
 data-authentication library. It is an experimental source release, not a
 stable API line or a production managed gateway.
 
-The first candidate must be tagged `v0.0.3-rc.1`. After candidate and
-external-consumer validation, the final tag must be exactly `v0.0.3`.
-`v0.0.3-core-boundary` is not a final release tag.
+The source tree was validated first as `v0.0.3-rc.1`, then published from the
+same approved commit as the final `v0.0.3` tag. The historical
+`v0.0.3-core-boundary` milestone is not a release tag.
 
 ## Highlights
 
@@ -30,6 +30,9 @@ external-consumer validation, the final tag must be exactly `v0.0.3`.
 - `runtimegraph.NewGraph` no longer accepts an unused CAS argument.
 - MIP-1011 and the reference specs define the experimental `v0alpha1` typed
   read/result and ProofList binding profile.
+- Typed-root decoding and KZG proof verification fail closed on invalid
+  commitment lengths, out-of-range proof indices, and non-canonical proof
+  lengths.
 
 ## Compatibility And Limits
 
@@ -48,10 +51,12 @@ external-consumer validation, the final tag must be exactly `v0.0.3`.
   `layout/unixfs.VerifyRangeBody` or an equivalent body-binding check.
 - Current measured-list evidence uses fixed-width chunks. Variable-width
   measured lists remain future work.
+- The KZG batch API currently serializes and verifies one primitive proof per
+  index. A native multi-opening proof remains a post-release optimization.
 
-## Required Validation
+## Release Validation
 
-Run from the repository root:
+The release tree was validated from the repository root with:
 
 ```bash
 git diff --check
@@ -76,6 +81,9 @@ Also verify:
 - a temporary external Go module can import the root `malt` facade and
   `auth/verifier` without importing `server`.
 - the CLI proof smoke below succeeds against isolated daemon state.
+- malformed typed roots and proof-carried KZG indices are rejected without
+  truncation or panic; the primitive proof parser is covered by negative and
+  fuzz tests.
 
 ## CLI Proof Smoke
 
@@ -118,24 +126,14 @@ The smoke owns the temporary state and ports it creates. If either port is in
 use, override `MALT_LISTEN` or `CAS_LISTEN` and record the chosen values in the
 release validation notes.
 
-## Tagging
+## Published Tags
 
-After the candidate checks pass and the maintainer approves it:
+- `v0.0.3-rc.1`: validated candidate source tag
+- `v0.0.3`: final experimental source release
 
-```bash
-git tag -a v0.0.3-rc.1 -m "MALT v0.0.3-rc.1"
-git push origin v0.0.3-rc.1
-```
-
-After candidate and external-consumer validation:
-
-```bash
-git tag -a v0.0.3 -m "MALT v0.0.3"
-git push origin v0.0.3
-```
-
-Tag only the exact commit whose validation results are recorded in the GitHub
-release notes.
+Both tags identify the same approved source tree. The GitHub Release records
+the exact commit and final validation results. This release does not publish
+binary artifacts; consumers build from source with Go 1.25.7 or newer.
 
 ## Related Documents
 

--- a/docs/spec/artifacts.md
+++ b/docs/spec/artifacts.md
@@ -6,7 +6,7 @@ JSON, content-proof headers, and evaluator schemas.
 ## Status
 
 Experimental and implementation-bound. The typed read/result and ProofList
-binding rules form the `v0alpha1` artifact profile targeted by `v0.0.3`. Only
+binding rules form the `v0alpha1` artifact profile introduced in `v0.0.3`. Only
 evaluator schemas currently have machine-readable JSON Schema files in the
 repository; resolve JSON and bare ProofList JSON remain documented Go DTO
 artifacts rather than stable named JSON schemas.

--- a/docs/spec/prooflist-format.md
+++ b/docs/spec/prooflist-format.md
@@ -162,8 +162,8 @@ mismatches, short segment data, and tampered returned bytes.
 
 ## Related Proposals
 
-- [MIP-1003](../mips/mip-1003-prooflist-verification-schema.md) tracks verifier-contract
-  formalization and range-body helper integration.
+- [MIP-1003](../mips/mip-1003-prooflist-verification-schema.md) tracks
+  verifier-contract stabilization beyond the released `v0alpha1` profile.
 - [MIP-1006](../mips/mip-1006-variable-size-measured-list-evidence.md) tracks a
   future variable-size measured-list model.
 - [MIP-1011](../mips/mip-1011-arc-authentication-core-contract.md) defines the


### PR DESCRIPTION
## Summary

- add the v0.0.3 changelog, released status, installation guidance, and supported-version policy
- finalize MIP-1011 and convert candidate/roadmap language into the released baseline and post-v0.0.3 priorities
- record the PR #160 typed-root/KZG verifier hardening and current KZG multi-opening limitation
- align architecture, threat model, artifact, ProofList, and release-process documentation with implemented range-body verification

## Why

PR #159 established the portable arc-authentication core, and the release audit added the verifier hardening in PR #160. The repository documentation still described v0.0.3 as a future release candidate and contained stale security/range-body wording. This PR makes the final source tree self-consistent before tagging.

The release remains experimental `v0alpha1`; this does not claim stable API or production readiness.

## Validation

- `git diff --check`
- repository-wide relative Markdown link check (38 files)
- `go test -run '^$' ./...`
- full code tests, race targets, fuzz, and vet passed on PR #160 before this docs-only change
