### PR TITLE
feat: publish v0.0.4 graph artifact contract

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,6 +42,18 @@ is still untrusted: `VerifyRead` binds a caller-supplied trusted root and typed
 query to the returned target, optional range segments, and ProofList before the
 portable `auth/verifier` checks the evidence.
 
+`malt.SegmentPath` is the application-neutral composition coordinate. Clients
+send segment arrays; the reference resolver may consume multiple leading
+segments with one authenticated arc and currently prefers the longest prefix at
+each root. The proof contract is existential: it authenticates the returned
+complete derivation, not the uniqueness or maximality of the selected path.
+Applications and layouts own overlap/conflict policy.
+
+The unversioned `artifact` package projects resolve, primitive prove, and
+verify operations into the explicit `malt.artifact/v0alpha2` envelope. This is
+the cross-process boundary for gateway, daemon, and SDK integrations. Profile
+versions belong in serialized artifacts and schemas, not Go package names.
+
 ArcTable is namespace-scoped arcset persistence/materialization and provides no
 correctness by itself. `graph` is a runtime composition boundary around
 resolver and writer ports, not a semantic owner or graph-node hierarchy.
@@ -59,13 +71,14 @@ but untrusted execution and application layers:
 | Layer | Responsibility |
 | --- | --- |
 | Portable auth kernel | Canonical arcs, typed roots, VC verification, semantic proof rules, and ProofList validation |
-| Root `malt` facade | Typed `Query`, `ReadRequest`, `ReadResult`, and `Engine.Read`/`Apply`/`VerifyRead` |
+| Root `malt` facade | Typed primitive queries, immutable segment paths, and `Engine.Read`/`Apply`/`VerifyRead` |
+| `artifact` contract | Profiled resolve/prove/verify request, result, ProofList binding, and schemas |
 | Execution engine | Proof generation, mutation application, operational scope, ArcTable, indexes, and caches |
 | Runtime adapters | Resolver/writer ports, reference daemon, HTTP transport, SDK, and storage wiring |
 | Application layout | Domain model over typed arcs and CAS payloads; UnixFS is one layout |
 
-The public core facade exposes typed semantic operations, not storage machinery
-or a UnixFS path API.
+The public core facade exposes typed semantic operations and MALT segment paths,
+not storage machinery, JavaScript/filesystem syntax, or a UnixFS path API.
 
 ### Semantic Layer
 
@@ -534,10 +547,10 @@ Open proposal-stage MIPs for the next discussion:
 
 - decide whether writer receipts in `docs/spec/writer-receipts.md` become a
   stable API and evaluation accounting contract
-- stabilize the current `v0alpha1` ProofList verifier contract and add
-  versioned cross-language conformance vectors
-- decide whether resolve JSON and bare ProofList JSON need stable named schemas
-  beyond the artifact reference in `docs/spec/artifacts.md`
+- expand `malt.artifact/v0alpha2` with cross-language map/list/range
+  conformance vectors while keeping incompatible profiles explicit
+- keep gateway, daemon, and SDK projections aligned with the checked-in
+  resolve/prove/verify schemas
 - decide whether list needs a future variable-size or compact range-proof API;
   the current prototype uses path/`@payload` proof plus one measured-list
   `list_range` step carrying metadata, segment CIDs, and metadata/index proofs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.4] - 2026-07-12
+
+### Added
+
+- Canonical immutable `SegmentPath` values and slash textual projection for
+  application-neutral multi-arc resolution.
+- Unversioned `artifact` package with the explicit
+  `malt.artifact/v0alpha2` resolve/prove/verify contract.
+- Embedded JSON Schemas, root-identity conformance fixtures, and stable
+  `/v1/artifacts/{resolve,prove,verify}` reference endpoints.
+- MIP-1012 and reference specifications for segment-path composition and
+  existential resolution.
+
+### Changed
+
+- New integrations carry canonical segment arrays instead of pre-discovering
+  how the current graph groups a long path into arcs.
+- Reference resolution may prefer the longest prefix, while verification proves
+  only the complete returned derivation and makes no longest/unique claim.
+- MIP-1004 is finalized with profiled artifacts and machine-readable schemas.
+
 ## [0.0.3] - 2026-07-12
 
 ### Added
@@ -40,5 +61,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - KZG verification rejects out-of-range proof indices and non-canonical proof
   lengths instead of allowing malformed input to panic or reuse a commitment.
 
