### PR TITLE
docs: prepare v0.0.5 release

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,9 @@ the separate `DeWebProtocol/gateway` service repository or private deployment
 overlays.
 
 ```text
+execution.Executor.Resolve(ResolveRequest{Root, Segments}) -> ResolveResult{Target, ProofList}
+VerifyResolve(request, result) -> valid / invalid
+
 execution.Executor.Read(ReadRequest{Root, Query}) -> ReadResult{Target, Segments, ProofList}
 VerifyRead(request, result) -> valid / invalid
 
@@ -37,12 +40,13 @@ List and map are semantic abstractions:
   to target CIDs
 
 The module-root `package malt` is the typed, application-neutral verification
-facade. It defines query/result bindings and `VerifyRead`; portable mutation
-values live in `mutation`. The separate `execution.Executor` composes map/list
-provers and mutation appliers while hiding runtime scope from canonical
-requests. Execution is untrusted: clients bind a caller-selected root and typed
-query to the returned target, optional range segments, and ProofList before the
-portable verifier checks the evidence.
+facade. It defines resolve/read request and result bindings plus
+`VerifyResolve`/`VerifyRead`; portable mutation values live in `mutation`. The
+separate `execution.Executor` composes path resolution, map/list proof
+generation, and mutation application while hiding runtime scope from canonical
+requests. Execution is untrusted: clients bind a caller-selected root and
+segments or typed query to the returned target, optional range segments, and
+ProofList before the portable verifier checks the evidence.
 
 `malt.SegmentPath` is the application-neutral composition coordinate. Clients
 send segment arrays; the reference resolver may consume multiple leading
@@ -360,7 +364,7 @@ malt/
 |   |-- resolver/     # resolver read port and explicit proof path
 |   `-- writer/       # reference mutation executor
 |-- mutation/         # portable mutation/delta/receipt contracts
-|-- execution/        # untrusted read/apply composition
+|-- execution/        # untrusted resolve/read/apply composition
 |-- model/unixfs/     # UnixFS application model/profile
 |-- runtime/          # node, graph composition, ArcTable, metrics, and semantic implementations
 |   `-- unixfs/       # optional UnixFS execution/content adapter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.5] - 2026-07-13
+
 ### Added
 
+- Operation-specific `malt.resolve/v0alpha1` and `malt.read/v0alpha1`
+  request, result, verification, JSON Schema, and reference HTTP contracts.
 - Portable `mutation` value contracts and a separate untrusted
-  `execution.Executor` facade.
+  `execution.Executor` facade implementing resolve, primitive read, and apply.
 - Client-local `sdk/verifier` plus a reproducible browser/WASM verifier build.
 - Explicit UnixFS `model/unixfs`, `sdk/unixfs`, and `runtime/unixfs` boundaries.
 
@@ -97,6 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - KZG verification rejects out-of-range proof indices and non-canonical proof
   lengths instead of allowing malformed input to panic or reuse a commitment.
 
-[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.4...HEAD
+[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.5...HEAD
+[0.0.5]: https://github.com/DeWebProtocol/malt/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/DeWebProtocol/malt/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/DeWebProtocol/malt/compare/v0.0.2...v0.0.3

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ managed product gateway lives outside this repository.
 [Threat Model](./docs/policy/threat-model.md) ·
 [Compatibility](./docs/policy/compatibility.md) · [Evaluation](./docs/evaluation.md) ·
 [MIPs](./docs/mips/README.md) ·
-[v0.0.4 Release](./docs/releases/v0.0.4.md) ·
+[v0.0.5 Release](./docs/releases/v0.0.5.md) ·
 [Roadmap](./ROADMAP.md) · [Security](./SECURITY.md) ·
 [Contributing](./CONTRIBUTING.md)
 
@@ -149,23 +149,25 @@ Current experimental boundaries:
 - large-file byte-range response bodies must be bound to authenticated segment
   CIDs with `sdk/unixfs.VerifyRangeBody` after local ProofList verification
 
-The `v0.0.4` source release adds canonical segment paths and the frozen
-`malt.artifact/v0alpha2` resolve/prove/verify compatibility profile with
-embedded JSON Schemas. Integrators should pin the exact release and reject
+The `v0.0.5` source release adds operation-specific
+`malt.resolve/v0alpha1` and `malt.read/v0alpha1` contracts, separates trusted
+client verification from untrusted resolve/read/apply execution, and splits
+the UnixFS application into model, client-SDK, and reference-runtime packages.
+The `malt.artifact/v0alpha2` profile released by v0.0.4 remains frozen
+compatibility behavior. Integrators should pin the exact release and reject
 unknown profiles:
 
 ```bash
