### PR TITLE
refactor: narrow core materializer and writer ports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,10 @@ when this checkout is part of the combined MALT workspace.
 - Keep canonical values, segment paths, semantic map/list authentication,
   commitments, ProofLists, resolve/read/mutation contracts, graph algorithms,
   portable verification, and transport-neutral schemas here.
-- Core algorithms may consume `auth/arcset/materializer.Store`, but must not
-  define durable ArcTable, KV, CAS, cache, HTTP, daemon, filesystem, UnixFS,
-  Merkle DAG application, tenant, publication, or trusted-root policy.
+- Core algorithms may consume narrow capabilities under
+  `auth/arcset/materializer`, but must not define durable ArcTable, KV, CAS,
+  cache, HTTP, daemon, filesystem, UnixFS, Merkle DAG application, tenant,
+  publication, or trusted-root policy.
 - Treat every resolver, materializer, cache, and gateway as untrusted execution
   state. Verification is relative to a caller-selected root and query.
 - Mutation receipts contain candidate result roots; they are not portable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+## Scope
+
+This repository is the application-neutral MALT SDK and the technical source
+of truth for current protocol, proof, wire-format, CID, compatibility, MIP, and
+core conformance behavior. Also follow the workspace guide at `../AGENTS.md`
+when this checkout is part of the combined MALT workspace.
+
+## Core Boundary
+
+- Keep canonical values, segment paths, semantic map/list authentication,
+  commitments, ProofLists, resolve/read/mutation contracts, graph algorithms,
+  portable verification, and transport-neutral schemas here.
+- Core algorithms may consume `auth/arcset/materializer.Store`, but must not
+  define durable ArcTable, KV, CAS, cache, HTTP, daemon, filesystem, UnixFS,
+  Merkle DAG application, tenant, publication, or trusted-root policy.
+- Treat every resolver, materializer, cache, and gateway as untrusted execution
+  state. Verification is relative to a caller-selected root and query.
+- Mutation receipts contain candidate result roots; they are not portable
+  transition proofs and must not be documented as authenticated updates.
+
+## Package Ownership
+
+- The module-root `malt` package owns the minimal in-process semantic facade.
+- `auth/` owns ArcSet values, commitments, semantic structures, ProofLists, and
+  portable proof verification.
+- `graph/` owns application-neutral traversal, runtime composition over injected
+  capabilities, and reference writer algorithms.
+- `execution/` owns the untrusted resolve/read/apply facade; it does not make
+  client trust decisions or own service state.
+- `mutation/` owns portable semantic mutation values and operational receipts.
+- `protocol/` and `wire/` own versioned transport-neutral JSON/schema and CID
+  projections. Incompatible wire changes require a new profile.
+- `artifact/` and its verifier entry points are frozen v0.0.4 compatibility
+  surfaces. Do not add new operations to `malt.artifact/v0alpha2`.
+- `cmd/malt-verifier-wasm` is a portable local-verification build target, not a
+  network client or application runtime.
+
+## Cross-Repository Routing
+
+- Put ArcTable/KV/CAS implementations, runtime composition, managed-service
+  policy, and product E2E in `gateway/`.
+- Put trusted-root policy, CLI/daemon lifecycle, UnixFS behavior, payload-byte
+  binding, Gateway transport, and Merkle DAG import in `malt-client/`.
+- Put executable benchmark runners, adapters, plans, and result schemas in
+  `malt-evaluation/`.
+- Put public tutorials and product narrative in `web/`, and research/paper
+  material in `documents/`.
+
+## Validation And Delivery
+
+- Run `gofmt` on changed Go files, `git diff --check`, `go test ./...`,
+  `go vet ./...`, and `go build -buildvcs=false ./...` when practical.
+- Keep architecture/import-boundary tests passing whenever packages move.
+- Use a topic branch/worktree, commit verified changes, push the branch, and
+  open a draft pull request to `main`; do not edit `main` directly unless the
+  maintainer explicitly requests it.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,20 +70,27 @@ authoritative root.
 
 `auth/arcset` is the canonical in-memory/traversable representation used by
 core algorithms. Proof generation also needs to load internal commitment nodes
-and root-relative ArcSet views. The SDK therefore accepts a narrow injected
-capability:
+and root-relative ArcSet views. The SDK therefore accepts small injected
+capabilities:
 
 ```go
-type Store interface {
+type Lookup interface {
     Get(context.Context, string, cid.Cid, arcset.Path) (cid.Cid, error)
     BatchGet(context.Context, string, cid.Cid, []arcset.Path) (map[arcset.Path]cid.Cid, error)
+}
+
+type Updater interface {
     Update(context.Context, string, cid.Cid, cid.Cid, arcset.ArcSet) error
+}
+
+type Snapshotter interface {
     Snapshot(context.Context, string, cid.Cid) (arcset.ArcSet, error)
-    Iterate(context.Context, string, cid.Cid) arcset.Iterator
 }
 ```
 
-The interface describes algorithmic capability only. It does not define:
+`NodeStore` composes `Lookup + Updater`; `MutableStore` adds `Snapshotter`.
+The full compatibility `Store` additionally supports iteration. These
+interfaces describe algorithmic capability only. They do not define:
 
 - ArcTable key formats or version chains;
 - KV/SQL/object-store persistence;
@@ -120,6 +127,11 @@ can apply them through an injected writer and returns an operational receipt.
 The receipt is not a cryptographic state-transition proof. A returned root is a
 candidate until the client accepts it under its own publication/freshness
 policy.
+
+`RuntimeGraph.Writer()` exposes only `MutationWriter`. Bootstrap creation is a
+separate `StructureCreator` because a new structure has no authenticated base
+root. Legacy `UpdateArc`, `BatchUpdateArcs`, and inspection helpers are exposed
+only through the explicitly named `ReferenceWriter()` capability.
 
 ## Verification boundary
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,9 @@ Run `gofmt` before committing. Prefer behavior-focused and table-driven tests.
   transport, storage, process, and application concerns.
 - Keep portable verification deterministic and free of materializer/CAS/network
   I/O.
-- Use `auth/arcset/materializer.Store` only as an injected algorithmic
-  capability; do not add ArcTable/KV persistence formats here.
+- Use the narrowest injected capability under `auth/arcset/materializer`; do
+  not make production algorithms depend on aggregate `Store`, and do not add
+  ArcTable/KV persistence formats here.
 - Keep HTTP, managed service policy, ArcTable/KV/CAS implementations, and
   product E2E in `DeWebProtocol/gateway`.
 - Keep CLI/daemon, accepted-root policy, UnixFS, and application payload

