### PR TITLE
docs: route client compatibility and evaluation ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ Those responsibilities are split across independent repositories:
 
 | Repository | Responsibility |
 | --- | --- |
-| [`DeWebProtocol/malt-client`](https://github.com/DeWebProtocol/malt-client) | CLI/client daemon, trusted roots, local verification, UnixFS planning and payload binding |
+| [`DeWebProtocol/malt-client`](https://github.com/DeWebProtocol/malt-client) | CLI/client daemon, trusted roots, local verification, UnixFS planning, payload binding, and Merkle DAG import compatibility |
 | [`DeWebProtocol/gateway`](https://github.com/DeWebProtocol/gateway) | Untrusted resolve/read/apply execution, ArcTable/KV/CAS, service and deployment policy |
-| [`DeWebProtocol/web`](https://github.com/DeWebProtocol/web) | Browser client, local WASM verification, public website and tutorials |
+| [`DeWebProtocol/malt-evaluation`](https://github.com/DeWebProtocol/malt-evaluation) | Reproducible evaluator, benchmark suites, comparison adapters, plans, and schemas |
+| [`DeWebProtocol/malt-web`](https://github.com/DeWebProtocol/malt-web) | Browser client, local WASM verification, public website and tutorials |
 
 ## Core composition
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,9 @@ root publication, backend orchestration, S3/Filecoin/IPFS deployment policy,
 quota, cache policy, and operations, belongs in `DeWebProtocol/gateway` or
 private deployment overlays. Client/daemon and UnixFS behavior belongs in
 `DeWebProtocol/malt-client`; this repository contains neither product layer.
+Executable benchmark suites, evaluator plans, comparison adapters, and result
+schemas live in `DeWebProtocol/malt-evaluation`; paper interpretation and
+research narrative remain in `DeWebProtocol/documents`.
 
 ## Concepts
 
@@ -28,6 +31,10 @@ private deployment overlays. Client/daemon and UnixFS behavior belongs in
 - [v0.0.6 release notes](./releases/v0.0.6.md)
 - [v0.0.5 release notes](./releases/v0.0.5.md)
 - [v0.0.4 release notes](./releases/v0.0.4.md)
+
+## Evaluation
+
+- [Evaluation ownership and migration](./evaluation.md)
 
 ## Specifications
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,8 +1,14 @@
 # Evaluation Routing
 
-The evaluator application, workload plans, result artifacts, and paper-facing
-analysis were removed from the SDK-only core in v0.0.6. Current research and
-paper evaluation material belongs in `DeWebProtocol/documents`.
+The evaluator application, workload plans, comparison adapters, and schemas
+were removed from the SDK-only core in v0.0.6. Their executable home is now
+[`DeWebProtocol/malt-evaluation`](https://github.com/DeWebProtocol/malt-evaluation).
+The initial repository preserves the complete v0.0.5 runner against its exact
+historical dependency; current v0.0.6 adapters migrate independently.
+
+Gateway-owned CAS-to-gateway-to-client end-to-end tests validate the current
+product boundary. Paper-facing result interpretation, figures, and research
+narrative belong in `DeWebProtocol/documents`.
 
 Core retains conformance and benchmark tests only when they directly exercise
 protocol, commitment, proof, semantic, or verifier behavior. Historical MIPs

--- a/docs/mips/README.md
+++ b/docs/mips/README.md
@@ -47,8 +47,8 @@ shapes, and benchmark record rules belong in:
 
 - [`../spec/`](../spec/) for protocol, API, proof, receipt, artifact, and wire
   references
-- [`../evaluation.md`](../evaluation.md) for routing historical evaluator work
-  to the research repository
+- [`../evaluation.md`](../evaluation.md) for routing executable evaluator work
+  to `malt-evaluation` and paper interpretation to the research repository
 
 A MIP may link to those reference docs and propose changing them, but it should
 not become the only copy of a schema or specification.

--- a/docs/mips/mip-1.md
+++ b/docs/mips/mip-1.md
@@ -46,8 +46,10 @@ A MIP is not implementation work by default.
 A MIP is also not the canonical home for long-lived field tables, wire formats,
 JSON schemas, benchmark record rules, or other reference specifications. Those
 belong in `docs/spec/` or implementation-owned protocol schema directories.
-Research evaluation artifacts belong in `DeWebProtocol/documents`. A MIP may
-propose or record changes to those references.
+Executable evaluation suites, plans, adapters, and schemas belong in
+`DeWebProtocol/malt-evaluation`. Research results, paper figures, and narrative
+belong in `DeWebProtocol/documents`. A MIP may propose or record changes to
+those references.
 
 ### MIP Types
 

--- a/docs/mips/mip-1009-benchmark-proof-reporting.md
+++ b/docs/mips/mip-1009-benchmark-proof-reporting.md
@@ -26,8 +26,10 @@ figures.
 
 ## Specification
 
-The current evaluation artifacts live in `DeWebProtocol/documents`. This MIP should decide
-which reporting rules must become stable for paper-facing figures:
+The executable evaluation suites, plans, adapters, and schemas live in
+`DeWebProtocol/malt-evaluation`; generated research artifacts and paper-facing
+interpretation live in `DeWebProtocol/documents`. This MIP should decide which
+reporting rules must become stable for paper-facing figures:
 
 - ProofList bytes and step counts
 - comparable Merkle DAG and HAMT evidence items
@@ -40,9 +42,10 @@ which reporting rules must become stable for paper-facing figures:
 
 ## Rationale
 
-The former in-tree evaluator was removed from SDK-only core in v0.0.6. Core
-benchmark tests may measure commitment/proof behavior; gateway product E2E owns
-CAS/ArcTable operational metrics; paper aggregation belongs in documents.
+The former in-tree evaluator was removed from SDK-only core in v0.0.6 and
+restored as an auditable v0.0.5 baseline in `malt-evaluation`. Core benchmark
+tests may measure commitment/proof behavior; gateway product E2E owns current
+CAS/ArcTable operational validation; paper aggregation belongs in documents.
 
 ## Backwards Compatibility
 
@@ -67,3 +70,6 @@ benchmark protocol docs, and fixture/result validation.
   this MIP now tracks stabilization of paper-facing benchmark reporting.
 - 2026-07-14: Routed evaluator artifacts to documents and operational metrics
   to gateway after the SDK-only core split.
+- 2026-07-14: Restored executable suites, plans, adapters, and schemas in the
+  independent `malt-evaluation` repository; kept paper interpretation in
+  documents.

--- a/docs/mips/mip-1013-client-gateway-core-boundary.md
+++ b/docs/mips/mip-1013-client-gateway-core-boundary.md
@@ -93,13 +93,21 @@ on verification only. Full commitment backends may implement both interfaces.
 ### UnixFS Application Model
 
 UnixFS is called the MALT UnixFS application model/profile. The term `layout`
-is reserved for a narrower materialization choice such as `flat` versus
-`hierarchical`, or raw versus fixed-list payload organization.
+is reserved for a narrower application materialization choice. The current
+native client exposes `hybrid`, combining authenticated directory map roots
+with descendant full-path bindings. Pure `flat` versus `hierarchical`, or raw
+versus fixed-list payload organization, remain possible future choices.
 
 The independent `malt-client` repository owns UnixFS schema, reserved
 coordinates, manifest/chunk formats, staging, upload planning, mutation
-construction, and local payload/range-body verification. The generic gateway
+construction, local payload/range-body verification, and optional
+IPFS-compatible Merkle DAG UnixFS import. A Merkle DAG root is a client
+compatibility output, not MALT authentication evidence. The generic gateway
 does not parse UnixFS paths or expose a UnixFS content adapter.
+
+The frozen v0.0.5 evaluator retains `MALT-flat`/`maltflat` for its full-path
+flat-map baseline. Those historical identifiers do not configure or describe
+the current `malt add --layout hybrid` path.
 
 Future TypeScript object support belongs primarily in a client SDK that maps
 JavaScript object syntax into canonical segments and mutations. Core does not

--- a/docs/releases/v0.0.6.md
+++ b/docs/releases/v0.0.6.md
@@ -31,6 +31,14 @@ resolve/read/apply service execution. `DeWebProtocol/malt-client` owns the
 trusted CLI/daemon, accepted roots, UnixFS planning, local verification, and
 payload-byte binding. Web remains a browser client using the WASM verifier.
 
+After release, the former evaluator was restored in
+`DeWebProtocol/malt-evaluation` as an auditable v0.0.5 baseline, and
+`malt-client` restored the optional Merkle DAG UnixFS import target. Neither
+change expands the SDK-only core boundary or moves the immutable v0.0.6 tag.
+The native client's current MALT materialization value is `hybrid`; frozen
+evaluator labels such as `maltflat` are historical identifiers, not client
+layout flags.
+
 ## ArcSet capability
 
 Proof-generation algorithms accept `auth/arcset/materializer.Store`. This is a


### PR DESCRIPTION
## Summary

- document `malt-client` as the owner of UnixFS application materialization and optional Merkle DAG import compatibility
- document `malt-evaluation` as the executable home for benchmark suites, adapters, plans, schemas, and historical v0.0.5 evaluator behavior
- keep MALT core scoped to the SDK, protocol, proof semantics, schemas, MIPs, and core conformance behavior
- clarify that `hybrid` is the current native MALT client materialization while `maltflat` is a frozen evaluator identifier

## Validation

- `git diff --check`
- `gofmt -l .`
- compile-only package test pass across `./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`

This PR changes documentation only; it does not alter the immutable v0.0.6 tag.