-[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.3...HEAD
+[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.4...HEAD
+[0.0.4]: https://github.com/DeWebProtocol/malt/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/DeWebProtocol/malt/compare/v0.0.2...v0.0.3

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ managed product gateway lives outside this repository.
 [Threat Model](./docs/policy/threat-model.md) ·
 [Compatibility](./docs/policy/compatibility.md) · [Evaluation](./docs/evaluation.md) ·
 [MIPs](./docs/mips/README.md) ·
-[v0.0.3 Release](./docs/releases/v0.0.3.md) ·
+[v0.0.4 Release](./docs/releases/v0.0.4.md) ·
 [Roadmap](./ROADMAP.md) · [Security](./SECURITY.md) ·
 [Contributing](./CONTRIBUTING.md)
 
@@ -66,6 +66,10 @@ MALT separates payload storage, arc authentication, and execution/access:
 - content reads can return normal HTTP bodies plus `X-Malt-ProofList` headers
 - clients verify `root + path -> result` without trusting gateways, caches, or
   materialized indexes
+- clients submit canonical segment arrays without discovering how each root
+  groups those segments into authenticated arcs
+- profiled resolve, prove, and verify artifacts carry the trusted inputs,
+  result, and ProofList together across gateway, daemon, and SDK boundaries
 - local structure updates advance structure roots without rewriting unrelated
   payload objects
 
@@ -140,16 +144,18 @@ Current experimental boundaries:
 - no stable public API compatibility guarantee yet
 - large-file byte-range response bodies must be bound to authenticated segment CIDs with layout/unixfs.VerifyRangeBody after ProofList verification
 
-The `v0.0.3` source release introduces the core facade and ProofList binding
-rules as the experimental `v0alpha1` profile. Integrators should pin the exact
-release and review the compatibility notes before upgrading:
+The `v0.0.4` source release adds canonical segment paths and the
+`malt.artifact/v0alpha2` resolve/prove/verify contract with embedded JSON
+Schemas. Integrators should pin the exact release and reject unknown artifact
+profiles:
 
 ```bash
-go get github.com/dewebprotocol/malt@v0.0.3
+go get github.com/dewebprotocol/malt@v0.0.4
 ```
 
-See the [release notes](./docs/releases/v0.0.3.md) and the
-[GitHub Release](https://github.com/DeWebProtocol/malt/releases/tag/v0.0.3).
+See the [release notes](./docs/releases/v0.0.4.md), the
+[artifact contract](./docs/spec/artifacts.md), and the
+[GitHub Release](https://github.com/DeWebProtocol/malt/releases/tag/v0.0.4).
 
 ## Use Cases
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,19 +10,19 @@ MALT is an experimental reference implementation. It is runnable end to end, but
 its public APIs, ProofList schemas, wire formats, and deployment policies may
 change. It is not production-ready.
 
-`v0.0.3` established the application-neutral, arc-granularity authentication
-baseline. The post-release focus is to consume that tagged core from product
-and application layers without importing the reference server or treating
-UnixFS as the core abstraction.
+`v0.0.4` establishes canonical segment-path composition and profiled
+resolve/prove/verify artifacts. The post-release focus is to consume that
+contract from product and application layers without importing the reference
+server or treating UnixFS as the core abstraction.
 
 ## Near Term
 
-- Wire `DeWebProtocol/gateway` to the tagged root `malt` facade and portable
-  verifier through a typed backend, with product-level end-to-end tests.
+- Harden the `DeWebProtocol/gateway` integration around identity,
+  authorization, root publication, backend availability, and cache policy.
 - Define the standalone client daemon/CLI boundary: local root selection,
   upload/synchronization, proof verification, and gateway interaction.
-- Add versioned conformance fixtures and test vectors for the experimental
-  `v0alpha1` typed read/result and ProofList profile before cross-language SDKs
+- Expand `malt.artifact/v0alpha2` conformance vectors with KZG/IPA map, list,
+  multi-hop resolve, and measured-range examples before cross-language SDKs
   depend on it.
 - Demonstrate at least one non-UnixFS layout, such as a PoDs-style personal
   datastore or agent-memory relation model.
@@ -69,3 +69,16 @@ The `v0.0.3` source release was completed on 2026-07-12. It includes:
 
 The validation record and compatibility limits live in
 [`docs/releases/v0.0.3.md`](docs/releases/v0.0.3.md).
+
+## v0.0.4 Release Layer
+
+The `v0.0.4` source release adds:
+
+- canonical `SegmentPath` semantics and slash textual projection
+- longest-prefix candidate discovery without a verifier maximality claim
+- the unversioned `artifact` package and `malt.artifact/v0alpha2` profile
+- checked-in and embedded resolve/prove/verify JSON Schemas
+- stable `/v1/artifacts/{resolve,prove,verify}` reference endpoints
+- root-identity codec fixtures and end-to-end artifact verification tests
+
+See [`docs/releases/v0.0.4.md`](docs/releases/v0.0.4.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,12 +13,13 @@ persistence.
 | Version | Security support |
 | --- | --- |
 | `main` | Best-effort review of current integration code |
-| `v0.0.3` | Current supported experimental source release |
+| `v0.0.4` | Current supported experimental source release |
+| `v0.0.3` | Previous experimental source release |
 | `v0.0.2` and earlier | Not supported |
 
 MALT remains pre-`v1.0.0` and experimental. Security fixes may require
 breaking API, proof, root, or wire-format changes. Reproducible consumers
-should pin `v0.0.3` rather than depend on `main`.
+should pin `v0.0.4` rather than depend on `main`.
 
 ## Reporting a Vulnerability
 

--- a/architecture_test.go
+++ b/architecture_test.go
@@ -50,6 +50,12 @@ func TestProductionImportBoundaries(t *testing.T) {
 			recursive: false,
 			forbidden: []string{"runtime", "storage", "layout", "api", "server"},
 		},
+		{
+			name:      "artifact contract",
+			dir:       filepath.Join(root, "artifact"),
+			recursive: true,
+			forbidden: []string{"graph", "runtime", "storage", "layout", "api", "server"},
+		},
 	}
 
 	for _, tc := range tests {

--- a/artifact/artifact_test.go
+++ b/artifact/artifact_test.go
@@ -1,0 +1,126 @@
+package artifact_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	malt "github.com/dewebprotocol/malt"
+	"github.com/dewebprotocol/malt/artifact"
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+type acceptingVerifier struct{}
+
+func (acceptingVerifier) VerifyProofList(context.Context, prooflist.ProofList) (bool, error) {
+	return true, nil
+}
+
+func TestVerifyResolveArtifactBindsSegmentsAndTarget(t *testing.T) {
+	root := testCID(t, "root")
+	target := testCID(t, "target")
+	pl := prooflist.ProofList{
+		Root:  root,
+		Query: "a/b/c/d",
+		Steps: []prooflist.Step{
+			{Kind: prooflist.KindMapStep, From: root, Path: "a/b", Target: target},
+		},
+	}
+	req := artifact.ResolveRequest{
+		Profile:  artifact.Profile,
+		Root:     root.String(),
+		Segments: []string{"a", "b", "c", "d"},
+	}
+	// Build the complete existential derivation expected by the request.
+	root2 := target
+	target2 := testCID(t, "target-2")
+	target3 := testCID(t, "target-3")
+	pl.Steps = []prooflist.Step{
+		{Kind: prooflist.KindMapStep, From: root, Path: "a/b", Target: root2},
+		{Kind: prooflist.KindMapStep, From: root2, Path: "c", Target: target2},
+		{Kind: prooflist.KindMapStep, From: target2, Path: "d", Target: target3},
+	}
+	art, err := artifact.NewResolveArtifact(req, target3, pl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := artifact.Verify(context.Background(), artifact.VerifyRequest{
+		Profile: artifact.Profile, Artifact: art,
+	}, acceptingVerifier{}); err != nil {
+		t.Fatalf("Verify() failed: %v", err)
+	}
+
+	art.Target = testCID(t, "tampered").String()
+	if err := artifact.Verify(context.Background(), artifact.VerifyRequest{
+		Profile: artifact.Profile, Artifact: art,
+	}, acceptingVerifier{}); err == nil {
+		t.Fatal("Verify() accepted a tampered target")
+	}
+}
+
+func TestResolveArtifactDoesNotRequireLongestOrUniqueProof(t *testing.T) {
+	root := testCID(t, "root")
+	target := testCID(t, "target")
+	req := artifact.ResolveRequest{Profile: artifact.Profile, Root: root.String(), Segments: []string{"a", "b"}}
+	pl := prooflist.ProofList{
+		Root: root, Query: "a/b",
+		Steps: []prooflist.Step{{Kind: prooflist.KindMapStep, From: root, Path: "a/b", Target: target}},
+	}
+	art, err := artifact.NewResolveArtifact(req, target, pl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := artifact.Verify(context.Background(), artifact.VerifyRequest{
+		Profile: artifact.Profile, Artifact: art,
+	}, acceptingVerifier{}); err != nil {
+		t.Fatalf("Verify() failed: %v", err)
+	}
+}
+
+func TestPublishedSchemasAreJSONObjects(t *testing.T) {
+	for _, name := range artifact.SchemaNames() {
+		data, err := artifact.Schema(name)
+		if err != nil {
+			t.Fatalf("Schema(%q): %v", name, err)
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("Schema(%q) is invalid JSON: %v", name, err)
+		}
+		if parsed["$schema"] == nil || parsed["$id"] == nil {
+			t.Fatalf("Schema(%q) lacks identity metadata", name)
+		}
+	}
+}
+
+func TestQueryFromCoreRejectsUnsupportedKind(t *testing.T) {
+	if _, err := artifact.QueryFromCore(malt.Query{Kind: malt.QueryKind("future")}); err == nil {
+		t.Fatal("QueryFromCore accepted an unsupported query kind")
+	}
+}
+
+func TestRootIdentityConformanceFixture(t *testing.T) {
+	data, err := os.ReadFile("testdata/v0alpha2/verify-root-request.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request artifact.VerifyRequest
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatal(err)
+	}
+	if err := artifact.Verify(context.Background(), request, acceptingVerifier{}); err != nil {
+		t.Fatalf("fixture did not verify: %v", err)
+	}
+}
+
+func testCID(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	hash, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cid.NewCidV1(cid.Raw, hash)
+}

--- a/artifact/schema.go
+++ b/artifact/schema.go
@@ -1,0 +1,29 @@
+package artifact
+
+import (
+	"embed"
+	"fmt"
+)
+
+//go:embed schemas/*.schema.json
+var schemaFS embed.FS
+
+// Schema returns a checked-in JSON Schema by stable filename.
+func Schema(name string) ([]byte, error) {
+	data, err := schemaFS.ReadFile("schemas/" + name)
+	if err != nil {
+		return nil, fmt.Errorf("artifact schema %q: %w", name, err)
+	}
+	return append([]byte(nil), data...), nil
+}
+
+// SchemaNames lists the schemas published by this artifact profile.
+func SchemaNames() []string {
+	return []string{
+		"artifact.schema.json",
+		"prove-request.schema.json",
+		"resolve-request.schema.json",
+		"verify-request.schema.json",
+		"verify-result.schema.json",
+	}
+}

--- a/artifact/schemas/artifact.schema.json
+++ b/artifact/schemas/artifact.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/artifact/v0alpha2/artifact.schema.json",
+  "title": "MALT Proof Artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "operation", "root", "query", "target", "prooflist"],
+  "properties": {
+    "profile": {"const": "malt.artifact/v0alpha2"},
+    "operation": {"enum": ["resolve", "prove"]},
+    "root": {"type": "string", "minLength": 1},
+    "query": {"$ref": "#/$defs/query"},
+    "target": {"type": "string", "minLength": 1},
+    "range_segments": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "prooflist": {"$ref": "#/$defs/prooflist"}
+  },
+  "$defs": {
+    "cid_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["/"],
+      "properties": {"/": {"type": "string", "minLength": 1}}
+    },
+    "segments": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1, "pattern": "^[^/]+$"}
+    },
+    "query": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "segments"],
+          "properties": {
+            "kind": {"const": "path"},
+            "segments": {"$ref": "#/$defs/segments"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "segments"],
+          "properties": {
+            "kind": {"const": "map_key"},
+            "segments": {"$ref": "#/$defs/segments", "minItems": 1}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "index"],
+          "properties": {
+            "kind": {"const": "list_index"},
+            "index": {"type": "integer", "minimum": 0}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "start"],
+          "properties": {
+            "kind": {"const": "list_range"},
+            "start": {"type": "integer", "minimum": 0},
+            "end": {"type": "integer", "minimum": 1}
+          }
+        }
+      ]
+    },
+    "prooflist": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["root", "steps"],
+      "properties": {
+        "root": {"$ref": "#/$defs/cid_link"},
+        "query": {"type": "string"},
+        "steps": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/proof_step"}
+        }
+      }
+    },
+    "proof_step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "from", "target"],
+      "properties": {
+        "kind": {
+          "enum": ["map_step", "payload_binding", "list_index", "list_range", "blob_binding", "implicit_block", "legacy_unknown"]
+        },
+        "from": {"$ref": "#/$defs/cid_link"},
+        "query": {"type": "string"},
+        "coordinate": {"type": "string"},
+        "path": {"type": "string"},
+        "index": {"type": "integer", "minimum": 0},
+        "length": {"type": "integer", "minimum": 0},
+        "start": {"type": "integer", "minimum": 0},
+        "end": {"type": "integer", "minimum": 0},
+        "child_count": {"type": "integer", "minimum": 0},
+        "total_size": {"type": "integer", "minimum": 0},
+        "chunk_size": {"type": "integer", "minimum": 0},
+        "target": {"$ref": "#/$defs/cid_link"},
+        "segments": {"type": "array", "items": {"$ref": "#/$defs/cid_link"}},
+        "evidence_kind": {"type": "string"},
+        "evidence_backend": {"type": "string"},
+        "evidence": {"type": "string", "contentEncoding": "base64"},
+        "proof": {"type": "string", "contentEncoding": "base64"}
+      }
+    }
+  }
+}

--- a/artifact/schemas/prove-request.schema.json
+++ b/artifact/schemas/prove-request.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/artifact/v0alpha2/prove-request.schema.json",
+  "title": "MALT Prove Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "root", "query"],
+  "properties": {
+    "profile": {"const": "malt.artifact/v0alpha2"},
+    "root": {"type": "string", "minLength": 1},
+    "query": {"$ref": "artifact.schema.json#/$defs/query"}
+  }
+}

--- a/artifact/schemas/resolve-request.schema.json
+++ b/artifact/schemas/resolve-request.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/artifact/v0alpha2/resolve-request.schema.json",
+  "title": "MALT Resolve Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "root", "segments"],
+  "properties": {
+    "profile": {"const": "malt.artifact/v0alpha2"},
+    "root": {"type": "string", "minLength": 1},
+    "segments": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1, "pattern": "^[^/]+$"}
+    }
+  }
+}

--- a/artifact/schemas/verify-request.schema.json
+++ b/artifact/schemas/verify-request.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/artifact/v0alpha2/verify-request.schema.json",
+  "title": "MALT Verify Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "artifact"],
+  "properties": {
+    "profile": {"const": "malt.artifact/v0alpha2"},
+    "artifact": {"$ref": "artifact.schema.json"}
+  }
+}

--- a/artifact/schemas/verify-result.schema.json
+++ b/artifact/schemas/verify-result.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/artifact/v0alpha2/verify-result.schema.json",
+  "title": "MALT Verify Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "valid"],
+  "properties": {
+    "profile": {"const": "malt.artifact/v0alpha2"},
+    "valid": {"type": "boolean"}
+  }
+}

--- a/artifact/testdata/v0alpha2/README.md
+++ b/artifact/testdata/v0alpha2/README.md
@@ -1,0 +1,13 @@
+# `malt.artifact/v0alpha2` Conformance Fixtures
+
+These fixtures exercise the zero-segment root-identity case without relying on
+a commitment backend or mutable runtime state. They are stable byte-level
+examples for SDK request/response codecs.
+
+The fixture proves only identity: the trusted root is the returned target and
+the ProofList has no traversal steps. Non-empty resolve and primitive prove
+artifacts require real backend evidence and are covered by Go integration tests.
+
+Consumers should validate the JSON shape against the checked-in schemas and
+then run semantic/cryptographic verification. Passing schema validation alone
+is not conformance.

--- a/artifact/testdata/v0alpha2/resolve-root-artifact.json
+++ b/artifact/testdata/v0alpha2/resolve-root-artifact.json
@@ -1,0 +1,14 @@
+{
+  "profile": "malt.artifact/v0alpha2",
+  "operation": "resolve",
+  "root": "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku",
+  "query": {
+    "kind": "path",
+    "segments": []
+  },
+  "target": "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku",
+  "prooflist": {
+    "root": {"/": "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"},
+    "steps": []
+  }
+}

--- a/artifact/testdata/v0alpha2/resolve-root-request.json
+++ b/artifact/testdata/v0alpha2/resolve-root-request.json
@@ -1,0 +1,5 @@
+{
+  "profile": "malt.artifact/v0alpha2",
+  "root": "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku",
+  "segments": []
+}