--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ longest-prefix discovery. The verifier proves the returned derivation; it does
 not prove that the executor selected the unique or longest possible path. This
 is intentional existential resolution semantics.
 
-The core exposes only the minimal `auth/arcset/materializer.Store` capability
-needed by proof-generation algorithms. Implementations and persistence policy
+The core exposes narrow capabilities under `auth/arcset/materializer`:
+read-only lookup, node update, snapshot, and optional iteration. The full
+`Store` aggregate is retained for adapter compatibility, while each algorithm
+accepts only the capability it uses. Implementations and persistence policy
 remain outside this module. The included memory implementation exists for
 conformance tests and examples, not deployment.
 
@@ -117,7 +119,7 @@ in the application client.
 | `protocol` | Versioned serialized resolve/read profiles and schemas |
 | `mutation` | Portable mutation and receipt values |
 | `execution` | Untrusted resolve/read/apply composition |
-| `graph` | Resolver/writer algorithms over injected capabilities |
+| `graph` | Resolver, semantic mutation, bootstrap, and explicit reference-writer algorithms over injected capabilities |
 | `sdk/verifier` | Client-facing local verification facade |
 | `artifact` | Frozen `malt.artifact/v0alpha2` compatibility decoder/verifier |
 | `cmd/malt-verifier-wasm` | Browser verifier build entry point |

--- a/architecture_test.go
+++ b/architecture_test.go
@@ -106,6 +106,40 @@ func TestSDKOnlyRepositoryDoesNotReintroduceProductPackages(t *testing.T) {
 	}
 }
 
