### PR TITLE
docs: define product repository boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Those responsibilities are split across independent repositories:
 
 | Repository | Responsibility |
 | --- | --- |
-| [`DeWebProtocol/malt-client`](https://github.com/DeWebProtocol/malt-client) | CLI/client daemon, trusted roots, local verification, UnixFS planning, payload binding, and Merkle DAG import compatibility |
-| [`DeWebProtocol/gateway`](https://github.com/DeWebProtocol/gateway) | Untrusted resolve/read/apply execution, ArcTable/KV/CAS, service and deployment policy |
+| [`DeWebProtocol/malt-client`](https://github.com/DeWebProtocol/malt-client) | CLI/daemon plus separate transport, trusted-root policy, UnixFS, payload binding, and Merkle DAG compatibility layers |
+| [`DeWebProtocol/gateway`](https://github.com/DeWebProtocol/gateway) | Untrusted native/compatibility profiles, runtime composition, ArcTable/KV/CAS backends, scope and publication policy |
 | [`DeWebProtocol/malt-evaluation`](https://github.com/DeWebProtocol/malt-evaluation) | Reproducible evaluator, benchmark suites, comparison adapters, plans, and schemas |
 | [`DeWebProtocol/malt-web`](https://github.com/DeWebProtocol/malt-web) | Browser client, local WASM verification, public website and tutorials |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ with code, tests, schemas, and wire formats. Public
 website pages in `DeWebProtocol/malt-web` may summarize this material, but they
 should link back here for protocol, policy, and compatibility details.
 
-Managed gateway service behavior, including tenancy, identity, authorization,
+Managed gateway service behavior, including future tenancy, identity, authorization,
 root publication, backend orchestration, S3/Filecoin/IPFS deployment policy,
 quota, cache policy, and operations, belongs in `DeWebProtocol/gateway` or
 private deployment overlays. Client/daemon and UnixFS behavior belongs in

--- a/docs/mips/mip-1013-client-gateway-core-boundary.md
+++ b/docs/mips/mip-1013-client-gateway-core-boundary.md
@@ -79,6 +79,35 @@ client application:    DeWebProtocol/malt-client
 gateway runtime:       DeWebProtocol/gateway
 ```
 
+The client repository keeps three independently reviewable layers:
+
+```text
+transport/    untrusted native MALT, CAS, and diagnostic HTTP capabilities
+trust/        accepted/candidate root persistence and explicit promotion
+unixfs/       MALT-authenticated UnixFS application and payload binding
+merkledag/    separate CID/link-replay compatibility application
+```
+
+The concrete transport may share one HTTP connection, but callers depend on
+narrow capability interfaces. `transport` must not import application or trust
+packages. Merkle DAG compatibility must not import or manufacture MALT
+ProofList contracts.
+
+The gateway repository likewise separates composition from execution:
+
+```text
+internal/runtime/              per-scope service composition
+internal/profile/malt/         native Resolve/Read/mutation ports
+internal/profile/cas/          immutable byte ports
+internal/profile/merkledag/    CID/link-evidence compatibility ports
+internal/backend/              profile-neutral persistence capabilities
+internal/policy/               scope-adjacent managed-service policy
+```
+
+Named root publication is a gateway policy record, not a MALT head and not a
+client trust decision. It may track revisions or freeze a name, but every core
+resolve/read request still carries its explicit root.
+
 The root `malt` package must not import graph, runtime, server, storage,
 application-model, or SDK packages. `mutation` contains value types and
 validation only. `execution.Executor` may generate candidates but never
@@ -118,7 +147,9 @@ parse `.` or `[]` syntax.
 `malt-client` supplies the trusted local daemon/agent. It stores accepted and
 candidate roots, verifies locally, and communicates with a gateway without
 owning server ArcTable/KV/CAS state. The gateway is the untrusted execution
-process.
+process. A gateway may understand Merkle DAG/IPLD semantics only inside its
+separate compatibility profile; native MALT execution and generic CAS backends
+do not inherit those application semantics.
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

- record the concrete client transport, trust, UnixFS, and Merkle DAG package boundaries in MIP-1013
- record the Gateway runtime, native MALT, CAS, compatibility, backend, and managed-policy layers
- clarify that named-root publication is neither a MALT head nor a client trust decision
- update repository routing in the core documentation index

This is a documentation-only alignment PR. It does not change MALT v0.0.6 protocol or verifier behavior.

## Validation

- git diff --check
- gofmt clean
- go test -run '^$' ./...