-go get github.com/dewebprotocol/malt@v0.0.4
+go get github.com/dewebprotocol/malt@v0.0.5
 ```
 
-See the [release notes](./docs/releases/v0.0.4.md), the
+See the [release notes](./docs/releases/v0.0.5.md), the
 [artifact contract](./docs/spec/artifacts.md), and the
-[GitHub Release](https://github.com/DeWebProtocol/malt/releases/tag/v0.0.4).
+[GitHub Release](https://github.com/DeWebProtocol/malt/releases/tag/v0.0.5).
 
-The active pre-release contract on this branch replaces the generic artifact
-union for new integrations with `malt.resolve/v0alpha1` and
-`malt.read/v0alpha1`. Payload selection is an explicit `@payload` segment. See
-[Resolve and read contracts](./docs/spec/resolve-read-contracts.md).
+New integrations use the operation-specific resolve/read contracts rather than
+extending the generic artifact union. Payload selection is an explicit
+`@payload` segment. See [Resolve and read contracts](./docs/spec/resolve-read-contracts.md).
 
 ## Use Cases
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,12 +10,13 @@ MALT is an experimental reference implementation. It is runnable end to end, but
 its public APIs, ProofList schemas, wire formats, and deployment policies may
 change. It is not production-ready.
 
-`v0.0.4` establishes canonical segment-path composition and profiled
-resolve/prove/verify artifacts. The post-release focus is to consume that
-contract from product and application layers without importing the reference
-server or treating UnixFS as the core abstraction.
+`v0.0.5` establishes operation-specific resolve/read contracts, client-local
+verification, an untrusted resolve/read/apply executor, and explicit UnixFS
+model/SDK/runtime ownership. The post-release focus is to harden conformance
+and product integration without importing the reference server or treating
+UnixFS as the core abstraction.
 
-## Completed In The Active Core-Boundary Refactor
+## Completed In v0.0.5
 
 - Separate portable mutation values from graph writer execution.
 - Move proof generation and mutation application behind `execution.Executor`.
@@ -32,12 +33,12 @@ server or treating UnixFS as the core abstraction.
 - Implement a standalone client agent/daemon for local root selection,
   upload/synchronization, local verification, and gateway interaction. This is
   distinct from the existing reference executor process.
-- Expand `malt.artifact/v0alpha2` conformance vectors with KZG/IPA map, list,
-  multi-hop resolve, and measured-range examples before cross-language SDKs
-  depend on it.
-- After the tightened core boundary is reviewed, demonstrate a second
-  application model such as a PoDs-style datastore or agent-memory relation
-  model.
+- Expand `malt.resolve/v0alpha1` and `malt.read/v0alpha1` conformance vectors
+  with KZG/IPA map, list, multi-hop resolve, identity, payload, measured-range,
+  cross-kind, and cross-root cases before cross-language SDKs depend on them.
+- After resolve/read conformance and the UnixFS product path are stable,
+  demonstrate a second application model such as a PoDs-style datastore or
+  agent-memory relation model.
 - Refresh paper-grade evaluation artifacts with locked workloads, repeated
   runs, backend/config labels, and explicit aggregation policy.
 - Keep `auth/verifier` free of runtime, storage, layout, server, daemon, and
@@ -95,3 +96,18 @@ The `v0.0.4` source release adds:
 - root-identity codec fixtures and end-to-end artifact verification tests
 
 See [`docs/releases/v0.0.4.md`](docs/releases/v0.0.4.md).
+
+## v0.0.5 Release Layer
+
+The `v0.0.5` source release adds:
+
+- operation-specific `malt.resolve/v0alpha1` and `malt.read/v0alpha1` contracts
+- caller-request-bound `VerifyResolve` and `VerifyRead` trust decisions
+- untrusted `execution.Executor` resolve/read/apply composition
+- portable mutation values under `mutation`
+- separate `model/unixfs`, `sdk/unixfs`, and `runtime/unixfs` ownership
+- local Go, CLI, and browser/WASM verification with diagnostic-only remote
+  verify routes
+- frozen compatibility for the v0.0.4 `malt.artifact/v0alpha2` operation set
+
+See [`docs/releases/v0.0.5.md`](docs/releases/v0.0.5.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,13 +13,13 @@ persistence.
 | Version | Security support |
 | --- | --- |
 | `main` | Best-effort review of current integration code |
-| `v0.0.4` | Current supported experimental source release |
-| `v0.0.3` | Previous experimental source release |
-| `v0.0.2` and earlier | Not supported |
+| `v0.0.5` | Current supported experimental source release |
+| `v0.0.4` | Previous experimental source release |
+| `v0.0.3` and earlier | Not supported |
 
 MALT remains pre-`v1.0.0` and experimental. Security fixes may require
 breaking API, proof, root, or wire-format changes. Reproducible consumers
-should pin `v0.0.4` rather than depend on `main`.
+should pin `v0.0.5` rather than depend on `main`.
 
 ## Reporting a Vulnerability
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ reference/evaluation executor only to exercise MALT core end to end.
 - [Threat model](./policy/threat-model.md)
 - [Compatibility policy](./policy/compatibility.md)
 - [Release process](./policy/releasing.md)
+- [v0.0.5 release notes](./releases/v0.0.5.md)
 - [v0.0.4 release notes](./releases/v0.0.4.md)
 
 ## Evaluation
@@ -52,9 +53,9 @@ removed after migration. New implementation-bound MIP work should happen here.
 The current public-core contracts are
 [MIP-1011: Arc Authentication Core Contract](./mips/mip-1011-arc-authentication-core-contract.md),
 [MIP-1012: Segment Path Resolution](./mips/mip-1012-segment-path-resolution.md),
-the active
+the final
 [MIP-1013: Client, Gateway, And Core Responsibility Boundary](./mips/mip-1013-client-gateway-core-boundary.md),
-the operation-specific resolve/read profiles in that active MIP, and the
+the operation-specific resolve/read profiles introduced by that MIP, and the
 frozen v0.0.4 artifact compatibility profile recorded by
 [MIP-1004](./mips/mip-1004-resolve-prooflist-artifact-schema.md).
 

--- a/docs/mips/README.md
+++ b/docs/mips/README.md
@@ -86,7 +86,7 @@ not become the only copy of a schema or specification.
 | [MIP-1010](mip-1010-data-authentication-core-boundary.md) | Final | Standards Track | Core | Record the completed package-ownership split among authentication, graph ports, layouts, runtime, storage, SDK, and transport code. |
 | [MIP-1011](mip-1011-arc-authentication-core-contract.md) | Final | Standards Track | Core | Define the portable arc-level `Read`/`Apply`/`VerifyRead` contract introduced in `v0.0.3`. |
 | [MIP-1012](mip-1012-segment-path-resolution.md) | Final | Standards Track | Core | Define segment arrays, proof-carrying arc composition, and existential resolution. |
-| [MIP-1013](mip-1013-client-gateway-core-boundary.md) | In Progress | Standards Track | Core | Separate client trust, gateway execution, CAS payload, and UnixFS application-model responsibilities. |
+| [MIP-1013](mip-1013-client-gateway-core-boundary.md) | Final | Standards Track | Core | Separate client trust, gateway execution, CAS payload, and UnixFS application-model responsibilities. |
 
 ## Promotion Protocol
 

--- a/docs/mips/mip-1013-client-gateway-core-boundary.md
+++ b/docs/mips/mip-1013-client-gateway-core-boundary.md
@@ -3,7 +3,7 @@ mip: 1013
 title: Client, Gateway, And Core Responsibility Boundary
 description: Separate client trust decisions, gateway execution, CAS payload storage, and UnixFS application-model responsibilities.
 author: MALT maintainers
-status: In Progress
+status: Final
 type: Standards Track
 category: Core
 created: 2026-07-13
@@ -147,8 +147,7 @@ multi-writer policy remain application or managed-gateway concerns.
 
 ## Implementation Status
 
-The active implementation branch introduces the package split,
-operation-specific resolve/read profiles, local CLI and browser/WASM verifier,
-import-boundary tests, reference-executor terminology, and diagnostic remote
-verification. Move this MIP to Final only after that PR is merged and current
-documentation points at the merged package paths.
+Implemented by PR #163 and released in v0.0.5. The release includes the package
+split, operation-specific resolve/read profiles, local CLI and browser/WASM
+verification, import-boundary tests, reference-executor terminology, and
+diagnostic-only remote verification.

--- a/docs/policy/README.md
+++ b/docs/policy/README.md
@@ -5,4 +5,5 @@ This folder collects implementation-bound policy and release documents.
 - [Threat model](./threat-model.md)
 - [Compatibility policy](./compatibility.md)
 - [Release process](./releasing.md)
+- [v0.0.5 release notes and checklist](../releases/v0.0.5.md)
 - [v0.0.4 release notes and checklist](../releases/v0.0.4.md)

--- a/docs/policy/compatibility.md
+++ b/docs/policy/compatibility.md
@@ -62,8 +62,8 @@ commit unless release notes say so.
 The `v0.0.3` source release names the typed read/result and ProofList binding
 profile `v0alpha1`. The `v0.0.4` source release adds the explicit serialized
 profile `malt.artifact/v0alpha2` and checked-in JSON Schemas for `resolve`,
-`prove`, and `verify`. That operation set is frozen. Current unreleased work
-defines new operation-specific `malt.resolve/v0alpha1` and
+`prove`, and `verify`. That operation set is frozen. The `v0.0.5` source
+release defines operation-specific `malt.resolve/v0alpha1` and
 `malt.read/v0alpha1` profiles rather than extending v0alpha2 in place.
 Consumers must reject unknown profiles, pin an exact MALT tag or module
 version, and review release notes before upgrading.

--- a/docs/policy/releasing.md
+++ b/docs/policy/releasing.md
@@ -42,8 +42,9 @@ Review:
 - the browser verifier passes its accept/tamper-reject smoke and the published
   WASM checksum matches the web application asset.
 
-The completed `v0.0.3` validation record lives in
-[`docs/releases/v0.0.3.md`](../releases/v0.0.3.md). It includes a
+The latest validation record lives in
+[`docs/releases/v0.0.5.md`](../releases/v0.0.5.md). The completed `v0.0.3`
+record in [`docs/releases/v0.0.3.md`](../releases/v0.0.3.md) includes a
 portable-verifier smoke, a relation-only map test, import-boundary checks, an
 external-consumer compile test, evaluator smoke, and isolated CLI proof smoke.
 Future releases should add a new release-note file with equivalent gates rather

--- a/docs/releases/v0.0.5.md
+++ b/docs/releases/v0.0.5.md
@@ -1,0 +1,110 @@
+# MALT v0.0.5
+
+Status: released on 2026-07-13
+
+MALT `v0.0.5` tightens the boundary between the portable authentication core,
+trusted clients, untrusted gateway/executor work, immutable CAS payloads, and
+application models such as UnixFS. It is an experimental source release, not a
+stable API line or production managed service.
+
+## Release Contract
+
+- Go module: `github.com/dewebprotocol/malt@v0.0.5`
+- resolve profile: `malt.resolve/v0alpha1`
+- primitive-read profile: `malt.read/v0alpha1`
+- frozen compatibility profile: `malt.artifact/v0alpha2`
+- schemas: `protocol/schemas/*.schema.json`
+- reference routes:
+  - `POST /v1/resolve`
+  - `POST /v1/read`
+  - `POST /v1/verify/resolve` (diagnostic only)
+  - `POST /v1/verify/read` (diagnostic only)
+
+## Highlights
+
+- The module-root `malt` package exposes application-neutral
+  `ResolveRequest`/`ResolveResult` and typed primitive-read contracts together
+  with portable `VerifyResolve` and `VerifyRead` functions.
+- `execution.Executor` performs untrusted resolve/read/apply work over injected
+  resolver, semantic prover, and mutation-applier capabilities. It never makes
+  the client trust decision.
+- `protocol` publishes operation-specific request, result, verification, and
+  JSON Schema contracts. ProofList is evidence carried by those results, not a
+  generic operation envelope.
+- `mutation` owns namespace-free semantic mutation, delta, commit-descriptor,
+  and write-receipt values. Receipts and candidate roots are not cryptographic
+  state-transition proofs.
+- UnixFS is split across `model/unixfs`, `sdk/unixfs`, and `runtime/unixfs` so
+  application semantics, client planning/body verification, and reference
+  execution are not treated as MALT core.
+- `sdk/verifier`, `malt verify`, and the browser/WASM build bind a
+  caller-selected request to an untrusted result before portable ProofList
+  verification.
+- The process managed by `malt start` is documented as an all-in-one reference
+  executor. Remote verify routes are diagnostic/conformance helpers, not trust
+  authorities.
+
+## Resolution And Payload Semantics
+
+Clients submit canonical segment arrays without discovering authenticated arc
+boundaries. Resolution authenticates one complete returned derivation and does
+not claim longest-prefix maximality, uniqueness, or application preference.
+
+An empty segment array is strict root identity. Payload selection uses the
+explicit reserved `@payload` segment. A verified payload resolve authenticates
+a CID; clients must additionally bind returned full or ranged bytes to that CID
+using ordinary CID verification or `sdk/unixfs.VerifyRangeBody` as appropriate.
+
+## Compatibility
+
+The v0.0.4 `malt.artifact/v0alpha2` resolve/prove/verify operation set remains
+frozen. New integrations should use `malt.resolve/v0alpha1` and
+`malt.read/v0alpha1` rather than adding operations to that compatibility
+profile.
+
+This release intentionally removes the former `layout/unixfs` Go package path.
+Consumers should import the model, SDK, or runtime package matching their role.
+All current profiles and Go APIs remain experimental before `v1.0.0`.
+
+## Security Boundary
+
+Resolvers, ArcTable indexes, gateways, caches, CAS availability, and reference
+execution are untrusted for correctness. Clients accept results only after
+local verification against an explicit trusted root and caller-constructed
+request. Root freshness, authority, rollback prevention, tenant policy, and
+multi-writer arbitration remain application or managed-gateway concerns.
+
+## Validation Gate
+
+The release commit is validated with:
+
+```bash
+git diff --check
+gofmt -l .
+go test ./...
+go vet ./...
+go build -buildvcs=false ./...
+scripts/build-verifier-wasm.sh dist/verifier
+bin/malt-eval run --plan examples/eval-smoke-plan.json --run-id v0.0.5-smoke
+```
+
+Additional gates cover an external consumer of the root facade and protocol
+schemas, native and WASM builds, local verifier accept/tamper rejection, and
+gateway/Web integration against the exact release source.
+
+## Published Tags
+
+- `v0.0.5-rc.1`: validated candidate source tag
+- `v0.0.5`: final experimental source release
+
+Both tags identify the same approved source tree. Source tags are authoritative;
+native binaries remain build-from-source. Published browser verifier artifacts
+must identify their exact MALT source commit and SHA-256 checksum.
+
+## Related Documents
+
+- [MIP-1013: Client, Gateway, And Core Responsibility Boundary](../mips/mip-1013-client-gateway-core-boundary.md)
+- [Resolve and read contracts](../spec/resolve-read-contracts.md)
+- [Frozen artifact compatibility profile](../spec/artifacts.md)
+- [Compatibility policy](../policy/compatibility.md)
+- [Release process](../policy/releasing.md)


### PR DESCRIPTION
## Summary

- publish the v0.0.5 changelog and release validation record
- finalize MIP-1013 after the client/gateway/core boundary merged in PR #163
- align architecture, roadmap, compatibility, security, and documentation indexes with the released resolve/read contracts
- retain `malt.artifact/v0alpha2` as frozen v0.0.4 compatibility behavior

## Release contract

- `malt.resolve/v0alpha1`
- `malt.read/v0alpha1`
- untrusted `execution.Executor` resolve/read/apply execution
- client-local `VerifyResolve` / `VerifyRead`
- `model/unixfs`, `sdk/unixfs`, and `runtime/unixfs` ownership split
- frozen `malt.artifact/v0alpha2` compatibility profile

## Validation

- `git diff --check`
- `gofmt -l .` produced no output
- `go test ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- built `cas`, `malt`, and `malt-eval`
- `scripts/build-verifier-wasm.sh dist/verifier`
- `bin/malt-eval run --plan examples/eval-smoke-plan.json --run-id v0.0.5-smoke`
- external consumer compiled the root `malt` facade and `protocol` profiles
- rebuilt WASM matches the current Web asset: `2da799e52d8be4d6fbb77ba99b11553db790ee6ed8bbebe9cab540317470e384`

## Release flow

After merge, tag the approved commit as `v0.0.5-rc.1`, validate an external consumer against that tag, then tag the exact same commit as `v0.0.5` and create the GitHub Release.