+func TestProductionAlgorithmsUseNarrowMaterializerCapabilities(t *testing.T) {
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Dir(sourceFile)
+	allowed := filepath.Join(root, "auth", "arcset", "materializer", "memory", "store.go")
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" || entry.Name() == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if path == allowed || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(data), "materializer.Store") {
+			t.Errorf("production algorithm %s depends on aggregate materializer.Store", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func checkProductionImports(t *testing.T, dir string, recursive bool, forbidden []string) {
 	t.Helper()
 	err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {

--- a/architecture_test.go
+++ b/architecture_test.go
@@ -1,9 +1,11 @@
 package malt_test
 
 import (
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -11,7 +13,10 @@ import (
 	"testing"
 )
 
-const modulePath = "github.com/dewebprotocol/malt"
+const (
+	modulePath             = "github.com/dewebprotocol/malt"
+	materializerImportPath = modulePath + "/auth/arcset/materializer"
+)
 
 func TestProductionImportBoundaries(t *testing.T) {
 	_, sourceFile, _, ok := runtime.Caller(0)
@@ -126,11 +131,11 @@ func TestProductionAlgorithmsUseNarrowMaterializerCapabilities(t *testing.T) {
 		if path == allowed || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
-		data, err := os.ReadFile(path)
+		usesAggregate, err := importsAggregateMaterializerStore(path, nil)
 		if err != nil {
 			return err
 		}
-		if strings.Contains(string(data), "materializer.Store") {
+		if usesAggregate {
 			t.Errorf("production algorithm %s depends on aggregate materializer.Store", path)
 		}
 		return nil
@@ -138,6 +143,142 @@ func TestProductionAlgorithmsUseNarrowMaterializerCapabilities(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestAggregateMaterializerStoreImportDetection(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "default import",
+			src: `package fixture
+
+import "github.com/dewebprotocol/malt/auth/arcset/materializer"
+
+var _ materializer.Store
+`,
+			want: true,
+		},
+		{
+			name: "named import alias cannot bypass guard",
+			src: `package fixture
+
+import mat "github.com/dewebprotocol/malt/auth/arcset/materializer"
+
+var _ mat.Store
+`,
+			want: true,
+		},
+		{
+			name: "dot import is rejected",
+			src: `package fixture
+
+import . "github.com/dewebprotocol/malt/auth/arcset/materializer"
+
+var _ Store
+`,
+			want: true,
+		},
+		{
+			name: "narrow capability through alias",
+			src: `package fixture
+
+import mat "github.com/dewebprotocol/malt/auth/arcset/materializer"
+
+var _ mat.Lookup
+`,
+		},
+		{
+			name: "blank import has no aggregate reference",
+			src: `package fixture
+
+import _ "github.com/dewebprotocol/malt/auth/arcset/materializer"
+`,
+		},
+		{
+			name: "text is not a reference",
+			src: `package fixture
+
+const description = "materializer.Store"
+`,
+		},
+		{
+			name: "unrelated package selector",
+			src: `package fixture
+
+import materializer "example.com/another/materializer"
+
+var _ materializer.Store
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := importsAggregateMaterializerStore("fixture.go", tc.src)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("importsAggregateMaterializerStore() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// importsAggregateMaterializerStore reports whether a Go source file imports
+// the canonical materializer package and selects its aggregate Store contract.
+// A dot import is rejected conservatively because it removes the package
+// qualifier needed to distinguish Store from the narrow capabilities.
+func importsAggregateMaterializerStore(filename string, src any) (bool, error) {
+	file, err := parser.ParseFile(token.NewFileSet(), filename, src, 0)
+	if err != nil {
+		return false, err
+	}
+
+	aliases := make(map[string]struct{})
+	for _, spec := range file.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			return false, err
+		}
+		if importPath != materializerImportPath {
+			continue
+		}
+
+		alias := pathpkg.Base(importPath)
+		if spec.Name != nil {
+			alias = spec.Name.Name
+		}
+		switch alias {
+		case "_":
+			continue
+		case ".":
+			return true, nil
+		default:
+			aliases[alias] = struct{}{}
+		}
+	}
+
+	usesAggregate := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != "Store" {
+			return true
+		}
+		qualifier, ok := selector.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if _, ok := aliases[qualifier.Name]; ok {
+			usesAggregate = true
+			return false
+		}
+		return true
+	})
+	return usesAggregate, nil
 }
 
 func checkProductionImports(t *testing.T, dir string, recursive bool, forbidden []string) {

--- a/architecture_test.go
+++ b/architecture_test.go
@@ -2,10 +2,11 @@ package malt_test
 
 import (
 	"go/ast"
+	"go/importer"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"os"
-	pathpkg "path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -172,6 +173,24 @@ var _ mat.Store
 			want: true,
 		},
 		{
+			name: "local variable shadowing import alias is not a package reference",
+			src: `package fixture
+
+import mat "github.com/dewebprotocol/malt/auth/arcset/materializer"
+
+var _ mat.Lookup
+
+type localMaterializer struct {
+	Store int
+}
+
+func useLocalMaterializer() {
+	mat := localMaterializer{}
+	_ = mat.Store
+}
+`,
+		},
+		{
 			name: "dot import is rejected",
 			src: `package fixture
 
@@ -230,37 +249,26 @@ var _ materializer.Store
 
 // importsAggregateMaterializerStore reports whether a Go source file imports
 // the canonical materializer package and selects its aggregate Store contract.
-// A dot import is rejected conservatively because it removes the package
-// qualifier needed to distinguish Store from the narrow capabilities.
+// It uses type information so that a local variable which shadows an import
+// alias cannot turn an unrelated Store field selection into a false positive.
 func importsAggregateMaterializerStore(filename string, src any) (bool, error) {
-	file, err := parser.ParseFile(token.NewFileSet(), filename, src, 0)
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, filename, src, 0)
 	if err != nil {
 		return false, err
 	}
 
-	aliases := make(map[string]struct{})
-	for _, spec := range file.Imports {
-		importPath, err := strconv.Unquote(spec.Path.Value)
-		if err != nil {
-			return false, err
-		}
-		if importPath != materializerImportPath {
-			continue
-		}
-
-		alias := pathpkg.Base(importPath)
-		if spec.Name != nil {
-			alias = spec.Name.Name
-		}
-		switch alias {
-		case "_":
-			continue
-		case ".":
-			return true, nil
-		default:
-			aliases[alias] = struct{}{}
-		}
+	info := &types.Info{
+		Uses: make(map[*ast.Ident]types.Object),
 	}
+	config := &types.Config{
+		Importer: newMaterializerGuardImporter(),
+		// Files are checked independently from the rest of their package. Missing
+		// sibling declarations and unrelated imports may therefore produce type
+		// errors, but bindings available in Uses remain valid for this guard.
+		Error: func(error) {},
+	}
+	_, _ = config.Check("architecture/fixture", fileSet, []*ast.File{file}, info)
 
 	usesAggregate := false
 	ast.Inspect(file, func(node ast.Node) bool {
@@ -272,13 +280,57 @@ func importsAggregateMaterializerStore(filename string, src any) (bool, error) {
 		if !ok {
 			return true
 		}
-		if _, ok := aliases[qualifier.Name]; ok {
+		packageName, ok := info.Uses[qualifier].(*types.PkgName)
+		if ok && packageName.Imported().Path() == materializerImportPath {
 			usesAggregate = true
 			return false
 		}
 		return true
 	})
+	if usesAggregate {
+		return true, nil
+	}
+
+	// A dot import has no qualifier. In that case go/types binds an unqualified
+	// Store identifier directly to the target package's exported type object.
+	for identifier, object := range info.Uses {
+		if identifier.Name != "Store" || object.Pkg() == nil {
+			continue
+		}
+		if object.Pkg().Path() == materializerImportPath {
+			return true, nil
+		}
+	}
 	return usesAggregate, nil
+}
+
+type materializerGuardImporter struct {
+	fallback     types.Importer
+	materializer *types.Package
+}
+
+func newMaterializerGuardImporter() types.Importer {
+	materializer := types.NewPackage(materializerImportPath, "materializer")
+	for _, name := range []string{
+		"Lookup", "Updater", "Snapshotter", "Iterator", "NodeStore",
+		"MutableStore", "Store", "BranchingStore",
+	} {
+		typeName := types.NewTypeName(token.NoPos, materializer, name, nil)
+		types.NewNamed(typeName, types.NewInterfaceType(nil, nil).Complete(), nil)
+		materializer.Scope().Insert(typeName)
+	}
+	materializer.MarkComplete()
+	return materializerGuardImporter{
+		fallback:     importer.Default(),
+		materializer: materializer,
+	}
+}
+
+func (i materializerGuardImporter) Import(importPath string) (*types.Package, error) {
+	if importPath == materializerImportPath {
+		return i.materializer, nil
+	}
+	return i.fallback.Import(importPath)
 }
 
 func checkProductionImports(t *testing.T, dir string, recursive bool, forbidden []string) {

--- a/auth/arcset/materializer/materializer.go
+++ b/auth/arcset/materializer/materializer.go
@@ -24,17 +24,52 @@ func IsNotFound(err error) bool {
 	return errors.Is(err, ErrNotFound)
 }
 
-// Store is an injected capability for opening and materializing ArcSet views.
-// Scope is opaque execution context chosen by the caller; MALT does not assign
-// tenant, graph, bucket, or persistence meaning to it.
-type Store interface {
+// Lookup is the read-only coordinate lookup capability used by semantic
+// provers. Scope is opaque execution context chosen by the caller; MALT does
+// not assign tenant, graph, bucket, or persistence meaning to it.
+type Lookup interface {
 	Get(context.Context, string, cid.Cid, arcset.Path) (cid.Cid, error)
 	BatchGet(context.Context, string, cid.Cid, []arcset.Path) (map[arcset.Path]cid.Cid, error)
+}
+
+// Updater materializes an immutable ArcSet root relative to an optional
+// previous root. Transaction and persistence semantics remain caller-owned.
+type Updater interface {
 	// Update materializes a new immutable ArcSet root relative to an optional
 	// previous root. Transaction and persistence semantics remain caller-owned.
 	Update(context.Context, string, cid.Cid, cid.Cid, arcset.ArcSet) error
+}
+
+// Snapshotter opens a complete root-relative ArcSet view.
+type Snapshotter interface {
 	Snapshot(context.Context, string, cid.Cid) (arcset.ArcSet, error)
+}
+
+// Iterator opens a streaming root-relative ArcSet traversal.
+type Iterator interface {
 	Iterate(context.Context, string, cid.Cid) arcset.Iterator
+}
+
+// NodeStore is the minimal mutable capability used by the reference map/list
+// commitment implementations for internal node slots.
+type NodeStore interface {
+	Lookup
+	Updater
+}
+
+// MutableStore is the capability required by graph mutation/reference writer
+// algorithms. It deliberately does not require iteration.
+type MutableStore interface {
+	NodeStore
+	Snapshotter
+}
+
+// Store is the full compatibility aggregate implemented by the in-memory
+// conformance store and current Gateway ArcTable adapters. New algorithms
+// should accept the narrowest capability above instead of Store.
+type Store interface {
+	MutableStore
+	Iterator
 }
 
 // BranchingStore is an optional capability for materializers that preserve

--- a/auth/semantic/list/tree/internal/layout.go
+++ b/auth/semantic/list/tree/internal/layout.go
@@ -98,7 +98,7 @@ func NodeSlotPath(root cid.Cid, slot uint64) arcset.Path {
 
 // LoadSlots reconstructs a fixed-width slot vector for a committed node.
 // Missing entries are treated as cid.Undef.
-func LoadSlots(ctx context.Context, e materializer.Store, namespace string, root cid.Cid, width int) ([]cid.Cid, error) {
+func LoadSlots(ctx context.Context, e materializer.Lookup, namespace string, root cid.Cid, width int) ([]cid.Cid, error) {
 	if e == nil {
 		return nil, fmt.Errorf("materializer is nil")
 	}
@@ -129,7 +129,7 @@ func LoadSlots(ctx context.Context, e materializer.Store, namespace string, root
 }
 
 // StoreSlots materializes a committed node in ArcSet materializer under its node-root namespace.
-func StoreSlots(ctx context.Context, e materializer.Store, namespace string, root cid.Cid, slots []cid.Cid) error {
+func StoreSlots(ctx context.Context, e materializer.Updater, namespace string, root cid.Cid, slots []cid.Cid) error {
 	if e == nil {
 		return fmt.Errorf("materializer is nil")
 	}

--- a/auth/semantic/list/tree/tree.go
+++ b/auth/semantic/list/tree/tree.go
@@ -23,7 +23,7 @@ import (
 
 type TreeList struct {
 	commitment   *list.Commitment
-	materializer materializer.Store
+	materializer materializer.NodeStore
 }
 
 type proofEnvelope struct {
@@ -48,7 +48,7 @@ type rangeIndexProof struct {
 	Proof []byte `json:"proof"`
 }
 
-func NewList(scheme commitment.IndexCommitment, materializer materializer.Store) (*TreeList, error) {
+func NewList(scheme commitment.IndexCommitment, materializer materializer.NodeStore) (*TreeList, error) {
 	if err := layout.ValidateCommitment(scheme); err != nil {
 		return nil, err
 	}

--- a/auth/semantic/mapping/radix/radix.go
+++ b/auth/semantic/mapping/radix/radix.go
@@ -34,7 +34,7 @@ const (
 
 type Map struct {
 	commitment   *mapping.Commitment
-	materializer materializer.Store
+	materializer materializer.NodeStore
 }
 
 // ProveTimings separates materialization from commitment-open cost for
@@ -82,7 +82,7 @@ type bucketWitness struct {
 	Proof []byte `json:"proof"`
 }
 
-func NewMap(scheme commitment.IndexCommitment, e materializer.Store) (*Map, error) {
+func NewMap(scheme commitment.IndexCommitment, e materializer.NodeStore) (*Map, error) {
 	if scheme == nil {
 		return nil, fmt.Errorf("scheme is nil")
 	}

--- a/docs/spec/semantic.md
+++ b/docs/spec/semantic.md
@@ -104,7 +104,8 @@ semantic owner.
 
 - resolver is the read/proof port: `(root, query) -> result + ProofList`
 - writer is an execution port: `Apply(baseRoot, semantic mutation) -> newRoot + receipt`
-- `graph.CompatWriter` contains algorithm compatibility helpers and is not a gateway product API
+- `graph.StructureCreator` is the separate no-base-root bootstrap capability
+- `graph.ReferenceWriter` contains legacy compatibility helpers and is not a gateway product API
 
 Resolver traversal lives under `graph/resolver`. Mutation application lives
 under `graph/writer`. These are SDK execution algorithms, not transport
@@ -117,12 +118,14 @@ application model, server, or gateway state.
 
 ## ArcSet Materialization Boundary
 
-Core proof-generation algorithms consume the narrow
-`auth/arcset/materializer.Store` capability. The capability loads and stores
-ArcSet views and internal commitment nodes, but does not define persistence or
-ArcTable semantics. ArcTable/KV implementations belong to executors such as
-the managed gateway. Incorrect materialized state should either fail proof
-generation or produce evidence that the portable verifier rejects.
+Core proof-generation algorithms consume the narrowest required capability
+from `auth/arcset/materializer`: `Lookup`, `Updater`, `NodeStore`, or
+`MutableStore`. The full `Store` aggregate is adapter compatibility, not the
+default algorithm dependency. These capabilities load and materialize ArcSet
+views and internal commitment nodes without defining persistence or ArcTable
+semantics. ArcTable/KV implementations belong to executors such as the managed
+gateway. Incorrect materialized state should either fail proof generation or
+produce evidence that the portable verifier rejects.
 
 Freshness, head publication, merge policy, CAS availability, pinning, garbage
 collection, tenant isolation, and quotas are deployment or application policy,

--- a/docs/spec/writer-receipts.md
+++ b/docs/spec/writer-receipts.md
@@ -35,12 +35,11 @@ Package `mutation` is the stable portable contract. It defines
 `mutation.WriteReceipt` with the caller-supplied base root and produced result
 root. `graph.MutationWriter` is the reference graph adapter over that contract.
 
-`graph.CompatWriter` groups algorithm compatibility methods such as
-`CreateStructure`, `UpdateArc`, `BatchUpdateArcs`, `GetArc`, and
-`GetSnapshot`. These helpers remain available to SDK consumers and tests, but
-they are not the gateway product API. New integrations
-should prefer semantic mutations through `MutationWriter` unless they
-intentionally need reference compatibility helpers.
+`graph.StructureCreator` separately bootstraps a root when no authenticated
+base exists. `graph.ReferenceWriter` groups legacy root-consuming and
+inspection methods such as `UpdateArc`, `BatchUpdateArcs`, `GetArc`, and
+`GetSnapshot`. `RuntimeGraph.Writer()` returns only `MutationWriter`; reference
+helpers require the explicitly named `ReferenceWriter()` accessor.
 
 Transport projections and application-level diagnostic counts belong to the
 gateway or client that exposes them. They are not verifier evidence unless

--- a/graph/interfaces.go
+++ b/graph/interfaces.go
@@ -28,19 +28,30 @@ type MutationWriter interface {
 	Apply(ctx context.Context, namespace string, mut mutation.SemanticMutation) (mutation.WriteReceipt, error)
 }
 
-// CompatWriter exposes reference-runtime helper methods used by the local
-// server, CLI, and tests. These helpers are not the gateway product API.
-type CompatWriter interface {
+// StructureCreator bootstraps a semantic structure without claiming that the
+// operation is an update from an already authenticated base root.
+type StructureCreator interface {
 	CreateStructure(ctx context.Context, namespace string, arcs arcset.ArcSet) (cid.Cid, error)
+}
+
+// ReferenceWriter exposes legacy root-consuming and inspection helpers used by
+// reference executors and conformance tests. New integrations should depend on
+// MutationWriter and, when required, the separate StructureCreator capability.
+type ReferenceWriter interface {
+	StructureCreator
 	UpdateArc(ctx context.Context, namespace string, root cid.Cid, path string, newTarget cid.Cid) (*writer.UpdateResult, error)
 	BatchUpdateArcs(ctx context.Context, namespace string, root cid.Cid, updates map[string]cid.Cid) (*writer.BatchUpdateResult, error)
 	GetArc(ctx context.Context, namespace string, root cid.Cid, path string) (cid.Cid, error)
 	GetSnapshot(ctx context.Context, namespace string, root cid.Cid) (arcset.ArcSet, error)
 }
 
-// Writer is the reference-runtime write surface. New core integrations should
-// prefer MutationWriter unless they intentionally need compatibility helpers.
+// CompatWriter is retained as a source-compatible alias for ReferenceWriter.
+// Deprecated: use ReferenceWriter or a narrower capability.
+type CompatWriter = ReferenceWriter
+
+// Writer is the complete reference-runtime write surface.
+// Deprecated: depend on MutationWriter, StructureCreator, or ReferenceWriter.
 type Writer interface {
 	MutationWriter
-	CompatWriter
+	ReferenceWriter
 }

--- a/graph/interfaces_test.go
+++ b/graph/interfaces_test.go
@@ -10,6 +10,7 @@ import (
 func TestResolverAndWriterImplementGraphPorts(t *testing.T) {
 	var _ Resolver = (*resolver.Resolver)(nil)
 	var _ MutationWriter = (*writer.Writer)(nil)
-	var _ CompatWriter = (*writer.Writer)(nil)
+	var _ StructureCreator = (*writer.Writer)(nil)
+	var _ ReferenceWriter = (*writer.Writer)(nil)
 	var _ Writer = (*writer.Writer)(nil)
 }

--- a/graph/runtime/graph.go
+++ b/graph/runtime/graph.go
@@ -30,7 +30,9 @@ type RuntimeGraph struct {
 	semantic     mapping.Semantics
 	listSemantic list.Semantics
 	resolver     graph.Resolver
-	wr           graph.Writer
+	wr           graph.MutationWriter
+	structures   graph.StructureCreator
+	reference    graph.ReferenceWriter
 }
 
 // NewGraph creates a new per-graph instance with its own semantic layer,
@@ -40,7 +42,7 @@ type RuntimeGraph struct {
 //   - id: unique graph identifier
 //   - materializer: caller-owned ArcSet materializer
 //   - opts: functional options (WithCommitmentScheme, WithNamespace, etc.)
-func NewGraph(id string, materializer materializer.Store, opts ...Option) (*RuntimeGraph, error) {
+func NewGraph(id string, materializer materializer.MutableStore, opts ...Option) (*RuntimeGraph, error) {
 	o := defaultOptions()
 	for _, opt := range opts {
 		opt(o)
@@ -87,6 +89,8 @@ func NewGraph(id string, materializer materializer.Store, opts ...Option) (*Runt
 		listSemantic: listSemantic,
 		resolver:     res,
 		wr:           wr,
+		structures:   wr,
+		reference:    wr,
 	}, nil
 }
 
@@ -146,7 +150,21 @@ func (g *RuntimeGraph) Resolve(ctx context.Context, req malt.ResolveRequest) (ma
 	return malt.ResolveResult{Target: resolved.Target, ProofList: *pl}, nil
 }
 
-// Writer returns the per-graph writer.
-func (g *RuntimeGraph) Writer() graph.Writer {
+// Writer returns the stable semantic-mutation capability. It intentionally
+// omits legacy root-consuming helpers and reference inspection methods.
+func (g *RuntimeGraph) Writer() graph.MutationWriter {
 	return g.wr
+}
+
+// StructureCreator returns the separate bootstrap capability used to create a
+// structure when there is no authenticated base root to mutate.
+func (g *RuntimeGraph) StructureCreator() graph.StructureCreator {
+	return g.structures
+}
+
+// ReferenceWriter returns legacy helpers for reference executors and
+// conformance tests. Product integrations should not use it as their default
+// mutation surface.
+func (g *RuntimeGraph) ReferenceWriter() graph.ReferenceWriter {
+	return g.reference
 }

--- a/graph/runtime/graph_test.go
+++ b/graph/runtime/graph_test.go
@@ -19,8 +19,8 @@ func TestNewGraphInitializesSDKComposition(t *testing.T) {
 	if g.Namespace() != "ns" {
 		t.Fatalf("Namespace = %q, want ns", g.Namespace())
 	}
-	if g.Resolver() == nil || g.Writer() == nil {
-		t.Fatal("resolver and writer must be initialized")
+	if g.Resolver() == nil || g.Writer() == nil || g.StructureCreator() == nil || g.ReferenceWriter() == nil {
+		t.Fatal("resolver, mutation, bootstrap, and reference capabilities must be initialized")
 	}
 	if g.Semantic() == nil || g.ListSemantic() == nil {
 		t.Fatal("semantic implementations must be initialized")

--- a/graph/writer/materialization_failure.go
+++ b/graph/writer/materialization_failure.go
@@ -1,0 +1,135 @@
+package writer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	cid "github.com/ipfs/go-cid"
+)
+
+// ErrMaterializationWriteFailed is returned when the semantic layer produced
+// a new root but the ArcSet materialization write failed. The semantic
+// commitment cannot be rolled back, so the error carries the exact retry.
+var ErrMaterializationWriteFailed = errors.New("materializer materialization write failed after semantic commit")
+
+// MaterializationWriteFailedError carries the root and exact materialization
+// transition produced before a caller-owned materializer failed.
+type MaterializationWriteFailedError struct {
+	NewRoot              cid.Cid
+	Namespace            string
+	OldRoot              cid.Cid
+	MaterializationBase  arcset.ArcSet
+	MaterializationDelta arcset.ArcSet
+	Cause                error
+}
+
+func (e *MaterializationWriteFailedError) Error() string {
+	return fmt.Errorf("%w (newRoot=%s): %v", ErrMaterializationWriteFailed, e.NewRoot, e.Cause).Error()
+}
+
+func (e *MaterializationWriteFailedError) Unwrap() error {
+	return errors.Join(ErrMaterializationWriteFailed, e.Cause)
+}
+
+// RetryMaterializationWrite retries the exact ArcSet transition captured by
+// this error. Prefer Writer.RetryMaterializationWrite when a writer is
+// available so legacy freshness guards serialize the retry.
+func (e *MaterializationWriteFailedError) RetryMaterializationWrite(ctx context.Context, table Materializer) error {
+	return e.retryMaterializationWrite(ctx, table)
+}
+
+func (e *MaterializationWriteFailedError) retryMaterializationWrite(ctx context.Context, table Materializer) error {
+	if e == nil {
+		return fmt.Errorf("materialization write failure is nil")
+	}
+	if table == nil {
+		return fmt.Errorf("materializer is nil")
+	}
+	if e.MaterializationDelta == nil {
+		return fmt.Errorf("%w: missing materialization delta", ErrMaterializationWriteFailed)
+	}
+	if !supportsConcurrentBranches(table) {
+		if e.MaterializationBase == nil {
+			return fmt.Errorf("%w: missing materialization retry base", ErrMaterializationWriteFailed)
+		}
+		current, err := table.Snapshot(ctx, e.Namespace, cid.Undef)
+		if err != nil {
+			return fmt.Errorf("Materializer.Snapshot failed during materialization retry: %w", err)
+		}
+		expectedAfter, err := applyArcSetDelta(e.MaterializationBase, e.MaterializationDelta)
+		if err != nil {
+			return err
+		}
+		matchesBase, err := arcSetsEqual(current, e.MaterializationBase)
+		if err != nil {
+			return err
+		}
+		matchesAfter, err := arcSetsEqual(current, expectedAfter)
+		if err != nil {
+			return err
+		}
+		if !matchesBase && !matchesAfter {
+			return fmt.Errorf("%w: stale materialization retry for namespace %q oldRoot=%s newRoot=%s", ErrStaleRoot, e.Namespace, e.OldRoot, e.NewRoot)
+		}
+	}
+	if err := table.Update(ctx, e.Namespace, e.NewRoot, e.OldRoot, e.MaterializationDelta); err != nil {
+		return &MaterializationWriteFailedError{
+			NewRoot:              e.NewRoot,
+			Namespace:            e.Namespace,
+			OldRoot:              e.OldRoot,
+			MaterializationBase:  e.MaterializationBase,
+			MaterializationDelta: e.MaterializationDelta,
+			Cause:                err,
+		}
+	}
+	return nil
+}
+
+func materializationRetryBase(ctx context.Context, table Materializer, namespace string) (arcset.ArcSet, error) {
+	if table == nil || supportsConcurrentBranches(table) {
+		return nil, nil
+	}
+	return table.Snapshot(ctx, namespace, cid.Undef)
+}
+
+func applyArcSetDelta(base, delta arcset.ArcSet) (arcset.ArcSet, error) {
+	baseMap, err := arcset.ToPathMap(base)
+	if err != nil {
+		return nil, err
+	}
+	deltaMap, err := arcset.ToPathMap(delta)
+	if err != nil {
+		return nil, err
+	}
+	for path, target := range deltaMap {
+		if target.Defined() {
+			baseMap[path] = target
+		} else {
+			delete(baseMap, path)
+		}
+	}
+	return arcset.NewArcSetFromPaths(baseMap)
+}
+
+func arcSetsEqual(a, b arcset.ArcSet) (bool, error) {
+	aMap, err := arcset.ToPathMap(a)
+	if err != nil {
+		return false, err
+	}
+	bMap, err := arcset.ToPathMap(b)
+	if err != nil {
+		return false, err
+	}
+	if len(aMap) != len(bMap) {
+		return false, nil
+	}
+	for path, aTarget := range aMap {
+		bTarget, ok := bMap[path]
+		if !ok || !aTarget.Equals(bTarget) {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/graph/writer/reference_freshness.go
+++ b/graph/writer/reference_freshness.go
@@ -1,0 +1,97 @@
+package writer
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	cid "github.com/ipfs/go-cid"
+)
+
+// Legacy root-consumption freshness is isolated from semantic mutation logic.
+// It protects overwrite-like reference materializers; authoritative head and
+// multi-writer policy remain outside MALT core.
+var sharedFreshnessGuards sync.Map
+
+type rootFreshnessGuard struct {
+	mu       sync.Mutex
+	consumed map[string]cid.Cid
+}
+
+func newRootFreshnessGuard() *rootFreshnessGuard {
+	return &rootFreshnessGuard{consumed: make(map[string]cid.Cid)}
+}
+
+func sharedRootFreshnessGuard(table Materializer) *rootFreshnessGuard {
+	key, ok := materializerFreshnessIdentity(table)
+	if !ok {
+		return newRootFreshnessGuard()
+	}
+	guard, _ := sharedFreshnessGuards.LoadOrStore(key, newRootFreshnessGuard())
+	return guard.(*rootFreshnessGuard)
+}
+
+func materializerFreshnessIdentity(table Materializer) (any, bool) {
+	if table == nil || !reflect.TypeOf(table).Comparable() {
+		return nil, false
+	}
+	return table, true
+}
+
+func rootFreshnessGuardFor(table Materializer) *rootFreshnessGuard {
+	if supportsConcurrentBranches(table) {
+		return nil
+	}
+	return sharedRootFreshnessGuard(table)
+}
+
+func supportsConcurrentBranches(table Materializer) bool {
+	if table == nil {
+		return false
+	}
+	branching, ok := table.(BranchingMaterializer)
+	return ok && branching.SupportsConcurrentBranches()
+}
+
+func freshnessKey(namespace string, root cid.Cid) string {
+	return namespace + "\x00" + root.String()
+}
+
+func (g *rootFreshnessGuard) beginUpdate(namespace string, root cid.Cid) (func(), error) {
+	key := freshnessKey(namespace, root)
+	g.mu.Lock()
+	advancedTo, ok := g.consumed[key]
+	if !ok {
+		return g.mu.Unlock, nil
+	}
+	g.mu.Unlock()
+	return nil, fmt.Errorf("%w: root %s in namespace %q already advanced to %s", ErrStaleRoot, root, namespace, advancedTo)
+}
+
+func (g *rootFreshnessGuard) markAdvanced(namespace string, oldRoot, newRoot cid.Cid) {
+	if !oldRoot.Defined() || !newRoot.Defined() || oldRoot.Equals(newRoot) {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.markAdvancedLocked(namespace, oldRoot, newRoot)
+}
+
+func (g *rootFreshnessGuard) markAdvancedLocked(namespace string, oldRoot, newRoot cid.Cid) {
+	if !oldRoot.Defined() || !newRoot.Defined() || oldRoot.Equals(newRoot) {
+		return
+	}
+	oldKey := freshnessKey(namespace, oldRoot)
+	newKey := freshnessKey(namespace, newRoot)
+	g.consumed[oldKey] = newRoot
+	delete(g.consumed, newKey)
+}
+
+func (g *rootFreshnessGuard) markCurrent(namespace string, root cid.Cid) {
+	if !root.Defined() {
+		return
+	}
+	g.mu.Lock()
+	delete(g.consumed, freshnessKey(namespace, root))
+	g.mu.Unlock()
+}

--- a/graph/writer/writer.go
+++ b/graph/writer/writer.go
@@ -1,14 +1,11 @@
-// Package writer implements the write-side API for MALT.
-// It provides the unified arc update procedure (UpdateArc) described in Sec 4.5,
-// coordinating map semantics and caller-owned ArcSet materialization.
+// Package writer implements semantic mutation and explicitly reference-only
+// arc update algorithms over caller-owned ArcSet materialization.
 package writer
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
-	"sync"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	materialization "github.com/dewebprotocol/malt/auth/arcset/materializer"
@@ -19,7 +16,7 @@ import (
 
 // Materializer is the caller-injected ArcSet capability consumed by Writer.
 // It is an alias for the core materializer contract, not a persistence model.
-type Materializer = materialization.Store
+type Materializer = materialization.MutableStore
 
 // BranchingMaterializer optionally reports support for concurrent children.
 type BranchingMaterializer = materialization.BranchingStore
@@ -38,162 +35,7 @@ var (
 	// update a base root that this writer has already advanced in the same
 	// namespace.
 	ErrStaleRoot = errors.New("stale root")
-
-	// ErrMaterializationWriteFailed is returned when the semantic layer produced a new
-	// root but the ArcSet materialization write failed. The semantic commitment is
-	// content-addressed and cannot be rolled back, so the returned newRoot is a
-	// cryptographically valid root whose materialized entries may be missing.
-	//
-	// To recover, use errors.As to recover MaterializationWriteFailedError and call
-	// Writer.RetryMaterializationWrite. The error carries the exact old->new materialization
-	// transition because retrying the original writer operation is not
-	// guaranteed to work after a non-atomic backend has partially applied the
-	// failed index update (for example, after invalidating the old root mapping).
-	ErrMaterializationWriteFailed = errors.New("materializer materialization write failed after semantic commit")
 )
-
-// MaterializationWriteFailedError carries the newRoot produced by the semantic layer when
-// the ArcSet materialization write failed. errors.Is(err, ErrMaterializationWriteFailed) and
-// errors.Is(err, <underlying cause>) both succeed.
-//
-// The fields are exposed for diagnostics, correlation, and materialization repair.
-// MaterializationBase and MaterializationDelta capture the failed publication so callers can retry
-// it with Writer.RetryMaterializationWrite. For non-branching materializers, retry
-// first verifies that the namespace has not advanced past this failed
-// transition; stale retries fail closed instead of overwriting later writes.
-type MaterializationWriteFailedError struct {
-	// NewRoot is the content-addressed root the semantic layer committed. It is
-	// valid in the semantic sense, but its ArcSet materialization may not have
-	// been persisted.
-	NewRoot cid.Cid
-	// Namespace is the namespace of the failed materialization write, for retry context.
-	Namespace string
-	// OldRoot is the base root the write transitioned from (cid.Undef for
-	// CreateStructure).
-	OldRoot cid.Cid
-	// MaterializationBase is the namespace arc snapshot immediately before the failed
-	// publication. It is used to reject stale retries on overwrite-like
-	// backends whose physical arc keys are namespace-scoped rather than
-	// root-scoped.
-	MaterializationBase arcset.ArcSet
-	// MaterializationDelta is the exact update payload for OldRoot -> NewRoot.
-	// It may be a full snapshot for create-style writes.
-	MaterializationDelta arcset.ArcSet
-	// Cause is the error returned by the materializer's Update method.
-	Cause error
-}
-
-func (e *MaterializationWriteFailedError) Error() string {
-	return fmt.Errorf("%w (newRoot=%s): %v", ErrMaterializationWriteFailed, e.NewRoot, e.Cause).Error()
-}
-
-func (e *MaterializationWriteFailedError) Unwrap() error {
-	return errors.Join(ErrMaterializationWriteFailed, e.Cause)
-}
-
-// RetryMaterializationWrite retries the failed ArcSet publication captured by this
-// error. Prefer Writer.RetryMaterializationWrite when a writer is available: the writer
-// method reuses the same freshness guard as normal updates and serializes retry
-// against concurrent root-consuming writes.
-func (e *MaterializationWriteFailedError) RetryMaterializationWrite(ctx context.Context, table Materializer) error {
-	return e.retryMaterializationWrite(ctx, table)
-}
-
-func (e *MaterializationWriteFailedError) retryMaterializationWrite(ctx context.Context, table Materializer) error {
-	if e == nil {
-		return fmt.Errorf("materialization write failure is nil")
-	}
-	if table == nil {
-		return fmt.Errorf("materializer is nil")
-	}
-	if e.MaterializationDelta == nil {
-		return fmt.Errorf("%w: missing materialization delta", ErrMaterializationWriteFailed)
-	}
-	if !supportsConcurrentBranches(table) {
-		if e.MaterializationBase == nil {
-			return fmt.Errorf("%w: missing materialization retry base", ErrMaterializationWriteFailed)
-		}
-		current, err := table.Snapshot(ctx, e.Namespace, cid.Undef)
-		if err != nil {
-			return fmt.Errorf("Materializer.Snapshot failed during materialization retry: %w", err)
-		}
-		expectedAfter, err := applyArcSetDelta(e.MaterializationBase, e.MaterializationDelta)
-		if err != nil {
-			return err
-		}
-		matchesBase, err := arcSetsEqual(current, e.MaterializationBase)
-		if err != nil {
-			return err
-		}
-		matchesAfter, err := arcSetsEqual(current, expectedAfter)
-		if err != nil {
-			return err
-		}
-		if !matchesBase && !matchesAfter {
-			return fmt.Errorf("%w: stale materialization retry for namespace %q oldRoot=%s newRoot=%s", ErrStaleRoot, e.Namespace, e.OldRoot, e.NewRoot)
-		}
-	}
-	if err := table.Update(ctx, e.Namespace, e.NewRoot, e.OldRoot, e.MaterializationDelta); err != nil {
-		return &MaterializationWriteFailedError{
-			NewRoot:              e.NewRoot,
-			Namespace:            e.Namespace,
-			OldRoot:              e.OldRoot,
-			MaterializationBase:  e.MaterializationBase,
-			MaterializationDelta: e.MaterializationDelta,
-			Cause:                err,
-		}
-	}
-	return nil
-}
-
-func materializationRetryBase(ctx context.Context, table Materializer, namespace string) (arcset.ArcSet, error) {
-	if table == nil || supportsConcurrentBranches(table) {
-		return nil, nil
-	}
-	// Overwrite-like backends need a namespace snapshot so retry can reject
-	// stale replays after a non-atomic materialization write failure.
-	return table.Snapshot(ctx, namespace, cid.Undef)
-}
-
-func applyArcSetDelta(base, delta arcset.ArcSet) (arcset.ArcSet, error) {
-	baseMap, err := arcset.ToPathMap(base)
-	if err != nil {
-		return nil, err
-	}
-	deltaMap, err := arcset.ToPathMap(delta)
-	if err != nil {
-		return nil, err
-	}
-	for path, target := range deltaMap {
-		if target.Defined() {
-			baseMap[path] = target
-		} else {
-			delete(baseMap, path)
-		}
-	}
-	return arcset.NewArcSetFromPaths(baseMap)
-}
-
-func arcSetsEqual(a, b arcset.ArcSet) (bool, error) {
-	aMap, err := arcset.ToPathMap(a)
-	if err != nil {
-		return false, err
-	}
-	bMap, err := arcset.ToPathMap(b)
-	if err != nil {
-		return false, err
-	}
-	if len(aMap) != len(bMap) {
-		return false, nil
-	}
-	for path, aTarget := range aMap {
-		bTarget, ok := bMap[path]
-		if !ok || !aTarget.Equals(bTarget) {
-			return false, nil
-		}
-	}
-	return true, nil
-}
 
 // ArcOp describes the type of arc operation performed.
 type ArcOp uint8
@@ -253,9 +95,9 @@ type BatchUpdateResult struct {
 	PerArc map[arcset.Path]UpdateResult
 }
 
-// Writer implements the write-side API for MALT.
-// It coordinates keyed-map semantics and Materializer (index) updates to execute
-// the unified arc update procedure from Sec 4.5.
+// Writer implements semantic mutation plus the legacy reference helpers exposed
+// through graph.ReferenceWriter. Product callers should receive it through a
+// narrow graph.MutationWriter or graph.StructureCreator interface.
 //
 // The legacy UpdateArc/BatchUpdateArcs paths only enforce single-consumer root
 // freshness for non-branching Materializer backends. MVCC-style backends such as
@@ -321,96 +163,6 @@ func (w *Writer) RetryMaterializationWrite(ctx context.Context, err *Materializa
 		}
 	}
 	return nil
-}
-
-var sharedFreshnessGuards sync.Map
-
-type rootFreshnessGuard struct {
-	mu       sync.Mutex
-	consumed map[string]cid.Cid
-}
-
-func newRootFreshnessGuard() *rootFreshnessGuard {
-	return &rootFreshnessGuard{
-		consumed: make(map[string]cid.Cid),
-	}
-}
-
-func sharedRootFreshnessGuard(table Materializer) *rootFreshnessGuard {
-	key, ok := materializerFreshnessIdentity(table)
-	if !ok {
-		return newRootFreshnessGuard()
-	}
-	guard, _ := sharedFreshnessGuards.LoadOrStore(key, newRootFreshnessGuard())
-	return guard.(*rootFreshnessGuard)
-}
-
-func materializerFreshnessIdentity(table Materializer) (any, bool) {
-	if table == nil {
-		return nil, false
-	}
-	if !reflect.TypeOf(table).Comparable() {
-		return nil, false
-	}
-	return table, true
-}
-
-func rootFreshnessGuardFor(table Materializer) *rootFreshnessGuard {
-	if supportsConcurrentBranches(table) {
-		return nil
-	}
-	return sharedRootFreshnessGuard(table)
-}
-
-func supportsConcurrentBranches(table Materializer) bool {
-	if table == nil {
-		return false
-	}
-	branching, ok := table.(BranchingMaterializer)
-	return ok && branching.SupportsConcurrentBranches()
-}
-
-func freshnessKey(namespace string, root cid.Cid) string {
-	return namespace + "\x00" + root.String()
-}
-
-func (g *rootFreshnessGuard) beginUpdate(namespace string, root cid.Cid) (func(), error) {
-	key := freshnessKey(namespace, root)
-	g.mu.Lock()
-	advancedTo, ok := g.consumed[key]
-	if !ok {
-		return g.mu.Unlock, nil
-	}
-	g.mu.Unlock()
-	return nil, fmt.Errorf("%w: root %s in namespace %q already advanced to %s", ErrStaleRoot, root, namespace, advancedTo)
-}
-
-func (g *rootFreshnessGuard) markAdvanced(namespace string, oldRoot, newRoot cid.Cid) {
-	if !oldRoot.Defined() || !newRoot.Defined() || oldRoot.Equals(newRoot) {
-		return
-	}
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.markAdvancedLocked(namespace, oldRoot, newRoot)
-}
-
-func (g *rootFreshnessGuard) markAdvancedLocked(namespace string, oldRoot, newRoot cid.Cid) {
-	if !oldRoot.Defined() || !newRoot.Defined() || oldRoot.Equals(newRoot) {
-		return
-	}
-	oldKey := freshnessKey(namespace, oldRoot)
-	newKey := freshnessKey(namespace, newRoot)
-	g.consumed[oldKey] = newRoot
-	delete(g.consumed, newKey)
-}
-
-func (g *rootFreshnessGuard) markCurrent(namespace string, root cid.Cid) {
-	if !root.Defined() {
-		return
-	}
-	g.mu.Lock()
-	delete(g.consumed, freshnessKey(namespace, root))
-	g.mu.Unlock()
 }
 
 func canonicalizeUpdateMap(updates map[string]cid.Cid) (map[arcset.Path]cid.Cid, error) {


### PR DESCRIPTION
## Summary

- add repository-local collaboration rules for the SDK-only MALT core
- split the aggregate ArcSet materializer into lookup, update, snapshot, node-store, and mutable-store capabilities
- make `RuntimeGraph.Writer()` expose only semantic mutation while bootstrap and legacy reference helpers use explicit ports
- isolate materialization-failure recovery and legacy freshness logic into focused writer files
- add an go/types import-binding architecture guard that prevents default, renamed, or dot imports from bypassing the aggregate `materializer.Store` boundary

## Why

The v0.0.6 migration removed product storage and application code from core, but production algorithms still accepted a five-method aggregate materializer and the default runtime writer exposed legacy root-consuming helpers. This change makes the compile-time API match the documented SDK boundary without introducing persistence, application, or transition-proof semantics.

## Compatibility

- the full `materializer.Store`, `graph.CompatWriter`, and `graph.Writer` aggregates remain available as compatibility surfaces
- the in-memory conformance store still implements the full aggregate
- `malt.artifact/v0alpha2` is unchanged
- `CreateStructure` remains a separate bootstrap capability because a new structure has no authenticated base root

## Validation

- regression fixtures cover default, renamed, dot, shadowed-local, blank, narrow-capability, string, and unrelated-package imports
- `go test . -run 'TestProductionAlgorithmsUseNarrowMaterializerCapabilities|TestAggregateMaterializerStoreImportDetection' -count=1`
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`