--- a/artifact/testdata/v0alpha2/verify-root-request.json
+++ b/artifact/testdata/v0alpha2/verify-root-request.json
@@ -1,0 +1,17 @@
+{
+  "profile": "malt.artifact/v0alpha2",
+  "artifact": {
+    "profile": "malt.artifact/v0alpha2",
+    "operation": "resolve",
+    "root": "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku",
+    "query": {
+      "kind": "path",
+      "segments": []
+    },
+    "target": "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku",
+    "prooflist": {
+      "root": {"/": "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"},
+      "steps": []
+    }
+  }
+}

--- a/artifact/testdata/v0alpha2/verify-valid-result.json
+++ b/artifact/testdata/v0alpha2/verify-valid-result.json
@@ -1,0 +1,4 @@
+{
+  "profile": "malt.artifact/v0alpha2",
+  "valid": true
+}

--- a/artifact/types.go
+++ b/artifact/types.go
@@ -1,0 +1,274 @@
+// Package artifact defines the transport-neutral, versioned MALT artifacts
+// shared by resolvers, provers, verifiers, gateways, daemons, and SDKs.
+package artifact
+
+import (
+	"fmt"
+
+	malt "github.com/dewebprotocol/malt"
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	cid "github.com/ipfs/go-cid"
+)
+
+// Profile identifies the artifact contract introduced by MALT v0.0.4. The
+// Go package remains unversioned; the serialized envelope carries the profile.
+const Profile = "malt.artifact/v0alpha2"
+
+type Operation string
+
+const (
+	OperationResolve Operation = "resolve"
+	OperationProve   Operation = "prove"
+)
+
+type QueryKind string
+
+const (
+	QueryPath      QueryKind = "path"
+	QueryMapKey    QueryKind = "map_key"
+	QueryListIndex QueryKind = "list_index"
+	QueryListRange QueryKind = "list_range"
+)
+
+// Query is the stable artifact projection of a MALT path or primitive typed
+// query. Exactly the fields selected by Kind are meaningful.
+type Query struct {
+	Kind     QueryKind `json:"kind"`
+	Segments []string  `json:"segments,omitempty"`
+	Index    *uint64   `json:"index,omitempty"`
+	Start    *uint64   `json:"start,omitempty"`
+	End      *uint64   `json:"end,omitempty"`
+}
+
+// ResolveRequest asks an execution engine for one authenticated derivation of
+// a caller-supplied segment path. Candidate selection is not part of the proof
+// contract; the reference engine currently prefers the longest prefix.
+type ResolveRequest struct {
+	Profile  string   `json:"profile"`
+	Root     string   `json:"root"`
+	Segments []string `json:"segments"`
+}
+
+// ProveRequest asks for one primitive typed map/list proof.
+type ProveRequest struct {
+	Profile string `json:"profile"`
+	Root    string `json:"root"`
+	Query   Query  `json:"query"`
+}
+
+// Artifact binds one request, target, and ProofList under an explicit profile.
+// RangeSegments is populated only for measured-list range proofs.
+type Artifact struct {
+	Profile       string              `json:"profile"`
+	Operation     Operation           `json:"operation"`
+	Root          string              `json:"root"`
+	Query         Query               `json:"query"`
+	Target        string              `json:"target"`
+	RangeSegments []string            `json:"range_segments,omitempty"`
+	ProofList     prooflist.ProofList `json:"prooflist"`
+}
+
+// VerifyRequest asks a verifier to validate all artifact bindings and proof
+// evidence without trusting the resolver or gateway that produced it.
+type VerifyRequest struct {
+	Profile  string   `json:"profile"`
+	Artifact Artifact `json:"artifact"`
+}
+
+type VerifyResult struct {
+	Profile string `json:"profile"`
+	Valid   bool   `json:"valid"`
+}
+
+func (r ResolveRequest) Validate() error {
+	if r.Profile != Profile {
+		return fmt.Errorf("unsupported artifact profile %q", r.Profile)
+	}
+	if _, err := cid.Parse(r.Root); err != nil {
+		return fmt.Errorf("invalid root CID: %w", err)
+	}
+	if _, err := malt.NewSegmentPath(r.Segments); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r ProveRequest) Validate() error {
+	if r.Profile != Profile {
+		return fmt.Errorf("unsupported artifact profile %q", r.Profile)
+	}
+	if _, err := cid.Parse(r.Root); err != nil {
+		return fmt.Errorf("invalid root CID: %w", err)
+	}
+	return r.Query.Validate(false)
+}
+
+func (r VerifyRequest) Validate() error {
+	if r.Profile != Profile {
+		return fmt.Errorf("unsupported verify profile %q", r.Profile)
+	}
+	return r.Artifact.Validate()
+}
+
+func (q Query) Validate(allowPath bool) error {
+	switch q.Kind {
+	case QueryPath:
+		if !allowPath {
+			return fmt.Errorf("path query is only valid for resolve artifacts")
+		}
+		_, err := malt.NewSegmentPath(q.Segments)
+		return err
+	case QueryMapKey:
+		path, err := malt.NewSegmentPath(q.Segments)
+		if err != nil {
+			return err
+		}
+		if path.Empty() {
+			return fmt.Errorf("map_key query has no segments")
+		}
+		if q.Index != nil || q.Start != nil || q.End != nil {
+			return fmt.Errorf("map_key query contains list fields")
+		}
+		return nil
+	case QueryListIndex:
+		if q.Index == nil {
+			return fmt.Errorf("list_index query has no index")
+		}
+		if len(q.Segments) != 0 || q.Start != nil || q.End != nil {
+			return fmt.Errorf("list_index query contains unrelated fields")
+		}
+		return nil
+	case QueryListRange:
+		if q.Start == nil {
+			return fmt.Errorf("list_range query has no start")
+		}
+		if q.End != nil && *q.End <= *q.Start {
+			return fmt.Errorf("list_range end must be greater than start")
+		}
+		if len(q.Segments) != 0 || q.Index != nil {
+			return fmt.Errorf("list_range query contains unrelated fields")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported artifact query kind %q", q.Kind)
+	}
+}
+
+func (q Query) Core() (malt.Query, error) {
+	if err := q.Validate(false); err != nil {
+		return malt.Query{}, err
+	}
+	switch q.Kind {
+	case QueryMapKey:
+		path, _ := malt.NewSegmentPath(q.Segments)
+		return malt.MapKeyQuery(path.String())
+	case QueryListIndex:
+		return malt.ListIndexQuery(*q.Index), nil
+	case QueryListRange:
+		return malt.ListRangeQuery(*q.Start, q.End)
+	default:
+		return malt.Query{}, fmt.Errorf("unsupported artifact query kind %q", q.Kind)
+	}
+}
+
+func QueryFromCore(query malt.Query) (Query, error) {
+	switch query.Kind {
+	case malt.QueryMapKey:
+		path, err := malt.ParseSegmentPath(query.Key.String())
+		if err != nil {
+			return Query{}, err
+		}
+		return Query{Kind: QueryMapKey, Segments: path.Segments()}, nil
+	case malt.QueryListIndex:
+		index := query.Index
+		return Query{Kind: QueryListIndex, Index: &index}, nil
+	case malt.QueryListRange:
+		start := query.Start
+		return Query{Kind: QueryListRange, Start: &start, End: cloneUint64(query.End)}, nil
+	default:
+		return Query{}, fmt.Errorf("unsupported core query kind %q", query.Kind)
+	}
+}
+
+func NewResolveArtifact(req ResolveRequest, target cid.Cid, pl prooflist.ProofList) (Artifact, error) {
+	if err := req.Validate(); err != nil {
+		return Artifact{}, err
+	}
+	if !target.Defined() {
+		return Artifact{}, fmt.Errorf("resolved target is undefined")
+	}
+	return Artifact{
+		Profile:   Profile,
+		Operation: OperationResolve,
+		Root:      req.Root,
+		Query:     Query{Kind: QueryPath, Segments: append([]string(nil), req.Segments...)},
+		Target:    target.String(),
+		ProofList: pl,
+	}, nil
+}
+
+func NewProveArtifact(req ProveRequest, result malt.ReadResult) (Artifact, error) {
+	if err := req.Validate(); err != nil {
+		return Artifact{}, err
+	}
+	if !result.Target.Defined() {
+		return Artifact{}, fmt.Errorf("proved target is undefined")
+	}
+	segments := make([]string, len(result.Segments))
+	for i, segment := range result.Segments {
+		segments[i] = segment.String()
+	}
+	return Artifact{
+		Profile:       Profile,
+		Operation:     OperationProve,
+		Root:          req.Root,
+		Query:         req.Query,
+		Target:        result.Target.String(),
+		RangeSegments: segments,
+		ProofList:     result.ProofList,
+	}, nil
+}
+
+func (a Artifact) Validate() error {
+	if a.Profile != Profile {
+		return fmt.Errorf("unsupported artifact profile %q", a.Profile)
+	}
+	if _, err := cid.Parse(a.Root); err != nil {
+		return fmt.Errorf("invalid artifact root CID: %w", err)
+	}
+	if _, err := cid.Parse(a.Target); err != nil {
+		return fmt.Errorf("invalid artifact target CID: %w", err)
+	}
+	switch a.Operation {
+	case OperationResolve:
+		if err := a.Query.Validate(true); err != nil {
+			return err
+		}
+		if a.Query.Kind != QueryPath {
+			return fmt.Errorf("resolve artifact must use a path query")
+		}
+		if len(a.RangeSegments) != 0 {
+			return fmt.Errorf("resolve artifact contains range segments")
+		}
+	case OperationProve:
+		if err := a.Query.Validate(false); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported artifact operation %q", a.Operation)
+	}
+	for i, segment := range a.RangeSegments {
+		if _, err := cid.Parse(segment); err != nil {
+			return fmt.Errorf("invalid range segment %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func cloneUint64(value *uint64) *uint64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}

--- a/artifact/verify.go
+++ b/artifact/verify.go
@@ -1,0 +1,75 @@
+package artifact
+
+import (
+	"context"
+	"fmt"
+
+	malt "github.com/dewebprotocol/malt"
+	cid "github.com/ipfs/go-cid"
+)
+
+// Verify validates the request/artifact envelope and all cryptographic
+// evidence. Resolution is existential: it proves the returned ordered arc
+// chain, not that the execution engine selected a unique or longest chain.
+func Verify(ctx context.Context, req VerifyRequest, verifier malt.ProofVerifier) error {
+	if verifier == nil {
+		return fmt.Errorf("artifact verifier is nil")
+	}
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	root, _ := cid.Parse(req.Artifact.Root)
+	target, _ := cid.Parse(req.Artifact.Target)
+	if !req.Artifact.ProofList.Root.Equals(root) {
+		return fmt.Errorf("artifact ProofList root does not match artifact root")
+	}
+	if req.Artifact.Operation == OperationResolve && len(req.Artifact.Query.Segments) == 0 {
+		if len(req.Artifact.ProofList.Steps) != 0 || req.Artifact.ProofList.Query != "" {
+			return fmt.Errorf("root identity artifact contains traversal evidence")
+		}
+		if !target.Equals(root) {
+			return fmt.Errorf("root identity artifact target does not match root")
+		}
+		return nil
+	}
+	lastTarget, err := req.Artifact.ProofList.LastStepTarget()
+	if err != nil {
+		return err
+	}
+	if !lastTarget.Equals(target) {
+		return fmt.Errorf("artifact ProofList target does not match artifact target")
+	}
+
+	switch req.Artifact.Operation {
+	case OperationResolve:
+		path, _ := malt.NewSegmentPath(req.Artifact.Query.Segments)
+		if req.Artifact.ProofList.Query != path.String() {
+			return fmt.Errorf("artifact ProofList query %q does not match segment path %q", req.Artifact.ProofList.Query, path.String())
+		}
+		ok, err := verifier.VerifyProofList(ctx, req.Artifact.ProofList)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return malt.ErrVerifierRejected
+		}
+		return nil
+	case OperationProve:
+		query, err := req.Artifact.Query.Core()
+		if err != nil {
+			return err
+		}
+		segments := make([]cid.Cid, len(req.Artifact.RangeSegments))
+		for i, raw := range req.Artifact.RangeSegments {
+			segments[i], _ = cid.Parse(raw)
+		}
+		return malt.VerifyRead(ctx, malt.ReadRequest{Root: root, Query: query}, malt.ReadResult{
+			Target:    target,
+			Segments:  segments,
+			ProofList: req.Artifact.ProofList,
+		}, verifier)
+	default:
+		return fmt.Errorf("unsupported artifact operation %q", req.Artifact.Operation)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ gateway only to exercise MALT core end to end.
 - [Threat model](./policy/threat-model.md)
 - [Compatibility policy](./policy/compatibility.md)
 - [Release process](./policy/releasing.md)
-- [v0.0.3 release notes](./releases/v0.0.3.md)
+- [v0.0.4 release notes](./releases/v0.0.4.md)
 
 ## Evaluation
 
@@ -49,8 +49,11 @@ the reference docs under `spec/` or `evaluation.md`, with MIPs linking to them.
 The previous `documents/MIPs` mirror in the research-paper workspace was
 removed after migration. New implementation-bound MIP work should happen here.
 
-The current public-core contract is
-[MIP-1011: Arc Authentication Core Contract](./mips/mip-1011-arc-authentication-core-contract.md).
+The current public-core contracts are
+[MIP-1011: Arc Authentication Core Contract](./mips/mip-1011-arc-authentication-core-contract.md),
+[MIP-1012: Segment Path Resolution](./mips/mip-1012-segment-path-resolution.md),
+and the profiled artifacts finalized by
+[MIP-1004](./mips/mip-1004-resolve-prooflist-artifact-schema.md).
 
 ## What Goes Where
 

--- a/docs/mips/README.md
+++ b/docs/mips/README.md
@@ -77,7 +77,7 @@ not become the only copy of a schema or specification.
 | [MIP-1001](mip-1001-semantic-object-and-arc-terminology.md) | Draft | Standards Track | Core | Define graph root, semantic object, payload, outgoing arc, map relation, and list child-reference terminology. |
 | [MIP-1002](mip-1002-writer-receipt-accounting.md) | Draft | Standards Track | Interface | Decide how writer receipts support storage, indexing, accounting, and benchmark reporting. |
 | [MIP-1003](mip-1003-prooflist-verification-schema.md) | Review | Standards Track | Core | Formalize ProofList verifier contract, body/header binding, omission behavior, and range-body verification. |
-| [MIP-1004](mip-1004-resolve-prooflist-artifact-schema.md) | Review | Standards Track | Interface | Decide whether `malt resolve` JSON and bare ProofList JSON need stable named schemas. |
+| [MIP-1004](mip-1004-resolve-prooflist-artifact-schema.md) | Final | Standards Track | Interface | Publish profiled resolve, prove, and verify artifacts with named schemas. |
 | [MIP-1005](mip-1005-kzg-map-label-domain.md) | Final | Standards Track | Core | Record the canonical binding-CID slot model for storage-free map commitment primitives. |
 | [MIP-1006](mip-1006-variable-size-measured-list-evidence.md) | Draft | Standards Track | Core | Specify a future range-addressable list model for variable-size children. |
 | [MIP-1007](mip-1007-incremental-add-root-optimization.md) | Draft | Standards Track | Tooling | Explore path-local incremental add for very large existing roots. |
@@ -85,6 +85,7 @@ not become the only copy of a schema or specification.
 | [MIP-1009](mip-1009-benchmark-proof-reporting.md) | Draft | Standards Track | Evaluation | Define paper-facing proof, receipt, and metrics reporting across benchmark suites. |
 | [MIP-1010](mip-1010-data-authentication-core-boundary.md) | Final | Standards Track | Core | Record the completed package-ownership split among authentication, graph ports, layouts, runtime, storage, SDK, and transport code. |
 | [MIP-1011](mip-1011-arc-authentication-core-contract.md) | Final | Standards Track | Core | Define the portable arc-level `Read`/`Apply`/`VerifyRead` contract introduced in `v0.0.3`. |
+| [MIP-1012](mip-1012-segment-path-resolution.md) | Final | Standards Track | Core | Define segment arrays, proof-carrying arc composition, and existential resolution. |
 
 ## Promotion Protocol
 

--- a/docs/mips/mip-1004-resolve-prooflist-artifact-schema.md
+++ b/docs/mips/mip-1004-resolve-prooflist-artifact-schema.md
@@ -1,91 +1,68 @@
 ---
 mip: 1004
-title: Resolve And ProofList Artifact Schema
-description: Decide whether exported resolve JSON and bare ProofList JSON need stable named schemas.
+title: Resolve, Prove, And Verify Artifact Schema
+description: Publish profiled transport-neutral artifacts and schemas for resolution, primitive proofs, and verification.
 author: MALT maintainers
-status: Review
+status: Final
 type: Standards Track
 category: Interface
 created: 2026-05-25
-requires: 1003
+requires: 1003, 1011, 1012
 replaces: none
 ---
 
 ## Abstract
 
-This MIP records the current decision boundary for the artifact surfaces
-described in [`docs/spec/artifacts.md`](../spec/artifacts.md): what is
-documented for `v0.0.3`, and what is deferred until a stable schema line.
+MALT `v0.0.4` publishes the `malt.artifact/v0alpha2` contract for `resolve`,
+`prove`, and `verify`. The contract binds a trusted root, typed query, target,
+optional measured-range segments, and ProofList in one transport-neutral
+envelope with checked-in JSON Schemas.
 
 ## Motivation
 
-`malt resolve` currently prints JSON containing `target` plus optional
-`prooflist`, and `malt verify --prooflist` accepts both bare ProofList JSON and
-resolve JSON containing a `prooflist` field. Benchmark and paper artifacts need
-the current shape documented, but premature stable named schemas would imply a
-compatibility commitment the repository has not yet made.
+The `v0.0.3` facade stabilized the in-process root/query/result binding but the
+CLI resolve DTO and bare ProofList did not carry a version discriminator or a
+complete self-describing request binding. Gateways, daemons, and cross-language
+SDKs need one shared contract rather than independently reconstructing those
+bindings from routes or headers.
 
-## Specification
+## Decision
 
-The current artifact reference lives in
-[`docs/spec/artifacts.md`](../spec/artifacts.md). For
-`v0.0.3`:
+- The Go package is the unversioned `artifact`; package names do not contain
+  release or alpha suffixes.
+- Every serialized request, artifact, and result carries the exact profile
+  `malt.artifact/v0alpha2`.
+- `resolve` accepts a root plus canonical MALT segments and returns one complete
+  proof-carrying derivation.
+- `prove` accepts exactly one primitive `map_key`, `list_index`, or
+  `list_range` query.
+- `verify` validates the envelope bindings before portable proof verification.
+- JSON Schemas are checked in under `artifact/schemas`, embedded in the Go
+  package, and identified by stable `$id` values.
+- Schema validation remains distinct from cryptographic and semantic proof
+  verification.
+- Legacy CLI, bare ProofList, and proof-header surfaces remain compatibility
+  adapters rather than the contract new integrations should copy.
 
-- `malt resolve` JSON is documented as `api/http.ResolveResponse`;
-- bare ProofList JSON is documented as `auth/proof/prooflist.ProofList`;
-- proof-bearing content response metadata is documented as
-  `X-Malt-ProofList` plus `X-Malt-ProofList-Encoding`;
-- evaluator record schemas remain the only checked-in machine-readable JSON
-  schemas;
-- resolve JSON and bare ProofList JSON remain experimental and do not get
-  stable named schema files in the `v0.0.3` source release.
+The normative field and verification rules live in
+[`docs/spec/artifacts.md`](../spec/artifacts.md).
 
-A later stable-schema proposal may add named schema files, CLI schema listing,
-and compatibility rules, but that work should happen in a separate issue or PR
-after the verifier contract has settled.
+## Compatibility
 
-## Rationale
-
-Current code evidence:
-
-- `cmd/malt/resolve.go` prints `api/http.ResolveResponse`.
-- `api/http/types.go` defines `ResolveResponse`.
-- `cmd/malt/verify.go` accepts ProofList inputs.
-- `auth/proof/prooflist/prooflist.go` defines bare ProofList.
-- `cmd/eval/schemas` has evaluator schemas but no stable resolve or
-  bare ProofList schema.
-- `docs/spec/artifacts.md` records the current artifact surfaces and explains
-  that schema validation is separate from proof verification.
-
-## Backwards Compatibility
-
-The review decision is intentionally non-breaking: document the current shapes,
-do not add stable named schemas, and do not change runtime output. Adding named
-schemas later must not be presented as proof verification and must document any
-compatibility commitment it introduces.
+This is an opt-in profiled contract. Consumers must reject unknown profiles.
+An incompatible pre-`v1` revision will publish a new profile value and schemas
+instead of silently changing `v0alpha2`.
 
 ## Security Considerations
 
-Schema validation is not proof verification. The MIP must keep structural JSON
-validation separate from cryptographic or semantic verification.
-
-## Implementation Plan
-
-For the current review pass:
-
-- keep the durable artifact reference in `docs/spec/artifacts.md`;
-- do not add stable resolve or ProofList JSON Schema files for `v0.0.3`;
-- keep evaluator schema listing scoped to `cmd/eval/schemas`;
-- revisit named schemas when the repository is ready to commit to a stable
-  artifact compatibility policy.
+A gateway-produced artifact is untrusted until verified relative to a
+caller-accepted root. JSON Schema validation only checks shape. Verification
+must also bind the root, query, target, range segments, ProofList ordering, and
+all backend evidence.
 
 ## History
 
-- 2026-05-25: Created from the previous open TODO list.
-- 2026-06-25: Moved current artifact boundaries to `docs/spec/artifacts.md`;
-  this MIP now tracks whether those artifacts need stable named schemas.
-- 2026-07-06: Recorded the initial core-boundary decision to document current
-  shapes without adding stable named resolve or ProofList JSON schemas; moved
-  to Review for maintainer judgment.
-- 2026-07-11: Carried the same decision into the `v0.0.3` `v0alpha1` artifact
-  profile.
+- 2026-05-25: Opened the question of stable resolve and ProofList schemas.
+- 2026-07-11: Deferred named schemas from the `v0.0.3` `v0alpha1` profile.
+- 2026-07-12: Finalized the profiled resolve/prove/verify contract and schemas
+  for `v0.0.4`.

--- a/docs/mips/mip-1011-arc-authentication-core-contract.md
+++ b/docs/mips/mip-1011-arc-authentication-core-contract.md
@@ -151,6 +151,11 @@ applications compose primitive reads when their domain operation requires
 multi-step traversal. The core facade does not standardize a Unix path policy,
 directory manifest, HTTP response, or latest-head service.
 
+MIP-1012 extends this boundary in `v0.0.4` with an application-neutral segment
+array and proof-carrying multi-arc resolution. It does not add Unix, URL, or
+language-object parsing to core and does not change the primitive `Query`
+contract defined here.
+
 ### Reserved `@payload` Coordinate
 
 `@payload` is the standard reserved coordinate for binding a semantic object to
@@ -198,6 +203,11 @@ envelope does not carry an embedded version discriminator and does not yet have
 a stable named JSON Schema. Consumers must pin the MALT module or source
 release. A later MIP may add explicit wire version negotiation or promote a
 machine-readable schema without treating the current shape as stable.
+
+MIP-1004 later publishes `malt.artifact/v0alpha2` as a separate explicit
+cross-process envelope around resolve, primitive prove, and verify. The
+original `v0alpha1` facade described here remains the in-process primitive
+binding baseline.
 
 ### Import Direction
 

--- a/docs/mips/mip-1012-segment-path-resolution.md
+++ b/docs/mips/mip-1012-segment-path-resolution.md
@@ -1,0 +1,80 @@
+---
+mip: 1012
+title: Segment Path Resolution
+description: Define canonical MALT segments, proof-carrying arc composition, and existential resolution semantics.
+author: MALT maintainers
+status: Final
+type: Standards Track
+category: Core
+created: 2026-07-12
+requires: 1001, 1011
+replaces: none
+---
+
+## Abstract
+
+MALT accepts application-neutral segment arrays and composes authenticated arcs
+without requiring clients to know arc boundaries. `/` is the canonical textual
+projection, while transports and applications remain free to map their own path
+syntax to segments.
+
+## Motivation
+
+If `root1` authenticates arc `a/b` to `root2`, `root2` authenticates `c` to
+`root3`, and `root3` authenticates `d`, a client should submit
+`["a", "b", "c", "d"]`. Requiring `["a/b", "c", "d"]` would leak the
+current graph's arc partitioning into every client and would require a separate
+untrusted discovery request before resolution.
+
+At the same time, the core should not parse JavaScript properties, filesystem
+paths, URLs, or other application grammars. Those syntaxes have different
+escaping and conflict rules.
+
+## Decision
+
+- A MALT path is an ordered array of non-empty UTF-8 segments.
+- A segment cannot contain `/`; joining segments with `/` is the canonical
+  textual map-coordinate projection.
+- The empty array denotes the caller-supplied root.
+- Transports carry segments directly where possible. Slash URLs are one
+  transport mapping, not the canonical API type.
+- The resolver may discover an arc that consumes multiple leading segments and
+  continue from its authenticated target until all requested segments are
+  consumed.
+- The reference resolver prefers the longest available prefix at each root.
+- Verification proves the returned complete derivation. It does not prove that
+  the chosen prefix or derivation was longest, shortest, unique, or otherwise
+  application-preferred.
+- Applications and layouts own overlap/conflict policy when multiple valid
+  derivations exist.
+
+The normative rules and examples live in
+[`docs/spec/segment-paths.md`](../spec/segment-paths.md).
+
+## Rationale
+
+This boundary gives clients a stable interface without making application
+syntax part of MALT. Candidate lookup remains optimizable and untrusted;
+correctness comes from verification of the ordered arc chain relative to the
+trusted root.
+
+Requiring a non-membership proof for every longer candidate would strengthen
+the result into a maximality claim that the application does not need. It would
+also enlarge the proof and couple verifier semantics to one execution policy.
+
+## Security Considerations
+
+Alternative valid derivations can return different authenticated targets if an
+application creates overlapping relations. This is not proof forgery: each
+accepted artifact still proves its own root-to-target derivation. Applications
+that require deterministic namespace behavior must impose and validate a layout
+policy for overlap.
+
+Transport adapters must not silently apply dot-segment or whitespace
+normalization to the canonical segment contract. If a transport reserves such
+values, it must reject or reversibly encode them before calling core.
+
+## History
+
+- 2026-07-12: Accepted and implemented for `v0.0.4`.
+

--- a/docs/policy/README.md
+++ b/docs/policy/README.md
@@ -5,4 +5,4 @@ This folder collects implementation-bound policy and release documents.
 - [Threat model](./threat-model.md)
 - [Compatibility policy](./compatibility.md)
 - [Release process](./releasing.md)
-- [v0.0.3 release notes and checklist](../releases/v0.0.3.md)
+- [v0.0.4 release notes and checklist](../releases/v0.0.4.md)

--- a/docs/policy/compatibility.md
+++ b/docs/policy/compatibility.md
@@ -18,6 +18,8 @@ release line exists.
 | CLI output text | Experimental |
 | Daemon HTTP API | Experimental |
 | ProofList JSON and typed read binding | Experimental `v0alpha1` and verifier-facing |
+| `artifact` resolve/prove/verify envelope | Profiled `malt.artifact/v0alpha2`; incompatible revisions require a new profile |
+| `SegmentPath` textual projection | `/`-joined UTF-8 segments; experimental before `v1` |
 | MALT root encoding | Experimental |
 | CID codecs and root-kind metadata | Experimental |
 | ArcTable internal storage | Not a public compatibility surface |
@@ -55,10 +57,11 @@ experimental. A verifier should not assume that a ProofList JSON shape or MALT
 root encoding from an unreleased commit will remain compatible with a future
 commit unless release notes say so.
 
-The `v0.0.3` source release names the current typed read/result and ProofList
-binding profile `v0alpha1`. That name does not add an embedded wire-version
-field or a stable JSON Schema. Experimental consumers should pin an exact MALT
-tag or module version and review release notes before upgrading.
+The `v0.0.3` source release names the typed read/result and ProofList binding
+profile `v0alpha1`. The `v0.0.4` source release adds the explicit serialized
+profile `malt.artifact/v0alpha2` and checked-in JSON Schemas for resolve, prove,
+and verify. Consumers must reject unknown profiles, pin an exact MALT tag or
+module version, and review release notes before upgrading.
 
 ArcTable records, local KV paths, materialized indexes, caches, metrics
 counters, and daemon process files are operational state. They are not public

--- a/docs/policy/threat-model.md
+++ b/docs/policy/threat-model.md
@@ -114,9 +114,17 @@ not match the query and evidence.
 ### Path Canonicalization Ambiguity
 
 Path parsing ambiguity can create disagreement between writer, resolver, and
-verifier behavior. Root-relative HTTP and UnixFS path parsers reject ambiguous
-transport paths such as parent traversal forms before typed-query construction.
-Generic map coordinates are not Unix paths: the portable verifier compares them
-using `auth/arcset` canonicalization and does not add transport-layer cleaning.
-Future changes to either policy should include verifier-facing tests and
-documentation updates.
+verifier behavior. The profiled artifact API carries canonical segment arrays;
+it does not apply filesystem dot-segment or whitespace cleaning. Root-relative
+legacy HTTP and UnixFS adapters may reject reserved transport paths before
+typed-query construction. Generic map coordinates are not Unix paths.
+
+### Alternative Valid Derivation
+
+If a root authenticates overlapping arcs, an untrusted resolver may choose a
+different complete derivation than an application expected. The artifact
+verifier proves the returned derivation but does not prove it was longest or
+unique. Applications that require one deterministic namespace must enforce an
+overlap/conflict policy when constructing or accepting the layout. This is
+separate from proof soundness: invalid evidence or a path that does not fully
+consume the requested segments is still rejected.

--- a/docs/releases/v0.0.4.md
+++ b/docs/releases/v0.0.4.md
@@ -1,0 +1,67 @@
+# MALT v0.0.4
+
+MALT `v0.0.4` packages application-neutral graph resolution as canonical
+segments and publishes one proof-carrying artifact contract for gateways,
+daemons, and SDKs.
+
+## Release Contract
+
+- Go module: `github.com/dewebprotocol/malt@v0.0.4`
+- artifact profile: `malt.artifact/v0alpha2`
+- Go package: `github.com/dewebprotocol/malt/artifact`
+- reference routes:
+  - `POST /v1/artifacts/resolve`
+  - `POST /v1/artifacts/prove`
+  - `POST /v1/artifacts/verify`
+- schemas: `artifact/schemas/*.schema.json`
+- codec fixtures: `artifact/testdata/v0alpha2/`
+
+## What Changed
+
+Clients now submit an array such as `["a", "b", "c", "d"]`; they do not
+need to discover that the current graph resolves it through arcs `a/b`, `c`,
+and `d`. `/` is MALT's canonical textual projection, while HTTP, RPC, and
+language SDKs own their transport/application syntax mapping.
+
+The reference resolver prefers the longest available prefix at each root. The
+verifier intentionally does not prove maximality or uniqueness. It accepts one
+complete authenticated derivation for the requested segment path. Applications
+that create overlapping valid derivations own their conflict policy.
+
+The `artifact` package carries the root, query, target, optional measured-range
+segments, and ProofList together. `artifact.Verify` rejects binding mismatches
+before portable cryptographic verification. A zero-segment resolve is the
+root-identity case and carries no proof steps.
+
+## Compatibility
+
+`malt.artifact/v0alpha2` is a versioned pre-`v1` profile. Consumers must reject
+unknown profiles. Future incompatible shapes will use a different profile;
+they will not silently change this discriminator.
+
+The `v0.0.3` typed `malt` facade and legacy daemon resolve/proof-header routes
+remain available. New cross-process integrations should prefer the profiled
+artifact endpoints.
+
+## Security Boundary
+
+Resolvers, ArcTable indexes, gateways, and caches remain untrusted execution
+state. Verification authenticates the returned derivation relative to the
+caller's trusted root. It does not establish root freshness, authorization,
+availability, uniqueness, or application namespace policy.
+
+JSON Schema validation is structural only and never replaces
+`artifact.Verify` or equivalent semantic and cryptographic verification.
+
+## Validation Gate
+
+The release gate requires:
+
+- `git diff --check`
+- `gofmt` check
+- `go test ./...`
+- `go vet ./...`
+- command builds and artifact endpoint smoke tests
+- external-consumer import and schema discovery smoke
+- gateway integration and public web build against the release candidate
+

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -10,10 +10,11 @@ For reader-facing background on hash authentication, Merkle DAGs, and MALT's
 positioning, start with [Concepts](../concepts/README.md). Keep normative
 behavior, wire formats, and proof semantics in this folder.
 
-The current experimental core profile is `v0alpha1`: typed map/list queries,
-root/request/result binding through the module-root `malt` facade, and portable
-ProofList verification through `auth/verifier`. See
-[MIP-1011](../mips/mip-1011-arc-authentication-core-contract.md).
+The current transport-neutral artifact profile is `malt.artifact/v0alpha2`:
+segment-path resolution, primitive typed proofs, and portable verification in a
+versioned envelope. See
+[MIP-1004](../mips/mip-1004-resolve-prooflist-artifact-schema.md) and
+[MIP-1012](../mips/mip-1012-segment-path-resolution.md).
 
 ## Documents
 
@@ -21,6 +22,7 @@ ProofList verification through `auth/verifier`. See
 - [ProofList format](./prooflist-format.md)
 - [Writer receipts](./writer-receipts.md)
 - [Artifacts and schemas](./artifacts.md)
+- [Segment paths and resolution](./segment-paths.md)
 - [Commitment model](./commitment.md)
 - [CID and wire format](./cid-and-wire-format.md)
 - [HTTP API](./http-api.md)

--- a/docs/spec/artifacts.md
+++ b/docs/spec/artifacts.md
@@ -1,84 +1,130 @@
-# Artifacts and Schemas
+# Resolve, Prove, And Verify Artifacts
 
-This document records the current artifact boundaries for CLI JSON, ProofList
-JSON, content-proof headers, and evaluator schemas.
+This document defines the transport-neutral artifact contract introduced in
+MALT `v0.0.4`.
 
-## Status
+## Profile And Ownership
 
-Experimental and implementation-bound. The typed read/result and ProofList
-binding rules form the `v0alpha1` artifact profile introduced in `v0.0.3`. Only
-evaluator schemas currently have machine-readable JSON Schema files in the
-repository; resolve JSON and bare ProofList JSON remain documented Go DTO
-artifacts rather than stable named JSON schemas.
+The serialized profile is `malt.artifact/v0alpha2`. The Go package is the
+unversioned `github.com/dewebprotocol/malt/artifact`; version identifiers live
+in artifact envelopes and schema identifiers rather than package names.
 
-## Current Artifact Surfaces
+The profile is stable by explicit discriminator: consumers must reject an
+unknown `profile` instead of guessing compatibility. It remains pre-`v1` and a
+future incompatible shape will use a different profile value.
 
-| Surface | Current owner | Stability |
-| --- | --- | --- |
-| `malt resolve` JSON | `api/http.ResolveResponse` | Experimental |
-| typed core read | root `malt.ReadRequest` and `malt.ReadResult` | Experimental `v0alpha1` binding contract |
-| bare ProofList JSON | `auth/proof/prooflist.ProofList` | Experimental `v0alpha1` verifier-facing artifact |
-| content proof headers | `server` and `sdk/client` | Experimental |
-| evaluator records | `cmd/eval/schemas` | Versioned where practical |
+The checked-in JSON Schemas live in `artifact/schemas/`, are embedded in the Go
+package, and are available through `artifact.Schema` and
+`artifact.SchemaNames`.
 
-## Resolve JSON
+## Operations
 
-`malt resolve` prints the daemon `ResolveResponse` shape:
+| Operation | Request | Result | Meaning |
+| --- | --- | --- | --- |
+| `resolve` | trusted root plus `segments` | artifact with `query.kind=path` | Authenticate one complete derivation for the supplied segment path. |
+| `prove` | trusted root plus one primitive typed query | artifact with `query.kind=map_key`, `list_index`, or `list_range` | Produce evidence for one primitive semantic query. |
+| `verify` | one complete artifact | `{profile, valid}` | Check envelope bindings and all portable proof evidence. |
+
+The reference HTTP projection is:
+
+```text
+POST /v1/artifacts/resolve
+POST /v1/artifacts/prove
+POST /v1/artifacts/verify
+```
+
+HTTP is only one projection. RPC and SDK integrations should carry the same
+typed fields directly and should not reconstruct path meaning from a URL.
+
+## Resolve Request
 
 ```json
 {
-  "target": "cid-string",
-  "prooflist": {}
+  "profile": "malt.artifact/v0alpha2",
+  "root": "b...",
+  "segments": ["a", "b", "c", "d"]
 }
 ```
 
-The `prooflist` field is omitted when proof generation is disabled. The target
-CID is not self-authenticating as a path result; callers need the root, query,
-target, and ProofList to verify the binding.
+`segments` is the canonical interface. The slash form `a/b/c/d` is only the
+MALT textual projection. See [Segment paths and resolution](./segment-paths.md).
 
-The generic Go facade represents those inputs as `malt.ReadRequest` and
-`malt.ReadResult`, then checks them with `Engine.VerifyRead` or package-level
-`malt.VerifyRead`. The HTTP DTO remains a reference transport projection rather
-than the generic core contract.
+The resulting artifact binds the request, target, and ProofList:
 
-## Bare ProofList JSON
+```json
+{
+  "profile": "malt.artifact/v0alpha2",
+  "operation": "resolve",
+  "root": "b...",
+  "query": {"kind": "path", "segments": ["a", "b", "c", "d"]},
+  "target": "b...",
+  "prooflist": {"root": {"/": "b..."}, "query": "a/b/c/d", "steps": []}
+}
+```
 
-`malt verify --prooflist` accepts a bare ProofList JSON document and also accepts
-resolve JSON containing a `prooflist` field. The structural shape is documented
-in [ProofList format](./prooflist-format.md).
+The abbreviated `steps` value above is not a real non-empty-path proof. A real
+artifact carries every selected proof step. Only a zero-segment root-identity
+resolve has no steps, in which case `target` must equal `root`.
 
-## Content Proof Headers
+The outer artifact uses CID strings for SDK-friendly request/result fields.
+The nested ProofList preserves the existing `go-cid` DAG-JSON link form
+`{"/":"cid"}` for its root, step endpoints, and range segment CIDs.
 
-Default content reads return proof evidence in headers instead of the response
-body:
+## Primitive Prove Request
 
-- `X-Malt-ProofList: <base64url-json>`
-- `X-Malt-ProofList-Encoding: base64url-json`
+Map key:
 
-Clients must decode the header before running ProofList verification.
+```json
+{
+  "profile": "malt.artifact/v0alpha2",
+  "root": "b...",
+  "query": {"kind": "map_key", "segments": ["account", "name"]}
+}
+```
 
-## Machine-Readable Schemas
+List index and measured range queries use `index`, or `start` plus optional
+`end`, respectively. A prove artifact may also carry `range_segments` for the
+ordered CIDs authenticated by a measured-list range proof.
 
-Evaluator JSON schemas live under `cmd/eval/schemas` and are embedded in the
-`malt-eval schema` command. Resolve JSON and bare ProofList JSON do not yet have
-stable named schema files.
+`prove` does not accept `query.kind=path`; multi-step composition belongs to
+`resolve`. Conversely, `resolve` does not erase primitive query kinds.
 
-The `v0.0.3` decision is to keep that boundary: document the `v0alpha1` resolve,
-typed read, and ProofList shapes, but avoid stable named schema files until the
-project is ready to commit to artifact compatibility. JSON shape validation is
-still separate from portable ProofList verification through `auth/verifier`.
+## Verification Contract
 
-If resolve or ProofList artifacts are promoted to stable named schemas, the
-same change should:
+Verification checks all of the following:
 
-- add the schema file in an implementation-owned path
-- add schema listing or discovery if needed by CLI users
-- update CLI help and examples
-- add tests that validate representative artifacts
-- keep schema validation separate from proof verification
+- request and artifact profiles are recognized;
+- root and target are valid CIDs;
+- the artifact root equals the ProofList root;
+- the final ProofList target equals the artifact target;
+- a resolve ProofList query equals the canonical projection of its segments;
+- a prove query and optional range segments match the proof evidence; and
+- the portable verifier accepts every cryptographic/semantic proof step.
 
-## Related Proposals
+Schema validation is not proof verification. A structurally valid JSON object
+must still pass `artifact.Verify` or an equivalent conforming implementation.
 
-[MIP-1004](../mips/mip-1004-resolve-prooflist-artifact-schema.md) tracks the
-decision about whether resolve JSON, bare ProofList JSON, and content proof
-metadata need stable named schemas.
+Resolution proofs are existential. They prove the ordered authenticated
+derivation returned by the execution engine. They do not prove that the
+derivation was unique, globally shortest, globally longest, or preferred by an
+application. Candidate choice can affect behavior and availability, but an
+accepted artifact always authenticates the returned path-to-target binding.
+
+## Legacy Transport Surfaces
+
+The legacy `malt resolve` DTO, bare ProofList input, `/verify`, and proof headers
+remain available as reference/compatibility surfaces in `v0.0.4`. New gateway,
+daemon, and SDK integrations should use the profiled artifact contract so the
+root, query, target, and evidence travel together.
+
+## Schemas
+
+- `artifact.schema.json`
+- `resolve-request.schema.json`
+- `prove-request.schema.json`
+- `verify-request.schema.json`
+- `verify-result.schema.json`
+
+Schema `$id` values are rooted at
+`https://deweb.world/schemas/malt/artifact/v0alpha2/`. The repository copy and
+embedded package data are authoritative for this release.

--- a/docs/spec/http-api.md
+++ b/docs/spec/http-api.md
@@ -10,9 +10,12 @@ Experimental and implementation-bound. Breaking route or DTO changes are
 allowed before a stable release, but they should update tests and docs in the
 same PR.
 
-This API is a reference transport projection. The application-neutral core
-contract is the module-root `malt` facade; managed gateways do not need to
-import `server` or reproduce these routes.
+Most of this API is a reference transport projection. The application-neutral
+core contract is the module-root `malt` facade; managed gateways do not need to
+import `server` or reproduce the local runtime routes. The three
+`/v1/artifacts/*` routes are the stable transport projection for new gateway,
+daemon, and SDK integrations. Their schemas are defined in
+[Artifacts and schemas](./artifacts.md).
 
 ## Core Routes
 
@@ -23,6 +26,9 @@ import `server` or reproduce these routes.
 | `/metrics` | `GET` | Runtime evaluation counters. |
 | `/metrics:reset` | `POST` | Reset runtime evaluation counters. |
 | `/verify` | `POST` | Verify a ProofList through the portable auth verifier adapter. |
+| `/v1/artifacts/resolve` | `POST` | Resolve a segment array and return a profiled proof-carrying artifact. |
+| `/v1/artifacts/prove` | `POST` | Prove one primitive typed map/list query. |
+| `/v1/artifacts/verify` | `POST` | Verify a complete profiled artifact. |
 | `/{root}/_mutate` | `POST` | Apply a root-relative semantic mutation. |
 | `/_unixfs?path=...` | `POST` | Create a new UnixFS-style root from uploaded payload data. |
 | `/resolve/{root}` and `/resolve/{root}/{path...}` | `GET` | Resolve a target CID and optional ProofList. |
@@ -125,7 +131,7 @@ through browser CORS by default.
 
 - [MIP-1002](../mips/mip-1002-writer-receipt-accounting.md) tracks receipt
   accounting decisions.
-- [MIP-1004](../mips/mip-1004-resolve-prooflist-artifact-schema.md) tracks the
-  decision about stable named schemas for resolve and ProofList artifacts.
+- [MIP-1004](../mips/mip-1004-resolve-prooflist-artifact-schema.md) defines the
+  profiled resolve/prove/verify artifacts and named schemas.
 - [MIP-1011](../mips/mip-1011-arc-authentication-core-contract.md) defines the
   transport-independent typed read and verification boundary.

--- a/docs/spec/segment-paths.md
+++ b/docs/spec/segment-paths.md
@@ -1,0 +1,73 @@
+# Segment Paths And Resolution
+
+## Canonical Path Model
+
+MALT defines an application-neutral path as an ordered array of UTF-8 segments.
+Each segment is non-empty and cannot contain the MALT textual separator `/`.
+The empty array denotes the caller-supplied root.
+
+```text
+["a", "b", "c", "d"] <-> a/b/c/d
+```
+
+The array is the canonical API form. `/` is the canonical MALT textual
+projection used by current map coordinates and slash-path adapters; it is not a
+requirement that every transport expose a slash-delimited string.
+
+Examples:
+
+- HTTP can map URL path components to segments.
+- RPC can send a repeated string field directly.
+- a TypeScript SDK can map object access syntax such as `user.name` or
+  `items[0]` to application-selected segments before calling MALT.
+
+MALT does not parse JavaScript property syntax, filesystem dot-segment rules,
+JSON Pointer escaping, or another application's grammar. Values such as `.` and
+`..` are ordinary MALT segments; an HTTP/file adapter may reject or escape them
+according to its own transport policy.
+
+The module-root `malt.SegmentPath`, `malt.NewSegmentPath`, and
+`malt.ParseSegmentPath` implement this contract.
+
+## Arc Selection And Composition
+
+One MALT map arc may consume one or more leading segments. Given the requested
+path:
+
+```text
+["a", "b", "c", "d"]
+```
+
+an execution engine may select the following authenticated derivation:
+
+```text
+root1 --"a/b"--> root2 --"c"--> root3 --"d"--> target
+```
+
+The reference resolver uses longest-prefix lookup at each root as its candidate
+selection strategy. This lets clients submit segments without discovering arc
+boundaries first and keeps ArcTable/index lookup outside the trusted kernel.
+
+## Acceptance Semantics
+
+Longest-prefix selection is not a verifier claim. Verification accepts one
+complete ordered derivation whose consumed arc coordinates concatenate to the
+requested segment path and whose evidence is valid from the trusted root to the
+returned target.
+
+The proof does not establish that a longer competing arc was absent. It also
+does not establish uniqueness, global optimality, or application preference.
+Multiple authenticated derivations are a supported graph feature. If an
+application permits overlapping arcs such as `a`, `a/b`, and `a/b/c`, its
+layout or client policy decides whether those alternatives are meaningful or a
+conflict. In a normal well-formed layout, an unintended alternative derivation
+should fail to consume and resolve the remaining segments.
+
+This division keeps the contract small:
+
+- core owns segments, canonical arc projection, proof-carrying composition,
+  and verification of the returned derivation;
+- execution owns candidate discovery and may prefer longest-prefix lookup;
+- applications/layouts own their namespace, overlap, and conflict policy;
+- transports own URL, RPC, object-syntax, and escaping rules.
+

--- a/path.go
+++ b/path.go
@@ -1,0 +1,85 @@
+package malt
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// PathSeparator is the canonical textual separator for MALT segment paths.
+// Transports may carry segments without using this textual projection.
+const PathSeparator = "/"
+
+// SegmentPath is an immutable application-neutral sequence of MALT path
+// segments. Applications and transports decide how their own path syntax maps
+// to segments; MALT owns the canonical segment-to-arc projection.
+type SegmentPath struct {
+	segments []string
+}
+
+// NewSegmentPath validates and clones a segment sequence. Segments are
+// non-empty UTF-8 strings and must not contain the canonical separator.
+func NewSegmentPath(segments []string) (SegmentPath, error) {
+	cloned := make([]string, len(segments))
+	for i, segment := range segments {
+		if segment == "" {
+			return SegmentPath{}, fmt.Errorf("MALT path segment %d is empty", i)
+		}
+		if !utf8.ValidString(segment) {
+			return SegmentPath{}, fmt.Errorf("MALT path segment %d is not valid UTF-8", i)
+		}
+		if strings.Contains(segment, PathSeparator) {
+			return SegmentPath{}, fmt.Errorf("MALT path segment %d contains separator %q", i, PathSeparator)
+		}
+		cloned[i] = segment
+	}
+	return SegmentPath{segments: cloned}, nil
+}
+
+// ParseSegmentPath parses the canonical textual projection used by the
+// reference slash-path adapters. The empty string denotes the root path.
+func ParseSegmentPath(raw string) (SegmentPath, error) {
+	if raw == "" {
+		return SegmentPath{}, nil
+	}
+	if strings.HasPrefix(raw, PathSeparator) || strings.HasSuffix(raw, PathSeparator) {
+		return SegmentPath{}, fmt.Errorf("MALT path must not start or end with %q", PathSeparator)
+	}
+	return NewSegmentPath(strings.Split(raw, PathSeparator))
+}
+
+// Segments returns a cloned segment slice.
+func (p SegmentPath) Segments() []string {
+	return append([]string(nil), p.segments...)
+}
+
+// String returns the canonical textual projection.
+func (p SegmentPath) String() string {
+	return strings.Join(p.segments, PathSeparator)
+}
+
+// Empty reports whether the path denotes the caller-supplied root.
+func (p SegmentPath) Empty() bool {
+	return len(p.segments) == 0
+}
+
+// HasPrefix reports whether prefix is a segment-aligned prefix of p.
+func (p SegmentPath) HasPrefix(prefix SegmentPath) bool {
+	if len(prefix.segments) > len(p.segments) {
+		return false
+	}
+	for i := range prefix.segments {
+		if p.segments[i] != prefix.segments[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Consume removes a segment-aligned prefix.
+func (p SegmentPath) Consume(prefix SegmentPath) (SegmentPath, bool) {
+	if !p.HasPrefix(prefix) {
+		return SegmentPath{}, false
+	}
+	return SegmentPath{segments: append([]string(nil), p.segments[len(prefix.segments):]...)}, true
+}

--- a/path_test.go
+++ b/path_test.go
@@ -1,0 +1,50 @@
+package malt_test
+
+import (
+	"reflect"
+	"testing"
+
+	malt "github.com/dewebprotocol/malt"
+)
+
+func TestSegmentPathRoundTripAndConsume(t *testing.T) {
+	path, err := malt.NewSegmentPath([]string{"a", "b", "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := path.String(), "a/b/c"; got != want {
+		t.Fatalf("String() = %q, want %q", got, want)
+	}
+	prefix, err := malt.ParseSegmentPath("a/b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	remaining, ok := path.Consume(prefix)
+	if !ok {
+		t.Fatal("Consume() rejected valid prefix")
+	}
+	if got, want := remaining.Segments(), []string{"c"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("remaining = %#v, want %#v", got, want)
+	}
+}
+
+func TestSegmentPathRejectsAmbiguousText(t *testing.T) {
+	for _, raw := range []string{"/a", "a/", "a//b"} {
+		if _, err := malt.ParseSegmentPath(raw); err == nil {
+			t.Fatalf("ParseSegmentPath(%q) succeeded", raw)
+		}
+	}
+	if _, err := malt.NewSegmentPath([]string{"a/b"}); err == nil {
+		t.Fatal("NewSegmentPath accepted a segment containing the separator")
+	}
+}
+
+func TestSegmentPathEmptyDenotesRoot(t *testing.T) {
+	path, err := malt.ParseSegmentPath("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !path.Empty() || path.String() != "" || len(path.Segments()) != 0 {
+		t.Fatalf("empty path = %#v", path)
+	}
+}

--- a/server/cors.go
+++ b/server/cors.go
@@ -155,7 +155,16 @@ func browserCORSRouteAllowed(method, rawPath string) bool {
 	case http.MethodGet, http.MethodHead:
 		return browserCORSReadPathAllowed(rawPath)
 	case http.MethodPost:
-		return rawPath == "/verify" || browserCORSUnixFSWritePathAllowed(rawPath)
+		return rawPath == "/verify" || browserCORSArtifactRouteAllowed(rawPath) || browserCORSUnixFSWritePathAllowed(rawPath)
+	default:
+		return false
+	}
+}
+
+func browserCORSArtifactRouteAllowed(rawPath string) bool {
+	switch rawPath {
+	case "/v1/artifacts/resolve", "/v1/artifacts/prove", "/v1/artifacts/verify":
+		return true
 	default:
 		return false
 	}

--- a/server/cors_test.go
+++ b/server/cors_test.go
@@ -58,6 +58,24 @@ func TestBrowserCORSAllowsConfiguredResolveAndVerifyRoutes(t *testing.T) {
 			t.Fatalf("Access-Control-Allow-Headers = %q, want content-type", headers)
 		}
 	})
+
+	for _, path := range []string{"/v1/artifacts/resolve", "/v1/artifacts/prove", "/v1/artifacts/verify"} {
+		t.Run(path+" POST preflight", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodOptions, path, nil)
+			req.Header.Set("Origin", "https://docs.example")
+			req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+			req.Header.Set("Access-Control-Request-Headers", "content-type")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("preflight status = %d, want %d", rec.Code, http.StatusNoContent)
+			}
+			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://docs.example" {
+				t.Fatalf("Access-Control-Allow-Origin = %q", got)
+			}
+		})
+	}
 }
 
 func TestBrowserCORSAllowsConfiguredUnixFSWriteRoutes(t *testing.T) {

--- a/server/routes_artifacts.go
+++ b/server/routes_artifacts.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+
+	malt "github.com/dewebprotocol/malt"
+	"github.com/dewebprotocol/malt/artifact"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	authverifier "github.com/dewebprotocol/malt/auth/verifier"
+	cid "github.com/ipfs/go-cid"
+)
+
+func (s *Server) handleArtifactResolve(w http.ResponseWriter, r *http.Request) {
+	var req artifact.ResolveRequest
+	if err := s.decodeJSONBody(w, r, &req); err != nil {
+		writeBodyDecodeError(w, err)
+		return
+	}
+	if err := req.Validate(); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	root, _ := cid.Parse(req.Root)
+	path, _ := malt.NewSegmentPath(req.Segments)
+	svc, err := s.graphService(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	resolved, err := svc.runtime.Resolver().ResolveKey(r.Context(), root, path.String())
+	if err != nil {
+		writeError(w, resolvePathStatus(err), err.Error())
+		return
+	}
+	if !resolved.RemainingPath.IsEmpty() || !resolved.Target.Defined() {
+		writeError(w, http.StatusNotFound, "segment path was not fully resolved")
+		return
+	}
+	pl, err := svc.ProofList(root, path.String(), resolved.Transcript)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	result, err := artifact.NewResolveArtifact(req, resolved.Target, *pl)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.node.RecordProofList(result.ProofList)
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) handleArtifactProve(w http.ResponseWriter, r *http.Request) {
+	var req artifact.ProveRequest
+	if err := s.decodeJSONBody(w, r, &req); err != nil {
+		writeBodyDecodeError(w, err)
+		return
+	}
+	if err := req.Validate(); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	root, _ := cid.Parse(req.Root)
+	query, _ := req.Query.Core()
+
+	svc, err := s.graphService(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	engine, err := malt.NewEngine(malt.EngineOptions{
+		Scope:    svc.runtime.Namespace(),
+		Maps:     svc.runtime.Semantic(),
+		Lists:    svc.runtime.ListSemantic(),
+		Writer:   svc.runtime.Writer(),
+		Verifier: authverifier.New(svc.runtime.Semantic(), svc.runtime.ListSemantic()),
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	readResult, err := engine.Read(r.Context(), malt.ReadRequest{Root: root, Query: query})
+	if err != nil {
+		status := http.StatusInternalServerError
+		if malt.IsQueryNotFound(err) || errors.Is(err, mapping.ErrPathNotFound) {
+			status = http.StatusNotFound
+		}
+		writeError(w, status, err.Error())
+		return
+	}
+	result, err := artifact.NewProveArtifact(req, readResult)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.node.RecordProofList(result.ProofList)
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) handleArtifactVerify(w http.ResponseWriter, r *http.Request) {
+	var req artifact.VerifyRequest
+	if err := s.decodeJSONBody(w, r, &req); err != nil {
+		writeBodyDecodeError(w, err)
+		return
+	}
+	if err := req.Validate(); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	svc, err := s.graphService(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	verifier := authverifier.New(svc.runtime.Semantic(), svc.runtime.ListSemantic())
+	if err := artifact.Verify(r.Context(), req, verifier); err != nil {
+		writeJSON(w, http.StatusOK, artifact.VerifyResult{Profile: artifact.Profile, Valid: false})
+		return
+	}
+	writeJSON(w, http.StatusOK, artifact.VerifyResult{Profile: artifact.Profile, Valid: true})
+}

--- a/server/routes_artifacts_test.go
+++ b/server/routes_artifacts_test.go
@@ -1,0 +1,176 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	httpapi "github.com/dewebprotocol/malt/api/http"
+	"github.com/dewebprotocol/malt/artifact"
+	casmock "github.com/dewebprotocol/malt/storage/cas/mock"
+)
+
+func TestArtifactResolveProveVerify(t *testing.T) {
+	node := newTestNode(t)
+	mockCAS, ok := node.CAS().(*casmock.CAS)
+	if !ok {
+		t.Fatal("expected mock CAS")
+	}
+
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	targetCID, err := mockCAS.Put(t.Context(), []byte("artifact target"))
+	if err != nil {
+		t.Fatalf("put target: %v", err)
+	}
+	createBody, err := json.Marshal(&httpapi.CreateStructureRequest{
+		Arcs: withPayloadBinding(map[string]string{"name": targetCID.String(), ".": targetCID.String()}),
+	})
+	if err != nil {
+		t.Fatalf("marshal create request: %v", err)
+	}
+	resp, err := http.Post(ts.URL+"/_", "application/json", bytes.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create root status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var created httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	resolved := postArtifactRequest[artifact.ResolveRequest, artifact.Artifact](t, ts.URL+"/v1/artifacts/resolve", artifact.ResolveRequest{
+		Profile:  artifact.Profile,
+		Root:     created.Root,
+		Segments: []string{"name"},
+	})
+	if resolved.Operation != artifact.OperationResolve {
+		t.Fatalf("resolve operation = %q, want %q", resolved.Operation, artifact.OperationResolve)
+	}
+	if resolved.Target != targetCID.String() {
+		t.Fatalf("resolve target = %q, want %q", resolved.Target, targetCID)
+	}
+	verified := postArtifactRequest[artifact.VerifyRequest, artifact.VerifyResult](t, ts.URL+"/v1/artifacts/verify", artifact.VerifyRequest{
+		Profile:  artifact.Profile,
+		Artifact: resolved,
+	})
+	if !verified.Valid {
+		t.Fatal("resolve artifact did not verify")
+	}
+	dotResolved := postArtifactRequest[artifact.ResolveRequest, artifact.Artifact](t, ts.URL+"/v1/artifacts/resolve", artifact.ResolveRequest{
+		Profile:  artifact.Profile,
+		Root:     created.Root,
+		Segments: []string{"."},
+	})
+	if dotResolved.Target != targetCID.String() {
+		t.Fatalf("dot-coordinate target = %q, want %q", dotResolved.Target, targetCID)
+	}
+	dotVerified := postArtifactRequest[artifact.VerifyRequest, artifact.VerifyResult](t, ts.URL+"/v1/artifacts/verify", artifact.VerifyRequest{
+		Profile: artifact.Profile, Artifact: dotResolved,
+	})
+	if !dotVerified.Valid {
+		t.Fatal("dot-coordinate artifact did not verify")
+	}
+
+	proved := postArtifactRequest[artifact.ProveRequest, artifact.Artifact](t, ts.URL+"/v1/artifacts/prove", artifact.ProveRequest{
+		Profile: artifact.Profile,
+		Root:    created.Root,
+		Query: artifact.Query{
+			Kind:     artifact.QueryMapKey,
+			Segments: []string{"name"},
+		},
+	})
+	if proved.Operation != artifact.OperationProve {
+		t.Fatalf("prove operation = %q, want %q", proved.Operation, artifact.OperationProve)
+	}
+	verified = postArtifactRequest[artifact.VerifyRequest, artifact.VerifyResult](t, ts.URL+"/v1/artifacts/verify", artifact.VerifyRequest{
+		Profile:  artifact.Profile,
+		Artifact: proved,
+	})
+	if !verified.Valid {
+		t.Fatal("prove artifact did not verify")
+	}
+
+	resolved.Target = created.Root
+	verified = postArtifactRequest[artifact.VerifyRequest, artifact.VerifyResult](t, ts.URL+"/v1/artifacts/verify", artifact.VerifyRequest{
+		Profile:  artifact.Profile,
+		Artifact: resolved,
+	})
+	if verified.Valid {
+		t.Fatal("tampered artifact verified")
+	}
+}
+
+func TestArtifactResolveRootIdentity(t *testing.T) {
+	node := newTestNode(t)
+	ts := httptest.NewServer(New(node, "127.0.0.1:0").Handler())
+	defer ts.Close()
+
+	mockCAS := node.CAS().(*casmock.CAS)
+	targetCID, err := mockCAS.Put(t.Context(), []byte("identity target"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := postCreateStructure(t, ts.URL, withPayloadBinding(map[string]string{"name": targetCID.String()}))
+	resolved := postArtifactRequest[artifact.ResolveRequest, artifact.Artifact](t, ts.URL+"/v1/artifacts/resolve", artifact.ResolveRequest{
+		Profile: artifact.Profile,
+		Root:    created.Root,
+	})
+	if resolved.Target != created.Root || len(resolved.ProofList.Steps) != 0 {
+		t.Fatalf("identity artifact = %+v", resolved)
+	}
+	verified := postArtifactRequest[artifact.VerifyRequest, artifact.VerifyResult](t, ts.URL+"/v1/artifacts/verify", artifact.VerifyRequest{
+		Profile: artifact.Profile, Artifact: resolved,
+	})
+	if !verified.Valid {
+		t.Fatal("root identity artifact did not verify")
+	}
+}
+
+func postCreateStructure(t *testing.T, baseURL string, arcs map[string]string) httpapi.CreateStructureResponse {
+	t.Helper()
+	body, err := json.Marshal(&httpapi.CreateStructureRequest{Arcs: arcs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(baseURL+"/_", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create root status = %d", resp.StatusCode)
+	}
+	var created httpapi.CreateStructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	return created
+}
+
+func postArtifactRequest[Request, Response any](t *testing.T, url string, request Request) Response {
+	t.Helper()
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("post %s status = %d, want %d", url, resp.StatusCode, http.StatusOK)
+	}
+	var response Response
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return response
+}

--- a/server/server.go
+++ b/server/server.go
@@ -193,6 +193,9 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /metrics", s.handleMetrics)
 	mux.HandleFunc("POST /metrics:reset", s.handleMetricsReset)
 	mux.HandleFunc("POST /verify", s.handleVerify)
+	mux.HandleFunc("POST /v1/artifacts/resolve", s.handleArtifactResolve)
+	mux.HandleFunc("POST /v1/artifacts/prove", s.handleArtifactProve)
+	mux.HandleFunc("POST /v1/artifacts/verify", s.handleArtifactVerify)
 
 	// Removed public APIs stay reserved so they do not fall through to root
 	// content routes.


### PR DESCRIPTION
## Summary

- define canonical MALT segment paths and proof-carrying multi-arc resolution
- publish the unversioned `artifact` package with the `malt.artifact/v0alpha2` resolve/prove/verify contract
- add embedded JSON Schemas, conformance fixtures, reference HTTP endpoints, CORS coverage, and import-boundary guards
- document existential resolution semantics: the returned derivation is authenticated without claiming longest-path maximality or uniqueness
- finalize MIP-1004, add MIP-1012, and update release, architecture, compatibility, threat-model, and roadmap documentation for v0.0.4

## Validation

- `git diff --check`
- `gofmt` check
- `go test ./...`
- `go vet ./...`
- built `malt`, `cas`, and `malt-eval`
- external consumer imported `malt.SegmentPath`, `artifact.Profile`, and embedded schema discovery
- endpoint tests cover resolve, primitive prove, verify, root identity, generic dot coordinates, tampering, and browser CORS

## Release flow

This PR is the v0.0.4 core candidate. After merge, the same approved commit will be tagged `v0.0.4-rc.1`, exercised through gateway/web integration, and then promoted to `v0.0.4` if the product smoke passes.