### PR TITLE
Add Resolve/Read conformance corpus and structured typed roots

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,11 +26,19 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Download modules
         run: go mod download
 
       - name: Run tests
         run: go test ./...
+
+      - name: Run WASM conformance vectors
+        run: sh scripts/test-verifier-wasm-vectors.sh
 
       - name: Run vet
         run: go vet ./...

--- a/cmd/malt-verifier-wasm/main.go
+++ b/cmd/malt-verifier-wasm/main.go
@@ -39,8 +39,8 @@ func main() {
 		if len(args) != 1 || args[0].Type() != js.TypeString {
 			return encodeProtocolResponse(protocol.VerificationResult{Profile: protocol.ResolveProfile, Error: "maltVerifyResolve expects one JSON string"})
 		}
-		var value protocol.ResolveVerification
-		if err := json.Unmarshal([]byte(args[0].String()), &value); err != nil {
+		value, err := protocol.DecodeResolveVerification([]byte(args[0].String()))
+		if err != nil {
 			return encodeProtocolResponse(protocol.VerificationResult{Profile: protocol.ResolveProfile, Error: fmt.Sprintf("decode resolve verification: %v", err)})
 		}
 		if err := verifier.VerifyResolve(context.Background(), value); err != nil {
@@ -55,8 +55,8 @@ func main() {
 		if len(args) != 1 || args[0].Type() != js.TypeString {
 			return encodeProtocolResponse(protocol.VerificationResult{Profile: protocol.ReadProfile, Error: "maltVerifyRead expects one JSON string"})
 		}
-		var value protocol.ReadVerification
-		if err := json.Unmarshal([]byte(args[0].String()), &value); err != nil {
+		value, err := protocol.DecodeReadVerification([]byte(args[0].String()))
+		if err != nil {
 			return encodeProtocolResponse(protocol.VerificationResult{Profile: protocol.ReadProfile, Error: fmt.Sprintf("decode read verification: %v", err)})
 		}
 		if err := verifier.VerifyRead(context.Background(), value); err != nil {

--- a/conformance/corpus.go
+++ b/conformance/corpus.go
@@ -1,0 +1,217 @@
+// Package conformance exposes the checked-in, language-neutral resolve/read
+// verification corpus. The corpus is immutable protocol test data; producing
+// runtime evidence remains the responsibility of the deterministic generator.
+package conformance
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/dewebprotocol/malt/protocol"
+)
+
+const (
+	// ResolveReadV1 is the independent conformance-corpus version. It is not a
+	// replacement for the resolve/read wire profile identifiers.
+	ResolveReadV1 = "malt.resolve-read.conformance/v1"
+
+	OperationResolve = "resolve"
+	OperationRead    = "read"
+
+	BackendNone = "none"
+	BackendKZG  = "kzg"
+	BackendIPA  = "ipa"
+)
+
+const corpusPath = "resolve-read/v1/vectors.json"
+
+//go:generate go run ../internal/conformancegen/cmd -out resolve-read/v1/vectors.json
+
+//go:embed resolve-read/v1/*.json
+var corpusFiles embed.FS
+
+// Corpus is the stable, ordered envelope shared by every verifier adapter.
+type Corpus struct {
+	SchemaVersion string   `json:"schema_version"`
+	Vectors       []Vector `json:"vectors"`
+}
+
+// Vector binds one exact serialized verification input to an accept/reject
+// expectation. Verification remains raw so malformed field encodings can be
+// tested without weakening the corpus envelope decoder.
+type Vector struct {
+	ID           string          `json:"id"`
+	Operation    string          `json:"operation"`
+	Backend      string          `json:"backend"`
+	Category     string          `json:"category"`
+	Verification json.RawMessage `json:"verification"`
+	Expected     Expected        `json:"expected"`
+}
+
+// Expected records the portable outcome. Error strings are deliberately not
+// conformance data because they are implementation-specific diagnostics.
+type Expected struct {
+	Valid bool `json:"valid"`
+}
+
+// UnmarshalJSON makes expected.valid required while retaining a convenient
+// bool-facing API for corpus consumers.
+func (e *Expected) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		Valid *bool `json:"valid"`
+	}
+	if err := decodeStrict(data, &wire); err != nil {
+		return err
+	}
+	if wire.Valid == nil {
+		return fmt.Errorf("expected.valid is required")
+	}
+	e.Valid = *wire.Valid
+	return nil
+}
+
+// Verifier is the portable resolve/read verification surface exercised by the
+// corpus. sdk/verifier.Verifier satisfies this interface.
+type Verifier interface {
+	VerifyResolve(context.Context, protocol.ResolveVerification) error
+	VerifyRead(context.Context, protocol.ReadVerification) error
+}
+
+// Load returns and validates the embedded v1 corpus.
+func Load() (Corpus, error) {
+	data, err := Bytes()
+	if err != nil {
+		return Corpus{}, err
+	}
+	var corpus Corpus
+	if err := decodeStrict(data, &corpus); err != nil {
+		return Corpus{}, fmt.Errorf("decode conformance corpus: %w", err)
+	}
+	if err := corpus.Validate(); err != nil {
+		return Corpus{}, err
+	}
+	return corpus, nil
+}
+
+// Bytes returns a detached copy of the canonical checked-in corpus bytes.
+func Bytes() ([]byte, error) {
+	data, err := corpusFiles.ReadFile(corpusPath)
+	if err != nil {
+		return nil, fmt.Errorf("read embedded conformance corpus: %w", err)
+	}
+	return slices.Clone(data), nil
+}
+
+// Schema returns a detached copy of one checked-in conformance schema.
+func Schema(name string) ([]byte, error) {
+	if name != "corpus.schema.json" && name != "vector.schema.json" {
+		return nil, fmt.Errorf("unknown conformance schema %q", name)
+	}
+	data, err := corpusFiles.ReadFile("resolve-read/v1/" + name)
+	if err != nil {
+		return nil, fmt.Errorf("read conformance schema %q: %w", name, err)
+	}
+	return slices.Clone(data), nil
+}
+
+// Validate checks corpus-level invariants that JSON Schema alone cannot make
+// convenient for small consumers, including stable ID uniqueness.
+func (c Corpus) Validate() error {
+	if c.SchemaVersion != ResolveReadV1 {
+		return fmt.Errorf("unsupported conformance schema version %q", c.SchemaVersion)
+	}
+	if len(c.Vectors) == 0 {
+		return fmt.Errorf("conformance corpus has no vectors")
+	}
+	seen := make(map[string]struct{}, len(c.Vectors))
+	for i, vector := range c.Vectors {
+		if err := vector.Validate(); err != nil {
+			return fmt.Errorf("vector %d: %w", i, err)
+		}
+		if _, exists := seen[vector.ID]; exists {
+			return fmt.Errorf("duplicate conformance vector id %q", vector.ID)
+		}
+		seen[vector.ID] = struct{}{}
+	}
+	return nil
+}
+
+// Validate checks the stable envelope without interpreting the operation DTO.
+func (v Vector) Validate() error {
+	if !validVectorID(v.ID) {
+		return fmt.Errorf("invalid vector id %q", v.ID)
+	}
+	if v.Operation != OperationResolve && v.Operation != OperationRead {
+		return fmt.Errorf("vector %q has unsupported operation %q", v.ID, v.Operation)
+	}
+	if v.Backend != BackendNone && v.Backend != BackendKZG && v.Backend != BackendIPA {
+		return fmt.Errorf("vector %q has unsupported backend %q", v.ID, v.Backend)
+	}
+	if v.Category == "" {
+		return fmt.Errorf("vector %q has empty category", v.ID)
+	}
+	trimmed := bytes.TrimSpace(v.Verification)
+	if len(trimmed) == 0 || trimmed[0] != '{' || !json.Valid(trimmed) {
+		return fmt.Errorf("vector %q verification is not a JSON object", v.ID)
+	}
+	return nil
+}
+
+func validVectorID(value string) bool {
+	if value == "" || strings.TrimSpace(value) != value {
+		return false
+	}
+	separator := true
+	for _, r := range value {
+		alphanumeric := r >= 'a' && r <= 'z' || r >= '0' && r <= '9'
+		if alphanumeric {
+			separator = false
+			continue
+		}
+		if (r != '.' && r != '_' && r != '-') || separator {
+			return false
+		}
+		separator = true
+	}
+	return !separator
+}
+
+// Accepted evaluates one vector through the same strict DTO decoders used by
+// transport adapters. Any decode, shape, binding, or cryptographic error is a
+// portable rejection; diagnostic error text is intentionally ignored.
+func Accepted(ctx context.Context, verifier Verifier, vector Vector) bool {
+	if verifier == nil {
+		return false
+	}
+	switch vector.Operation {
+	case OperationResolve:
+		value, err := protocol.DecodeResolveVerification(vector.Verification)
+		return err == nil && verifier.VerifyResolve(ctx, value) == nil
+	case OperationRead:
+		value, err := protocol.DecodeReadVerification(vector.Verification)
+		return err == nil && verifier.VerifyRead(ctx, value) == nil
+	default:
+		return false
+	}
+}
+
+func decodeStrict(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}

--- a/conformance/corpus_test.go
+++ b/conformance/corpus_test.go
@@ -1,0 +1,164 @@
+package conformance_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dewebprotocol/malt/conformance"
+	"github.com/dewebprotocol/malt/internal/conformancegen"
+	"github.com/dewebprotocol/malt/protocol"
+	sdkverifier "github.com/dewebprotocol/malt/sdk/verifier"
+)
+
+func TestResolveReadV1Corpus(t *testing.T) {
+	corpus, err := conformance.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	verifier, err := sdkverifier.NewDefault()
+	if err != nil {
+		t.Fatalf("NewDefault: %v", err)
+	}
+	for _, vector := range corpus.Vectors {
+		vector := vector
+		t.Run(vector.ID, func(t *testing.T) {
+			accepted := conformance.Accepted(context.Background(), verifier, vector)
+			if accepted != vector.Expected.Valid {
+				t.Fatalf("accepted = %t, want %t", accepted, vector.Expected.Valid)
+			}
+		})
+	}
+}
+
+func TestResolveReadV1CorpusIsGenerated(t *testing.T) {
+	want, err := conformance.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	got, err := conformancegen.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("checked-in vectors.json is stale; run go generate ./conformance")
+	}
+}
+
+func TestResolveReadV1SchemasAreJSON(t *testing.T) {
+	for _, name := range []string{"corpus.schema.json", "vector.schema.json"} {
+		data, err := conformance.Schema(name)
+		if err != nil {
+			t.Fatalf("Schema(%q): %v", name, err)
+		}
+		if !json.Valid(data) {
+			t.Fatalf("Schema(%q) is not valid JSON", name)
+		}
+	}
+}
+
+func TestResolveReadV1CoverageMatrix(t *testing.T) {
+	corpus, err := conformance.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	type coverageKey struct {
+		operation string
+		backend   string
+		category  string
+		valid     bool
+	}
+	covered := make(map[coverageKey]bool, len(corpus.Vectors))
+	for _, vector := range corpus.Vectors {
+		covered[coverageKey{vector.Operation, vector.Backend, vector.Category, vector.Expected.Valid}] = true
+	}
+
+	required := []coverageKey{{conformance.OperationResolve, conformance.BackendNone, "identity", true}}
+	for _, backend := range []string{conformance.BackendKZG, conformance.BackendIPA} {
+		required = append(required,
+			coverageKey{conformance.OperationResolve, backend, "map_key", true},
+			coverageKey{conformance.OperationResolve, backend, "multihop", true},
+			coverageKey{conformance.OperationResolve, backend, "payload", true},
+			coverageKey{conformance.OperationRead, backend, "map_key", true},
+			coverageKey{conformance.OperationRead, backend, "payload", true},
+			coverageKey{conformance.OperationRead, backend, "list_index", true},
+			coverageKey{conformance.OperationRead, backend, "list_range", true},
+			coverageKey{conformance.OperationResolve, backend, "tamper", false},
+			coverageKey{conformance.OperationResolve, backend, "cross_root", false},
+			coverageKey{conformance.OperationResolve, backend, "malformed_evidence", false},
+			coverageKey{conformance.OperationResolve, backend, "strict_json", false},
+			coverageKey{conformance.OperationRead, backend, "tamper", false},
+			coverageKey{conformance.OperationRead, backend, "cross_root", false},
+			coverageKey{conformance.OperationRead, backend, "cross_kind", false},
+			coverageKey{conformance.OperationRead, backend, "cross_backend", false},
+			coverageKey{conformance.OperationRead, backend, "malformed_evidence", false},
+			coverageKey{conformance.OperationRead, backend, "strict_json", false},
+		)
+	}
+	for _, key := range required {
+		if !covered[key] {
+			t.Errorf("missing coverage: operation=%s backend=%s category=%s valid=%t", key.operation, key.backend, key.category, key.valid)
+		}
+	}
+}
+
+func TestResolveReadV1CryptographicTamperInputsRemainDecodable(t *testing.T) {
+	corpus, err := conformance.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, vector := range corpus.Vectors {
+		if !strings.Contains(vector.ID, ".proof-tamper.") && !strings.Contains(vector.ID, ".evidence-tamper.") {
+			continue
+		}
+		vector := vector
+		t.Run(vector.ID, func(t *testing.T) {
+			var semanticProof []byte
+			switch vector.Operation {
+			case conformance.OperationResolve:
+				value, err := protocol.DecodeResolveVerification(vector.Verification)
+				if err != nil {
+					t.Fatalf("strict DTO decode: %v", err)
+				}
+				semanticProof = value.Result.ProofList.Steps[0].Evidence
+			case conformance.OperationRead:
+				value, err := protocol.DecodeReadVerification(vector.Verification)
+				if err != nil {
+					t.Fatalf("strict DTO decode: %v", err)
+				}
+				semanticProof = value.Result.ProofList.Steps[0].Proof
+			default:
+				t.Fatalf("unexpected operation %q", vector.Operation)
+			}
+			if err := validateSemanticProofEnvelope(semanticProof); err != nil {
+				t.Fatalf("semantic proof envelope: %v", err)
+			}
+		})
+	}
+}
+
+func validateSemanticProofEnvelope(raw []byte) error {
+	var envelope struct {
+		Steps []struct {
+			Proof string `json:"proof"`
+		} `json:"steps"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return err
+	}
+	if len(envelope.Steps) == 0 {
+		return fmt.Errorf("steps are empty")
+	}
+	proof, err := base64.StdEncoding.DecodeString(envelope.Steps[0].Proof)
+	if err != nil {
+		return err
+	}
+	if len(proof) < 4 {
+		return fmt.Errorf("primitive proof is too short")
+	}
+	return nil
+}

--- a/conformance/resolve-read/v1/corpus.schema.json
+++ b/conformance/resolve-read/v1/corpus.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dewebprotocol.github.io/malt/conformance/resolve-read/v1/corpus.schema.json",
+  "title": "MALT Resolve/Read Conformance Corpus v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "vectors"],
+  "properties": {
+    "schema_version": {
+      "const": "malt.resolve-read.conformance/v1"
+    },
+    "vectors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "vector.schema.json"
+      }
+    }
+  }
+}

--- a/conformance/resolve-read/v1/vector.schema.json
+++ b/conformance/resolve-read/v1/vector.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dewebprotocol.github.io/malt/conformance/resolve-read/v1/vector.schema.json",
+  "title": "MALT Resolve/Read Conformance Vector v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "operation",
+    "backend",
+    "category",
+    "verification",
+    "expected"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+    },
+    "operation": {
+      "enum": ["resolve", "read"]
+    },
+    "backend": {
+      "enum": ["none", "kzg", "ipa"]
+    },
+    "category": {
+      "type": "string",
+      "minLength": 1
+    },
+    "verification": {
+      "type": "object"
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["valid"],
+      "properties": {
+        "valid": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/conformance/resolve-read/v1/vectors.json
+++ b/conformance/resolve-read/v1/vectors.json
@@ -9,7 +9,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -23,14 +23,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -40,7 +40,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -58,7 +58,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "query": {
             "kind": "list_index",
             "index": 0
@@ -69,14 +69,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "list:0",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -86,7 +86,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -104,7 +104,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
+          "root": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -118,14 +118,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+              "/": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+                  "/": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -135,7 +135,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -153,7 +153,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagcibqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy",
+          "root": "bagbkjqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy",
           "query": {
             "kind": "list_index",
             "index": 1
@@ -164,14 +164,14 @@
           "target": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga",
           "prooflist": {
             "root": {
-              "/": "bagcibqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
+              "/": "bagbkjqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
             },
             "query": "list:1",
             "steps": [
               {
                 "kind": "list_index",
                 "from": {
-                  "/": "bagcibqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
+                  "/": "bagbkjqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
                 },
                 "query": "list:1",
                 "coordinate": "1",
@@ -200,7 +200,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "root": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "query": {
             "kind": "list_range",
             "start": 2,
@@ -209,7 +209,7 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "target": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "range_segments": [
             "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
@@ -217,14 +217,14 @@
           ],
           "prooflist": {
             "root": {
-              "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+              "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
             },
             "query": "range:2:18",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "query": "range:2:18",
                 "coordinate": "range:2:18",
@@ -234,7 +234,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "segments": [
                   {
@@ -267,7 +267,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "root": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "query": {
             "kind": "list_range",
             "start": 8
@@ -275,21 +275,21 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "target": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "range_segments": [
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
             "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
           ],
           "prooflist": {
             "root": {
-              "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+              "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
             },
             "query": "range:8:",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "query": "range:8:",
                 "coordinate": "range:8:",
@@ -298,7 +298,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "segments": [
                   {
@@ -335,14 +335,14 @@
               "name"
             ]
           },
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
         },
         "result": {
           "profile": "malt.read/v0alpha1",
           "prooflist": {
             "query": "profile/name",
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "steps": [
               {
@@ -350,7 +350,7 @@
                 "evidence_backend": "map",
                 "evidence_kind": "structure",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "kind": "map_step",
                 "path": "profile/name",
@@ -377,7 +377,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -391,14 +391,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -408,7 +408,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -426,7 +426,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -440,14 +440,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -474,7 +474,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -487,14 +487,14 @@
           "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "@payload",
             "steps": [
               {
                 "kind": "payload_binding",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "@payload",
                 "coordinate": "@payload",
@@ -504,7 +504,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6IkFBQUFDR0M4aXVobU95ZVdHL1NlYkJUbzdzVXRRWHdTTUJDd2xnOERVaTNaV3E5T0NEcW9rQ05UU2VQWEx1V1RUWEVxRHA2M1RNMy9sNUpKV0pVSXE2TzBleWNKSEVSS2gwWW12K2w2b3RuaFRkdE5Ka2UxdDVBLzFQbnUvbCtWaUl3UHpoV2Z1RFBVM3VJMXR0alk2WVBZSjVseWorYXdvN1dyYklPVFFnaGlFZWVZT3RsWGJFMmpZclZYa09uang4Z1p5M1RFeEZ1S2RPcDVrdDc2N2lQM1VzZ3JHNFVJTzU5cVQyd2tCOHBBM1N4Ulg3bllKUXluWGQrSUpnbTdTT2hEaHlSY1hza3pXT0g1dHpZMzJ1M25WT256TStJMS9zeWR6THVwdmNXeVJCeGpDcHN1bmlCVlNKK3U2WXlHeFpXaVcyKytqSUFkRHd3eVN2WG1BSjNUUHFveE0wTlpnblA3bTV2ODJBZFFEbklNL0ZLN1RYRWxoS2VpcnJWVDVha3A3Zzd5OVFzTUgxNTFHM05RWVk1NGp1SFVuL0syeVZiYTMzaHpFSnBSTmYzRUtmZkRMbkFneXlhR1F1c1FpdFBJMC9rMXpPcWNDSThmN3RaZ2xDM21rcDFJTXk4Z1VCZ3JUUE94ckFxVmpkNTRNOVVqNktVNGtHMEdlOUxoUFJpUDlpVGU1REh2UGZnZXZLQUMzNHJOSmFLNXFqZmhYUjJpQklscksrSWZ3ZUpYRnZYN2hPcXg5M0pEaVhWUmtOMkZPK2VrUUhzWUlPcEkvWXFCUlNVK21iMU1oWE1IZ3B3RXdDTHJjeU9RaGt6dU82K0p0Y3ZEQWJQRjh1cFVYQk0ya0Z1alVidlFUK2FiUFJQUytaK2RCelhUbk5kaXhRK0I0WFU3RVBteWE1TjRyYjN6SkxldHpnSkh5dU40TmtDMHBDeFY2d04rNXJoWUU0bXllVHMxdGhJQUFBQ1cifV19"
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6IkFBQUFDR0M4aXVobU95ZVdHL1NlYkJUbzdzVXRRWHdTTUJDd2xnOERVaTNaV3E5T1R0clBUMGszYnlwcFJZK2NFa3lKQXJkeTlscndGeWZKNG12Y1pJTHZveXNsYXZIQWRKSWlSWnZYdERraHlJZm85eUhNY21JNDFjUVVGMC90YURPZnpRMEdwL2prZmoyR3p0dlFkU0RwZGpXRkhRZkZyVHhYNEFNdnNUMUhHclUwY3o1Y0l6M29xeTRqY0h6aWc4L002S1BrdkNFQzFUTFFCNldXNy9YRGM0bHBoN0E0eGVubWVyN3l5aUdLT3NPWmpOZ3hCdVlOSlJkMlh4VGNmcytUbUVSOUtnWlFGbzFwRXJJWUpBc1VsbWoxWHRtbUozQ2tpN0wySnlFWGdZWFlDMFJKM0FsYzdXS3JHNzNUdEdkeGFnbVhGbFlqNi93c282WnlzZG9jS2ZNU3I3V3pwdUVGWlJoR0Z5ZHdsMW9zL3ptY1VqNmhwdWNXMlBFc3RZQzJtMCtXalVoQWR4UjR5SlNtMWdIWEFPVGo5ZVMzdjcxaG4vQzFmNHh6ZGVlZmJBa2Z0Z3ZpZEFscDk1QVg0bkFVRTVnbHQza2pad29aNUFPZi9OOXBKSmN6dnFoUkVlU25aY3F6NFlDMTZZcmRJWGowWjluRU9yKzVUTUFFYWVrakUwSEdUNFZYMWZmbjFQcDA3Q0JUOVVVdGRia2NhUUx1SmNWb3JLQ0pkRjA4VXRKN1FrYXd4aFBOVy9Xa3ZxK203dVJyKzliRWVhV3plUktBVkVLazF3QWlVekpqdi9wbDZWdGJZUEowbDM4emdwSkloeU9keFY0b293TVVNWFVLaW11am4wR3VMTzVhclNiM2paZ2pEOXlyK25rRk42M3JaUkdDeEMrRVoxbGQ3ZWkvMjRlbHdZaWRrR3J0U1RCNHF1dGlhV3JxRGVETEpsall6dG8zN3dnQUFBQ1cifV19"
               }
             ]
           }
@@ -522,7 +522,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -536,14 +536,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -553,7 +553,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFlIiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFlIiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
               }
             ]
           }
@@ -571,7 +571,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "root": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "query": {
             "kind": "list_range",
             "start": 2,
@@ -580,7 +580,7 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "target": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "range_segments": [
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
             "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
@@ -588,14 +588,14 @@
           ],
           "prooflist": {
             "root": {
-              "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+              "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
             },
             "query": "range:2:18",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "query": "range:2:18",
                 "coordinate": "range:2:18",
@@ -605,7 +605,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "segments": [
                   {
@@ -638,7 +638,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -652,14 +652,14 @@
           "target": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -669,7 +669,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -687,7 +687,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -701,14 +701,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -718,7 +718,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUE9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUE9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
               }
             ]
           }
@@ -743,14 +743,14 @@
               "name"
             ]
           },
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
         },
         "result": {
           "profile": "malt.read/v0alpha1",
           "prooflist": {
             "query": "profile/name",
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "steps": [
               {
@@ -758,11 +758,11 @@
                 "evidence_backend": "map",
                 "evidence_kind": "structure",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "kind": "map_step",
                 "path": "profile/name",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ==",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ==",
                 "query": "profile/name",
                 "target": {
                   "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
@@ -786,7 +786,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -800,14 +800,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -817,7 +817,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -835,7 +835,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "query": {
             "kind": "list_index",
             "index": 0
@@ -846,14 +846,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "list:0",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -863,7 +863,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -881,7 +881,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26",
+          "root": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -895,14 +895,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+              "/": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+                  "/": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -912,7 +912,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -930,7 +930,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbibqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x",
+          "root": "baga2jqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x",
           "query": {
             "kind": "list_index",
             "index": 1
@@ -941,14 +941,14 @@
           "target": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga",
           "prooflist": {
             "root": {
-              "/": "bagbibqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x"
+              "/": "baga2jqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x"
             },
             "query": "list:1",
             "steps": [
               {
                 "kind": "list_index",
                 "from": {
-                  "/": "bagbibqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x"
+                  "/": "baga2jqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x"
                 },
                 "query": "list:1",
                 "coordinate": "1",
@@ -977,7 +977,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "root": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
           "query": {
             "kind": "list_range",
             "start": 2,
@@ -986,7 +986,7 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "target": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
           "range_segments": [
             "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
@@ -994,14 +994,14 @@
           ],
           "prooflist": {
             "root": {
-              "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+              "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
             },
             "query": "range:2:18",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
                 },
                 "query": "range:2:18",
                 "coordinate": "range:2:18",
@@ -1011,7 +1011,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
                 },
                 "segments": [
                   {
@@ -1044,7 +1044,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "root": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
           "query": {
             "kind": "list_range",
             "start": 8
@@ -1052,21 +1052,21 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "target": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
           "range_segments": [
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
             "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
           ],
           "prooflist": {
             "root": {
-              "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+              "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
             },
             "query": "range:8:",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
                 },
                 "query": "range:8:",
                 "coordinate": "range:8:",
@@ -1075,7 +1075,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
                 },
                 "segments": [
                   {
@@ -1112,14 +1112,14 @@
               "name"
             ]
           },
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
         },
         "result": {
           "profile": "malt.read/v0alpha1",
           "prooflist": {
             "query": "profile/name",
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "steps": [
               {
@@ -1127,7 +1127,7 @@
                 "evidence_backend": "map",
                 "evidence_kind": "structure",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "kind": "map_step",
                 "path": "profile/name",
@@ -1154,7 +1154,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1168,14 +1168,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -1185,7 +1185,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -1203,7 +1203,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1217,14 +1217,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -1251,7 +1251,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1264,14 +1264,14 @@
           "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "@payload",
             "steps": [
               {
                 "kind": "payload_binding",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "@payload",
                 "coordinate": "@payload",
@@ -1281,7 +1281,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6InBLazhnMHdnME92TkFHU0p3WU9VSVVINklnTUZoSFhZckxQZjJ5MkRyU3lQTDQzdjI5OUxncWZuQVRqdTVpOEJQSDd6am0vMm1aOEJBa3RsQWtEQUcxWXVNU2xuYk5xQ3NoWXgyRVFWQWdRQUFBQ1cifV19"
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6Imc0ckIrT0pocU1KblNVT3l0MDh1Wlc3Z1lBdDhrUW1HV0FKbkQ2L1FKbGJtTndrem9GMHRubGU2UzZkZzRnaUxQSDd6am0vMm1aOEJBa3RsQWtEQUcxWXVNU2xuYk5xQ3NoWXgyRVFWQWdRQUFBQ1cifV19"
               }
             ]
           }
@@ -1299,7 +1299,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1313,14 +1313,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -1330,7 +1330,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFlIiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFlIiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
               }
             ]
           }
@@ -1348,7 +1348,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "root": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
           "query": {
             "kind": "list_range",
             "start": 2,
@@ -1357,7 +1357,7 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "target": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
           "range_segments": [
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
             "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
@@ -1365,14 +1365,14 @@
           ],
           "prooflist": {
             "root": {
-              "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+              "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
             },
             "query": "range:2:18",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
                 },
                 "query": "range:2:18",
                 "coordinate": "range:2:18",
@@ -1382,7 +1382,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
                 },
                 "segments": [
                   {
@@ -1415,7 +1415,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1429,14 +1429,14 @@
           "target": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -1446,7 +1446,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -1464,7 +1464,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1478,14 +1478,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -1495,7 +1495,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUE9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUE9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
               }
             ]
           }
@@ -1520,14 +1520,14 @@
               "name"
             ]
           },
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
         },
         "result": {
           "profile": "malt.read/v0alpha1",
           "prooflist": {
             "query": "profile/name",
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "steps": [
               {
@@ -1535,11 +1535,11 @@
                 "evidence_backend": "map",
                 "evidence_kind": "structure",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "kind": "map_step",
                 "path": "profile/name",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ==",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ==",
                 "query": "profile/name",
                 "target": {
                   "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
@@ -1589,7 +1589,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
+          "root": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
           "segments": [
             "docs",
             "leaf"
@@ -1600,27 +1600,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+              "/": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+                  "/": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNHdDIvSGNqUmd2OWliVC9wR1IvTlBESXlESEZqTTFOMFhobVZKK2RkeURWVS9zdXFiMlgyZHJQZmoxWkRCRFZJdm1zZVhxc0Z2M1g5RDJ0SXBNdGZaczJheEVhYkllWnBCTVZKVWg2OE4vR2dZOFBoZFdHczQ2MnRWTWM3Tk5raEdwaURFaUEzOXVZb0JTSWI3VmVyQTJrMFdBajJiVjAyMjlXNmlCejAxQU1QZStBRUxWa2lRRXMwU2krUFFvYWc2T0owZW1Dd1p2NUFpOEZyTndGYmZ4aFkzVy9zMVpYMW10dVRFbGlGVFYrQmdRbCs3clo0L0ZuRmtISURPR2JGQVpZQThJaHM1ZE14bDFsMVhnWDBlSkpOVFZ5SlNRWUN5QWdjVGo4UlpMVlpHcTV2YUo3d3gwdEVQd3ZxeGJDTHhtN1JzSTdhQ3pxY0JlV2tTVHd2Y1lHRE03SVVjWElacE92VW1mc1gwNEVLRFRLRXFWeDlRUDBaN2dESkthOVdGV1p5L1RNVVozTWlxV3J2dEFMN1hEc1JnRS8vOExxVXdGVWFnNlc4MTRQWHdobXlsblkwdXJrNTJiS0pneTFJbzlWTklHQitCeVZ1K21zTG95QTN2SlhXZ1dRYTRPZTN4dEpPUndrRjRuZmJtMllUR3d1ckd4SUVLMmxIekc4QW0wM2hkZ1V6ZmM3UXlKeHBtQjRqVFZHdXRHNnVQdWNDaExQbDhXM2RsbWRJTFlHd0NYTDBMNE82SW85NFVQbDdsY3Y1OXNCdFNaNjFDRlgySXgrNlowUXJHWGV5KzUxaG5PRERaaVR5d09KUDRmTzIyREVUbGgyZlRVTVE1ZzVGVnhXS096U1FjTnlaT2x5WFJqeU00b0QvVUJPMnM2dXYwSnhtMC9yanVBWmlNWVVFRG9zMUJ4RENJTzRxRDcwcDJQRkNRNGRpU3puL2lSOXpIWWU2UWdBQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNDcEtnOG03dW9wbGlsbWczY25wdkdqaWJBRVR3Z1ZQV29XNUpES2ZpZittWkZGcmQvdHoxc3BVbHFZTXZWKzJiVFlCMGp6YVFuVkNPOXhCY1h3MlpzQUg3QlFxQVBQSnVBS1c4Tk1zMUVjVmVuOGdYQmJnaXBZS0pKanM1blZqamdYZkpueXJkSkZkVVJsM0pEMGJhRUxIQzdxRWU3MnkzcnhwQ1U1TlBiQUZEMmhlWkRuK1BNM21IeHlwd3lQUWpWODdvSDhHdUhJRUdtS3VwZzA3Q2ZWUmV0UHNjQ3Z2MzJrWmIvbmdEN2FrZHJmTUZnUkd3WTFwUU9YMmtTU09RbWllT2F2TVBqNlU1Z3FPNUNVS0gvNURIbDlrS3lrVlJIOHJoYkphZDlNU1J2eHJvKy9jOGRxUEsyUTZIclg4NG0reE5hVTRsc3ZhOTY1TVVjSFhyOFlyYnVQVHhacHlLR0VqaU5TUVpmN3NpNEcveHdLS1JBNnRtNG11YVhrQzBsUnVHcVhNOURTdW1QREZ0dk1UVTd6UWhCTDBYV1RIYnBUOUVXMTFuYnYyUHBrZ3pIemxiNC8wdEo4Tlc3SjhBbVgwaEpmRU1xZGVYUVhrMkhTRHZVa0tGRHFPaHlBV1RHaGpVd0w4UENvZkt6M3pKekVsSGZpREpneUs1RmlNYVcremhUbFJJZE9lc3VSL2UzWlJvV1QwWUMrcFYxa2V3WllWNDZ0Z3JLRHNRMExyRW9aTTRId2s3NUpoSlphOE1EQkZIZmYrZ2VoSWk0bC9uWnNXV1dSZXBLQjZaMHVnNWtGdEowOFJkeTNHWUs5YzRxeGVCendVT2U1SlZhZXhBbHhlZnRBbHpLUGN1TGFJTWZYMlNNemhqVlpJWnNlcDN0aVJ1N3hjcEJ1NDc2djM4SDdXWVY1ZzR6Sk1MSUlaRXlTOTlad3pKR1JJTndCSGsrblJRQU1BQUFCRyJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -1646,7 +1646,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "segments": [
             "docs",
             "leaf"
@@ -1657,27 +1657,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0d0Mi9IY2pSZ3Y5aWJUL3BHUi9OUERJeURIRmpNMU4wWGhtVkorZGR5RFZVL3N1cWIyWDJkclBmajFaREJEVkl2bXNlWHFzRnYzWDlEMnRJcE10ZlpzMmF4RWFiSWVacEJNVkpVaDY4Ti9HZ1k4UGhkV0dzNDYydFZNYzdOTmtoR3BpREVpQTM5dVlvQlNJYjdWZXJBMmswV0FqMmJWMDIyOVc2aUJ6MDFBTVBlK0FFTFZraVFFczBTaStQUW9hZzZPSjBlbUN3WnY1QWk4RnJOd0ZiZnhoWTNXL3MxWlgxbXR1VEVsaUZUVitCZ1FsKzdyWjQvRm5Ga0hJRE9HYkZBWllBOEloczVkTXhsMWwxWGdYMGVKSk5UVnlKU1FZQ3lBZ2NUajhSWkxWWkdxNXZhSjd3eDB0RVB3dnF4YkNMeG03UnNJN2FDenFjQmVXa1NUd3ZjWUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0ZXWnkvVE1VWjNNaXFXcnZ0QUw3WERzUmdFLy84THFVd0ZVYWc2VzgxNFBYd2hteWxuWTB1cms1MmJLSmd5MUlvOVZOSUdCK0J5VnUrbXNMb3lBM3ZKWFdnV1FhNE9lM3h0Sk9Sd2tGNG5mYm0yWVRHd3VyR3hJRUsybEh6RzhBbTAzaGRnVXpmYzdReUp4cG1CNGpUVkd1dEc2dVB1Y0NoTFBsOFczZGxtZElMWUd3Q1hMMEw0TzZJbzk0VVBsN2xjdjU5c0J0U1o2MUNGWDJJeCs2WjBRckdYZXkrNTFobk9ERFppVHl3T0pQNGZPMjJERVRsaDJmVFVNUTVnNUZWeFdLT3pTUWNOeVpPbHlYUmp5TTRvRC9VQk8yczZ1djBKeG0wL3JqdUFaaU1ZVUVEb3MxQnhEQ0lPNHFENzBwMlBGQ1E0ZGlTem4vaVI5ekhZZTZRZ0FBQUJIIiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0NwS2c4bTd1b3BsaWxtZzNjbnB2R2ppYkFFVHdnVlBXb1c1SkRLZmlmK21aRkZyZC90ejFzcFVscVlNdlYrMmJUWUIwanphUW5WQ085eEJjWHcyWnNBSDdCUXFBUFBKdUFLVzhOTXMxRWNWZW44Z1hCYmdpcFlLSkpqczVuVmpqZ1hmSm55cmRKRmRVUmwzSkQwYmFFTEhDN3FFZTcyeTNyeHBDVTVOUGJBRkQyaGVaRG4rUE0zbUh4eXB3eVBRalY4N29IOEd1SElFR21LdXBnMDdDZlZSZXRQc2NDdnYzMmtaYi9uZ0Q3YWtkcmZNRmdSR3dZMXBRT1gya1NTT1FtaWVPYXZNUGo2VTVncU81Q1VLSC81REhsOWtLeWtWUkg4cmhiSmFkOU1TUnZ4cm8rL2M4ZHFQSzJRNkhyWDg0bSt4TmFVNGxzdmE5NjVNVWNIWHI4WXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGxSdUdxWE05RFN1bVBERnR2TVRVN3pRaEJMMFhXVEhicFQ5RVcxMW5idjJQcGtnekh6bGI0LzB0SjhOVzdKOEFtWDBoSmZFTXFkZVhRWGsySFNEdlVrS0ZEcU9oeUFXVEdoalV3TDhQQ29mS3ozekp6RWxIZmlESmd5SzVGaU1hVyt6aFRsUklkT2VzdVIvZTNaUm9XVDBZQytwVjFrZXdaWVY0NnRncktEc1EwTHJFb1pNNEh3azc1SmhKWmE4TURCRkhmZitnZWhJaTRsL25ac1dXV1JlcEtCNlowdWc1a0Z0SjA4UmR5M0dZSzljNHF4ZUJ6d1VPZTVKVmFleEFseGVmdEFsektQY3VMYUlNZlgyU016aGpWWklac2VwM3RpUnU3eGNwQnU0NzZ2MzhIN1dZVjVnNHpKTUxJSVpFeVM5OVp3ekpHUklOd0JIaytuUlFBTUFBQUJIIiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -1703,7 +1703,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "segments": [
             "docs",
             "leaf"
@@ -1714,27 +1714,27 @@
           "prooflist": {
             "query": "docs/leaf",
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "steps": [
               {
                 "evidence": "not-base64%%%",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "kind": "map_step",
                 "path": "docs",
                 "query": "docs",
                 "target": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 }
               },
               {
                 "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ==",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "kind": "map_step",
                 "path": "leaf",
@@ -1760,7 +1760,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "segments": [
             "profile",
             "name"
@@ -1771,14 +1771,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "profile/name",
                 "path": "profile/name",
@@ -1786,7 +1786,7 @@
                   "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -1804,7 +1804,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "segments": [
             "docs",
             "leaf"
@@ -1815,26 +1815,26 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit"
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -1860,7 +1860,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "segments": [
             "docs",
             "leaf"
@@ -1871,27 +1871,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNHdDIvSGNqUmd2OWliVC9wR1IvTlBESXlESEZqTTFOMFhobVZKK2RkeURWVS9zdXFiMlgyZHJQZmoxWkRCRFZJdm1zZVhxc0Z2M1g5RDJ0SXBNdGZaczJheEVhYkllWnBCTVZKVWg2OE4vR2dZOFBoZFdHczQ2MnRWTWM3Tk5raEdwaURFaUEzOXVZb0JTSWI3VmVyQTJrMFdBajJiVjAyMjlXNmlCejAxQU1QZStBRUxWa2lRRXMwU2krUFFvYWc2T0owZW1Dd1p2NUFpOEZyTndGYmZ4aFkzVy9zMVpYMW10dVRFbGlGVFYrQmdRbCs3clo0L0ZuRmtISURPR2JGQVpZQThJaHM1ZE14bDFsMVhnWDBlSkpOVFZ5SlNRWUN5QWdjVGo4UlpMVlpHcTV2YUo3d3gwdEVQd3ZxeGJDTHhtN1JzSTdhQ3pxY0JlV2tTVHd2Y1lHRE03SVVjWElacE92VW1mc1gwNEVLRFRLRXFWeDlRUDBaN2dESkthOVdGV1p5L1RNVVozTWlxV3J2dEFMN1hEc1JnRS8vOExxVXdGVWFnNlc4MTRQWHdobXlsblkwdXJrNTJiS0pneTFJbzlWTklHQitCeVZ1K21zTG95QTN2SlhXZ1dRYTRPZTN4dEpPUndrRjRuZmJtMllUR3d1ckd4SUVLMmxIekc4QW0wM2hkZ1V6ZmM3UXlKeHBtQjRqVFZHdXRHNnVQdWNDaExQbDhXM2RsbWRJTFlHd0NYTDBMNE82SW85NFVQbDdsY3Y1OXNCdFNaNjFDRlgySXgrNlowUXJHWGV5KzUxaG5PRERaaVR5d09KUDRmTzIyREVUbGgyZlRVTVE1ZzVGVnhXS096U1FjTnlaT2x5WFJqeU00b0QvVUJPMnM2dXYwSnhtMC9yanVBWmlNWVVFRG9zMUJ4RENJTzRxRDcwcDJQRkNRNGRpU3puL2lSOXpIWWU2UWdBQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNDcEtnOG03dW9wbGlsbWczY25wdkdqaWJBRVR3Z1ZQV29XNUpES2ZpZittWkZGcmQvdHoxc3BVbHFZTXZWKzJiVFlCMGp6YVFuVkNPOXhCY1h3MlpzQUg3QlFxQVBQSnVBS1c4Tk1zMUVjVmVuOGdYQmJnaXBZS0pKanM1blZqamdYZkpueXJkSkZkVVJsM0pEMGJhRUxIQzdxRWU3MnkzcnhwQ1U1TlBiQUZEMmhlWkRuK1BNM21IeHlwd3lQUWpWODdvSDhHdUhJRUdtS3VwZzA3Q2ZWUmV0UHNjQ3Z2MzJrWmIvbmdEN2FrZHJmTUZnUkd3WTFwUU9YMmtTU09RbWllT2F2TVBqNlU1Z3FPNUNVS0gvNURIbDlrS3lrVlJIOHJoYkphZDlNU1J2eHJvKy9jOGRxUEsyUTZIclg4NG0reE5hVTRsc3ZhOTY1TVVjSFhyOFlyYnVQVHhacHlLR0VqaU5TUVpmN3NpNEcveHdLS1JBNnRtNG11YVhrQzBsUnVHcVhNOURTdW1QREZ0dk1UVTd6UWhCTDBYV1RIYnBUOUVXMTFuYnYyUHBrZ3pIemxiNC8wdEo4Tlc3SjhBbVgwaEpmRU1xZGVYUVhrMkhTRHZVa0tGRHFPaHlBV1RHaGpVd0w4UENvZkt6M3pKekVsSGZpREpneUs1RmlNYVcremhUbFJJZE9lc3VSL2UzWlJvV1QwWUMrcFYxa2V3WllWNDZ0Z3JLRHNRMExyRW9aTTRId2s3NUpoSlphOE1EQkZIZmYrZ2VoSWk0bC9uWnNXV1dSZXBLQjZaMHVnNWtGdEowOFJkeTNHWUs5YzRxeGVCendVT2U1SlZhZXhBbHhlZnRBbHpLUGN1TGFJTWZYMlNNemhqVlpJWnNlcDN0aVJ1N3hjcEJ1NDc2djM4SDdXWVY1ZzR6Sk1MSUlaRXlTOTlad3pKR1JJTndCSGsrblJRQU1BQUFCRyJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -1917,7 +1917,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "segments": [
             "docs",
             "@payload"
@@ -1928,27 +1928,27 @@
           "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "docs/@payload",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNHdDIvSGNqUmd2OWliVC9wR1IvTlBESXlESEZqTTFOMFhobVZKK2RkeURWVS9zdXFiMlgyZHJQZmoxWkRCRFZJdm1zZVhxc0Z2M1g5RDJ0SXBNdGZaczJheEVhYkllWnBCTVZKVWg2OE4vR2dZOFBoZFdHczQ2MnRWTWM3Tk5raEdwaURFaUEzOXVZb0JTSWI3VmVyQTJrMFdBajJiVjAyMjlXNmlCejAxQU1QZStBRUxWa2lRRXMwU2krUFFvYWc2T0owZW1Dd1p2NUFpOEZyTndGYmZ4aFkzVy9zMVpYMW10dVRFbGlGVFYrQmdRbCs3clo0L0ZuRmtISURPR2JGQVpZQThJaHM1ZE14bDFsMVhnWDBlSkpOVFZ5SlNRWUN5QWdjVGo4UlpMVlpHcTV2YUo3d3gwdEVQd3ZxeGJDTHhtN1JzSTdhQ3pxY0JlV2tTVHd2Y1lHRE03SVVjWElacE92VW1mc1gwNEVLRFRLRXFWeDlRUDBaN2dESkthOVdGV1p5L1RNVVozTWlxV3J2dEFMN1hEc1JnRS8vOExxVXdGVWFnNlc4MTRQWHdobXlsblkwdXJrNTJiS0pneTFJbzlWTklHQitCeVZ1K21zTG95QTN2SlhXZ1dRYTRPZTN4dEpPUndrRjRuZmJtMllUR3d1ckd4SUVLMmxIekc4QW0wM2hkZ1V6ZmM3UXlKeHBtQjRqVFZHdXRHNnVQdWNDaExQbDhXM2RsbWRJTFlHd0NYTDBMNE82SW85NFVQbDdsY3Y1OXNCdFNaNjFDRlgySXgrNlowUXJHWGV5KzUxaG5PRERaaVR5d09KUDRmTzIyREVUbGgyZlRVTVE1ZzVGVnhXS096U1FjTnlaT2x5WFJqeU00b0QvVUJPMnM2dXYwSnhtMC9yanVBWmlNWVVFRG9zMUJ4RENJTzRxRDcwcDJQRkNRNGRpU3puL2lSOXpIWWU2UWdBQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNDcEtnOG03dW9wbGlsbWczY25wdkdqaWJBRVR3Z1ZQV29XNUpES2ZpZittWkZGcmQvdHoxc3BVbHFZTXZWKzJiVFlCMGp6YVFuVkNPOXhCY1h3MlpzQUg3QlFxQVBQSnVBS1c4Tk1zMUVjVmVuOGdYQmJnaXBZS0pKanM1blZqamdYZkpueXJkSkZkVVJsM0pEMGJhRUxIQzdxRWU3MnkzcnhwQ1U1TlBiQUZEMmhlWkRuK1BNM21IeHlwd3lQUWpWODdvSDhHdUhJRUdtS3VwZzA3Q2ZWUmV0UHNjQ3Z2MzJrWmIvbmdEN2FrZHJmTUZnUkd3WTFwUU9YMmtTU09RbWllT2F2TVBqNlU1Z3FPNUNVS0gvNURIbDlrS3lrVlJIOHJoYkphZDlNU1J2eHJvKy9jOGRxUEsyUTZIclg4NG0reE5hVTRsc3ZhOTY1TVVjSFhyOFlyYnVQVHhacHlLR0VqaU5TUVpmN3NpNEcveHdLS1JBNnRtNG11YVhrQzBsUnVHcVhNOURTdW1QREZ0dk1UVTd6UWhCTDBYV1RIYnBUOUVXMTFuYnYyUHBrZ3pIemxiNC8wdEo4Tlc3SjhBbVgwaEpmRU1xZGVYUVhrMkhTRHZVa0tGRHFPaHlBV1RHaGpVd0w4UENvZkt6M3pKekVsSGZpREpneUs1RmlNYVcremhUbFJJZE9lc3VSL2UzWlJvV1QwWUMrcFYxa2V3WllWNDZ0Z3JLRHNRMExyRW9aTTRId2s3NUpoSlphOE1EQkZIZmYrZ2VoSWk0bC9uWnNXV1dSZXBLQjZaMHVnNWtGdEowOFJkeTNHWUs5YzRxeGVCendVT2U1SlZhZXhBbHhlZnRBbHpLUGN1TGFJTWZYMlNNemhqVlpJWnNlcDN0aVJ1N3hjcEJ1NDc2djM4SDdXWVY1ZzR6Sk1MSUlaRXlTOTlad3pKR1JJTndCSGsrblJRQU1BQUFCRyJ9XX0="
               },
               {
                 "kind": "payload_binding",
                 "from": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "@payload",
                 "path": "@payload",
@@ -1974,7 +1974,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "segments": [
             "docs",
             "leaf"
@@ -1985,27 +1985,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0d0Mi9IY2pSZ3Y5aWJUL3BHUi9OUERJeURIRmpNMU4wWGhtVkorZGR5RFZVL3N1cWIyWDJkclBmajFaREJEVkl2bXNlWHFzRnYzWDlEMnRJcE10ZlpzMmF4RWFiSWVacEJNVkpVaDY4Ti9HZ1k4UGhkV0dzNDYydFZNYzdOTmtoR3BpREVpQTM5dVlvQlNJYjdWZXJBMmswV0FqMmJWMDIyOVc2aUJ6MDFBTVBlK0FFTFZraVFFczBTaStQUW9hZzZPSjBlbUN3WnY1QWk4RnJOd0ZiZnhoWTNXL3MxWlgxbXR1VEVsaUZUVitCZ1FsKzdyWjQvRm5Ga0hJRE9HYkZBWllBOEloczVkTXhsMWwxWGdYMGVKSk5UVnlKU1FZQ3lBZ2NUajhSWkxWWkdxNXZhSjd3eDB0RVB3dnF4YkNMeG03UnNJN2FDenFjQmVXa1NUd3ZjWUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0ZXWnkvVE1VWjNNaXFXcnZ0QUw3WERzUmdFLy84THFVd0ZVYWc2VzgxNFBYd2hteWxuWTB1cms1MmJLSmd5MUlvOVZOSUdCK0J5VnUrbXNMb3lBM3ZKWFdnV1FhNE9lM3h0Sk9Sd2tGNG5mYm0yWVRHd3VyR3hJRUsybEh6RzhBbTAzaGRnVXpmYzdReUp4cG1CNGpUVkd1dEc2dVB1Y0NoTFBsOFczZGxtZElMWUd3Q1hMMEw0TzZJbzk0VVBsN2xjdjU5c0J0U1o2MUNGWDJJeCs2WjBRckdYZXkrNTFobk9ERFppVHl3T0pQNGZPMjJERVRsaDJmVFVNUTVnNUZWeFdLT3pTUWNOeVpPbHlYUmp5TTRvRC9VQk8yczZ1djBKeG0wL3JqdUFaaU1ZVUVEb3MxQnhEQ0lPNHFENzBwMlBGQ1E0ZGlTem4vaVI5ekhZZTZRZ0FBQUE9Iiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0NwS2c4bTd1b3BsaWxtZzNjbnB2R2ppYkFFVHdnVlBXb1c1SkRLZmlmK21aRkZyZC90ejFzcFVscVlNdlYrMmJUWUIwanphUW5WQ085eEJjWHcyWnNBSDdCUXFBUFBKdUFLVzhOTXMxRWNWZW44Z1hCYmdpcFlLSkpqczVuVmpqZ1hmSm55cmRKRmRVUmwzSkQwYmFFTEhDN3FFZTcyeTNyeHBDVTVOUGJBRkQyaGVaRG4rUE0zbUh4eXB3eVBRalY4N29IOEd1SElFR21LdXBnMDdDZlZSZXRQc2NDdnYzMmtaYi9uZ0Q3YWtkcmZNRmdSR3dZMXBRT1gya1NTT1FtaWVPYXZNUGo2VTVncU81Q1VLSC81REhsOWtLeWtWUkg4cmhiSmFkOU1TUnZ4cm8rL2M4ZHFQSzJRNkhyWDg0bSt4TmFVNGxzdmE5NjVNVWNIWHI4WXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGxSdUdxWE05RFN1bVBERnR2TVRVN3pRaEJMMFhXVEhicFQ5RVcxMW5idjJQcGtnekh6bGI0LzB0SjhOVzdKOEFtWDBoSmZFTXFkZVhRWGsySFNEdlVrS0ZEcU9oeUFXVEdoalV3TDhQQ29mS3ozekp6RWxIZmlESmd5SzVGaU1hVyt6aFRsUklkT2VzdVIvZTNaUm9XVDBZQytwVjFrZXdaWVY0NnRncktEc1EwTHJFb1pNNEh3azc1SmhKWmE4TURCRkhmZitnZWhJaTRsL25ac1dXV1JlcEtCNlowdWc1a0Z0SjA4UmR5M0dZSzljNHF4ZUJ6d1VPZTVKVmFleEFseGVmdEFsektQY3VMYUlNZlgyU016aGpWWklac2VwM3RpUnU3eGNwQnU0NzZ2MzhIN1dZVjVnNHpKTUxJSVpFeVM5OVp3ekpHUklOd0JIaytuUlFBTUFBQUE9Iiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2031,7 +2031,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
           "segments": [
             "docs",
             "leaf"
@@ -2042,27 +2042,27 @@
           "prooflist": {
             "query": "docs/leaf",
             "root": {
-              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
             },
             "steps": [
               {
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNHdDIvSGNqUmd2OWliVC9wR1IvTlBESXlESEZqTTFOMFhobVZKK2RkeURWVS9zdXFiMlgyZHJQZmoxWkRCRFZJdm1zZVhxc0Z2M1g5RDJ0SXBNdGZaczJheEVhYkllWnBCTVZKVWg2OE4vR2dZOFBoZFdHczQ2MnRWTWM3Tk5raEdwaURFaUEzOXVZb0JTSWI3VmVyQTJrMFdBajJiVjAyMjlXNmlCejAxQU1QZStBRUxWa2lRRXMwU2krUFFvYWc2T0owZW1Dd1p2NUFpOEZyTndGYmZ4aFkzVy9zMVpYMW10dVRFbGlGVFYrQmdRbCs3clo0L0ZuRmtISURPR2JGQVpZQThJaHM1ZE14bDFsMVhnWDBlSkpOVFZ5SlNRWUN5QWdjVGo4UlpMVlpHcTV2YUo3d3gwdEVQd3ZxeGJDTHhtN1JzSTdhQ3pxY0JlV2tTVHd2Y1lHRE03SVVjWElacE92VW1mc1gwNEVLRFRLRXFWeDlRUDBaN2dESkthOVdGV1p5L1RNVVozTWlxV3J2dEFMN1hEc1JnRS8vOExxVXdGVWFnNlc4MTRQWHdobXlsblkwdXJrNTJiS0pneTFJbzlWTklHQitCeVZ1K21zTG95QTN2SlhXZ1dRYTRPZTN4dEpPUndrRjRuZmJtMllUR3d1ckd4SUVLMmxIekc4QW0wM2hkZ1V6ZmM3UXlKeHBtQjRqVFZHdXRHNnVQdWNDaExQbDhXM2RsbWRJTFlHd0NYTDBMNE82SW85NFVQbDdsY3Y1OXNCdFNaNjFDRlgySXgrNlowUXJHWGV5KzUxaG5PRERaaVR5d09KUDRmTzIyREVUbGgyZlRVTVE1ZzVGVnhXS096U1FjTnlaT2x5WFJqeU00b0QvVUJPMnM2dXYwSnhtMC9yanVBWmlNWVVFRG9zMUJ4RENJTzRxRDcwcDJQRkNRNGRpU3puL2lSOXpIWWU2UWdBQUFCRyJ9XX0=",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNDcEtnOG03dW9wbGlsbWczY25wdkdqaWJBRVR3Z1ZQV29XNUpES2ZpZittWkZGcmQvdHoxc3BVbHFZTXZWKzJiVFlCMGp6YVFuVkNPOXhCY1h3MlpzQUg3QlFxQVBQSnVBS1c4Tk1zMUVjVmVuOGdYQmJnaXBZS0pKanM1blZqamdYZkpueXJkSkZkVVJsM0pEMGJhRUxIQzdxRWU3MnkzcnhwQ1U1TlBiQUZEMmhlWkRuK1BNM21IeHlwd3lQUWpWODdvSDhHdUhJRUdtS3VwZzA3Q2ZWUmV0UHNjQ3Z2MzJrWmIvbmdEN2FrZHJmTUZnUkd3WTFwUU9YMmtTU09RbWllT2F2TVBqNlU1Z3FPNUNVS0gvNURIbDlrS3lrVlJIOHJoYkphZDlNU1J2eHJvKy9jOGRxUEsyUTZIclg4NG0reE5hVTRsc3ZhOTY1TVVjSFhyOFlyYnVQVHhacHlLR0VqaU5TUVpmN3NpNEcveHdLS1JBNnRtNG11YVhrQzBsUnVHcVhNOURTdW1QREZ0dk1UVTd6UWhCTDBYV1RIYnBUOUVXMTFuYnYyUHBrZ3pIemxiNC8wdEo4Tlc3SjhBbVgwaEpmRU1xZGVYUVhrMkhTRHZVa0tGRHFPaHlBV1RHaGpVd0w4UENvZkt6M3pKekVsSGZpREpneUs1RmlNYVcremhUbFJJZE9lc3VSL2UzWlJvV1QwWUMrcFYxa2V3WllWNDZ0Z3JLRHNRMExyRW9aTTRId2s3NUpoSlphOE1EQkZIZmYrZ2VoSWk0bC9uWnNXV1dSZXBLQjZaMHVnNWtGdEowOFJkeTNHWUs5YzRxeGVCendVT2U1SlZhZXhBbHhlZnRBbHpLUGN1TGFJTWZYMlNNemhqVlpJWnNlcDN0aVJ1N3hjcEJ1NDc2djM4SDdXWVY1ZzR6Sk1MSUlaRXlTOTlad3pKR1JJTndCSGsrblJRQU1BQUFCRyJ9XX0=",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
                 },
                 "kind": "map_step",
                 "path": "docs",
                 "query": "docs",
                 "target": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 }
               },
               {
                 "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ==",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "kind": "map_step",
                 "path": "leaf",
@@ -2089,7 +2089,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26",
+          "root": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26",
           "segments": [
             "docs",
             "leaf"
@@ -2100,27 +2100,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+              "/": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+                  "/": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoib214MWdNU2lweFdzTW1BZS96TmVyeGd3NUFtWW1uV2lKSmUwcEJRclQxREYweHAzcjA5MHFyZmRZOVF0b2JqZUpiVURJcytvT2s4Si9PSkpscmlWSFBwQllEOWNYeHlkRnR4T2Z2enFLWTRBQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoicGRRTDdzS2lpRlJhWlJMVHhUbnRGdGZ4aWRkdjFlVkJCR0NrT0Y2cFhMWVJaenVmNVlObTlwVVdKK1J0VFdheFFqV0pmZ3c3blVHVExoYnkrai9Ec29NK3Vpd25qZllTUjJ5SnNVTVR4NjRBQUFCRyJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2146,7 +2146,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "segments": [
             "docs",
             "leaf"
@@ -2157,27 +2157,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJvbXgxZ01TaXB4V3NNbUFlL3pOZXJ4Z3c1QW1ZbW5XaUpKZTBwQlFyVDFERjB4cDNyMDkwcXJmZFk5UXRvYmplSmJVRElzK29PazhKL09KSmxyaVZIUHBCWUQ5Y1h4eWRGdHhPZnZ6cUtZNEFBQUJIIiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJwZFFMN3NLaWlGUmFaUkxUeFRudEZ0ZnhpZGR2MWVWQkJHQ2tPRjZwWExZUlp6dWY1WU5tOXBVV0orUnRUV2F4UWpXSmZndzduVUdUTGhieStqL0Rzb00rdWl3bmpmWVNSMnlKc1VNVHg2NEFBQUJIIiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2203,7 +2203,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "segments": [
             "docs",
             "leaf"
@@ -2214,27 +2214,27 @@
           "prooflist": {
             "query": "docs/leaf",
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "steps": [
               {
                 "evidence": "not-base64%%%",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "kind": "map_step",
                 "path": "docs",
                 "query": "docs",
                 "target": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 }
               },
               {
                 "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ==",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "kind": "map_step",
                 "path": "leaf",
@@ -2260,7 +2260,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "segments": [
             "profile",
             "name"
@@ -2271,14 +2271,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "profile/name",
                 "path": "profile/name",
@@ -2286,7 +2286,7 @@
                   "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -2304,7 +2304,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "segments": [
             "docs",
             "leaf"
@@ -2315,26 +2315,26 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "evidence_kind": "explicit"
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2360,7 +2360,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "segments": [
             "docs",
             "leaf"
@@ -2371,27 +2371,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoib214MWdNU2lweFdzTW1BZS96TmVyeGd3NUFtWW1uV2lKSmUwcEJRclQxREYweHAzcjA5MHFyZmRZOVF0b2JqZUpiVURJcytvT2s4Si9PSkpscmlWSFBwQllEOWNYeHlkRnR4T2Z2enFLWTRBQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoicGRRTDdzS2lpRlJhWlJMVHhUbnRGdGZ4aWRkdjFlVkJCR0NrT0Y2cFhMWVJaenVmNVlObTlwVVdKK1J0VFdheFFqV0pmZ3c3blVHVExoYnkrai9Ec29NK3Vpd25qZllTUjJ5SnNVTVR4NjRBQUFCRyJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2417,7 +2417,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "segments": [
             "docs",
             "@payload"
@@ -2428,27 +2428,27 @@
           "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "docs/@payload",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoib214MWdNU2lweFdzTW1BZS96TmVyeGd3NUFtWW1uV2lKSmUwcEJRclQxREYweHAzcjA5MHFyZmRZOVF0b2JqZUpiVURJcytvT2s4Si9PSkpscmlWSFBwQllEOWNYeHlkRnR4T2Z2enFLWTRBQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoicGRRTDdzS2lpRlJhWlJMVHhUbnRGdGZ4aWRkdjFlVkJCR0NrT0Y2cFhMWVJaenVmNVlObTlwVVdKK1J0VFdheFFqV0pmZ3c3blVHVExoYnkrai9Ec29NK3Vpd25qZllTUjJ5SnNVTVR4NjRBQUFCRyJ9XX0="
               },
               {
                 "kind": "payload_binding",
                 "from": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "query": "@payload",
                 "path": "@payload",
@@ -2474,7 +2474,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "segments": [
             "docs",
             "leaf"
@@ -2485,27 +2485,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJvbXgxZ01TaXB4V3NNbUFlL3pOZXJ4Z3c1QW1ZbW5XaUpKZTBwQlFyVDFERjB4cDNyMDkwcXJmZFk5UXRvYmplSmJVRElzK29PazhKL09KSmxyaVZIUHBCWUQ5Y1h4eWRGdHhPZnZ6cUtZNEFBQUE9Iiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJwZFFMN3NLaWlGUmFaUkxUeFRudEZ0ZnhpZGR2MWVWQkJHQ2tPRjZwWExZUlp6dWY1WU5tOXBVV0orUnRUV2F4UWpXSmZndzduVUdUTGhieStqL0Rzb00rdWl3bmpmWVNSMnlKc1VNVHg2NEFBQUE9Iiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2531,7 +2531,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
           "segments": [
             "docs",
             "leaf"
@@ -2542,27 +2542,27 @@
           "prooflist": {
             "query": "docs/leaf",
             "root": {
-              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
             },
             "steps": [
               {
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoib214MWdNU2lweFdzTW1BZS96TmVyeGd3NUFtWW1uV2lKSmUwcEJRclQxREYweHAzcjA5MHFyZmRZOVF0b2JqZUpiVURJcytvT2s4Si9PSkpscmlWSFBwQllEOWNYeHlkRnR4T2Z2enFLWTRBQUFCRyJ9XX0=",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoicGRRTDdzS2lpRlJhWlJMVHhUbnRGdGZ4aWRkdjFlVkJCR0NrT0Y2cFhMWVJaenVmNVlObTlwVVdKK1J0VFdheFFqV0pmZ3c3blVHVExoYnkrai9Ec29NK3Vpd25qZllTUjJ5SnNVTVR4NjRBQUFCRyJ9XX0=",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
                 },
                 "kind": "map_step",
                 "path": "docs",
                 "query": "docs",
                 "target": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 }
               },
               {
                 "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ==",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
                 },
                 "kind": "map_step",
                 "path": "leaf",

--- a/conformance/resolve-read/v1/vectors.json
+++ b/conformance/resolve-read/v1/vectors.json
@@ -1,0 +1,2585 @@
+{
+  "schema_version": "malt.resolve-read.conformance/v1",
+  "vectors": [
+    {
+      "id": "read.ipa.cross-backend-kzg-evidence.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "cross_backend",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.cross-kind.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "cross_kind",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "query": {
+            "kind": "list_index",
+            "index": 0
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "list:0",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.cross-root.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "cross_root",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.list-index.accept",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "list_index",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagcibqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy",
+          "query": {
+            "kind": "list_index",
+            "index": 1
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga",
+          "prooflist": {
+            "root": {
+              "/": "bagcibqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
+            },
+            "query": "list:1",
+            "steps": [
+              {
+                "kind": "list_index",
+                "from": {
+                  "/": "bagcibqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
+                },
+                "query": "list:1",
+                "coordinate": "1",
+                "index": 1,
+                "length": 3,
+                "target": {
+                  "/": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6IkFBQUFDQmVoeGFVdVdMbmRpQ1lXYXBMRTdWbDd5eHBNenpUV3diVy81N0t3TCtTTVlwY3d6SmswaVRYakYvSUpmcmdqOExnRnZKdE1uMXlhQXZEN2p3MXFUQVVJa1dUZ2NaY3FJYjZYbzZXckw1NE80eXhTV3J3YndYSkM2dGRrYnZQZ3MxN1NEU0hXZytOaG94SHFWNy9ZeXpZRXFLMkdyZUV5VTdwOVJmTUhMcENiVXlCMGdxOFZvbWxuUUswclBZUDdMMElVQmF1OVhQQWh2UlFWb25zV2tsdzl6dDZVTmc3VmxNTWtEVGVoNVFLdVhxQUxZYkFOakZ0cURuNjY3RmwyM1N3Zkl0Q1gySG5CcjJ1R2dQK1BHcVJISm5zcXBxOEtJLy82OGdpOFJZbTZhckVLd1VyUHNiQUk1N1k1RWdBVWFabTBIckYyeGE1V0x3U2Vic1ROci9kdDExZjhhdnN5U2c4QTY0NmhDWTVza2JIVmM4MDY0WTdzeFF6emw0V1JJbXVmOE4rNjZXQXFaWlRmdnJxUGMzYnBTdUxiMDhGZGhYWmVpd1lhcU1jNkZNaTJJMVNFUXV6c1F2RVZQVWc2eUg1Ui82bDRuejdScWhtNlRQZ3g0MVk5cFBWb3NWTzI1TExmZVlDckh6ODZ2dTBIbGwvM2lwU3ZuSVdhckhmMFIyMXdkUEFqMlNZRFltYlpseHY2dmw0dGJuQS9zNVYyVjlTMzUxcUx4S1dIQUN3cll4NUJpaFp2NXp4d1RGaXRobXE1VzlUTTc0WXNsT2FDdFJadGpTd1ZRbWdldGpWU1RnZU5rclNiTmxCTEppODE1MHYzOU93TjhDSnphN2NXTGw0Y0pURmpMeFROYWZBeEZXY1o3UXZQZzNNL0dVdjY2d2VlTVBzMGNSN0xIcHhUa01XYkVhY3RLMERmRVdkYzVNZ2ZOUFIzUlNiRUZ4eVpVcmZvZ0JJQUFBQUEiLCJzdGVwcyI6W3sidGFyZ2V0IjoiQVZVU0lDZWtiLzNFZ21IazNnMzd6YjdlRHc2VTRLNDRZTUZJZnh4Z2RibTJXZ013IiwicHJvb2YiOiJBQUFBQ0FGaWNzWWRUejd5SzdxbUZLdEl0K2JsbUQvN0pUMnBieFpVWlBkbmluMEFhYXpKa0MwdXZOUlhIQjg2a0xkVmNsSjFTN0JWcGVLckNYeDcvT1N6cmZ0R3dNMkpQMDI4d3VKZE5TdEJHZVAraFlQOTM1UVpRNUViVlBNQUtOYWEyd3NhS2JSU0c3SFRSZjVCN1UzWVhaR0pJYmZZc3pSK3ZNcW5hMkdyNUpXSEVGQ2ZjUEdMOUk3ZHFBL01NcTBNd3BYVXpOeW5BbXhYdlNZZHNtZEZ5d0U0bnBqVWUxdWdwL0ErTUJ6aG9kT1pFZXhQclVVeEFVYm14NDBxaGx0Y2x3djBMN0pUdUE5Vy9lLzFFbXJnSGd1aFU2V1pPb2JrSnprUmluUGc4cGlZVkljeXpyV0ZsNThEdHRJV3NoTlRSUDRLbHlCTFBUaHFLTUdKRGJPU1d1OXQxMWY4YXZzeVNnOEE2NDZoQ1k1c2tiSFZjODA2NFk3c3hRenpsNFdSSWtJREFQMXZXSFo1N0JFaGZ4eUQvS1VUaGhVSURPRG4wbC9pcVhTT0tPZWpERnV3NGhvVi95QmRzSGFNK3hmSmVublZkamNqVjIvNGZZR05nUE9MR3pSSGxpcUVnZGlWK1RDSzVmemlGRW1kRWFIeHVtUGNXVVZRMEJic2hzM09jbk5WNFJERXhTM2FndG1OK05tTWw5MHZ5Qm5PNUYyY1ExVWtDUXVLejFyWFEwQmE5bmlBcDZNdkhaQjUxTDhKaEF0RWRTMGZWNWx5WENLLzJVVmVZR01GRVFVN3ZzcEVUV0xCRE9wWmRGMTNoNEgzZWlMTTFkSHBuU0xPa0hLNDZDVks3SlRiWVg1WFhzNmFRZTg1VXV2TXd0aVBuaW5PZ0ZXWjVVYmxjVFJ3OXgzZlRBMDZ5endaY3Z2cTFtK1VTV3YvRzhONnhhblBqNFFIVkxDS1JBQUFBQUFDIiwic2xvdCI6Mn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.ipa.list-range-bounded.accept",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "list_range",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "query": {
+            "kind": "list_range",
+            "start": 2,
+            "end": 18
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "range_segments": [
+            "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+            },
+            "query": "range:2:18",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "query": "range:2:18",
+                "coordinate": "range:2:18",
+                "start": 2,
+                "end": 18,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga"
+                  },
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6IkFBQUFDRk50RTJKWEErRXlGNnZzRXhEYUVFMldPT0VudURLc1JTbXNkaTBaRUowSEZKM0dFUENKYzlUVXBHVkIxT0k5NHRNVS85b3ZicW4rSktiYWpUL1ZUaVFRa2xWNnRGM1cyS1l6ZGhTVmpuY2VLdERzRkhESzBsQzduV2xTekJ5MUkwRlJRdTZsd1htT3hqc2VVckVpSDhMMVVJYjVVMUFYYVRoUCs0c3VaWW9hUzIwVW4rdEF4a0lrNCsxWEFGcitLaEhudnZva2FZY3BUN2RaSlpUVTNjaHNURjhjVHhSc2daMmxHWWRmc1ozWVF6OGtZT1NIUjZ4QXhmbDR3ZUlXd21pZEVKMEFTRWlJbFNkbVR5NWt3c205WTFqWVBsemx6M3lISDdzWjdwOU1URkxBc2xjRmVQVHNYcnp2eS85WjBBME9uUTZnSkE1SkFBeDVEdWFIc21GaFpERVZvSndhVk1hb2tqRzZlWmZwOXA0Vk80OThScDQrU05pQ0lRMG5reDBxbWlTR1EwMENtMzhreHVIOVU1VVh5ODYwQ3dQcmxmeGhOOExiOStmY1ZEY3VRNDZUK25oeDFLS01hWEloZklRakNlU05ramRXbkFFOWMyYW9QZXc1cDZUOWV3eTdwNEJKdU1XT29hVzNLZ1VpVWVsVHgwdzFHNVhLLzhFTFNVbktGcURjU0o5NDdsamk1NC9CbC92UkQyQWNXaTZEbjFvYmtxQW1YOGdtUUszVFg3dEtYd08rYmkwYmo3UWVsY0hWcjg5TVNkZGtsT3V3N3A1LzI4NHZ6Snd4Nmp2akxENHM1NzEyRkRGZzFRRHJjOG1RblB2eXJtVkYvNmRIUENNQ2NjL1ZMY0FSbklBd2Vid2t2UWFmYlRGT3VrOXVQcUNEeWpVYjd5YVVBTm52eVpodTVaQmF4dXZvQjhQSEt2YisrTEEyUGhVMk0rOXl5clRxMUJ3QUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNklrRkJRVUZEUms1MFJUSktXRUVyUlhsR05uWnpSWGhFWVVWRk1sZFBUMFZ1ZFVSTGMxSlRiWE5rYVRCYVJVb3dTRVpLTTBkRlVFTktZemxVVlhCSFZrSXhUMGs1TkhSTlZTODViM1ppY1c0clNrdGlZV3BVTDFaVWFWRlJhMnhXTm5SR00xY3lTMWw2WkdoVFZtcHVZMlZMZEVSelJraEVTekJzUXpkdVYyeFRla0o1TVVrd1JsSlJkVFpzZDFodFQzaHFjMlZWY2tWcFNEaE1NVlZKWWpWVk1VRllZVlJvVUNzMGMzVmFXVzloVXpJd1ZXNHJkRUY0YTBsck5Dc3hXRUZHY2l0TGFFaHVkblp2YTJGWlkzQlVOMlJhU2xwVVZUTmphSE5VUmpoalZIaFNjMmRhTW14SFdXUm1jMW96V1ZGNk9HdFpUMU5JVWpaNFFYaG1iRFIzWlVsWGQyMXBaRVZLTUVGVFJXbEpiRk5rYlZSNU5XdDNjMjA1V1RGcVdWQnNlbXg2TTNsSVNEZHpXamR3T1UxVVJreEJjMnhqUm1WUVZITlljbnAyZVM4NVdqQkJNRTl1VVRablNrRTFTa0ZCZURWRWRXRkljMjFHYUZwRVJWWnZTbmRoVmsxaGIydHFSelpsV21ad09YQTBWazgwT1RoU2NEUXJVMDVwUTBsUk1HNXJlREJ4YldsVFIxRXdNRU50TXpocmVIVklPVlUxVlZoNU9EWXdRM2RRY214bWVHaE9PRXhpT1N0bVkxWkVZM1ZSTkRaVUsyNW9lREZMUzAxaFdFbG9aa2xSYWtObFUwNXJhbVJYYmtGRk9XTXlZVzlRWlhjMWNEWlVPV1YzZVRkd05FSktkVTFYVDI5aFZ6TkxaMVZwVldWc1ZIZ3dkekZITlZoTEx6aEZURk5WYmt0R2NVUmpVMG81TkRkc2FtazFOQzlDYkM5MlVrUXlRV05YYVRaRWJqRnZZbXR4UVcxWU9HZHRVVXN6VkZnM2RFdFlkMDhyWW1rd1ltbzNVV1ZzWTBoV2NqZzVUVk5rWkd0c1QzVjNOM0ExTHpJNE5IWjZTbmQ0Tm1wMmFreEVOSE0xTnpFeVJrUkdaekZSUkhKak9HMVJibEIyZVhKdFZrWXZObVJJVUVOTlEyTmpMMVpNWTBGU2JrbEJkMlZpZDJ0MlVXRm1ZbFJHVDNWck9YVlFjVU5FZVdwVllqZDVZVlZCVG01MmVWcG9kVFZhUW1GNGRYWnZRamhRU0V0Mllpc3JURUV5VUdoVk1rMHJPWGw1Y2xSeE1VSjNRVUZCUVVFaUxDSnRaWFJoWkdGMFlWOTBZWEpuWlhRaU9pSkJWbFZCVGtjeGFHSklVVFppUjJ4NlpFUndkV0l5VW14TVZ6RnNaRWRGTmtGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFYZEJRVUZCUVVGQlFVRlZRVUZCUVVGQlFVRkJRV2M5SWl3aWMzUmxjSE1pT2x0N0luUmhjbWRsZENJNklrRldWVk5KU2pCa1ZsUTRhblJ6UlRac05XVnhPVmN3Y1d0dlFYSnpSa1JMWWpNdmNXNTFObk0wYm5Kd2EzVTRkeUlzSW5CeWIyOW1Jam9pUVVGQlFVTkZUbTVQV1haTGFra3JjMEZoVjFFNWRUZG9VVzR5WlRKRGJEbGtOVTFxVlU5blEzWnNiRkZKZUVKTlVtTjBjRXB4YW5FelEyWjBVbHBSU0UxMldYUnlTSGhSU1d3MVUwZDRaWFpzTjNSMVVYZEtUa0o1WTNWV1pXcHhVMVl5VWlzNGFtMHhaR0ZXVFZkTlF6QnpRVkpoTm1wTmEwbE5LekZWTjJocmIxZGlWRVl5TmpWQmRGWjFkbFF2V21aUFJERmxXRWxCV1RsdGJFOW9WakozUzB4T2FVSjZWekpUVlVGMmFXZFJWVU5sT1ZoNlFYUTFMMWxsWjJGV1dqVnNTSEZ4Um5reFMwRkpWVVpYSzJSbGJIRXpWM2s1TW1sSlEwaDZjbUp6VDFrelNqRTVRMjh5VEc1VlZpOUJWWFZUVW5KRmNrOUZRamRXVjBSd1NFbFNiRGc0VW1ZMVlYRTNjMWd5WTBkTmNrSnFNbU5JZFhvNGRrRXhhM1ZWWVZwNkwzUnpOVTVpWTNreWRtbHhibUl3YmsxS0wydDVhakppVURab2RUbFdkVk5qV1VGMVNFSm1aRmMwTmpKbGIxUlZSelZKVkhCa2FXeG9Xa1JGVm05S2QyRldUV0Z2YTJwSE5tVmFabkE1Y0RSV1R6UTVPRkp3TkN0VFRtbERTVkV3Ym10NmJVRTBWMHB3WjA4cmEyOWhWQzh3UVRneU1WazBRWHAxVEc5eGExcDVWMmxPTlVabWJHMVhhRUZVWVhOdVVUWTRjako1VFZSUVNYWXJlbGwxZERaSFNFTjBabWxxTW1OYWIxUktVbGd2UW1KNVJsbDJjM053VmxkT1pVZDVPRU5FZVhWb2JFRm1NVFJJVGxWWk4xZHZiV0p6UkV4SmRITTJjSG8xWlZaeVJsSXpTMHB3YmtOaVNqRXhhR3MxVVZadFZtVjRUMHhYT1RCblVGQjVZMDlDT1ZselJYRnpaVGQwYTJ0TFRsWTRMM2xtUm5rM2QyZGxZVk5VZDI1R1VGQlVXR05JYm1KbVluQjViVVJ5YkZnMlprWm9TeTkzY0ZoQlJHVXlja2MwZVV0SGVuRlpMMkkyWkhaQlpXUndVVXBuU0daVlJrcEZaR3hTTmxCUVozRTNiREFyTlVVNFJWaDVjbGxoVlUxRlpFdE5PVlpKVXpOdWVWWXpaMmhMWjFkWU5sQkdaMkpwUWtwSGRXSk9VVlJMT0RjMVluRjFTVGc0TmxRdk5IRnRkMDVEV1RSSmFUSjJlazlOTW05U05GVlFaek5SUW1kQlFVRkJRaUlzSW5Oc2IzUWlPakY5WFgwPSJ9LHsiaW5kZXgiOjEsInByb29mIjoiZXlKdFpYUmhaR0YwWVY5d2NtOXZaaUk2SWtGQlFVRkRSazUwUlRKS1dFRXJSWGxHTm5aelJYaEVZVVZGTWxkUFQwVnVkVVJMYzFKVGJYTmthVEJhUlVvd1NFWktNMGRGVUVOS1l6bFVWWEJIVmtJeFQwazVOSFJOVlM4NWIzWmljVzRyU2t0aVlXcFVMMVpVYVZGUmEyeFdOblJHTTFjeVMxbDZaR2hUVm1wdVkyVkxkRVJ6UmtoRVN6QnNRemR1VjJ4VGVrSjVNVWt3UmxKUmRUWnNkMWh0VDNocWMyVlZja1ZwU0RoTU1WVkpZalZWTVVGWVlWUm9VQ3MwYzNWYVdXOWhVekl3Vlc0cmRFRjRhMGxyTkNzeFdFRkdjaXRMYUVodWRuWnZhMkZaWTNCVU4yUmFTbHBVVlROamFITlVSamhqVkhoU2MyZGFNbXhIV1dSbWMxb3pXVkY2T0d0WlQxTklValo0UVhobWJEUjNaVWxYZDIxcFpFVktNRUZUUldsSmJGTmtiVlI1Tld0M2MyMDVXVEZxV1ZCc2VteDZNM2xJU0RkeldqZHdPVTFVUmt4QmMyeGpSbVZRVkhOWWNucDJlUzg1V2pCQk1FOXVVVFpuU2tFMVNrRkJlRFZFZFdGSWMyMUdhRnBFUlZadlNuZGhWazFoYjJ0cVJ6WmxXbVp3T1hBMFZrODBPVGhTY0RRclUwNXBRMGxSTUc1cmVEQnhiV2xUUjFFd01FTnRNemhyZUhWSU9WVTFWVmg1T0RZd1EzZFFjbXhtZUdoT09FeGlPU3RtWTFaRVkzVlJORFpVSzI1b2VERkxTMDFoV0Vsb1prbFJha05sVTA1cmFtUlhia0ZGT1dNeVlXOVFaWGMxY0RaVU9XVjNlVGR3TkVKS2RVMVhUMjloVnpOTFoxVnBWV1ZzVkhnd2R6RkhOVmhMTHpoRlRGTlZia3RHY1VSalUwbzVORGRzYW1rMU5DOUNiQzkyVWtReVFXTlhhVFpFYmpGdlltdHhRVzFZT0dkdFVVc3pWRmczZEV0WWQwOHJZbWt3WW1vM1VXVnNZMGhXY2pnNVRWTmtaR3RzVDNWM04zQTFMekk0TkhaNlNuZDRObXAyYWt4RU5ITTFOekV5UmtSR1p6RlJSSEpqT0cxUmJsQjJlWEp0VmtZdk5tUklVRU5OUTJOakwxWk1ZMEZTYmtsQmQyVmlkMnQyVVdGbVlsUkdUM1ZyT1hWUWNVTkVlV3BWWWpkNVlWVkJUbTUyZVZwb2RUVmFRbUY0ZFhadlFqaFFTRXQyWWlzclRFRXlVR2hWTWswck9YbDVjbFJ4TVVKM1FVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2lRVUZCUVVORWNYbE9jMmxITldNeVIydG9SVWxJZEU0elQydFFZMmxQUlZGcVJWRjVWbmR4VEcxTVJscDJVRlYwUWxaUFlVOHZiV1pFZWtaNGRtOWFZM2cyVVU5YWFIZDVZVmg1VUdkVk5VWkZiekk1Y1hsR2RXeENiMEp3ZFRWSFRYZHlZbVJMVkVVMFNYYzJUbFV5VW01emRrcDNNV05hUkRkYVRHUjNOazB4VVV0blVHbzRkM0l2U0RKMGFEVklaakpRWVZoU2VESnJUVXRDYldjM2MyMDJiVkZDUm0xblVtdFlOVVowWWtkTmFFZG9UMlpVVm13MWVVVXdRVkU1WXk4eFQzUnZZVnAzSzFwWWVVOVphbXhxVTJNNFlrdHBWakJOV1ZobFVIUnFMekZzUVM5WVdpOVRUM1EyTlV0dEwyazNjbXRMVTFoaE1pczFUVXN2V2twNU9VeGhhR1VyVm1SV09HUmtaWEJJUkcxdllXdE5WeXN2UzA4MlIxSktWWEJNVm5kWWRXRXJWak14Y2tGdVFVTXhOVkJaVG01eFJtaDNOemRsVXpsWWRtMHJXSFI2THpaaFNVMU1kMlJZT1hjeVNIUlhUM1VyVGtab1drUkZWbTlLZDJGV1RXRnZhMnBITm1WYVpuQTVjRFJXVHpRNU9GSndOQ3RUVG1sRFNWRXdibXN5ZUhodGFGUnBiVWt2ZVdNNFVXcFhaRmRISzFVelozZGxjVmxuV1hGc1RFUXdZbVZYTmtZclNqaHNRVEZhVUZobU9DdGtUbFIyT0Zkd2EzaDVjR2gwUTAwMk1pOHhOM1pUUkROU1RYRjFiRVJpVTNRMGMzTXdjVTFPTkd0Rk1tZ3ZaMjFCZUUwelNEbDVkblJwZGtSelUyZDJlREl3VldONmVXUmpla3Q1U1hwSmNWTnRTMmRQV1RkU2RtbFZWaTltTUVGdmFVcFplVEZTU0hwbGJWcExNVGRXSzFFNVVsaG5SbEZHYlVZNFNGWnhVMjlpTjFsYVNFdFBlbmMzVVc5cFVGQlNVSFp1TlZOcU9FeG1NMFJ6WWtRMk9GSnpaMnQ2VnpCalRWaG1kalZQUWxKeVl6RlpibFp5ZDFWRlZrOXRhV1UyWnpOUlJGbG5PWGcwVkdwT01sQlZRV0ZNYlV0ekwwNTFWVE5OVHlzMWNtVldWblpQYzNGMmFrcHJlSHBGTHpBM2VYQlpiM0JCVW5ZeGNYWkNWMEZGTTFWS2JIVTJjVmxJVDNwMlNqUjZaazVVUkZsdll6TnRZalkzTDNWVU1WQTVaMUZCUVVGQlF5SXNJbk5zYjNRaU9qSjlYWDA9In0seyJpbmRleCI6MiwicHJvb2YiOiJleUp0WlhSaFpHRjBZVjl3Y205dlppSTZJa0ZCUVVGRFJrNTBSVEpLV0VFclJYbEdOblp6UlhoRVlVVkZNbGRQVDBWdWRVUkxjMUpUYlhOa2FUQmFSVW93U0VaS00wZEZVRU5LWXpsVVZYQkhWa0l4VDBrNU5IUk5WUzg1YjNaaWNXNHJTa3RpWVdwVUwxWlVhVkZSYTJ4V05uUkdNMWN5UzFsNlpHaFRWbXB1WTJWTGRFUnpSa2hFU3pCc1F6ZHVWMnhUZWtKNU1Va3dSbEpSZFRac2QxaHRUM2hxYzJWVmNrVnBTRGhNTVZWSllqVlZNVUZZWVZSb1VDczBjM1ZhV1c5aFV6SXdWVzRyZEVGNGEwbHJOQ3N4V0VGR2NpdExhRWh1ZG5admEyRlpZM0JVTjJSYVNscFVWVE5qYUhOVVJqaGpWSGhTYzJkYU1teEhXV1JtYzFveldWRjZPR3RaVDFOSVVqWjRRWGhtYkRSM1pVbFhkMjFwWkVWS01FRlRSV2xKYkZOa2JWUjVOV3QzYzIwNVdURnFXVkJzZW14Nk0zbElTRGR6V2pkd09VMVVSa3hCYzJ4alJtVlFWSE5ZY25wMmVTODVXakJCTUU5dVVUWm5Ta0UxU2tGQmVEVkVkV0ZJYzIxR2FGcEVSVlp2U25kaFZrMWhiMnRxUnpabFdtWndPWEEwVms4ME9UaFNjRFFyVTA1cFEwbFJNRzVyZURCeGJXbFRSMUV3TUVOdE16aHJlSFZJT1ZVMVZWaDVPRFl3UTNkUWNteG1lR2hPT0V4aU9TdG1ZMVpFWTNWUk5EWlVLMjVvZURGTFMwMWhXRWxvWmtsUmFrTmxVMDVyYW1SWGJrRkZPV015WVc5UVpYYzFjRFpVT1dWM2VUZHdORUpLZFUxWFQyOWhWek5MWjFWcFZXVnNWSGd3ZHpGSE5WaExMemhGVEZOVmJrdEdjVVJqVTBvNU5EZHNhbWsxTkM5Q2JDOTJVa1F5UVdOWGFUWkViakZ2WW10eFFXMVlPR2R0VVVzelZGZzNkRXRZZDA4cllta3dZbW8zVVdWc1kwaFdjamc1VFZOa1pHdHNUM1YzTjNBMUx6STROSFo2U25kNE5tcDJha3hFTkhNMU56RXlSa1JHWnpGUlJISmpPRzFSYmxCMmVYSnRWa1l2Tm1SSVVFTk5RMk5qTDFaTVkwRlNia2xCZDJWaWQydDJVV0ZtWWxSR1QzVnJPWFZRY1VORWVXcFZZamQ1WVZWQlRtNTJlVnBvZFRWYVFtRjRkWFp2UWpoUVNFdDJZaXNyVEVFeVVHaFZNazByT1hsNWNsUnhNVUozUVVGQlFVRWlMQ0p0WlhSaFpHRjBZVjkwWVhKblpYUWlPaUpCVmxWQlRrY3hhR0pJVVRaaVIyeDZaRVJ3ZFdJeVVteE1WekZzWkVkRk5rRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRWGRCUVVGQlFVRkJRVUZWUVVGQlFVRkJRVUZCUVdjOUlpd2ljM1JsY0hNaU9sdDdJblJoY21kbGRDSTZJa0ZXVlZOSlNEUXJiWE5VVURKc0t6RjZXVnAwT1VGa2FuUjVSblJvWVRnM2QxaE1RbTlFWm5KRE1ERTFjREJpTWlJc0luQnliMjltSWpvaVFVRkJRVU5IY1RZdkwzaDZPV2MzV2xwMFVrOVZjazV6WXpKQ0wzWlVkM0JCY1hoeWRERldSbkZUV1dKalRsSjZRbTFaZGtsaGQzVlZPRXd4VDBkNGRsQkdTMHcwZVhSRlMweDVlVE50UVRoa1R6QnhZMU5TV2k5a1pFVlNWemxZZDNkNmFsSXpjV2R4ZDNnNFJERTFWbXc0TDFodmVFVnZkMDVWU1RoS2RHaHVNbGhOWjFZeFdteDFZMnhvYmtwc1RrWlplSGMzZWtWTU5EQnRORGRrU25jek56SklRVFZRUzBjdlRsUlllWGhOV21obGQwazVXVVJKZVhwcVIzVmxRa3RWV2tWd1ltUkJhMjVFUWtReFNXeG9XRTFJUnpWa1pVTnZaMEpoUVZRelprdGFOR3BZZVhWRGJuTnRlWEJ0VG5KbVIzSTJZbkJYY0c5UlJXTjZOM1lyTm5veVJYSlZhMEU1VkRkTVFuSjVZblUwUzI4clNqbDZMMkp4Um0welp6TnFZVnAzYjFaeFZEQkVWRGxFVUZscVJIQXlURmd6TUhSek5FVkZTVGwzZGt0dWFtRm5LMVUyUmpCUFpsZDFlR2N3VERWTGNWYzRaVlpvV2tSRlZtOUtkMkZXVFdGdmEycEhObVZhWm5BNWNEUldUelE1T0ZKd05DdFRUbWxEU1ZFd2Jtc3lXbTVIVVRWd1ZHWlRVVXR2TUZWTlZreFBNVk5WVEZWek5pdEhSMGhwY0ZwTmJEUTNkbGd3ZGxaelZtcEphRmhKYjBNdlRFbEpXVEZQZWl0dU1XczVhWFpxYW05elFWTjVOa2hRTDA5V1lXY3JVVll3TVU1ek1UWlljVEptWWpkVE1HVjJTV1VyVkdwbFZqRjVlRFpVYzNReE5IbEtPWFJ0WWpVeGFIRk9la1JZVDNGUllqUjRRWHBITlVod2FEWkVTRUZPWkdsaGFFRXdNVVpUZW1KeFdXWTFhRVpxVlhvMGNtSkpiSGRPVkdsMFVGQnZVak5ZVjNoWGVuRTRUSE5qT1ZseU1IaDFPREY0UjJSNU9GQm1iRFk0T1hoVmMyZEdNbGM0YUd4cU4yeGhPRlJ0VmpoMll5dElhbTF2VEdsVVkwbEJTR3hHYTFoQ1puWmtZVUYwVmpKNE1HUk9TbkJZYTNkelpsSnlZak50TW5wTk9HUjBUMmRLUVhoRkwwMTJPV040TWpCeU5uQmpTU3MwYTB0MGNuZzJTa0ZRWTBnclVYZ3ZZbTlHT0hOd1RXWnBSWE5qU1RWeWRUaFdUVXhETnpKcFFrVkJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.ipa.list-range-eof.accept",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "list_range",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "query": {
+            "kind": "list_range",
+            "start": 8
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "range_segments": [
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+            },
+            "query": "range:8:",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "query": "range:8:",
+                "coordinate": "range:8:",
+                "start": 8,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6IkFBQUFDRk50RTJKWEErRXlGNnZzRXhEYUVFMldPT0VudURLc1JTbXNkaTBaRUowSEZKM0dFUENKYzlUVXBHVkIxT0k5NHRNVS85b3ZicW4rSktiYWpUL1ZUaVFRa2xWNnRGM1cyS1l6ZGhTVmpuY2VLdERzRkhESzBsQzduV2xTekJ5MUkwRlJRdTZsd1htT3hqc2VVckVpSDhMMVVJYjVVMUFYYVRoUCs0c3VaWW9hUzIwVW4rdEF4a0lrNCsxWEFGcitLaEhudnZva2FZY3BUN2RaSlpUVTNjaHNURjhjVHhSc2daMmxHWWRmc1ozWVF6OGtZT1NIUjZ4QXhmbDR3ZUlXd21pZEVKMEFTRWlJbFNkbVR5NWt3c205WTFqWVBsemx6M3lISDdzWjdwOU1URkxBc2xjRmVQVHNYcnp2eS85WjBBME9uUTZnSkE1SkFBeDVEdWFIc21GaFpERVZvSndhVk1hb2tqRzZlWmZwOXA0Vk80OThScDQrU05pQ0lRMG5reDBxbWlTR1EwMENtMzhreHVIOVU1VVh5ODYwQ3dQcmxmeGhOOExiOStmY1ZEY3VRNDZUK25oeDFLS01hWEloZklRakNlU05ramRXbkFFOWMyYW9QZXc1cDZUOWV3eTdwNEJKdU1XT29hVzNLZ1VpVWVsVHgwdzFHNVhLLzhFTFNVbktGcURjU0o5NDdsamk1NC9CbC92UkQyQWNXaTZEbjFvYmtxQW1YOGdtUUszVFg3dEtYd08rYmkwYmo3UWVsY0hWcjg5TVNkZGtsT3V3N3A1LzI4NHZ6Snd4Nmp2akxENHM1NzEyRkRGZzFRRHJjOG1RblB2eXJtVkYvNmRIUENNQ2NjL1ZMY0FSbklBd2Vid2t2UWFmYlRGT3VrOXVQcUNEeWpVYjd5YVVBTm52eVpodTVaQmF4dXZvQjhQSEt2YisrTEEyUGhVMk0rOXl5clRxMUJ3QUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNklrRkJRVUZEUms1MFJUSktXRUVyUlhsR05uWnpSWGhFWVVWRk1sZFBUMFZ1ZFVSTGMxSlRiWE5rYVRCYVJVb3dTRVpLTTBkRlVFTktZemxVVlhCSFZrSXhUMGs1TkhSTlZTODViM1ppY1c0clNrdGlZV3BVTDFaVWFWRlJhMnhXTm5SR00xY3lTMWw2WkdoVFZtcHVZMlZMZEVSelJraEVTekJzUXpkdVYyeFRla0o1TVVrd1JsSlJkVFpzZDFodFQzaHFjMlZWY2tWcFNEaE1NVlZKWWpWVk1VRllZVlJvVUNzMGMzVmFXVzloVXpJd1ZXNHJkRUY0YTBsck5Dc3hXRUZHY2l0TGFFaHVkblp2YTJGWlkzQlVOMlJhU2xwVVZUTmphSE5VUmpoalZIaFNjMmRhTW14SFdXUm1jMW96V1ZGNk9HdFpUMU5JVWpaNFFYaG1iRFIzWlVsWGQyMXBaRVZLTUVGVFJXbEpiRk5rYlZSNU5XdDNjMjA1V1RGcVdWQnNlbXg2TTNsSVNEZHpXamR3T1UxVVJreEJjMnhqUm1WUVZITlljbnAyZVM4NVdqQkJNRTl1VVRablNrRTFTa0ZCZURWRWRXRkljMjFHYUZwRVJWWnZTbmRoVmsxaGIydHFSelpsV21ad09YQTBWazgwT1RoU2NEUXJVMDVwUTBsUk1HNXJlREJ4YldsVFIxRXdNRU50TXpocmVIVklPVlUxVlZoNU9EWXdRM2RRY214bWVHaE9PRXhpT1N0bVkxWkVZM1ZSTkRaVUsyNW9lREZMUzAxaFdFbG9aa2xSYWtObFUwNXJhbVJYYmtGRk9XTXlZVzlRWlhjMWNEWlVPV1YzZVRkd05FSktkVTFYVDI5aFZ6TkxaMVZwVldWc1ZIZ3dkekZITlZoTEx6aEZURk5WYmt0R2NVUmpVMG81TkRkc2FtazFOQzlDYkM5MlVrUXlRV05YYVRaRWJqRnZZbXR4UVcxWU9HZHRVVXN6VkZnM2RFdFlkMDhyWW1rd1ltbzNVV1ZzWTBoV2NqZzVUVk5rWkd0c1QzVjNOM0ExTHpJNE5IWjZTbmQ0Tm1wMmFreEVOSE0xTnpFeVJrUkdaekZSUkhKak9HMVJibEIyZVhKdFZrWXZObVJJVUVOTlEyTmpMMVpNWTBGU2JrbEJkMlZpZDJ0MlVXRm1ZbFJHVDNWck9YVlFjVU5FZVdwVllqZDVZVlZCVG01MmVWcG9kVFZhUW1GNGRYWnZRamhRU0V0Mllpc3JURUV5VUdoVk1rMHJPWGw1Y2xSeE1VSjNRVUZCUVVFaUxDSnRaWFJoWkdGMFlWOTBZWEpuWlhRaU9pSkJWbFZCVGtjeGFHSklVVFppUjJ4NlpFUndkV0l5VW14TVZ6RnNaRWRGTmtGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFYZEJRVUZCUVVGQlFVRlZRVUZCUVVGQlFVRkJRV2M5SWl3aWMzUmxjSE1pT2x0N0luUmhjbWRsZENJNklrRldWVk5KU2xWTk5uWm1jVTlSU1M5SWIwWm1XbXRpWm5Jck5rTXhhbk5HYjJFdlpGUkdTSEI2YVROd1UzSk9iU0lzSW5CeWIyOW1Jam9pUVVGQlFVTkVjWGxPYzJsSE5XTXlSMnRvUlVsSWRFNHpUMnRRWTJsUFJWRnFSVkY1Vm5keFRHMU1SbHAyVUZWMFFsWlBZVTh2YldaRWVrWjRkbTlhWTNnMlVVOWFhSGQ1WVZoNVVHZFZOVVpGYnpJNWNYbEdkV3hDYjBKd2RUVkhUWGR5WW1STFZFVTBTWGMyVGxVeVVtNXpka3AzTVdOYVJEZGFUR1IzTmsweFVVdG5VR280ZDNJdlNESjBhRFZJWmpKUVlWaFNlREpyVFV0Q2JXYzNjMjAyYlZGQ1JtMW5VbXRZTlVaMFlrZE5hRWRvVDJaVVZtdzFlVVV3UVZFNVl5OHhUM1J2WVZwM0sxcFllVTlaYW14cVUyTTRZa3RwVmpCTldWaGxVSFJxTHpGc1FTOVlXaTlUVDNRMk5VdHRMMmszY210TFUxaGhNaXMxVFVzdldrcDVPVXhoYUdVclZtUldPR1JrWlhCSVJHMXZZV3ROVnlzdlMwODJSMUpLVlhCTVZuZFlkV0VyVmpNeGNrRnVRVU14TlZCWlRtNXhSbWgzTnpkbFV6bFlkbTByV0hSNkx6WmhTVTFNZDJSWU9YY3lTSFJYVDNVclRrWm9Xa1JGVm05S2QyRldUV0Z2YTJwSE5tVmFabkE1Y0RSV1R6UTVPRkp3TkN0VFRtbERTVkV3Ym1zeWVIaHRhRlJwYlVrdmVXTTRVV3BYWkZkSEsxVXpaM2RsY1ZsbldYRnNURVF3WW1WWE5rWXJTamhzUVRGYVVGaG1PQ3RrVGxSMk9GZHdhM2g1Y0doMFEwMDJNaTh4TjNaVFJETlNUWEYxYkVSaVUzUTBjM013Y1UxT05HdEZNbWd2WjIxQmVFMHpTRGw1ZG5ScGRrUnpVMmQyZURJd1ZXTjZlV1JqZWt0NVNYcEpjVk50UzJkUFdUZFNkbWxWVmk5bU1FRnZhVXBaZVRGU1NIcGxiVnBMTVRkV0sxRTVVbGhuUmxGR2JVWTRTRlp4VTI5aU4xbGFTRXRQZW5jM1VXOXBVRkJTVUhadU5WTnFPRXhtTTBSellrUTJPRkp6WjJ0NlZ6QmpUVmhtZGpWUFFsSnlZekZaYmxaeWQxVkZWazl0YVdVMlp6TlJSRmxuT1hnMFZHcE9NbEJWUVdGTWJVdHpMMDUxVlROTlR5czFjbVZXVm5aUGMzRjJha3ByZUhwRkx6QTNlWEJaYjNCQlVuWXhjWFpDVjBGRk0xVktiSFUyY1ZsSVQzcDJTalI2Wms1VVJGbHZZek50WWpZM0wzVlVNVkE1WjFGQlFVRkJReUlzSW5Oc2IzUWlPako5WFgwPSJ9LHsiaW5kZXgiOjIsInByb29mIjoiZXlKdFpYUmhaR0YwWVY5d2NtOXZaaUk2SWtGQlFVRkRSazUwUlRKS1dFRXJSWGxHTm5aelJYaEVZVVZGTWxkUFQwVnVkVVJMYzFKVGJYTmthVEJhUlVvd1NFWktNMGRGVUVOS1l6bFVWWEJIVmtJeFQwazVOSFJOVlM4NWIzWmljVzRyU2t0aVlXcFVMMVpVYVZGUmEyeFdOblJHTTFjeVMxbDZaR2hUVm1wdVkyVkxkRVJ6UmtoRVN6QnNRemR1VjJ4VGVrSjVNVWt3UmxKUmRUWnNkMWh0VDNocWMyVlZja1ZwU0RoTU1WVkpZalZWTVVGWVlWUm9VQ3MwYzNWYVdXOWhVekl3Vlc0cmRFRjRhMGxyTkNzeFdFRkdjaXRMYUVodWRuWnZhMkZaWTNCVU4yUmFTbHBVVlROamFITlVSamhqVkhoU2MyZGFNbXhIV1dSbWMxb3pXVkY2T0d0WlQxTklValo0UVhobWJEUjNaVWxYZDIxcFpFVktNRUZUUldsSmJGTmtiVlI1Tld0M2MyMDVXVEZxV1ZCc2VteDZNM2xJU0RkeldqZHdPVTFVUmt4QmMyeGpSbVZRVkhOWWNucDJlUzg1V2pCQk1FOXVVVFpuU2tFMVNrRkJlRFZFZFdGSWMyMUdhRnBFUlZadlNuZGhWazFoYjJ0cVJ6WmxXbVp3T1hBMFZrODBPVGhTY0RRclUwNXBRMGxSTUc1cmVEQnhiV2xUUjFFd01FTnRNemhyZUhWSU9WVTFWVmg1T0RZd1EzZFFjbXhtZUdoT09FeGlPU3RtWTFaRVkzVlJORFpVSzI1b2VERkxTMDFoV0Vsb1prbFJha05sVTA1cmFtUlhia0ZGT1dNeVlXOVFaWGMxY0RaVU9XVjNlVGR3TkVKS2RVMVhUMjloVnpOTFoxVnBWV1ZzVkhnd2R6RkhOVmhMTHpoRlRGTlZia3RHY1VSalUwbzVORGRzYW1rMU5DOUNiQzkyVWtReVFXTlhhVFpFYmpGdlltdHhRVzFZT0dkdFVVc3pWRmczZEV0WWQwOHJZbWt3WW1vM1VXVnNZMGhXY2pnNVRWTmtaR3RzVDNWM04zQTFMekk0TkhaNlNuZDRObXAyYWt4RU5ITTFOekV5UmtSR1p6RlJSSEpqT0cxUmJsQjJlWEp0VmtZdk5tUklVRU5OUTJOakwxWk1ZMEZTYmtsQmQyVmlkMnQyVVdGbVlsUkdUM1ZyT1hWUWNVTkVlV3BWWWpkNVlWVkJUbTUyZVZwb2RUVmFRbUY0ZFhadlFqaFFTRXQyWWlzclRFRXlVR2hWTWswck9YbDVjbFJ4TVVKM1FVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2lRVUZCUVVOSGNUWXZMM2g2T1djM1dscDBVazlWY2s1ell6SkNMM1pVZDNCQmNYaHlkREZXUm5GVFdXSmpUbEo2UW0xWmRrbGhkM1ZWT0V3eFQwZDRkbEJHUzB3MGVYUkZTMHg1ZVROdFFUaGtUekJ4WTFOU1dpOWtaRVZTVnpsWWQzZDZhbEl6Y1dkeGQzZzRSREUxVm13NEwxaHZlRVZ2ZDA1VlNUaEtkR2h1TWxoTloxWXhXbXgxWTJ4b2JrcHNUa1paZUhjM2VrVk1OREJ0TkRka1NuY3pOekpJUVRWUVMwY3ZUbFJZZVhoTldtaGxkMGs1V1VSSmVYcHFSM1ZsUWt0VldrVndZbVJCYTI1RVFrUXhTV3hvV0UxSVJ6VmtaVU52WjBKaFFWUXpaa3RhTkdwWWVYVkRibk50ZVhCdFRuSm1SM0kyWW5CWGNHOVJSV042TjNZck5ub3lSWEpWYTBFNVZEZE1Rbko1WW5VMFMyOHJTamw2TDJKeFJtMHpaek5xWVZwM2IxWnhWREJFVkRsRVVGbHFSSEF5VEZnek1IUnpORVZGU1RsM2RrdHVhbUZuSzFVMlJqQlBabGQxZUdjd1REVkxjVmM0WlZab1drUkZWbTlLZDJGV1RXRnZhMnBITm1WYVpuQTVjRFJXVHpRNU9GSndOQ3RUVG1sRFNWRXdibXN5V201SFVUVndWR1pUVVV0dk1GVk5Wa3hQTVZOVlRGVnpOaXRIUjBocGNGcE5iRFEzZGxnd2RsWnpWbXBKYUZoSmIwTXZURWxKV1RGUGVpdHVNV3M1YVhacWFtOXpRVk41TmtoUUwwOVdZV2NyVVZZd01VNXpNVFpZY1RKbVlqZFRNR1YyU1dVclZHcGxWakY1ZURaVWMzUXhOSGxLT1hSdFlqVXhhSEZPZWtSWVQzRlJZalI0UVhwSE5VaHdhRFpFU0VGT1pHbGhhRUV3TVVaVGVtSnhXV1kxYUVacVZYbzBjbUpKYkhkT1ZHbDBVRkJ2VWpOWVYzaFhlbkU0VEhOak9WbHlNSGgxT0RGNFIyUjVPRkJtYkRZNE9YaFZjMmRHTWxjNGFHeHFOMnhoT0ZSdFZqaDJZeXRJYW0xdlRHbFVZMGxCU0d4R2ExaENablprWVVGMFZqSjRNR1JPU25CWWEzZHpabEp5WWpOdE1ucE5PR1IwVDJkS1FYaEZMMDEyT1dONE1qQnlObkJqU1NzMGEwdDBjbmcyU2tGUVkwZ3JVWGd2WW05R09ITndUV1pwUlhOalNUVnlkVGhXVFV4RE56SnBRa1ZCUVVGQlJDSXNJbk5zYjNRaU9qTjlYWDA9In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.ipa.malformed-base64.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          },
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "prooflist": {
+            "query": "profile/name",
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "steps": [
+              {
+                "coordinate": "profile/name",
+                "evidence_backend": "map",
+                "evidence_kind": "structure",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "kind": "map_step",
+                "path": "profile/name",
+                "proof": "not-base64%%%",
+                "query": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                }
+              }
+            ]
+          },
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.map-key.accept",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "map_key",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.ipa.missing-evidence.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.payload.accept",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "payload",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "@payload"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "@payload",
+            "steps": [
+              {
+                "kind": "payload_binding",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "@payload",
+                "coordinate": "@payload",
+                "path": "@payload",
+                "target": {
+                  "/": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6IkFBQUFDR0M4aXVobU95ZVdHL1NlYkJUbzdzVXRRWHdTTUJDd2xnOERVaTNaV3E5T0NEcW9rQ05UU2VQWEx1V1RUWEVxRHA2M1RNMy9sNUpKV0pVSXE2TzBleWNKSEVSS2gwWW12K2w2b3RuaFRkdE5Ka2UxdDVBLzFQbnUvbCtWaUl3UHpoV2Z1RFBVM3VJMXR0alk2WVBZSjVseWorYXdvN1dyYklPVFFnaGlFZWVZT3RsWGJFMmpZclZYa09uang4Z1p5M1RFeEZ1S2RPcDVrdDc2N2lQM1VzZ3JHNFVJTzU5cVQyd2tCOHBBM1N4Ulg3bllKUXluWGQrSUpnbTdTT2hEaHlSY1hza3pXT0g1dHpZMzJ1M25WT256TStJMS9zeWR6THVwdmNXeVJCeGpDcHN1bmlCVlNKK3U2WXlHeFpXaVcyKytqSUFkRHd3eVN2WG1BSjNUUHFveE0wTlpnblA3bTV2ODJBZFFEbklNL0ZLN1RYRWxoS2VpcnJWVDVha3A3Zzd5OVFzTUgxNTFHM05RWVk1NGp1SFVuL0syeVZiYTMzaHpFSnBSTmYzRUtmZkRMbkFneXlhR1F1c1FpdFBJMC9rMXpPcWNDSThmN3RaZ2xDM21rcDFJTXk4Z1VCZ3JUUE94ckFxVmpkNTRNOVVqNktVNGtHMEdlOUxoUFJpUDlpVGU1REh2UGZnZXZLQUMzNHJOSmFLNXFqZmhYUjJpQklscksrSWZ3ZUpYRnZYN2hPcXg5M0pEaVhWUmtOMkZPK2VrUUhzWUlPcEkvWXFCUlNVK21iMU1oWE1IZ3B3RXdDTHJjeU9RaGt6dU82K0p0Y3ZEQWJQRjh1cFVYQk0ya0Z1alVidlFUK2FiUFJQUytaK2RCelhUbk5kaXhRK0I0WFU3RVBteWE1TjRyYjN6SkxldHpnSkh5dU40TmtDMHBDeFY2d04rNXJoWUU0bXllVHMxdGhJQUFBQ1cifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.ipa.proof-tamper.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFlIiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.range-segments-tamper.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "query": {
+            "kind": "list_range",
+            "start": 2,
+            "end": 18
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "range_segments": [
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+            },
+            "query": "range:2:18",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "query": "range:2:18",
+                "coordinate": "range:2:18",
+                "start": 2,
+                "end": 18,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "bagcibqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga"
+                  },
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6IkFBQUFDRk50RTJKWEErRXlGNnZzRXhEYUVFMldPT0VudURLc1JTbXNkaTBaRUowSEZKM0dFUENKYzlUVXBHVkIxT0k5NHRNVS85b3ZicW4rSktiYWpUL1ZUaVFRa2xWNnRGM1cyS1l6ZGhTVmpuY2VLdERzRkhESzBsQzduV2xTekJ5MUkwRlJRdTZsd1htT3hqc2VVckVpSDhMMVVJYjVVMUFYYVRoUCs0c3VaWW9hUzIwVW4rdEF4a0lrNCsxWEFGcitLaEhudnZva2FZY3BUN2RaSlpUVTNjaHNURjhjVHhSc2daMmxHWWRmc1ozWVF6OGtZT1NIUjZ4QXhmbDR3ZUlXd21pZEVKMEFTRWlJbFNkbVR5NWt3c205WTFqWVBsemx6M3lISDdzWjdwOU1URkxBc2xjRmVQVHNYcnp2eS85WjBBME9uUTZnSkE1SkFBeDVEdWFIc21GaFpERVZvSndhVk1hb2tqRzZlWmZwOXA0Vk80OThScDQrU05pQ0lRMG5reDBxbWlTR1EwMENtMzhreHVIOVU1VVh5ODYwQ3dQcmxmeGhOOExiOStmY1ZEY3VRNDZUK25oeDFLS01hWEloZklRakNlU05ramRXbkFFOWMyYW9QZXc1cDZUOWV3eTdwNEJKdU1XT29hVzNLZ1VpVWVsVHgwdzFHNVhLLzhFTFNVbktGcURjU0o5NDdsamk1NC9CbC92UkQyQWNXaTZEbjFvYmtxQW1YOGdtUUszVFg3dEtYd08rYmkwYmo3UWVsY0hWcjg5TVNkZGtsT3V3N3A1LzI4NHZ6Snd4Nmp2akxENHM1NzEyRkRGZzFRRHJjOG1RblB2eXJtVkYvNmRIUENNQ2NjL1ZMY0FSbklBd2Vid2t2UWFmYlRGT3VrOXVQcUNEeWpVYjd5YVVBTm52eVpodTVaQmF4dXZvQjhQSEt2YisrTEEyUGhVMk0rOXl5clRxMUJ3QUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNklrRkJRVUZEUms1MFJUSktXRUVyUlhsR05uWnpSWGhFWVVWRk1sZFBUMFZ1ZFVSTGMxSlRiWE5rYVRCYVJVb3dTRVpLTTBkRlVFTktZemxVVlhCSFZrSXhUMGs1TkhSTlZTODViM1ppY1c0clNrdGlZV3BVTDFaVWFWRlJhMnhXTm5SR00xY3lTMWw2WkdoVFZtcHVZMlZMZEVSelJraEVTekJzUXpkdVYyeFRla0o1TVVrd1JsSlJkVFpzZDFodFQzaHFjMlZWY2tWcFNEaE1NVlZKWWpWVk1VRllZVlJvVUNzMGMzVmFXVzloVXpJd1ZXNHJkRUY0YTBsck5Dc3hXRUZHY2l0TGFFaHVkblp2YTJGWlkzQlVOMlJhU2xwVVZUTmphSE5VUmpoalZIaFNjMmRhTW14SFdXUm1jMW96V1ZGNk9HdFpUMU5JVWpaNFFYaG1iRFIzWlVsWGQyMXBaRVZLTUVGVFJXbEpiRk5rYlZSNU5XdDNjMjA1V1RGcVdWQnNlbXg2TTNsSVNEZHpXamR3T1UxVVJreEJjMnhqUm1WUVZITlljbnAyZVM4NVdqQkJNRTl1VVRablNrRTFTa0ZCZURWRWRXRkljMjFHYUZwRVJWWnZTbmRoVmsxaGIydHFSelpsV21ad09YQTBWazgwT1RoU2NEUXJVMDVwUTBsUk1HNXJlREJ4YldsVFIxRXdNRU50TXpocmVIVklPVlUxVlZoNU9EWXdRM2RRY214bWVHaE9PRXhpT1N0bVkxWkVZM1ZSTkRaVUsyNW9lREZMUzAxaFdFbG9aa2xSYWtObFUwNXJhbVJYYmtGRk9XTXlZVzlRWlhjMWNEWlVPV1YzZVRkd05FSktkVTFYVDI5aFZ6TkxaMVZwVldWc1ZIZ3dkekZITlZoTEx6aEZURk5WYmt0R2NVUmpVMG81TkRkc2FtazFOQzlDYkM5MlVrUXlRV05YYVRaRWJqRnZZbXR4UVcxWU9HZHRVVXN6VkZnM2RFdFlkMDhyWW1rd1ltbzNVV1ZzWTBoV2NqZzVUVk5rWkd0c1QzVjNOM0ExTHpJNE5IWjZTbmQ0Tm1wMmFreEVOSE0xTnpFeVJrUkdaekZSUkhKak9HMVJibEIyZVhKdFZrWXZObVJJVUVOTlEyTmpMMVpNWTBGU2JrbEJkMlZpZDJ0MlVXRm1ZbFJHVDNWck9YVlFjVU5FZVdwVllqZDVZVlZCVG01MmVWcG9kVFZhUW1GNGRYWnZRamhRU0V0Mllpc3JURUV5VUdoVk1rMHJPWGw1Y2xSeE1VSjNRVUZCUVVFaUxDSnRaWFJoWkdGMFlWOTBZWEpuWlhRaU9pSkJWbFZCVGtjeGFHSklVVFppUjJ4NlpFUndkV0l5VW14TVZ6RnNaRWRGTmtGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFYZEJRVUZCUVVGQlFVRlZRVUZCUVVGQlFVRkJRV2M5SWl3aWMzUmxjSE1pT2x0N0luUmhjbWRsZENJNklrRldWVk5KU2pCa1ZsUTRhblJ6UlRac05XVnhPVmN3Y1d0dlFYSnpSa1JMWWpNdmNXNTFObk0wYm5Kd2EzVTRkeUlzSW5CeWIyOW1Jam9pUVVGQlFVTkZUbTVQV1haTGFra3JjMEZoVjFFNWRUZG9VVzR5WlRKRGJEbGtOVTFxVlU5blEzWnNiRkZKZUVKTlVtTjBjRXB4YW5FelEyWjBVbHBSU0UxMldYUnlTSGhSU1d3MVUwZDRaWFpzTjNSMVVYZEtUa0o1WTNWV1pXcHhVMVl5VWlzNGFtMHhaR0ZXVFZkTlF6QnpRVkpoTm1wTmEwbE5LekZWTjJocmIxZGlWRVl5TmpWQmRGWjFkbFF2V21aUFJERmxXRWxCV1RsdGJFOW9WakozUzB4T2FVSjZWekpUVlVGMmFXZFJWVU5sT1ZoNlFYUTFMMWxsWjJGV1dqVnNTSEZ4Um5reFMwRkpWVVpYSzJSbGJIRXpWM2s1TW1sSlEwaDZjbUp6VDFrelNqRTVRMjh5VEc1VlZpOUJWWFZUVW5KRmNrOUZRamRXVjBSd1NFbFNiRGc0VW1ZMVlYRTNjMWd5WTBkTmNrSnFNbU5JZFhvNGRrRXhhM1ZWWVZwNkwzUnpOVTVpWTNreWRtbHhibUl3YmsxS0wydDVhakppVURab2RUbFdkVk5qV1VGMVNFSm1aRmMwTmpKbGIxUlZSelZKVkhCa2FXeG9Xa1JGVm05S2QyRldUV0Z2YTJwSE5tVmFabkE1Y0RSV1R6UTVPRkp3TkN0VFRtbERTVkV3Ym10NmJVRTBWMHB3WjA4cmEyOWhWQzh3UVRneU1WazBRWHAxVEc5eGExcDVWMmxPTlVabWJHMVhhRUZVWVhOdVVUWTRjako1VFZSUVNYWXJlbGwxZERaSFNFTjBabWxxTW1OYWIxUktVbGd2UW1KNVJsbDJjM053VmxkT1pVZDVPRU5FZVhWb2JFRm1NVFJJVGxWWk4xZHZiV0p6UkV4SmRITTJjSG8xWlZaeVJsSXpTMHB3YmtOaVNqRXhhR3MxVVZadFZtVjRUMHhYT1RCblVGQjVZMDlDT1ZselJYRnpaVGQwYTJ0TFRsWTRMM2xtUm5rM2QyZGxZVk5VZDI1R1VGQlVXR05JYm1KbVluQjViVVJ5YkZnMlprWm9TeTkzY0ZoQlJHVXlja2MwZVV0SGVuRlpMMkkyWkhaQlpXUndVVXBuU0daVlJrcEZaR3hTTmxCUVozRTNiREFyTlVVNFJWaDVjbGxoVlUxRlpFdE5PVlpKVXpOdWVWWXpaMmhMWjFkWU5sQkdaMkpwUWtwSGRXSk9VVlJMT0RjMVluRjFTVGc0TmxRdk5IRnRkMDVEV1RSSmFUSjJlazlOTW05U05GVlFaek5SUW1kQlFVRkJRaUlzSW5Oc2IzUWlPakY5WFgwPSJ9LHsiaW5kZXgiOjEsInByb29mIjoiZXlKdFpYUmhaR0YwWVY5d2NtOXZaaUk2SWtGQlFVRkRSazUwUlRKS1dFRXJSWGxHTm5aelJYaEVZVVZGTWxkUFQwVnVkVVJMYzFKVGJYTmthVEJhUlVvd1NFWktNMGRGVUVOS1l6bFVWWEJIVmtJeFQwazVOSFJOVlM4NWIzWmljVzRyU2t0aVlXcFVMMVpVYVZGUmEyeFdOblJHTTFjeVMxbDZaR2hUVm1wdVkyVkxkRVJ6UmtoRVN6QnNRemR1VjJ4VGVrSjVNVWt3UmxKUmRUWnNkMWh0VDNocWMyVlZja1ZwU0RoTU1WVkpZalZWTVVGWVlWUm9VQ3MwYzNWYVdXOWhVekl3Vlc0cmRFRjRhMGxyTkNzeFdFRkdjaXRMYUVodWRuWnZhMkZaWTNCVU4yUmFTbHBVVlROamFITlVSamhqVkhoU2MyZGFNbXhIV1dSbWMxb3pXVkY2T0d0WlQxTklValo0UVhobWJEUjNaVWxYZDIxcFpFVktNRUZUUldsSmJGTmtiVlI1Tld0M2MyMDVXVEZxV1ZCc2VteDZNM2xJU0RkeldqZHdPVTFVUmt4QmMyeGpSbVZRVkhOWWNucDJlUzg1V2pCQk1FOXVVVFpuU2tFMVNrRkJlRFZFZFdGSWMyMUdhRnBFUlZadlNuZGhWazFoYjJ0cVJ6WmxXbVp3T1hBMFZrODBPVGhTY0RRclUwNXBRMGxSTUc1cmVEQnhiV2xUUjFFd01FTnRNemhyZUhWSU9WVTFWVmg1T0RZd1EzZFFjbXhtZUdoT09FeGlPU3RtWTFaRVkzVlJORFpVSzI1b2VERkxTMDFoV0Vsb1prbFJha05sVTA1cmFtUlhia0ZGT1dNeVlXOVFaWGMxY0RaVU9XVjNlVGR3TkVKS2RVMVhUMjloVnpOTFoxVnBWV1ZzVkhnd2R6RkhOVmhMTHpoRlRGTlZia3RHY1VSalUwbzVORGRzYW1rMU5DOUNiQzkyVWtReVFXTlhhVFpFYmpGdlltdHhRVzFZT0dkdFVVc3pWRmczZEV0WWQwOHJZbWt3WW1vM1VXVnNZMGhXY2pnNVRWTmtaR3RzVDNWM04zQTFMekk0TkhaNlNuZDRObXAyYWt4RU5ITTFOekV5UmtSR1p6RlJSSEpqT0cxUmJsQjJlWEp0VmtZdk5tUklVRU5OUTJOakwxWk1ZMEZTYmtsQmQyVmlkMnQyVVdGbVlsUkdUM1ZyT1hWUWNVTkVlV3BWWWpkNVlWVkJUbTUyZVZwb2RUVmFRbUY0ZFhadlFqaFFTRXQyWWlzclRFRXlVR2hWTWswck9YbDVjbFJ4TVVKM1FVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2lRVUZCUVVORWNYbE9jMmxITldNeVIydG9SVWxJZEU0elQydFFZMmxQUlZGcVJWRjVWbmR4VEcxTVJscDJVRlYwUWxaUFlVOHZiV1pFZWtaNGRtOWFZM2cyVVU5YWFIZDVZVmg1VUdkVk5VWkZiekk1Y1hsR2RXeENiMEp3ZFRWSFRYZHlZbVJMVkVVMFNYYzJUbFV5VW01emRrcDNNV05hUkRkYVRHUjNOazB4VVV0blVHbzRkM0l2U0RKMGFEVklaakpRWVZoU2VESnJUVXRDYldjM2MyMDJiVkZDUm0xblVtdFlOVVowWWtkTmFFZG9UMlpVVm13MWVVVXdRVkU1WXk4eFQzUnZZVnAzSzFwWWVVOVphbXhxVTJNNFlrdHBWakJOV1ZobFVIUnFMekZzUVM5WVdpOVRUM1EyTlV0dEwyazNjbXRMVTFoaE1pczFUVXN2V2twNU9VeGhhR1VyVm1SV09HUmtaWEJJUkcxdllXdE5WeXN2UzA4MlIxSktWWEJNVm5kWWRXRXJWak14Y2tGdVFVTXhOVkJaVG01eFJtaDNOemRsVXpsWWRtMHJXSFI2THpaaFNVMU1kMlJZT1hjeVNIUlhUM1VyVGtab1drUkZWbTlLZDJGV1RXRnZhMnBITm1WYVpuQTVjRFJXVHpRNU9GSndOQ3RUVG1sRFNWRXdibXN5ZUhodGFGUnBiVWt2ZVdNNFVXcFhaRmRISzFVelozZGxjVmxuV1hGc1RFUXdZbVZYTmtZclNqaHNRVEZhVUZobU9DdGtUbFIyT0Zkd2EzaDVjR2gwUTAwMk1pOHhOM1pUUkROU1RYRjFiRVJpVTNRMGMzTXdjVTFPTkd0Rk1tZ3ZaMjFCZUUwelNEbDVkblJwZGtSelUyZDJlREl3VldONmVXUmpla3Q1U1hwSmNWTnRTMmRQV1RkU2RtbFZWaTltTUVGdmFVcFplVEZTU0hwbGJWcExNVGRXSzFFNVVsaG5SbEZHYlVZNFNGWnhVMjlpTjFsYVNFdFBlbmMzVVc5cFVGQlNVSFp1TlZOcU9FeG1NMFJ6WWtRMk9GSnpaMnQ2VnpCalRWaG1kalZQUWxKeVl6RlpibFp5ZDFWRlZrOXRhV1UyWnpOUlJGbG5PWGcwVkdwT01sQlZRV0ZNYlV0ekwwNTFWVE5OVHlzMWNtVldWblpQYzNGMmFrcHJlSHBGTHpBM2VYQlpiM0JCVW5ZeGNYWkNWMEZGTTFWS2JIVTJjVmxJVDNwMlNqUjZaazVVUkZsdll6TnRZalkzTDNWVU1WQTVaMUZCUVVGQlF5SXNJbk5zYjNRaU9qSjlYWDA9In0seyJpbmRleCI6MiwicHJvb2YiOiJleUp0WlhSaFpHRjBZVjl3Y205dlppSTZJa0ZCUVVGRFJrNTBSVEpLV0VFclJYbEdOblp6UlhoRVlVVkZNbGRQVDBWdWRVUkxjMUpUYlhOa2FUQmFSVW93U0VaS00wZEZVRU5LWXpsVVZYQkhWa0l4VDBrNU5IUk5WUzg1YjNaaWNXNHJTa3RpWVdwVUwxWlVhVkZSYTJ4V05uUkdNMWN5UzFsNlpHaFRWbXB1WTJWTGRFUnpSa2hFU3pCc1F6ZHVWMnhUZWtKNU1Va3dSbEpSZFRac2QxaHRUM2hxYzJWVmNrVnBTRGhNTVZWSllqVlZNVUZZWVZSb1VDczBjM1ZhV1c5aFV6SXdWVzRyZEVGNGEwbHJOQ3N4V0VGR2NpdExhRWh1ZG5admEyRlpZM0JVTjJSYVNscFVWVE5qYUhOVVJqaGpWSGhTYzJkYU1teEhXV1JtYzFveldWRjZPR3RaVDFOSVVqWjRRWGhtYkRSM1pVbFhkMjFwWkVWS01FRlRSV2xKYkZOa2JWUjVOV3QzYzIwNVdURnFXVkJzZW14Nk0zbElTRGR6V2pkd09VMVVSa3hCYzJ4alJtVlFWSE5ZY25wMmVTODVXakJCTUU5dVVUWm5Ta0UxU2tGQmVEVkVkV0ZJYzIxR2FGcEVSVlp2U25kaFZrMWhiMnRxUnpabFdtWndPWEEwVms4ME9UaFNjRFFyVTA1cFEwbFJNRzVyZURCeGJXbFRSMUV3TUVOdE16aHJlSFZJT1ZVMVZWaDVPRFl3UTNkUWNteG1lR2hPT0V4aU9TdG1ZMVpFWTNWUk5EWlVLMjVvZURGTFMwMWhXRWxvWmtsUmFrTmxVMDVyYW1SWGJrRkZPV015WVc5UVpYYzFjRFpVT1dWM2VUZHdORUpLZFUxWFQyOWhWek5MWjFWcFZXVnNWSGd3ZHpGSE5WaExMemhGVEZOVmJrdEdjVVJqVTBvNU5EZHNhbWsxTkM5Q2JDOTJVa1F5UVdOWGFUWkViakZ2WW10eFFXMVlPR2R0VVVzelZGZzNkRXRZZDA4cllta3dZbW8zVVdWc1kwaFdjamc1VFZOa1pHdHNUM1YzTjNBMUx6STROSFo2U25kNE5tcDJha3hFTkhNMU56RXlSa1JHWnpGUlJISmpPRzFSYmxCMmVYSnRWa1l2Tm1SSVVFTk5RMk5qTDFaTVkwRlNia2xCZDJWaWQydDJVV0ZtWWxSR1QzVnJPWFZRY1VORWVXcFZZamQ1WVZWQlRtNTJlVnBvZFRWYVFtRjRkWFp2UWpoUVNFdDJZaXNyVEVFeVVHaFZNazByT1hsNWNsUnhNVUozUVVGQlFVRWlMQ0p0WlhSaFpHRjBZVjkwWVhKblpYUWlPaUpCVmxWQlRrY3hhR0pJVVRaaVIyeDZaRVJ3ZFdJeVVteE1WekZzWkVkRk5rRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRWGRCUVVGQlFVRkJRVUZWUVVGQlFVRkJRVUZCUVdjOUlpd2ljM1JsY0hNaU9sdDdJblJoY21kbGRDSTZJa0ZXVlZOSlNEUXJiWE5VVURKc0t6RjZXVnAwT1VGa2FuUjVSblJvWVRnM2QxaE1RbTlFWm5KRE1ERTFjREJpTWlJc0luQnliMjltSWpvaVFVRkJRVU5IY1RZdkwzaDZPV2MzV2xwMFVrOVZjazV6WXpKQ0wzWlVkM0JCY1hoeWRERldSbkZUV1dKalRsSjZRbTFaZGtsaGQzVlZPRXd4VDBkNGRsQkdTMHcwZVhSRlMweDVlVE50UVRoa1R6QnhZMU5TV2k5a1pFVlNWemxZZDNkNmFsSXpjV2R4ZDNnNFJERTFWbXc0TDFodmVFVnZkMDVWU1RoS2RHaHVNbGhOWjFZeFdteDFZMnhvYmtwc1RrWlplSGMzZWtWTU5EQnRORGRrU25jek56SklRVFZRUzBjdlRsUlllWGhOV21obGQwazVXVVJKZVhwcVIzVmxRa3RWV2tWd1ltUkJhMjVFUWtReFNXeG9XRTFJUnpWa1pVTnZaMEpoUVZRelprdGFOR3BZZVhWRGJuTnRlWEJ0VG5KbVIzSTJZbkJYY0c5UlJXTjZOM1lyTm5veVJYSlZhMEU1VkRkTVFuSjVZblUwUzI4clNqbDZMMkp4Um0welp6TnFZVnAzYjFaeFZEQkVWRGxFVUZscVJIQXlURmd6TUhSek5FVkZTVGwzZGt0dWFtRm5LMVUyUmpCUFpsZDFlR2N3VERWTGNWYzRaVlpvV2tSRlZtOUtkMkZXVFdGdmEycEhObVZhWm5BNWNEUldUelE1T0ZKd05DdFRUbWxEU1ZFd2Jtc3lXbTVIVVRWd1ZHWlRVVXR2TUZWTlZreFBNVk5WVEZWek5pdEhSMGhwY0ZwTmJEUTNkbGd3ZGxaelZtcEphRmhKYjBNdlRFbEpXVEZQZWl0dU1XczVhWFpxYW05elFWTjVOa2hRTDA5V1lXY3JVVll3TVU1ek1UWlljVEptWWpkVE1HVjJTV1VyVkdwbFZqRjVlRFpVYzNReE5IbEtPWFJ0WWpVeGFIRk9la1JZVDNGUllqUjRRWHBITlVod2FEWkVTRUZPWkdsaGFFRXdNVVpUZW1KeFdXWTFhRVpxVlhvMGNtSkpiSGRPVkdsMFVGQnZVak5ZVjNoWGVuRTRUSE5qT1ZseU1IaDFPREY0UjJSNU9GQm1iRFk0T1hoVmMyZEdNbGM0YUd4cU4yeGhPRlJ0VmpoMll5dElhbTF2VEdsVVkwbEJTR3hHYTFoQ1puWmtZVUYwVmpKNE1HUk9TbkJZYTNkelpsSnlZak50TW5wTk9HUjBUMmRLUVhoRkwwMTJPV040TWpCeU5uQmpTU3MwYTB0MGNuZzJTa0ZRWTBnclVYZ3ZZbTlHT0hOd1RXWnBSWE5qU1RWeWRUaFdUVXhETnpKcFFrVkJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.target-tamper.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.truncated-evidence.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUE9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.unknown-field.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "strict_json",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          },
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "prooflist": {
+            "query": "profile/name",
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "steps": [
+              {
+                "coordinate": "profile/name",
+                "evidence_backend": "map",
+                "evidence_kind": "structure",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "kind": "map_step",
+                "path": "profile/name",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ==",
+                "query": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                }
+              }
+            ]
+          },
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+        },
+        "unexpected": true
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.cross-backend-ipa-evidence.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "cross_backend",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.cross-kind.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "cross_kind",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "query": {
+            "kind": "list_index",
+            "index": 0
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "list:0",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.cross-root.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "cross_root",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.list-index.accept",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "list_index",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbibqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x",
+          "query": {
+            "kind": "list_index",
+            "index": 1
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga",
+          "prooflist": {
+            "root": {
+              "/": "bagbibqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x"
+            },
+            "query": "list:1",
+            "steps": [
+              {
+                "kind": "list_index",
+                "from": {
+                  "/": "bagbibqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x"
+                },
+                "query": "list:1",
+                "coordinate": "1",
+                "index": 1,
+                "length": 3,
+                "target": {
+                  "/": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6InJobFY3R1IxMGs0SCs0SVNDYmhFTm9zR2FNY1pLVHc3RVRidDh6cXhWTGNqekNiNVVCWldSc1gzT0haL3paa1ZRWHRyZVh0VTY3Qy9GMUQ0MnNjL0x0Tm8yaS9qWFZMQ29MSnlnY2libHI4QUFBQUEiLCJzdGVwcyI6W3sidGFyZ2V0IjoiQVZVU0lDZWtiLzNFZ21IazNnMzd6YjdlRHc2VTRLNDRZTUZJZnh4Z2RibTJXZ013IiwicHJvb2YiOiJwOFNwdWp4cis0WlBoQ0ZFUVNtbXlXakM0NW56TTg3blZhQmg0ZDZ4ZThROFd6MGRoY25RSk1FeVZqcGVaN1AyRHhzbXRZU3RadlRvVkxXMVFMYWZZVVpmMkJWT2ZuWFRiQlg0VmprcVRLVUFBQUFDIiwic2xvdCI6Mn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.kzg.list-range-bounded.accept",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "list_range",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "query": {
+            "kind": "list_range",
+            "start": 2,
+            "end": 18
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "range_segments": [
+            "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+            },
+            "query": "range:2:18",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                },
+                "query": "range:2:18",
+                "coordinate": "range:2:18",
+                "start": 2,
+                "end": 18,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga"
+                  },
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6InFaeS9WU2VGa0pkL1V6Lzk0cVRTL2U5eXl4VmNhZGpPUytmK3dOWkFFcHFXUjBJWEZ1dXhOdEZ3L3BjdDl1NTBFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTakJrVmxRNGFuUnpSVFpzTldWeE9WY3djV3R2UVhKelJrUkxZak12Y1c1MU5uTTBibkp3YTNVNGR5SXNJbkJ5YjI5bUlqb2lhblIwYTJjd00yTnNPVzU0TVhWRFpsWklkMUZ4VG05MloweGFWV3haTTFFemRYRlRSSFV3VFVGalYxcHhlVXA0Tm5KamFuSnBibUZ5SzBGU2VFZG9WMEU0YmtORmNHdEpOa1pwVVVoSmMycG1VblJ0Y2tad1ZIcHZVbE5aTmt4d2N6Z3pSVWhPYTFabllsRkJRVUZCUWlJc0luTnNiM1FpT2pGOVhYMD0ifSx7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2laM1p5YTNaUVYwVllaVzlwT0hFNFpWbHBhR3RrZFdaWU5GcHJOR3RtV2pkNFJWUjFSRVkyT0VwTmNFTXJWVFJ1Y214VFJqWmFOSG8yZERGT1FXOUpXRlJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2ljV3N6Y3l0d1NGWXZLMmhJYWpoUlUxRXljVXBxVTNBeFVUTk1jVTFtWWt3NEwwbHJRV05NUm1abWVuQkViMWN3V0dGak9YcHpUMnRaY0ZwMVJ5dEphVlJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.kzg.list-range-eof.accept",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "list_range",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "query": {
+            "kind": "list_range",
+            "start": 8
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "range_segments": [
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+            },
+            "query": "range:8:",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                },
+                "query": "range:8:",
+                "coordinate": "range:8:",
+                "start": 8,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6InFaeS9WU2VGa0pkL1V6Lzk0cVRTL2U5eXl4VmNhZGpPUytmK3dOWkFFcHFXUjBJWEZ1dXhOdEZ3L3BjdDl1NTBFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2laM1p5YTNaUVYwVllaVzlwT0hFNFpWbHBhR3RrZFdaWU5GcHJOR3RtV2pkNFJWUjFSRVkyT0VwTmNFTXJWVFJ1Y214VFJqWmFOSG8yZERGT1FXOUpXRlJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2ljV3N6Y3l0d1NGWXZLMmhJYWpoUlUxRXljVXBxVTNBeFVUTk1jVTFtWWt3NEwwbHJRV05NUm1abWVuQkViMWN3V0dGak9YcHpUMnRaY0ZwMVJ5dEphVlJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.kzg.malformed-base64.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          },
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "prooflist": {
+            "query": "profile/name",
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "steps": [
+              {
+                "coordinate": "profile/name",
+                "evidence_backend": "map",
+                "evidence_kind": "structure",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "kind": "map_step",
+                "path": "profile/name",
+                "proof": "not-base64%%%",
+                "query": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                }
+              }
+            ]
+          },
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.map-key.accept",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "map_key",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.kzg.missing-evidence.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.payload.accept",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "payload",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "@payload"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "@payload",
+            "steps": [
+              {
+                "kind": "payload_binding",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "@payload",
+                "coordinate": "@payload",
+                "path": "@payload",
+                "target": {
+                  "/": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6InBLazhnMHdnME92TkFHU0p3WU9VSVVINklnTUZoSFhZckxQZjJ5MkRyU3lQTDQzdjI5OUxncWZuQVRqdTVpOEJQSDd6am0vMm1aOEJBa3RsQWtEQUcxWXVNU2xuYk5xQ3NoWXgyRVFWQWdRQUFBQ1cifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.kzg.proof-tamper.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFlIiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.range-segments-tamper.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "query": {
+            "kind": "list_range",
+            "start": 2,
+            "end": 18
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "range_segments": [
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+            },
+            "query": "range:2:18",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                },
+                "query": "range:2:18",
+                "coordinate": "range:2:18",
+                "start": 2,
+                "end": 18,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "bagbibqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga"
+                  },
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6InFaeS9WU2VGa0pkL1V6Lzk0cVRTL2U5eXl4VmNhZGpPUytmK3dOWkFFcHFXUjBJWEZ1dXhOdEZ3L3BjdDl1NTBFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTakJrVmxRNGFuUnpSVFpzTldWeE9WY3djV3R2UVhKelJrUkxZak12Y1c1MU5uTTBibkp3YTNVNGR5SXNJbkJ5YjI5bUlqb2lhblIwYTJjd00yTnNPVzU0TVhWRFpsWklkMUZ4VG05MloweGFWV3haTTFFemRYRlRSSFV3VFVGalYxcHhlVXA0Tm5KamFuSnBibUZ5SzBGU2VFZG9WMEU0YmtORmNHdEpOa1pwVVVoSmMycG1VblJ0Y2tad1ZIcHZVbE5aTmt4d2N6Z3pSVWhPYTFabllsRkJRVUZCUWlJc0luTnNiM1FpT2pGOVhYMD0ifSx7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2laM1p5YTNaUVYwVllaVzlwT0hFNFpWbHBhR3RrZFdaWU5GcHJOR3RtV2pkNFJWUjFSRVkyT0VwTmNFTXJWVFJ1Y214VFJqWmFOSG8yZERGT1FXOUpXRlJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2ljV3N6Y3l0d1NGWXZLMmhJYWpoUlUxRXljVXBxVTNBeFVUTk1jVTFtWWt3NEwwbHJRV05NUm1abWVuQkViMWN3V0dGak9YcHpUMnRaY0ZwMVJ5dEphVlJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.target-tamper.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.truncated-evidence.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUE9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.unknown-field.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "strict_json",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          },
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "prooflist": {
+            "query": "profile/name",
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "steps": [
+              {
+                "coordinate": "profile/name",
+                "evidence_backend": "map",
+                "evidence_kind": "structure",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "kind": "map_step",
+                "path": "profile/name",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ==",
+                "query": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                }
+              }
+            ]
+          },
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+        },
+        "unexpected": true
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.identity.accept",
+      "operation": "resolve",
+      "backend": "none",
+      "category": "identity",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bafkreihj7frihi7mfoo4ano74bl563eme4koaajxnlvrr4qpyunbf6x4ha",
+          "segments": []
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreihj7frihi7mfoo4ano74bl563eme4koaajxnlvrr4qpyunbf6x4ha",
+          "prooflist": {
+            "root": {
+              "/": "bafkreihj7frihi7mfoo4ano74bl563eme4koaajxnlvrr4qpyunbf6x4ha"
+            },
+            "steps": []
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.ipa.cross-root.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "cross_root",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNHdDIvSGNqUmd2OWliVC9wR1IvTlBESXlESEZqTTFOMFhobVZKK2RkeURWVS9zdXFiMlgyZHJQZmoxWkRCRFZJdm1zZVhxc0Z2M1g5RDJ0SXBNdGZaczJheEVhYkllWnBCTVZKVWg2OE4vR2dZOFBoZFdHczQ2MnRWTWM3Tk5raEdwaURFaUEzOXVZb0JTSWI3VmVyQTJrMFdBajJiVjAyMjlXNmlCejAxQU1QZStBRUxWa2lRRXMwU2krUFFvYWc2T0owZW1Dd1p2NUFpOEZyTndGYmZ4aFkzVy9zMVpYMW10dVRFbGlGVFYrQmdRbCs3clo0L0ZuRmtISURPR2JGQVpZQThJaHM1ZE14bDFsMVhnWDBlSkpOVFZ5SlNRWUN5QWdjVGo4UlpMVlpHcTV2YUo3d3gwdEVQd3ZxeGJDTHhtN1JzSTdhQ3pxY0JlV2tTVHd2Y1lHRE03SVVjWElacE92VW1mc1gwNEVLRFRLRXFWeDlRUDBaN2dESkthOVdGV1p5L1RNVVozTWlxV3J2dEFMN1hEc1JnRS8vOExxVXdGVWFnNlc4MTRQWHdobXlsblkwdXJrNTJiS0pneTFJbzlWTklHQitCeVZ1K21zTG95QTN2SlhXZ1dRYTRPZTN4dEpPUndrRjRuZmJtMllUR3d1ckd4SUVLMmxIekc4QW0wM2hkZ1V6ZmM3UXlKeHBtQjRqVFZHdXRHNnVQdWNDaExQbDhXM2RsbWRJTFlHd0NYTDBMNE82SW85NFVQbDdsY3Y1OXNCdFNaNjFDRlgySXgrNlowUXJHWGV5KzUxaG5PRERaaVR5d09KUDRmTzIyREVUbGgyZlRVTVE1ZzVGVnhXS096U1FjTnlaT2x5WFJqeU00b0QvVUJPMnM2dXYwSnhtMC9yanVBWmlNWVVFRG9zMUJ4RENJTzRxRDcwcDJQRkNRNGRpU3puL2lSOXpIWWU2UWdBQUFCRyJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.ipa.evidence-tamper.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0d0Mi9IY2pSZ3Y5aWJUL3BHUi9OUERJeURIRmpNMU4wWGhtVkorZGR5RFZVL3N1cWIyWDJkclBmajFaREJEVkl2bXNlWHFzRnYzWDlEMnRJcE10ZlpzMmF4RWFiSWVacEJNVkpVaDY4Ti9HZ1k4UGhkV0dzNDYydFZNYzdOTmtoR3BpREVpQTM5dVlvQlNJYjdWZXJBMmswV0FqMmJWMDIyOVc2aUJ6MDFBTVBlK0FFTFZraVFFczBTaStQUW9hZzZPSjBlbUN3WnY1QWk4RnJOd0ZiZnhoWTNXL3MxWlgxbXR1VEVsaUZUVitCZ1FsKzdyWjQvRm5Ga0hJRE9HYkZBWllBOEloczVkTXhsMWwxWGdYMGVKSk5UVnlKU1FZQ3lBZ2NUajhSWkxWWkdxNXZhSjd3eDB0RVB3dnF4YkNMeG03UnNJN2FDenFjQmVXa1NUd3ZjWUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0ZXWnkvVE1VWjNNaXFXcnZ0QUw3WERzUmdFLy84THFVd0ZVYWc2VzgxNFBYd2hteWxuWTB1cms1MmJLSmd5MUlvOVZOSUdCK0J5VnUrbXNMb3lBM3ZKWFdnV1FhNE9lM3h0Sk9Sd2tGNG5mYm0yWVRHd3VyR3hJRUsybEh6RzhBbTAzaGRnVXpmYzdReUp4cG1CNGpUVkd1dEc2dVB1Y0NoTFBsOFczZGxtZElMWUd3Q1hMMEw0TzZJbzk0VVBsN2xjdjU5c0J0U1o2MUNGWDJJeCs2WjBRckdYZXkrNTFobk9ERFppVHl3T0pQNGZPMjJERVRsaDJmVFVNUTVnNUZWeFdLT3pTUWNOeVpPbHlYUmp5TTRvRC9VQk8yczZ1djBKeG0wL3JqdUFaaU1ZVUVEb3MxQnhEQ0lPNHFENzBwMlBGQ1E0ZGlTem4vaVI5ekhZZTZRZ0FBQUJIIiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.ipa.malformed-base64.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "prooflist": {
+            "query": "docs/leaf",
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "steps": [
+              {
+                "evidence": "not-base64%%%",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "kind": "map_step",
+                "path": "docs",
+                "query": "docs",
+                "target": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                }
+              },
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ==",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "kind": "map_step",
+                "path": "leaf",
+                "query": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                }
+              }
+            ]
+          },
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.ipa.map-key.accept",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "map_key",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "segments": [
+            "profile",
+            "name"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0JWRzNMNWY3RWI1TkpLY0ZydHE0bzBDdzFoNnRwN0U1RUlkL2Y3M09RSllHUVhtNndPVU5hakgvREEzOGlyMmlqbXp0Uy9seHNUY2NJNGNVMkh6NjBwUnd2dXdJTm9qWVBIMndwZFpaUStSZ1ByNkkvdG4yejA1NWFObmpBTWRtQ1BlZEx0cnpZaHJVSjBJWFdoUkpreklSa1drcjI4L0ZHVFNoenVuMjdxVEFkK3JEbkFKMmdyL05USk1zTTJ1SzlvT2NCeDZSRjB5RzZ5WG1seVdySVlvcWgxWWxJaUdHS1JiZEEzV2RwUGpMN3p3QmdmUTN4b2IxV0Fzc2Jvd0tTYUVKQWlLS09KTVo2NFhCRkxBRmtNWnZ3cEpkNHJmN0xuWEhJV3VERGVWR0NZaFp1UTBXYWk2elFJbGxUc3grR0hTNmlIdE9xVHpVVEdnQTloVENpRUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0RnSkh3aFN6QnRZN2g4bDFSRlRNcS9WSHVMQlhRRXBPZ0wvei9pbTVXbkdCNldvUWVqR202TDhOMXRVdWtsSXlvcktHSkF1VG1DZFE4ZmEyY0QzV0hjc01iZDhSZWdvNDNhUGlPTGtKTkN5OXBIcDZ5REhrQzVxSTl4OHNxa0xtQVlqaGtZS1AxVXplUkl3bkxDZWNRRG9IdGhldDJwTXZ3UEFKcHo0SVpvelZBenNHY2Y2VFp3NXRTK2lwZUpQWkFkanVtbnRPb0hPZ0ZSTkhrbTEyZWMvem9OTE1PT2Z0aXNDMitTL0RTYTJkckNOVWd6WXp1dWF4MHl4eHpUUkxFakVpSzY4RTlGUDNKK0gwQ0ZGWG5QbWVGbHA3Mzdram9tZDRRVHdFMG9oNnNlS09NL2NIdVlrdnlkWlBzMXVzVFQ2cFNnTWxDTTBPeFA2M3VKTGZoTUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.ipa.missing-evidence.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit"
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.ipa.multihop.accept",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "multihop",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNHdDIvSGNqUmd2OWliVC9wR1IvTlBESXlESEZqTTFOMFhobVZKK2RkeURWVS9zdXFiMlgyZHJQZmoxWkRCRFZJdm1zZVhxc0Z2M1g5RDJ0SXBNdGZaczJheEVhYkllWnBCTVZKVWg2OE4vR2dZOFBoZFdHczQ2MnRWTWM3Tk5raEdwaURFaUEzOXVZb0JTSWI3VmVyQTJrMFdBajJiVjAyMjlXNmlCejAxQU1QZStBRUxWa2lRRXMwU2krUFFvYWc2T0owZW1Dd1p2NUFpOEZyTndGYmZ4aFkzVy9zMVpYMW10dVRFbGlGVFYrQmdRbCs3clo0L0ZuRmtISURPR2JGQVpZQThJaHM1ZE14bDFsMVhnWDBlSkpOVFZ5SlNRWUN5QWdjVGo4UlpMVlpHcTV2YUo3d3gwdEVQd3ZxeGJDTHhtN1JzSTdhQ3pxY0JlV2tTVHd2Y1lHRE03SVVjWElacE92VW1mc1gwNEVLRFRLRXFWeDlRUDBaN2dESkthOVdGV1p5L1RNVVozTWlxV3J2dEFMN1hEc1JnRS8vOExxVXdGVWFnNlc4MTRQWHdobXlsblkwdXJrNTJiS0pneTFJbzlWTklHQitCeVZ1K21zTG95QTN2SlhXZ1dRYTRPZTN4dEpPUndrRjRuZmJtMllUR3d1ckd4SUVLMmxIekc4QW0wM2hkZ1V6ZmM3UXlKeHBtQjRqVFZHdXRHNnVQdWNDaExQbDhXM2RsbWRJTFlHd0NYTDBMNE82SW85NFVQbDdsY3Y1OXNCdFNaNjFDRlgySXgrNlowUXJHWGV5KzUxaG5PRERaaVR5d09KUDRmTzIyREVUbGgyZlRVTVE1ZzVGVnhXS096U1FjTnlaT2x5WFJqeU00b0QvVUJPMnM2dXYwSnhtMC9yanVBWmlNWVVFRG9zMUJ4RENJTzRxRDcwcDJQRkNRNGRpU3puL2lSOXpIWWU2UWdBQUFCRyJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.ipa.payload.accept",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "payload",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "segments": [
+            "docs",
+            "@payload"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "docs/@payload",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNHdDIvSGNqUmd2OWliVC9wR1IvTlBESXlESEZqTTFOMFhobVZKK2RkeURWVS9zdXFiMlgyZHJQZmoxWkRCRFZJdm1zZVhxc0Z2M1g5RDJ0SXBNdGZaczJheEVhYkllWnBCTVZKVWg2OE4vR2dZOFBoZFdHczQ2MnRWTWM3Tk5raEdwaURFaUEzOXVZb0JTSWI3VmVyQTJrMFdBajJiVjAyMjlXNmlCejAxQU1QZStBRUxWa2lRRXMwU2krUFFvYWc2T0owZW1Dd1p2NUFpOEZyTndGYmZ4aFkzVy9zMVpYMW10dVRFbGlGVFYrQmdRbCs3clo0L0ZuRmtISURPR2JGQVpZQThJaHM1ZE14bDFsMVhnWDBlSkpOVFZ5SlNRWUN5QWdjVGo4UlpMVlpHcTV2YUo3d3gwdEVQd3ZxeGJDTHhtN1JzSTdhQ3pxY0JlV2tTVHd2Y1lHRE03SVVjWElacE92VW1mc1gwNEVLRFRLRXFWeDlRUDBaN2dESkthOVdGV1p5L1RNVVozTWlxV3J2dEFMN1hEc1JnRS8vOExxVXdGVWFnNlc4MTRQWHdobXlsblkwdXJrNTJiS0pneTFJbzlWTklHQitCeVZ1K21zTG95QTN2SlhXZ1dRYTRPZTN4dEpPUndrRjRuZmJtMllUR3d1ckd4SUVLMmxIekc4QW0wM2hkZ1V6ZmM3UXlKeHBtQjRqVFZHdXRHNnVQdWNDaExQbDhXM2RsbWRJTFlHd0NYTDBMNE82SW85NFVQbDdsY3Y1OXNCdFNaNjFDRlgySXgrNlowUXJHWGV5KzUxaG5PRERaaVR5d09KUDRmTzIyREVUbGgyZlRVTVE1ZzVGVnhXS096U1FjTnlaT2x5WFJqeU00b0QvVUJPMnM2dXYwSnhtMC9yanVBWmlNWVVFRG9zMUJ4RENJTzRxRDcwcDJQRkNRNGRpU3puL2lSOXpIWWU2UWdBQUFCRyJ9XX0="
+              },
+              {
+                "kind": "payload_binding",
+                "from": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "@payload",
+                "path": "@payload",
+                "target": {
+                  "/": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6IkFBQUFDR3BTWVpQWmdYcElkbFhVM2ZOTEMrN0xZT2NBbnNHOTNtcVNUTjZka2cwQ0gxWVNSQW45cU5NbTlOK2ErUVh6TEp3S0xaVjhSVXExVldPblg0NUtxakJzdlFLayt6NWZDUWJYMCtjVTBnc2U3aHZ5T2JYaFRWQkZIa0dXOEVYV2ZqR3hVbHFra3psU21hZGtYWlBjR2lCUGtzNjd5TTBzODNFSE8rNHRjbWI4UFdVSVVTdVZxZkxwaEVvQlloRlp4dXpzNmtCZmlZUmFod2ZndWNaS2JNaHlES0lvbmo2dHJnRkI1OG1OZkJsRCttVHNyUDdoQ0F6a1VQQk9UVHVPdFdlOWcrWlV3NEcybHQ3TEJMOWEzZ2haUkhlUFMweHVaVkVqUmlQWXMyUTBDbnBBSnhUVHZZR0o0aGFYNFpEQ3MwM1l2VjF3SjYvbDJYNlhUV1MxNmh0Qmh4Ym53eTVhVEdtbFAzRnh4RlVwdHovV3o1ZllyREtQUnpKYXNmNXdEMUZlbHRIRXFiS0poNExCNU1PRkY1QU4yZ0NrcjFrWDJaZHluT0g2QndiMUsvOHpLRlpodzhaTGQ3M08xTEhiY210dVpJSXlSREIwbVJPMFRPd3NHTTVQV1ltcDZnMmVyTThyRWM0emtSV1o2NWRMWUNCRXRkdGd4NzhxSUFzczBWVUJqN1phK0J6ckE2TXlVQndkWVYrTm51V3ZLZWVselhDR0lYK0V0TkhEVlBoL3RGTFJmankwRUZFTG1OcjRwai9BdytoVGp3SmZIMzBhTDlPWmxDZG9wTzdGeHhPVjE1UldqdHovckpYK0JrUjRGV3d0M3JFUlE1UlNvb0dTN2lwT29LbUwrbCsyTER3VzZGTW5NWEhoenRMWDJVSmMrNTZlSVgvU0hMbkdWSEJJelB0SmlLS2VVK0J6VnlYcGY2alZnVFN2dk43NDlhTjVQdGR6QXdJQUFBQ1cifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.ipa.truncated-evidence.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0d0Mi9IY2pSZ3Y5aWJUL3BHUi9OUERJeURIRmpNMU4wWGhtVkorZGR5RFZVL3N1cWIyWDJkclBmajFaREJEVkl2bXNlWHFzRnYzWDlEMnRJcE10ZlpzMmF4RWFiSWVacEJNVkpVaDY4Ti9HZ1k4UGhkV0dzNDYydFZNYzdOTmtoR3BpREVpQTM5dVlvQlNJYjdWZXJBMmswV0FqMmJWMDIyOVc2aUJ6MDFBTVBlK0FFTFZraVFFczBTaStQUW9hZzZPSjBlbUN3WnY1QWk4RnJOd0ZiZnhoWTNXL3MxWlgxbXR1VEVsaUZUVitCZ1FsKzdyWjQvRm5Ga0hJRE9HYkZBWllBOEloczVkTXhsMWwxWGdYMGVKSk5UVnlKU1FZQ3lBZ2NUajhSWkxWWkdxNXZhSjd3eDB0RVB3dnF4YkNMeG03UnNJN2FDenFjQmVXa1NUd3ZjWUdETTdJVWNYSVpwT3ZVbWZzWDA0RUtEVEtFcVZ4OVFQMFo3Z0RKS2E5V0ZXWnkvVE1VWjNNaXFXcnZ0QUw3WERzUmdFLy84THFVd0ZVYWc2VzgxNFBYd2hteWxuWTB1cms1MmJLSmd5MUlvOVZOSUdCK0J5VnUrbXNMb3lBM3ZKWFdnV1FhNE9lM3h0Sk9Sd2tGNG5mYm0yWVRHd3VyR3hJRUsybEh6RzhBbTAzaGRnVXpmYzdReUp4cG1CNGpUVkd1dEc2dVB1Y0NoTFBsOFczZGxtZElMWUd3Q1hMMEw0TzZJbzk0VVBsN2xjdjU5c0J0U1o2MUNGWDJJeCs2WjBRckdYZXkrNTFobk9ERFppVHl3T0pQNGZPMjJERVRsaDJmVFVNUTVnNUZWeFdLT3pTUWNOeVpPbHlYUmp5TTRvRC9VQk8yczZ1djBKeG0wL3JqdUFaaU1ZVUVEb3MxQnhEQ0lPNHFENzBwMlBGQ1E0ZGlTem4vaVI5ekhZZTZRZ0FBQUE9Iiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.ipa.unknown-field.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "strict_json",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "prooflist": {
+            "query": "docs/leaf",
+            "root": {
+              "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+            },
+            "steps": [
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlPQXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNHdDIvSGNqUmd2OWliVC9wR1IvTlBESXlESEZqTTFOMFhobVZKK2RkeURWVS9zdXFiMlgyZHJQZmoxWkRCRFZJdm1zZVhxc0Z2M1g5RDJ0SXBNdGZaczJheEVhYkllWnBCTVZKVWg2OE4vR2dZOFBoZFdHczQ2MnRWTWM3Tk5raEdwaURFaUEzOXVZb0JTSWI3VmVyQTJrMFdBajJiVjAyMjlXNmlCejAxQU1QZStBRUxWa2lRRXMwU2krUFFvYWc2T0owZW1Dd1p2NUFpOEZyTndGYmZ4aFkzVy9zMVpYMW10dVRFbGlGVFYrQmdRbCs3clo0L0ZuRmtISURPR2JGQVpZQThJaHM1ZE14bDFsMVhnWDBlSkpOVFZ5SlNRWUN5QWdjVGo4UlpMVlpHcTV2YUo3d3gwdEVQd3ZxeGJDTHhtN1JzSTdhQ3pxY0JlV2tTVHd2Y1lHRE03SVVjWElacE92VW1mc1gwNEVLRFRLRXFWeDlRUDBaN2dESkthOVdGV1p5L1RNVVozTWlxV3J2dEFMN1hEc1JnRS8vOExxVXdGVWFnNlc4MTRQWHdobXlsblkwdXJrNTJiS0pneTFJbzlWTklHQitCeVZ1K21zTG95QTN2SlhXZ1dRYTRPZTN4dEpPUndrRjRuZmJtMllUR3d1ckd4SUVLMmxIekc4QW0wM2hkZ1V6ZmM3UXlKeHBtQjRqVFZHdXRHNnVQdWNDaExQbDhXM2RsbWRJTFlHd0NYTDBMNE82SW85NFVQbDdsY3Y1OXNCdFNaNjFDRlgySXgrNlowUXJHWGV5KzUxaG5PRERaaVR5d09KUDRmTzIyREVUbGgyZlRVTVE1ZzVGVnhXS096U1FjTnlaT2x5WFJqeU00b0QvVUJPMnM2dXYwSnhtMC9yanVBWmlNWVVFRG9zMUJ4RENJTzRxRDcwcDJQRkNRNGRpU3puL2lSOXpIWWU2UWdBQUFCRyJ9XX0=",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagbybqabaaqhf5u3ezdqscp7s6gj2jrkbuw45dg4ikaafr6dtsdyuhrtjkjzr2i"
+                },
+                "kind": "map_step",
+                "path": "docs",
+                "query": "docs",
+                "target": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                }
+              },
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ==",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagbybqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "kind": "map_step",
+                "path": "leaf",
+                "query": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                }
+              }
+            ]
+          },
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+        },
+        "unexpected": true
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.cross-root.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "cross_root",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoib214MWdNU2lweFdzTW1BZS96TmVyeGd3NUFtWW1uV2lKSmUwcEJRclQxREYweHAzcjA5MHFyZmRZOVF0b2JqZUpiVURJcytvT2s4Si9PSkpscmlWSFBwQllEOWNYeHlkRnR4T2Z2enFLWTRBQUFCRyJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.evidence-tamper.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJvbXgxZ01TaXB4V3NNbUFlL3pOZXJ4Z3c1QW1ZbW5XaUpKZTBwQlFyVDFERjB4cDNyMDkwcXJmZFk5UXRvYmplSmJVRElzK29PazhKL09KSmxyaVZIUHBCWUQ5Y1h4eWRGdHhPZnZ6cUtZNEFBQUJIIiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.malformed-base64.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "prooflist": {
+            "query": "docs/leaf",
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "steps": [
+              {
+                "evidence": "not-base64%%%",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "kind": "map_step",
+                "path": "docs",
+                "query": "docs",
+                "target": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                }
+              },
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ==",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "kind": "map_step",
+                "path": "leaf",
+                "query": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                }
+              }
+            ]
+          },
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.map-key.accept",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "map_key",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "segments": [
+            "profile",
+            "name"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoVXdyRU0waVpNMkZpMk5HdnFCbFh3WDBkZS9HcDR0blNmVTAzMTdnbzEwSm1tNWd1SzBqbHBYT2pHS0ZneDIrRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.kzg.missing-evidence.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "evidence_kind": "explicit"
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.multihop.accept",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "multihop",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoib214MWdNU2lweFdzTW1BZS96TmVyeGd3NUFtWW1uV2lKSmUwcEJRclQxREYweHAzcjA5MHFyZmRZOVF0b2JqZUpiVURJcytvT2s4Si9PSkpscmlWSFBwQllEOWNYeHlkRnR4T2Z2enFLWTRBQUFCRyJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.kzg.payload.accept",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "payload",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "segments": [
+            "docs",
+            "@payload"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "docs/@payload",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoib214MWdNU2lweFdzTW1BZS96TmVyeGd3NUFtWW1uV2lKSmUwcEJRclQxREYweHAzcjA5MHFyZmRZOVF0b2JqZUpiVURJcytvT2s4Si9PSkpscmlWSFBwQllEOWNYeHlkRnR4T2Z2enFLWTRBQUFCRyJ9XX0="
+              },
+              {
+                "kind": "payload_binding",
+                "from": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "query": "@payload",
+                "path": "@payload",
+                "target": {
+                  "/": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6InQyaGM1cEpkUE5VTlRJWVhJOGdrSnhGRHBnaG14NzRIWVEvdkFkSThxZGozVk1GL3I3WnV3ZWRKSWxlV0dmV3dQSDd6am0vMm1aOEJBa3RsQWtEQUcxWXVNU2xuYk5xQ3NoWXgyRVFWQWdRQUFBQ1cifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.kzg.truncated-evidence.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJvbXgxZ01TaXB4V3NNbUFlL3pOZXJ4Z3c1QW1ZbW5XaUpKZTBwQlFyVDFERjB4cDNyMDkwcXJmZFk5UXRvYmplSmJVRElzK29PazhKL09KSmxyaVZIUHBCWUQ5Y1h4eWRGdHhPZnZ6cUtZNEFBQUE9Iiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.unknown-field.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "strict_json",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "prooflist": {
+            "query": "docs/leaf",
+            "root": {
+              "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+            },
+            "steps": [
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHQXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoib214MWdNU2lweFdzTW1BZS96TmVyeGd3NUFtWW1uV2lKSmUwcEJRclQxREYweHAzcjA5MHFyZmRZOVF0b2JqZUpiVURJcytvT2s4Si9PSkpscmlWSFBwQllEOWNYeHlkRnR4T2Z2enFLWTRBQUFCRyJ9XX0=",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagaybqabaayk45ivzfkpt4si67uekos3duioeaykznbtkbtdxkq4pyt2vba6lvk2wc7ortquizlzffm4yigpbqed"
+                },
+                "kind": "map_step",
+                "path": "docs",
+                "query": "docs",
+                "target": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                }
+              },
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ==",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagaybqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                },
+                "kind": "map_step",
+                "path": "leaf",
+                "query": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                }
+              }
+            ]
+          },
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+        },
+        "unexpected": true
+      },
+      "expected": {
+        "valid": false
+      }
+    }
+  ]
+}

--- a/docs/policy/compatibility.md
+++ b/docs/policy/compatibility.md
@@ -35,6 +35,11 @@ documentation in the same PR:
 - mutation or receipt value semantics;
 - payload-binding and measured-list evidence.
 
+Typed-root decoders accept only the current registered `MALTVersionID`,
+semantic IDs, backend suite IDs, and combinations. Earlier experimental codec
+allocations are not compatibility inputs and must not be recognized through
+fallback mappings.
+
 v0.0.6 intentionally removes application and deployment packages from this
 module. Consumers of the former CLI/daemon/UnixFS/server/storage packages must
 use `malt-client` or `gateway`; no forwarding packages are provided.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -25,7 +25,9 @@ compatibility. See [MIP-1012](../mips/mip-1012-segment-path-resolution.md) and
 - [Frozen artifact compatibility profile](./artifacts.md)
 - [Segment paths and resolution](./segment-paths.md)
 - [Commitment model](./commitment.md)
+- [Commitment and proof encoding](./commitment-proof-encoding.md)
 - [CID and wire format](./cid-and-wire-format.md)
+- [Resolve/Read conformance corpus v1](./resolve-read-conformance-v1.md)
 
 ## Notes
 

--- a/docs/spec/cid-and-wire-format.md
+++ b/docs/spec/cid-and-wire-format.md
@@ -5,20 +5,77 @@ objects remain ordinary CAS CIDs.
 
 ## Status
 
-Experimental and implementation-bound. The current codec values are locked for
-the prototype but are not yet a stable release contract.
+Experimental and implementation-bound. The current layout is the only accepted
+typed-root encoding, but it is not yet a stable release contract.
 
-## MALT Root Codecs
+## MALT Root Codec Namespace
 
-MALT uses the multicodec Private Use Area `0x300000-0x3FFFFF` for typed
-structure roots:
+Multicodec reserves `0x300000-0x3FFFFF` as a Private Use Area. MALT typed
+roots use only the `0x300000-0x30FFFF` subrange. Values in
+`0x310000-0x3FFFFF` are not MALT typed-root codecs.
+
+The CIDv1 content-type multicodec remains an unsigned varint. The
+`0x30VSBB` notation below describes fields in the decoded codec integer; it
+does not append two literal bytes to the CID.
+
+## `0x30VSBB` Layout
+
+The low 16 bits of a MALT root codec have three fields:
+
+| Field | Bits | Meaning |
+| --- | ---: | --- |
+| `V` | 4 | MALT typed-root wire-format version |
+| `S` | 4 | semantic kind |
+| `BB` | 8 | commitment backend suite |
+
+The normative construction is:
+
+```text
+codec = 0x300000
+      | (malt_version_id << 12)
+      | (semantic_id << 8)
+      | backend_id
+```
+
+The current `MALTVersionID` is `1`. It identifies this typed-root layout;
+it is not the CID version, a source release, a Resolve/Read profile, or a
+conformance-corpus version. Adding a semantic kind or backend suite does not
+change it. It changes only when the interpretation of the root codec or
+commitment envelope changes incompatibly.
+
+### Semantic Registry
+
+| ID | Kind |
+| ---: | --- |
+| `0x0` | invalid |
+| `0x1` | map |
+| `0x2` | list |
+| `0x3-0xF` | unassigned |
+
+### Commitment Backend Registry
+
+Backend IDs identify complete commitment suites, including parameters,
+commitment encoding, and commitment-size validation. They are not inferred
+from digest length.
+
+| ID | Backend suite | Commitment size |
+| ---: | --- | ---: |
+| `0x00` | invalid | - |
+| `0x01` | current KZG suite | 48 bytes |
+| `0x02` | current IPA suite | 32 bytes |
+| `0x03-0xFF` | unassigned | - |
+
+An incompatible parameter set or commitment encoding receives a new backend
+ID even when it belongs to the same broad cryptographic family.
+
+### Current Codecs
 
 | Name | Value | Semantic kind | Backend |
 | --- | ---: | --- | --- |
-| `malt-map-kzg` | `0x300001` | map | KZG |
-| `malt-list-kzg` | `0x300002` | list | KZG |
-| `malt-map-ipa` | `0x300003` | map | IPA |
-| `malt-list-ipa` | `0x300004` | list | IPA |
+| `malt-map-kzg` | `0x301101` | map | KZG |
+| `malt-list-kzg` | `0x301201` | list | KZG |
+| `malt-map-ipa` | `0x301102` | map | IPA |
+| `malt-list-ipa` | `0x301202` | list | IPA |
 
 The implementation owner is `wire/maltcid`.
 
@@ -34,21 +91,37 @@ Current commitment byte sizes:
 | KZG | 48 bytes |
 | IPA | 32 bytes |
 
-Code that creates or validates typed roots must reject commitment byte lengths
-that do not match the selected backend.
+Code that creates or validates typed roots must select the backend descriptor
+from `BB` and reject commitment byte lengths that do not match it. Length
+alone must never select or override the backend.
 
 ## Root Classification
 
 `wire/maltcid` exposes helpers for:
 
 - detecting whether a CID is a MALT structure root
+- extracting the encoded MALT wire-format version
 - extracting semantic kind: `map`, `list`, or `unknown`
 - extracting backend kind: `kzg`, `ipa`, or `unknown`
 - extracting raw commitment bytes from a typed MALT root CID
 - comparing commitment bytes across typed roots
 
-Verifiers should reject roots or proof steps whose semantic kind, backend kind,
-or expected target type does not match the query and evidence.
+A supported typed root must satisfy all of these checks:
+
+1. its codec is in `0x300000-0x30FFFF`;
+2. `V` equals the current `MALTVersionID`;
+3. `S` and `BB` are nonzero registered IDs and their combination is
+   supported;
+4. the multihash code is identity;
+5. the identity digest length matches the selected backend descriptor.
+
+Unknown versions, semantics, backends, combinations, and codecs outside the
+typed-root subrange fail closed. Classifiers must validate the complete codec
+before returning either semantic or backend; independently masking one field
+is insufficient.
+
+Verifiers must also reject roots or proof steps whose semantic kind, backend
+kind, or expected target type does not match the query and evidence.
 
 ## Payload CIDs
 

--- a/docs/spec/cid-and-wire-format.md
+++ b/docs/spec/cid-and-wire-format.md
@@ -123,6 +123,18 @@ is insufficient.
 Verifiers must also reject roots or proof steps whose semantic kind, backend
 kind, or expected target type does not match the query and evidence.
 
+Proof producers follow the same rule. For an operation over an existing root,
+`S` selects the semantic implementation and `BB` selects the commitment
+prover. Runtime configuration may restrict the registered backends, but it
+must not override the backend encoded by the root. Multi-step resolution makes
+this selection independently for every proof step from that step's `from`
+root, so linked structures may use different registered backends.
+
+An operation that creates a structure without an existing root has no codec
+from which to select a backend. Its executor therefore uses an explicit or
+configured default backend; all later operations use the backend encoded in
+the resulting root CID.
+
 ## Payload CIDs
 
 Immutable file bytes, chunks, manifests, and other payload objects keep their

--- a/docs/spec/commitment-proof-encoding.md
+++ b/docs/spec/commitment-proof-encoding.md
@@ -7,11 +7,12 @@ Resolve/Read conformance corpus v1. It complements the typed-root rules in
 
 ## Status And Scope
 
-These encodings are experimental, but the checked-in v1 vectors are immutable
-conformance inputs. A byte-level change to an encoding exercised by those
-vectors requires a new corpus version. If the change also makes a
-`malt.resolve/v0alpha1` or `malt.read/v0alpha1` value incompatible, it requires
-a new enclosing protocol profile as well.
+These encodings are experimental. Before the first release, an intentional
+wire change may regenerate the checked-in v1 vectors in the same change. Once
+the corpus is released, its vectors are immutable conformance inputs and a
+byte-level change to an exercised encoding requires a new corpus version. If
+the change also makes a `malt.resolve/v0alpha1` or `malt.read/v0alpha1` value
+incompatible, it requires a new enclosing protocol profile as well.
 
 Resolve/Read evidence uses single-index openings wrapped in the map or list
 semantic envelopes described below. The primitive batch encodings are recorded
@@ -24,13 +25,17 @@ A primitive commitment authenticates an indexed vector of opaque
 `commitment.Cell` byte strings. A CID-valued semantic slot is the binary CID
 bytes, not its text form. An undefined slot is the empty cell.
 
-Typed MALT roots are CIDv1 values whose multicodec selects map/list and KZG/IPA,
-and whose identity multihash digest is the raw commitment:
+Typed MALT roots are CIDv1 values whose `0x30VSBB` multicodec fields select the
+MALT wire version, map/list semantic, and KZG/IPA backend suite. Their identity
+multihash digest is the raw commitment:
 
 | Backend | Commitment bytes | Maximum primitive vector length |
 | --- | ---: | ---: |
 | KZG | 48 | 4096 |
 | IPA | 32 | 256 |
+
+The backend ID determines the commitment encoding and expected byte length.
+Verification must not infer or override the backend from the digest length.
 
 Map radix nodes and list tree nodes use 256 physical slots. Thus IPA's full
 vector and the first 256 positions of KZG's vector carry those node cells; all

--- a/docs/spec/commitment-proof-encoding.md
+++ b/docs/spec/commitment-proof-encoding.md
@@ -1,0 +1,238 @@
+# Commitment And Proof Encoding
+
+This document fixes the implementation-bound byte encodings exercised by the
+Resolve/Read conformance corpus v1. It complements the typed-root rules in
+[CID and wire format](./cid-and-wire-format.md) and the semantic contract in
+[ProofList format](./prooflist-format.md).
+
+## Status And Scope
+
+These encodings are experimental, but the checked-in v1 vectors are immutable
+conformance inputs. A byte-level change to an encoding exercised by those
+vectors requires a new corpus version. If the change also makes a
+`malt.resolve/v0alpha1` or `malt.read/v0alpha1` value incompatible, it requires
+a new enclosing protocol profile as well.
+
+Resolve/Read evidence uses single-index openings wrapped in the map or list
+semantic envelopes described below. The primitive batch encodings are recorded
+for completeness, but they are not inputs to the v1 Resolve/Read verifier and
+are not independently locked by this corpus.
+
+## Common Cell And Root Rules
+
+A primitive commitment authenticates an indexed vector of opaque
+`commitment.Cell` byte strings. A CID-valued semantic slot is the binary CID
+bytes, not its text form. An undefined slot is the empty cell.
+
+Typed MALT roots are CIDv1 values whose multicodec selects map/list and KZG/IPA,
+and whose identity multihash digest is the raw commitment:
+
+| Backend | Commitment bytes | Maximum primitive vector length |
+| --- | ---: | ---: |
+| KZG | 48 | 4096 |
+| IPA | 32 | 256 |
+
+Map radix nodes and list tree nodes use 256 physical slots. Thus IPA's full
+vector and the first 256 positions of KZG's vector carry those node cells; all
+remaining primitive positions are zero.
+
+## KZG
+
+The current implementation is `auth/commitment/kzg` and uses
+`go-kzg-4844` v1.1.0. Its `NewContext4096Secure` supplies the Ethereum KZG
+ceremony parameters.
+
+### Cell To Scalar
+
+For each cell:
+
+1. compute SHA-256 over the exact cell bytes;
+2. interpret the 32-byte digest as an unsigned big-endian integer;
+3. reduce it modulo the BLS12-381 scalar-field modulus
+   `0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`;
+4. serialize the result as exactly 32 big-endian bytes.
+
+The fixed 4096-position blob is zero-filled after the supplied cells.
+
+### Index Domain
+
+Index openings use a 4096-point BLS12-381 scalar-field domain. The
+implementation starts from the order-`2^32` root
+`10238227357739495823651030575849232062558860180284477541189508159991286009131`,
+raises it to `2^(32-log2(4096))`, enumerates successive powers beginning with
+one, and bit-reverses the resulting array. Position `i` is opened at domain
+point `domain[i]`.
+
+### Single Proof
+
+A KZG index proof is exactly 84 bytes:
+
+| Offset | Size | Encoding |
+| ---: | ---: | --- |
+| 0 | 48 | compressed KZG proof |
+| 48 | 32 | claimed scalar, in the backend scalar serialization |
+| 80 | 4 | index as unsigned big-endian `uint32` |
+
+Verification rejects any other length, an index above 4095, a proof-carried
+index different from the requested index, or a claimed scalar different from
+the SHA-256-derived cell scalar.
+
+### Current Batch Proof
+
+KZG batch proof generation currently concatenates single proofs; it is not a
+native KZG multi-opening. Its bytes are a 4-byte unsigned big-endian proof
+count followed by that many 84-byte single proofs in caller-supplied index
+order. The ordered index and cell arrays are supplied separately to
+verification.
+
+## IPA
+
+The current implementation is `auth/commitment/ipa`. It uses the 256-element
+configuration from `go-ipa`
+v0.0.0-20240724233137-53bbb0ceb27a.
+
+The 256 SRS points are generated deterministically. Starting with counter zero,
+hash ASCII `eth_verkle_oct_2021` followed by the counter as big-endian `uint64`,
+interpret the digest as an unsigned big-endian integer reduced modulo the
+BLS12-381 scalar modulus used as the Bandersnatch base field, serialize it as
+32 big-endian bytes, pass that encoding to Banderwagon point decoding, skip
+unsuccessful decodes, and continue until 256 points have been accepted. The IPA
+auxiliary point `Q` is the dependency's `banderwagon.Generator`.
+
+### Cell To Scalar
+
+For each cell, compute SHA-256 over the exact bytes, interpret the digest as an
+unsigned big-endian integer, and reduce it modulo the Bandersnatch scalar-field
+modulus
+`13108968793781547619861935127046491459309155893440570251786403306729687672801`.
+The fixed 256-element vector is zero-filled after the supplied cells. The
+commitment is the multiscalar multiplication of that vector by the ordered SRS;
+commitment bytes are the 32-byte `banderwagon.Element.Bytes()` result.
+
+### Single Proof
+
+Single openings use transcript label `malt-ipa` and the field element created
+from the requested integer index as the evaluation point. The proof encoding
+is:
+
+| Order | Size | Encoding |
+| --- | ---: | --- |
+| round count | 4 | unsigned big-endian `uint32` |
+| `L[0..rounds)` | `32 * rounds` | each `banderwagon.Element.Bytes()` |
+| `R[0..rounds)` | `32 * rounds` | each `banderwagon.Element.Bytes()` |
+| `A_scalar` | 32 | little-endian field element |
+| index | 4 | unsigned big-endian `uint32` |
+
+For the current 256-element vector, there are eight rounds and the proof is
+552 bytes. Verification requires the proof-carried index to equal the requested
+index.
+
+### Current Batch Proof
+
+Batch openings use transcript label `malt-ipa-batch`. The locked `go-ipa`
+`MultiProof.Write` encoding is 576 bytes: the 32-byte `D` point, eight 32-byte
+`L` points, eight 32-byte `R` points, and a 32-byte little-endian `A_scalar`.
+It contains no count or index list; the ordered indices and expected cells are
+separate verifier inputs.
+
+## Radix Map Semantic Proof
+
+Both resolve map steps and primitive map reads carry the same UTF-8 JSON proof
+envelope. Every byte-valued field below uses standard padded base64 when the
+envelope itself is JSON-encoded:
+
+```json
+{
+  "steps": [
+    {"slot": "<CID bytes>", "proof": "<primitive single proof>"}
+  ],
+  "bucket": {"proof": "<primitive single proof>"}
+}
+```
+
+`bucket` is optional. Each radix step uses the next byte of
+`SHA-256(canonical_key_utf8)` as its primitive slot index. A `slot` is either an
+intermediate root marker, a terminal leaf marker, or a bucket-reference marker.
+The marker encodings are raw CIDv1 values with identity multihashes over:
+
+- leaf: `malt:map:radix:leaf:v1:` || key-byte-length as big-endian `uint16` ||
+  canonical key UTF-8 || target CID bytes;
+- bucket reference: `malt:map:radix:bucket:v1:` || bucket-root CID bytes.
+
+A bucket witness opens the expected leaf marker from the bucket commitment;
+its primitive proof carries the bucket index. Current map proofs authenticate
+membership only.
+
+In a resolve ProofList this envelope is stored in `step.evidence` with
+`evidence_kind="explicit"`; the primitive backend is inferred from the typed
+`step.from` root. In a primitive map read it is stored in `step.proof` with
+`evidence_kind="structure"` and `evidence_backend="map"`.
+
+## Tree List Semantic Proofs
+
+Every committed list node has 256 slots. Slot 0 authenticates node metadata and
+slots 1 through 255 authenticate content. Metadata is a raw CIDv1 identity
+marker over:
+
+```text
+"malt:list:node-meta:"
+|| height      as big-endian uint64
+|| child_count as big-endian uint64
+|| total_size  as big-endian uint64
+|| chunk_size  as big-endian uint64
+```
+
+`chunk_size == 0` denotes a plain list node and requires `total_size == 0`.
+A positive `chunk_size` denotes fixed-width measured metadata.
+
+### Index Envelope
+
+```json
+{
+  "metadata_proof": "<primitive single proof>",
+  "metadata_target": "<optional metadata-marker CID bytes>",
+  "steps": [
+    {
+      "target": "<CID bytes>",
+      "proof": "<primitive single proof>",
+      "slot": 1
+    }
+  ]
+}
+```
+
+`metadata_target` is omitted when plain metadata can be reconstructed from the
+authenticated length. `slot` is the physical content slot and is emitted by
+the current prover. Each intermediate target is the next list-node root; the
+last target is the queried child CID.
+
+This envelope is stored in `step.proof` with
+`evidence_kind="structure"` and `evidence_backend="list"`.
+
+### Fixed-Width Range Envelope
+
+```json
+{
+  "metadata_proof": "<primitive single proof>",
+  "index_proofs": [
+    {"index": 0, "proof": "<complete index-envelope bytes>"}
+  ]
+}
+```
+
+The outer ProofList step supplies the authenticated `child_count`,
+`total_size`, `chunk_size`, ordered segment CIDs, and requested bounds. Each
+`index_proofs[].proof` is itself a complete index-envelope JSON byte string.
+The range envelope is stored in `step.proof` with
+`evidence_kind="structure"` and `evidence_backend="measured_list"`.
+
+Only the current fixed-width measured list is covered. Variable-size measured
+evidence is proposal-stage and has no v1 conformance encoding.
+
+## JSON Projection
+
+ProofList CID fields serialize as IPLD-link objects such as
+`{"/":"<cid>"}`. Go `[]byte` fields serialize as standard padded base64
+strings. Implementations must treat decoded proof bytes, CID bytes, segment
+order, integer widths, and optional-field presence as verifier inputs; error
+message text is not part of conformance.

--- a/docs/spec/commitment.md
+++ b/docs/spec/commitment.md
@@ -56,10 +56,12 @@ slot proof primitive.
 ## Typed Roots
 
 Commitment outputs are carried in typed MALT root CIDs. See
-[CID and wire format](./cid-and-wire-format.md) for codec values and commitment
-byte-size rules. The exact cell transforms, index domains, primitive proof
-bytes, and semantic proof envelopes exercised by portable verification are
-fixed in [Commitment and proof encoding](./commitment-proof-encoding.md).
+[CID and wire format](./cid-and-wire-format.md) for the `0x30VSBB` codec
+layout and commitment backend registry. A backend ID denotes a complete suite
+and determines commitment-size validation; implementations must not infer a
+backend from byte length. The exact cell transforms, index domains, primitive
+proof bytes, and semantic proof envelopes exercised by portable verification
+are fixed in [Commitment and proof encoding](./commitment-proof-encoding.md).
 
 ## Related Proposals
 

--- a/docs/spec/commitment.md
+++ b/docs/spec/commitment.md
@@ -63,6 +63,12 @@ backend from byte length. The exact cell transforms, index domains, primitive
 proof bytes, and semantic proof envelopes exercised by portable verification
 are fixed in [Commitment and proof encoding](./commitment-proof-encoding.md).
 
+For existing roots, both proof generation and verification select the backend
+from the typed root. A process-level default applies only when creating a new
+root without a base root. A resolver that crosses multiple structure roots
+repeats backend selection for each step rather than pinning the first root's
+backend for the complete traversal.
+
 ## Related Proposals
 
 - [MIP-1005](../mips/mip-1005-kzg-map-label-domain.md) records the accepted

--- a/docs/spec/commitment.md
+++ b/docs/spec/commitment.md
@@ -57,7 +57,9 @@ slot proof primitive.
 
 Commitment outputs are carried in typed MALT root CIDs. See
 [CID and wire format](./cid-and-wire-format.md) for codec values and commitment
-byte-size rules.
+byte-size rules. The exact cell transforms, index domains, primitive proof
+bytes, and semantic proof envelopes exercised by portable verification are
+fixed in [Commitment and proof encoding](./commitment-proof-encoding.md).
 
 ## Related Proposals
 

--- a/docs/spec/prooflist-format.md
+++ b/docs/spec/prooflist-format.md
@@ -108,6 +108,10 @@ HTTP/UnixFS path cleaning. Transport and application adapters may enforce their 
 path policy before constructing a typed query.
 
 These encodings remain experimental and consumers must pin a MALT release.
+The byte-level map/list envelopes inside `evidence` and `proof` are specified in
+[Commitment and proof encoding](./commitment-proof-encoding.md). Cross-language
+accept/reject behavior is locked by the
+[Resolve/Read conformance corpus v1](./resolve-read-conformance-v1.md).
 
 ## Serialization And Transport
 

--- a/docs/spec/resolve-read-conformance-v1.md
+++ b/docs/spec/resolve-read-conformance-v1.md
@@ -13,11 +13,12 @@ same checked-in bytes; they do not redefine proof semantics or maintain edited
 copies.
 
 The corpus version is `malt.resolve-read.conformance/v1`. It is independent of
-the two enclosed operation profiles. Once released, a vector ID and its input
-and expected verdict are immutable. Additive coverage may be published in the
-same corpus only before release; later behavioral or encoding changes require
-v2. Error strings, timing, and implementation-specific exception types are not
-conformance outputs.
+the two enclosed operation profiles and of the typed-root
+`MALTVersionID=1`. Before the first release, an intentional encoding change
+may regenerate the corpus as part of the same reviewed change. Once released,
+a vector ID and its input and expected verdict are immutable; later behavioral
+or encoding changes require v2. Error strings, timing, and
+implementation-specific exception types are not conformance outputs.
 
 ## File And Envelope
 
@@ -62,7 +63,9 @@ JSON is outside v1.
 Consumers must select the verifier from `operation`; they must not infer the
 operation from fields inside `verification`, and they must not use `backend` to
 override the backend encoded by typed roots. `backend` is test metadata used to
-make coverage visible.
+make coverage visible. Typed-root consumers select the backend from the
+registered `0x30VSBB` backend ID and validate its declared commitment size;
+they must not infer a backend from commitment length.
 
 The current category vocabulary is `identity`, `map_key`, `multihop`,
 `payload`, `list_index`, `list_range`, `tamper`, `cross_root`, `cross_kind`,

--- a/docs/spec/resolve-read-conformance-v1.md
+++ b/docs/spec/resolve-read-conformance-v1.md
@@ -1,0 +1,164 @@
+# Resolve/Read Conformance Corpus V1
+
+The v1 corpus is the language-neutral executable contract for local
+verification of `malt.resolve/v0alpha1` and `malt.read/v0alpha1` values. The
+canonical files live under `conformance/resolve-read/v1/` in this repository:
+`vectors.json`, `corpus.schema.json`, and `vector.schema.json`.
+
+## Ownership And Versioning
+
+MALT core owns the corpus, its schema, generation rules, and expected verdicts.
+Gateway, native client, browser/WASM, and future language SDK tests consume the
+same checked-in bytes; they do not redefine proof semantics or maintain edited
+copies.
+
+The corpus version is `malt.resolve-read.conformance/v1`. It is independent of
+the two enclosed operation profiles. Once released, a vector ID and its input
+and expected verdict are immutable. Additive coverage may be published in the
+same corpus only before release; later behavioral or encoding changes require
+v2. Error strings, timing, and implementation-specific exception types are not
+conformance outputs.
+
+## File And Envelope
+
+`conformance/resolve-read/v1/vectors.json` has this shape:
+
+```json
+{
+  "schema_version": "malt.resolve-read.conformance/v1",
+  "vectors": [
+    {
+      "id": "resolve.identity.accept",
+      "operation": "resolve",
+      "backend": "none",
+      "category": "identity",
+      "verification": {
+        "request": {},
+        "result": {}
+      },
+      "expected": {"valid": true}
+    }
+  ]
+}
+```
+
+Every vector has exactly these fields:
+
+| Field | Contract |
+| --- | --- |
+| `id` | Stable, unique case identifier. Consumers report it verbatim. |
+| `operation` | `resolve` or `read`; selects the operation-specific decoder and verifier. |
+| `backend` | `kzg`, `ipa`, or `none`. The current corpus uses `none` for zero-step identity; it is not a commitment backend. |
+| `category` | Stable coverage label used by the generator and coverage-matrix test. The schema requires a non-empty string. |
+| `verification` | A JSON object conforming to the selected operation's verification contract, or intentionally malformed at the schema/field level for a negative case. |
+| `expected.valid` | The only normative outcome: acceptance is `true`, rejection is `false`. |
+
+The corpus itself is valid JSON. Negative cases remain parseable JSON objects.
+Malformed-evidence cases remove, truncate, or corrupt encoded proof bytes;
+strict-JSON cases add an unknown verification field. Semantic and
+cryptographic tampering remain separately categorized. Syntactically invalid
+JSON is outside v1.
+
+Consumers must select the verifier from `operation`; they must not infer the
+operation from fields inside `verification`, and they must not use `backend` to
+override the backend encoded by typed roots. `backend` is test metadata used to
+make coverage visible.
+
+The current category vocabulary is `identity`, `map_key`, `multihop`,
+`payload`, `list_index`, `list_range`, `tamper`, `cross_root`, `cross_kind`,
+`cross_backend`, `malformed_evidence`, and `strict_json`. Vectors are sorted by
+stable ID so regeneration is byte-deterministic; JSON object key order and
+whitespace inside `verification` are not verifier inputs.
+
+## Locked Coverage
+
+The identity case is backend-independent. Every other positive and negative
+class below is generated for both KZG and IPA:
+
+| Category | Expected | Checked case |
+| --- | --- | --- |
+| `identity` | accept | empty resolve segments, equal request/ProofList/result roots, empty query, and no steps |
+| `map_key` | accept | grouped-segment resolve and one exact primitive map read of `profile/name` |
+| `multihop` | accept | ordered root-map to child-map to leaf resolution |
+| `payload` | accept | nested resolve and primitive map read of explicit `@payload -> CID` |
+| `list_index` | accept | one stable index with authenticated length and target |
+| `list_range` | accept | bounded and authenticated-EOF fixed-width ranges with ordered segment CIDs |
+| `tamper` | reject | modified resolve/read primitive proof index, forged read target, or reordered returned range segments |
+| `cross_root` | reject | same-backend root splice with evidence retained from another root |
+| `cross_kind` | reject | map evidence presented for a list-index request |
+| `cross_backend` | reject | KZG evidence under an IPA root, and IPA evidence under a KZG root |
+| `malformed_evidence` | reject | invalid base64, missing proof/evidence, or truncated inner proof bytes |
+| `strict_json` | reject | unknown field in the operation verification object |
+
+Identity is a strict zero-step contract. It does not execute a commitment
+backend or prove an empty path cryptographically. The request root, ProofList
+root, and result target must be equal, the ProofList query must be empty, and
+the steps array must be empty.
+
+Payload coverage authenticates the relation `@payload -> CID`. It does not
+authenticate raw bytes stored under that CID. Full-object and ranged byte
+binding remain client/application work after ProofList verification.
+
+Range coverage is limited to the current fixed-width measured-list semantic.
+The end is exclusive; an omitted end means the authenticated total size.
+Variable-size measured lists are not silently interpreted as v1 evidence.
+
+## Verification Procedure
+
+For each vector, a consumer:
+
+1. validates the corpus envelope and required fields;
+2. decodes `verification` using the strict operation-specific JSON contract;
+3. constructs the built-in local verifier without network, ArcTable,
+   materializer, CAS, gateway, or daemon state;
+4. invokes complete request/result verification, not bare ProofList
+   verification;
+5. maps success to `valid=true` and every decode, shape, binding, semantic, or
+   cryptographic rejection to `valid=false`;
+6. compares only that boolean with `expected.valid` and reports the vector ID
+   on mismatch.
+
+The current protocol decoder also rejects empty input, unknown fields at any
+decoded nesting level, trailing JSON values, and inputs larger than 96 MiB.
+
+The complete verification call is essential: cross-root, cross-kind, target,
+range-segment, and request/query tampering can remain cryptographically valid
+as isolated proof bytes while violating the caller-selected operation.
+
+## JSON Integers And TypeScript
+
+The current profiles encode `index`, `start`, `end`, lengths, and measured
+metadata as JSON numbers projected from Go `uint64`. JavaScript's ordinary
+`JSON.parse` cannot preserve integers above `2^53-1` exactly.
+
+V1 vectors keep these fields within the safe integer range so ordinary WASM
+adapter code does not lose test inputs. A future native TypeScript verifier
+must either use a lossless JSON parser and represent protocol integers as
+`bigint`, or reject values above `Number.MAX_SAFE_INTEGER` before conversion.
+Encoding those fields as strings is not compatible with the current schemas
+and would require a new protocol profile.
+
+## Consumer Boundaries
+
+- Go is the reference generator and runs the embedded corpus against the local
+  SDK verifier.
+- The WASM test feeds the same JSON objects through the exported local-verifier
+  boundary. Because the current WASM target contains the Go verifier, this
+  proves adapter and serialization parity, not an independent cryptographic
+  implementation.
+- Gateway tests use the corpus to check their transport adapter without making
+  Gateway execution state or publication policy part of core validity.
+- Native client tests use the corpus below trust-root, UnixFS, daemon, and
+  payload-byte policy. Candidate/accepted root policy is not encoded here.
+- A future `malt-ts` implementation must consume the released JSON and obtain
+  the same verdicts with its own decoder and verifier before claiming parity.
+
+Product E2E, persistence, scope routing, publication, and accepted-root policy
+belong in their owning repositories and must not be added to this corpus.
+
+## Related Documents
+
+- [Resolve and read contracts](./resolve-read-contracts.md)
+- [ProofList format](./prooflist-format.md)
+- [Commitment and proof encoding](./commitment-proof-encoding.md)
+- [CID and wire format](./cid-and-wire-format.md)

--- a/docs/spec/resolve-read-contracts.md
+++ b/docs/spec/resolve-read-contracts.md
@@ -15,6 +15,10 @@ Serialized values live in `github.com/dewebprotocol/malt/protocol`. Checked-in
 JSON Schemas live in `protocol/schemas/` and are embedded through
 `protocol.Schema` and `protocol.SchemaNames`.
 
+Cross-language accept/reject behavior for these complete request/result pairs
+is locked by the
+[Resolve/Read conformance corpus v1](./resolve-read-conformance-v1.md).
+
 ## Resolve
 
 A request carries the caller-selected root and canonical segment array:

--- a/graph/runtime/backend_dispatch.go
+++ b/graph/runtime/backend_dispatch.go
@@ -1,0 +1,250 @@
+package runtimegraph
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	structure "github.com/dewebprotocol/malt/auth/semantic"
+	"github.com/dewebprotocol/malt/auth/semantic/list"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+)
+
+type mapBackendDispatcher struct {
+	defaultBackend maltcid.BackendKind
+	backends       map[maltcid.BackendKind]mapping.Semantics
+}
+
+func (d *mapBackendDispatcher) Commitment() *mapping.Commitment {
+	return d.backends[d.defaultBackend].Commitment()
+}
+
+func (d *mapBackendDispatcher) Commit(ctx context.Context, namespace string, view mapping.View) (cid.Cid, error) {
+	backend, err := d.defaultSemantics()
+	if err != nil {
+		return cid.Undef, err
+	}
+	return backend.Commit(ctx, namespace, view)
+}
+
+func (d *mapBackendDispatcher) Prove(ctx context.Context, namespace string, root cid.Cid, key arcset.Path) (mapping.Binding, structure.Proof, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return mapping.Binding{}, nil, err
+	}
+	return backend.Prove(ctx, namespace, root, key)
+}
+
+func (d *mapBackendDispatcher) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, proof structure.Proof) (bool, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return false, err
+	}
+	return backend.Verify(root, key, expected, proof)
+}
+
+func (d *mapBackendDispatcher) Update(ctx context.Context, namespace string, root cid.Cid, key arcset.Path, oldValue, newValue cid.Cid) (cid.Cid, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return backend.Update(ctx, namespace, root, key, oldValue, newValue)
+}
+
+func (d *mapBackendDispatcher) BatchUpdate(ctx context.Context, namespace string, root cid.Cid, updates []mapping.BatchUpdate) (cid.Cid, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return backend.BatchUpdate(ctx, namespace, root, updates)
+}
+
+func (d *mapBackendDispatcher) defaultSemantics() (mapping.Semantics, error) {
+	backend := d.backends[d.defaultBackend]
+	if backend == nil {
+		return nil, fmt.Errorf("default commitment backend %q is not registered", d.defaultBackend)
+	}
+	return backend, nil
+}
+
+func (d *mapBackendDispatcher) forRoot(root cid.Cid) (mapping.Semantics, error) {
+	if !root.Defined() {
+		return nil, fmt.Errorf("map root is undefined")
+	}
+	if kind := maltcid.SemanticKindOf(root); kind != maltcid.SemanticKindMap {
+		return nil, fmt.Errorf("root %s has semantic kind %q, expected map", root, kind)
+	}
+	backendKind := maltcid.BackendKindOf(root)
+	if backendKind == maltcid.BackendKindUnknown {
+		return nil, fmt.Errorf("root %s does not encode a supported commitment backend", root)
+	}
+	backend := d.backends[backendKind]
+	if backend == nil {
+		return nil, fmt.Errorf("commitment backend %q is not registered for proving", backendKind)
+	}
+	return backend, nil
+}
+
+type listBackendDispatcher struct {
+	defaultBackend maltcid.BackendKind
+	backends       map[maltcid.BackendKind]list.MeasuredSemantics
+}
+
+func (d *listBackendDispatcher) Commitment() *list.Commitment {
+	return d.backends[d.defaultBackend].Commitment()
+}
+
+func (d *listBackendDispatcher) Commit(ctx context.Context, namespace string, view list.View) (cid.Cid, error) {
+	backend, err := d.defaultSemantics()
+	if err != nil {
+		return cid.Undef, err
+	}
+	return backend.Commit(ctx, namespace, view)
+}
+
+func (d *listBackendDispatcher) CommitFixed(ctx context.Context, namespace string, chunks []cid.Cid, chunkSize, totalSize uint64) (cid.Cid, error) {
+	backend, err := d.defaultSemantics()
+	if err != nil {
+		return cid.Undef, err
+	}
+	fixed, ok := backend.(interface {
+		CommitFixed(context.Context, string, []cid.Cid, uint64, uint64) (cid.Cid, error)
+	})
+	if !ok {
+		return cid.Undef, fmt.Errorf("default list backend %q does not support fixed measured commits", d.defaultBackend)
+	}
+	return fixed.CommitFixed(ctx, namespace, chunks, chunkSize, totalSize)
+}
+
+func (d *listBackendDispatcher) Prove(ctx context.Context, namespace string, root cid.Cid, index uint64) (list.Query, structure.Proof, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return list.Query{}, nil, err
+	}
+	return backend.Prove(ctx, namespace, root, index)
+}
+
+func (d *listBackendDispatcher) Verify(root cid.Cid, index uint64, expected list.Query, proof structure.Proof) (bool, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return false, err
+	}
+	return backend.Verify(root, index, expected, proof)
+}
+
+func (d *listBackendDispatcher) Replace(ctx context.Context, namespace string, root cid.Cid, index uint64, oldKey, newKey cid.Cid) (cid.Cid, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return backend.Replace(ctx, namespace, root, index, oldKey, newKey)
+}
+
+func (d *listBackendDispatcher) Append(ctx context.Context, namespace string, root cid.Cid, key cid.Cid) (cid.Cid, uint64, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return cid.Undef, 0, err
+	}
+	return backend.Append(ctx, namespace, root, key)
+}
+
+func (d *listBackendDispatcher) AppendFixed(ctx context.Context, namespace string, root cid.Cid, key cid.Cid, totalSize uint64) (cid.Cid, uint64, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return cid.Undef, 0, err
+	}
+	appender, ok := backend.(interface {
+		AppendFixed(context.Context, string, cid.Cid, cid.Cid, uint64) (cid.Cid, uint64, error)
+	})
+	if !ok {
+		return cid.Undef, 0, fmt.Errorf("list backend %q does not support fixed measured append", maltcid.BackendKindOf(root))
+	}
+	return appender.AppendFixed(ctx, namespace, root, key, totalSize)
+}
+
+func (d *listBackendDispatcher) Truncate(ctx context.Context, namespace string, root cid.Cid, newLen uint64) (cid.Cid, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return backend.Truncate(ctx, namespace, root, newLen)
+}
+
+func (d *listBackendDispatcher) ProveRange(ctx context.Context, namespace string, root cid.Cid, start uint64, end *uint64) (list.RangeResult, structure.Proof, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return list.RangeResult{}, nil, err
+	}
+	return backend.ProveRange(ctx, namespace, root, start, end)
+}
+
+func (d *listBackendDispatcher) VerifyRange(root cid.Cid, start uint64, end *uint64, expected list.RangeResult, proof structure.Proof) (bool, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return false, err
+	}
+	return backend.VerifyRange(root, start, end, expected, proof)
+}
+
+func (d *listBackendDispatcher) defaultSemantics() (list.MeasuredSemantics, error) {
+	backend := d.backends[d.defaultBackend]
+	if backend == nil {
+		return nil, fmt.Errorf("default commitment backend %q is not registered", d.defaultBackend)
+	}
+	return backend, nil
+}
+
+func (d *listBackendDispatcher) forRoot(root cid.Cid) (list.MeasuredSemantics, error) {
+	if !root.Defined() {
+		return nil, fmt.Errorf("list root is undefined")
+	}
+	if kind := maltcid.SemanticKindOf(root); kind != maltcid.SemanticKindList {
+		return nil, fmt.Errorf("root %s has semantic kind %q, expected list", root, kind)
+	}
+	backendKind := maltcid.BackendKindOf(root)
+	if backendKind == maltcid.BackendKindUnknown {
+		return nil, fmt.Errorf("root %s does not encode a supported commitment backend", root)
+	}
+	backend := d.backends[backendKind]
+	if backend == nil {
+		return nil, fmt.Errorf("commitment backend %q is not registered for proving", backendKind)
+	}
+	return backend, nil
+}
+
+func validateBackendOptions(options *Options) (maltcid.BackendKind, error) {
+	if options.Scheme != nil {
+		return maltcid.BackendKindUnknown, fmt.Errorf("WithCommitmentScheme cannot be combined with registered commitment backends")
+	}
+	if len(options.Backends) == 0 {
+		return maltcid.BackendKindUnknown, fmt.Errorf("no commitment backends are registered")
+	}
+	for kind, scheme := range options.Backends {
+		if kind == "" || kind == maltcid.BackendKindUnknown {
+			return maltcid.BackendKindUnknown, fmt.Errorf("cannot register an unknown commitment backend")
+		}
+		if scheme == nil {
+			return maltcid.BackendKindUnknown, fmt.Errorf("commitment backend %q is nil", kind)
+		}
+	}
+	defaultBackend := options.DefaultBackend
+	if (defaultBackend == "" || defaultBackend == maltcid.BackendKindUnknown) && len(options.Backends) == 1 {
+		for kind := range options.Backends {
+			defaultBackend = kind
+		}
+	}
+	if defaultBackend == "" || defaultBackend == maltcid.BackendKindUnknown {
+		return maltcid.BackendKindUnknown, fmt.Errorf("default commitment backend is required when multiple backends are registered")
+	}
+	if options.Backends[defaultBackend] == nil {
+		return maltcid.BackendKindUnknown, fmt.Errorf("default commitment backend %q is not registered", defaultBackend)
+	}
+	return defaultBackend, nil
+}
+
+var (
+	_ mapping.Semantics      = (*mapBackendDispatcher)(nil)
+	_ list.MeasuredSemantics = (*listBackendDispatcher)(nil)
+)

--- a/graph/runtime/graph.go
+++ b/graph/runtime/graph.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dewebprotocol/malt/graph/resolver"
 	"github.com/dewebprotocol/malt/graph/resolver/step/explicit"
 	"github.com/dewebprotocol/malt/graph/writer"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 )
 
 // RuntimeGraph is a per-graph runtime composition of semantic implementations,
@@ -54,23 +55,47 @@ func NewGraph(id string, materializer materializer.MutableStore, opts ...Option)
 		namespace = id
 	}
 
-	// Default commitment scheme: KZG
-	scheme := o.Scheme
-	if scheme == nil {
-		s, err := kzg.NewScheme()
+	var semantic mapping.Semantics
+	var listSemantic list.Semantics
+	if len(o.Backends) > 0 || o.DefaultBackend != "" {
+		defaultBackend, err := validateBackendOptions(o)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create default KZG scheme: %w", err)
+			return nil, err
 		}
-		scheme = s
-	}
+		maps := make(map[maltcid.BackendKind]mapping.Semantics, len(o.Backends))
+		lists := make(map[maltcid.BackendKind]list.MeasuredSemantics, len(o.Backends))
+		for kind, scheme := range o.Backends {
+			maps[kind], err = mappingradix.NewMap(scheme, materializer)
+			if err != nil {
+				return nil, fmt.Errorf("create %s mapping semantic: %w", kind, err)
+			}
+			lists[kind], err = listtree.NewList(scheme, materializer)
+			if err != nil {
+				return nil, fmt.Errorf("create %s list semantic: %w", kind, err)
+			}
+		}
+		semantic = &mapBackendDispatcher{defaultBackend: defaultBackend, backends: maps}
+		listSemantic = &listBackendDispatcher{defaultBackend: defaultBackend, backends: lists}
+	} else {
+		// Default commitment scheme: KZG.
+		scheme := o.Scheme
+		if scheme == nil {
+			s, err := kzg.NewScheme()
+			if err != nil {
+				return nil, fmt.Errorf("failed to create default KZG scheme: %w", err)
+			}
+			scheme = s
+		}
 
-	semantic, err := mappingradix.NewMap(scheme, materializer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create mapping semantic: %w", err)
-	}
-	listSemantic, err := listtree.NewList(scheme, materializer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create list semantic: %w", err)
+		var err error
+		semantic, err = mappingradix.NewMap(scheme, materializer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create mapping semantic: %w", err)
+		}
+		listSemantic, err = listtree.NewList(scheme, materializer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create list semantic: %w", err)
+		}
 	}
 
 	// Create per-graph explicit resolver

--- a/graph/runtime/graph_test.go
+++ b/graph/runtime/graph_test.go
@@ -1,9 +1,19 @@
 package runtimegraph
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	malt "github.com/dewebprotocol/malt"
+	"github.com/dewebprotocol/malt/auth/arcset"
 	materialmemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/semantic/list"
+	clientverifier "github.com/dewebprotocol/malt/sdk/verifier"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
 )
 
 func TestNewGraphInitializesSDKComposition(t *testing.T) {
@@ -24,5 +34,166 @@ func TestNewGraphInitializesSDKComposition(t *testing.T) {
 	}
 	if g.Semantic() == nil || g.ListSemantic() == nil {
 		t.Fatal("semantic implementations must be initialized")
+	}
+}
+
+func TestRuntimeGraphDispatchesEachResolveStepByTypedRootBackend(t *testing.T) {
+	ctx := context.Background()
+	store := materialmemory.New(true)
+	kzgScheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipaScheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dynamic, err := NewGraph("dynamic", store,
+		WithNamespace("mixed"),
+		WithCommitmentBackend(maltcid.BackendKindKZG, kzgScheme),
+		WithCommitmentBackend(maltcid.BackendKindIPA, ipaScheme),
+		WithDefaultCommitmentBackend(maltcid.BackendKindKZG),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kzgGraph, err := NewGraph("kzg", store, WithNamespace("mixed"), WithCommitmentScheme(kzgScheme))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipaGraph, err := NewGraph("ipa", store, WithNamespace("mixed"), WithCommitmentScheme(ipaScheme))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target := cid.MustParse("bafkqaaa")
+	childSet, err := arcset.NewArcSet(map[string]cid.Cid{"name": target})
+	if err != nil {
+		t.Fatal(err)
+	}
+	childRoot, err := ipaGraph.StructureCreator().CreateStructure(ctx, "mixed", childSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentSet, err := arcset.NewArcSet(map[string]cid.Cid{"child": childRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentRoot, err := kzgGraph.StructureCreator().CreateStructure(ctx, "mixed", parentSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := malt.ResolveRequest{Root: parentRoot, Segments: []string{"child", "name"}}
+	result, err := dynamic.Resolve(ctx, request)
+	if err != nil {
+		t.Fatalf("mixed-backend resolve: %v", err)
+	}
+	if !result.Target.Equals(target) || len(result.ProofList.Steps) != 2 {
+		t.Fatalf("mixed-backend result = %#v", result)
+	}
+	if maltcid.BackendKindOf(result.ProofList.Steps[0].From) != maltcid.BackendKindKZG ||
+		maltcid.BackendKindOf(result.ProofList.Steps[1].From) != maltcid.BackendKindIPA {
+		t.Fatalf("proof step backends = %s, %s", maltcid.BackendKindOf(result.ProofList.Steps[0].From), maltcid.BackendKindOf(result.ProofList.Steps[1].From))
+	}
+	verifier, err := clientverifier.NewDefault()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := malt.VerifyResolve(ctx, request, result, verifier); err != nil {
+		t.Fatalf("verify mixed-backend resolve: %v", err)
+	}
+}
+
+func TestRuntimeGraphDispatchesListProofsAndKeepsCreateDefault(t *testing.T) {
+	ctx := context.Background()
+	store := materialmemory.New(true)
+	kzgScheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipaScheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dynamic, err := NewGraph("dynamic", store,
+		WithNamespace("mixed-list"),
+		WithCommitmentBackend(maltcid.BackendKindKZG, kzgScheme),
+		WithCommitmentBackend(maltcid.BackendKindIPA, ipaScheme),
+		WithDefaultCommitmentBackend(maltcid.BackendKindKZG),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipaGraph, err := NewGraph("ipa", store, WithNamespace("mixed-list"), WithCommitmentScheme(ipaScheme))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values := []cid.Cid{cid.MustParse("bafkqaaa"), cid.MustParse("bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku")}
+	ipaRoot, err := ipaGraph.ListSemantic().Commit(ctx, "mixed-list", list.NewViewFromSlice(values))
+	if err != nil {
+		t.Fatal(err)
+	}
+	query, proof, err := dynamic.ListSemantic().Prove(ctx, "mixed-list", ipaRoot, 1)
+	if err != nil {
+		t.Fatalf("prove IPA list with KZG default: %v", err)
+	}
+	valid, err := dynamic.ListSemantic().Verify(ipaRoot, 1, query, proof)
+	if err != nil || !valid {
+		t.Fatalf("verify IPA list with KZG default = %v, %v", valid, err)
+	}
+
+	defaultRoot, err := dynamic.ListSemantic().Commit(ctx, "mixed-list", list.NewViewFromSlice(values))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := maltcid.BackendKindOf(defaultRoot); got != maltcid.BackendKindKZG {
+		t.Fatalf("default list backend = %s, want KZG", got)
+	}
+	if _, _, err := dynamic.Semantic().Prove(ctx, "mixed-list", ipaRoot, arcset.CanonicalizePath("name")); err == nil || !strings.Contains(err.Error(), "expected map") {
+		t.Fatalf("map prover accepted list root: %v", err)
+	}
+
+	fixedCommitter := ipaGraph.ListSemantic().(interface {
+		CommitFixed(context.Context, string, []cid.Cid, uint64, uint64) (cid.Cid, error)
+	})
+	fixedRoot, err := fixedCommitter.CommitFixed(ctx, "mixed-list", values[:1], 4, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixedAppender := dynamic.ListSemantic().(interface {
+		AppendFixed(context.Context, string, cid.Cid, cid.Cid, uint64) (cid.Cid, uint64, error)
+	})
+	appendedRoot, index, err := fixedAppender.AppendFixed(ctx, "mixed-list", fixedRoot, values[1], 8)
+	if err != nil {
+		t.Fatalf("append IPA fixed list with KZG default: %v", err)
+	}
+	if index != 1 || maltcid.BackendKindOf(appendedRoot) != maltcid.BackendKindIPA {
+		t.Fatalf("fixed append root=%s index=%d", maltcid.BackendKindOf(appendedRoot), index)
+	}
+}
+
+func TestRuntimeGraphBackendRegistrationValidation(t *testing.T) {
+	store := materialmemory.New(true)
+	kzgScheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipaScheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewGraph("missing-default", store,
+		WithCommitmentBackend(maltcid.BackendKindKZG, kzgScheme),
+		WithCommitmentBackend(maltcid.BackendKindIPA, ipaScheme),
+	); err == nil || !strings.Contains(err.Error(), "default commitment backend is required") {
+		t.Fatalf("missing default error = %v", err)
+	}
+	if _, err := NewGraph("mixed-options", store,
+		WithCommitmentScheme(kzgScheme),
+		WithCommitmentBackend(maltcid.BackendKindKZG, kzgScheme),
+	); err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("mixed option error = %v", err)
 	}
 }

--- a/graph/runtime/options.go
+++ b/graph/runtime/options.go
@@ -2,6 +2,7 @@ package runtimegraph
 
 import (
 	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 )
 
 // Option configures a Graph instance.
@@ -9,12 +10,14 @@ type Option func(*Options)
 
 // Options holds configuration for Graph creation.
 type Options struct {
-	Scheme    commitment.IndexCommitment
-	Namespace string
+	Scheme         commitment.IndexCommitment
+	Backends       map[maltcid.BackendKind]commitment.IndexCommitment
+	DefaultBackend maltcid.BackendKind
+	Namespace      string
 }
 
 func defaultOptions() *Options {
-	return &Options{}
+	return &Options{Backends: make(map[maltcid.BackendKind]commitment.IndexCommitment)}
 }
 
 // WithCommitmentScheme sets the commitment scheme for this Graph.
@@ -22,6 +25,28 @@ func defaultOptions() *Options {
 func WithCommitmentScheme(scheme commitment.IndexCommitment) Option {
 	return func(o *Options) {
 		o.Scheme = scheme
+	}
+}
+
+// WithCommitmentBackend registers one execution backend for typed-root
+// dispatch. Existing-root operations select a registered backend from the
+// root CID; use [WithDefaultCommitmentBackend] for operations that create a
+// structure without an existing root.
+func WithCommitmentBackend(kind maltcid.BackendKind, scheme commitment.IndexCommitment) Option {
+	return func(o *Options) {
+		if o.Backends == nil {
+			o.Backends = make(map[maltcid.BackendKind]commitment.IndexCommitment)
+		}
+		o.Backends[kind] = scheme
+	}
+}
+
+// WithDefaultCommitmentBackend selects the registered backend used only when
+// an operation creates a structure without an existing typed root. It never
+// overrides the backend encoded by an existing root CID.
+func WithDefaultCommitmentBackend(kind maltcid.BackendKind) Option {
+	return func(o *Options) {
+		o.DefaultBackend = kind
 	}
 }
 

--- a/internal/conformancegen/cmd/main.go
+++ b/internal/conformancegen/cmd/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/dewebprotocol/malt/internal/conformancegen"
+)
+
+func main() {
+	out := flag.String("out", "", "output path for the generated corpus")
+	flag.Parse()
+	if *out == "" {
+		fmt.Fprintln(os.Stderr, "-out is required")
+		os.Exit(2)
+	}
+	data, err := conformancegen.Generate()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "generate conformance corpus: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(*out, data, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write conformance corpus: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/conformancegen/generator.go
+++ b/internal/conformancegen/generator.go
@@ -1,0 +1,716 @@
+// Package conformancegen deterministically produces the checked-in portable
+// resolve/read verification vectors from the reference runtime.
+package conformancegen
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	malt "github.com/dewebprotocol/malt"
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materialmemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	"github.com/dewebprotocol/malt/auth/semantic/list"
+	"github.com/dewebprotocol/malt/conformance"
+	"github.com/dewebprotocol/malt/execution"
+	runtimegraph "github.com/dewebprotocol/malt/graph/runtime"
+	"github.com/dewebprotocol/malt/protocol"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+type backendFixture struct {
+	name      string
+	mapRoot   cid.Cid
+	positives map[string]conformance.Vector
+	vectors   []conformance.Vector
+}
+
+type fixedListCommitter interface {
+	CommitFixed(context.Context, string, []cid.Cid, uint64, uint64) (cid.Cid, error)
+}
+
+// Generate builds and serializes the canonical corpus. Map iteration is never
+// allowed to determine output order; vectors are sorted by stable ID.
+func Generate() ([]byte, error) {
+	identity, err := identityVector()
+	if err != nil {
+		return nil, err
+	}
+
+	kzgScheme, err := kzg.NewScheme()
+	if err != nil {
+		return nil, fmt.Errorf("create KZG scheme: %w", err)
+	}
+	kzgFixture, err := generateBackend(conformance.BackendKZG, kzgScheme)
+	if err != nil {
+		return nil, err
+	}
+
+	ipaScheme, err := ipa.NewScheme()
+	if err != nil {
+		return nil, fmt.Errorf("create IPA scheme: %w", err)
+	}
+	ipaFixture, err := generateBackend(conformance.BackendIPA, ipaScheme)
+	if err != nil {
+		return nil, err
+	}
+
+	vectors := []conformance.Vector{identity}
+	vectors = append(vectors, kzgFixture.vectors...)
+	vectors = append(vectors, ipaFixture.vectors...)
+
+	kzgOnIPA, err := crossBackendVector(kzgFixture.positives["read-map-key"], ipaFixture.mapRoot, conformance.BackendIPA, conformance.BackendKZG)
+	if err != nil {
+		return nil, err
+	}
+	ipaOnKZG, err := crossBackendVector(ipaFixture.positives["read-map-key"], kzgFixture.mapRoot, conformance.BackendKZG, conformance.BackendIPA)
+	if err != nil {
+		return nil, err
+	}
+	vectors = append(vectors, kzgOnIPA, ipaOnKZG)
+
+	slices.SortFunc(vectors, func(a, b conformance.Vector) int {
+		if a.ID < b.ID {
+			return -1
+		}
+		if a.ID > b.ID {
+			return 1
+		}
+		return 0
+	})
+
+	corpus := conformance.Corpus{SchemaVersion: conformance.ResolveReadV1, Vectors: vectors}
+	if err := corpus.Validate(); err != nil {
+		return nil, fmt.Errorf("validate generated corpus: %w", err)
+	}
+	data, err := json.MarshalIndent(corpus, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal generated corpus: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func identityVector() (conformance.Vector, error) {
+	root, err := rawCID("resolve-identity-root")
+	if err != nil {
+		return conformance.Vector{}, err
+	}
+	request := malt.ResolveRequest{Root: root, Segments: []string{}}
+	result := malt.ResolveResult{
+		Target: root,
+		ProofList: prooflist.ProofList{
+			Root:  root,
+			Query: "",
+			Steps: []prooflist.Step{},
+		},
+	}
+	verification, err := portableResolve(request, result)
+	if err != nil {
+		return conformance.Vector{}, err
+	}
+	return vector("resolve.identity.accept", conformance.OperationResolve, conformance.BackendNone, "identity", verification, true)
+}
+
+func generateBackend(name string, scheme commitment.IndexCommitment) (*backendFixture, error) {
+	ctx := context.Background()
+
+	mapScope := "conformance-v1-" + name + "-map"
+	mapGraph, err := newGraph(mapScope, scheme)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := rawCID("payload")
+	if err != nil {
+		return nil, err
+	}
+	leaf, err := rawCID("leaf")
+	if err != nil {
+		return nil, err
+	}
+	profileName, err := rawCID("profile-name")
+	if err != nil {
+		return nil, err
+	}
+
+	childRoot, err := createMap(ctx, mapGraph, map[string]cid.Cid{
+		"@payload": payload,
+		"leaf":     leaf,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s child map: %w", name, err)
+	}
+	mapRoot, err := createMap(ctx, mapGraph, map[string]cid.Cid{
+		"@payload":     payload,
+		"docs":         childRoot,
+		"profile/name": profileName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s root map: %w", name, err)
+	}
+	otherRoot, err := createMap(ctx, mapGraph, map[string]cid.Cid{
+		"other": leaf,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s alternate map: %w", name, err)
+	}
+	mapExecutor, err := execution.NewExecutor(execution.Options{
+		Scope:    mapScope,
+		Resolver: mapGraph,
+		Maps:     mapGraph.Semantic(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	indexScope := "conformance-v1-" + name + "-list-index"
+	indexGraph, err := newGraph(indexScope, scheme)
+	if err != nil {
+		return nil, err
+	}
+	listValues, err := rawCIDs("list", 3)
+	if err != nil {
+		return nil, err
+	}
+	listRoot, err := indexGraph.ListSemantic().Commit(ctx, indexScope, list.NewViewFromSlice(listValues))
+	if err != nil {
+		return nil, fmt.Errorf("%s list commit: %w", name, err)
+	}
+	indexExecutor, err := execution.NewExecutor(execution.Options{Scope: indexScope, Lists: indexGraph.ListSemantic()})
+	if err != nil {
+		return nil, err
+	}
+
+	rangeScope := "conformance-v1-" + name + "-list-range"
+	rangeGraph, err := newGraph(rangeScope, scheme)
+	if err != nil {
+		return nil, err
+	}
+	chunks, err := rawCIDs("chunk", 3)
+	if err != nil {
+		return nil, err
+	}
+	fixed, ok := rangeGraph.ListSemantic().(fixedListCommitter)
+	if !ok {
+		return nil, fmt.Errorf("%s list semantics do not support fixed-width ranges", name)
+	}
+	rangeRoot, err := fixed.CommitFixed(ctx, rangeScope, chunks, 8, 20)
+	if err != nil {
+		return nil, fmt.Errorf("%s fixed list commit: %w", name, err)
+	}
+	rangeExecutor, err := execution.NewExecutor(execution.Options{Scope: rangeScope, Lists: rangeGraph.ListSemantic()})
+	if err != nil {
+		return nil, err
+	}
+
+	fixture := &backendFixture{name: name, mapRoot: mapRoot, positives: map[string]conformance.Vector{}}
+	addPositive := func(key, id, operation, category string, verification any) error {
+		entry, err := vector(id, operation, name, category, verification, true)
+		if err != nil {
+			return err
+		}
+		fixture.positives[key] = entry
+		fixture.vectors = append(fixture.vectors, entry)
+		return nil
+	}
+
+	mapKeyResolve, err := executeResolve(ctx, mapExecutor, malt.ResolveRequest{Root: mapRoot, Segments: []string{"profile", "name"}})
+	if err != nil {
+		return nil, err
+	}
+	if err := addPositive("resolve-map-key", "resolve."+name+".map-key.accept", conformance.OperationResolve, "map_key", mapKeyResolve); err != nil {
+		return nil, err
+	}
+	multihop, err := executeResolve(ctx, mapExecutor, malt.ResolveRequest{Root: mapRoot, Segments: []string{"docs", "leaf"}})
+	if err != nil {
+		return nil, err
+	}
+	if err := addPositive("resolve-multihop", "resolve."+name+".multihop.accept", conformance.OperationResolve, "multihop", multihop); err != nil {
+		return nil, err
+	}
+	payloadResolve, err := executeResolve(ctx, mapExecutor, malt.ResolveRequest{Root: mapRoot, Segments: []string{"docs", "@payload"}})
+	if err != nil {
+		return nil, err
+	}
+	if err := addPositive("resolve-payload", "resolve."+name+".payload.accept", conformance.OperationResolve, "payload", payloadResolve); err != nil {
+		return nil, err
+	}
+
+	mapQuery, err := malt.MapKeyQuery("profile/name")
+	if err != nil {
+		return nil, err
+	}
+	mapRead, err := executeRead(ctx, mapExecutor, malt.ReadRequest{Root: mapRoot, Query: mapQuery})
+	if err != nil {
+		return nil, err
+	}
+	if err := addPositive("read-map-key", "read."+name+".map-key.accept", conformance.OperationRead, "map_key", mapRead); err != nil {
+		return nil, err
+	}
+	payloadQuery, err := malt.MapKeyQuery("@payload")
+	if err != nil {
+		return nil, err
+	}
+	payloadRead, err := executeRead(ctx, mapExecutor, malt.ReadRequest{Root: mapRoot, Query: payloadQuery})
+	if err != nil {
+		return nil, err
+	}
+	if err := addPositive("read-payload", "read."+name+".payload.accept", conformance.OperationRead, "payload", payloadRead); err != nil {
+		return nil, err
+	}
+	indexRead, err := executeRead(ctx, indexExecutor, malt.ReadRequest{Root: listRoot, Query: malt.ListIndexQuery(1)})
+	if err != nil {
+		return nil, err
+	}
+	if err := addPositive("read-list-index", "read."+name+".list-index.accept", conformance.OperationRead, "list_index", indexRead); err != nil {
+		return nil, err
+	}
+	end := uint64(18)
+	boundedQuery, err := malt.ListRangeQuery(2, &end)
+	if err != nil {
+		return nil, err
+	}
+	boundedRange, err := executeRead(ctx, rangeExecutor, malt.ReadRequest{Root: rangeRoot, Query: boundedQuery})
+	if err != nil {
+		return nil, err
+	}
+	if err := addPositive("read-list-range", "read."+name+".list-range-bounded.accept", conformance.OperationRead, "list_range", boundedRange); err != nil {
+		return nil, err
+	}
+	eofQuery, err := malt.ListRangeQuery(8, nil)
+	if err != nil {
+		return nil, err
+	}
+	eofRange, err := executeRead(ctx, rangeExecutor, malt.ReadRequest{Root: rangeRoot, Query: eofQuery})
+	if err != nil {
+		return nil, err
+	}
+	if err := addPositive("read-list-range-eof", "read."+name+".list-range-eof.accept", conformance.OperationRead, "list_range", eofRange); err != nil {
+		return nil, err
+	}
+
+	negatives, err := negativeVectors(name, fixture.positives, otherRoot)
+	if err != nil {
+		return nil, err
+	}
+	fixture.vectors = append(fixture.vectors, negatives...)
+	return fixture, nil
+}
+
+func negativeVectors(name string, positives map[string]conformance.Vector, otherRoot cid.Cid) ([]conformance.Vector, error) {
+	var vectors []conformance.Vector
+	appendVector := func(value conformance.Vector, err error) error {
+		if err != nil {
+			return err
+		}
+		vectors = append(vectors, value)
+		return nil
+	}
+
+	resolveBase := positives["resolve-multihop"]
+	if err := appendVector(tamperResolveEvidence(resolveBase, "resolve."+name+".evidence-tamper.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(crossRootResolve(resolveBase, otherRoot, "resolve."+name+".cross-root.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(malformedBase64(resolveBase, "resolve."+name+".malformed-base64.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(truncatedEvidence(resolveBase, "resolve."+name+".truncated-evidence.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(missingEvidence(resolveBase, "resolve."+name+".missing-evidence.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(unknownVerificationField(resolveBase, "resolve."+name+".unknown-field.reject", name)); err != nil {
+		return nil, err
+	}
+
+	readBase := positives["read-map-key"]
+	if err := appendVector(tamperReadProof(readBase, "read."+name+".proof-tamper.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(tamperReadTarget(readBase, "read."+name+".target-tamper.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(crossRootRead(readBase, otherRoot, "read."+name+".cross-root.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(crossKindRead(readBase, "read."+name+".cross-kind.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(malformedBase64(readBase, "read."+name+".malformed-base64.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(truncatedEvidence(readBase, "read."+name+".truncated-evidence.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(missingEvidence(readBase, "read."+name+".missing-evidence.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(unknownVerificationField(readBase, "read."+name+".unknown-field.reject", name)); err != nil {
+		return nil, err
+	}
+	if err := appendVector(tamperRangeSegments(positives["read-list-range"], "read."+name+".range-segments-tamper.reject", name)); err != nil {
+		return nil, err
+	}
+	return vectors, nil
+}
+
+func newGraph(scope string, scheme commitment.IndexCommitment) (*runtimegraph.RuntimeGraph, error) {
+	graph, err := runtimegraph.NewGraph(scope, materialmemory.New(true), runtimegraph.WithNamespace(scope), runtimegraph.WithCommitmentScheme(scheme))
+	if err != nil {
+		return nil, fmt.Errorf("create graph %q: %w", scope, err)
+	}
+	return graph, nil
+}
+
+func createMap(ctx context.Context, graph *runtimegraph.RuntimeGraph, entries map[string]cid.Cid) (cid.Cid, error) {
+	arcs, err := arcset.NewArcSet(entries)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return graph.StructureCreator().CreateStructure(ctx, graph.Namespace(), arcs)
+}
+
+func executeResolve(ctx context.Context, executor *execution.Executor, request malt.ResolveRequest) (protocol.ResolveVerification, error) {
+	result, err := executor.Resolve(ctx, request)
+	if err != nil {
+		return protocol.ResolveVerification{}, fmt.Errorf("execute resolve: %w", err)
+	}
+	return portableResolve(request, result)
+}
+
+func portableResolve(request malt.ResolveRequest, result malt.ResolveResult) (protocol.ResolveVerification, error) {
+	portableRequest, err := protocol.NewResolveRequest(request)
+	if err != nil {
+		return protocol.ResolveVerification{}, err
+	}
+	portableResult, err := protocol.NewResolveResult(result)
+	if err != nil {
+		return protocol.ResolveVerification{}, err
+	}
+	return protocol.ResolveVerification{Request: portableRequest, Result: portableResult}, nil
+}
+
+func executeRead(ctx context.Context, executor *execution.Executor, request malt.ReadRequest) (protocol.ReadVerification, error) {
+	result, err := executor.Read(ctx, request)
+	if err != nil {
+		return protocol.ReadVerification{}, fmt.Errorf("execute read: %w", err)
+	}
+	portableRequest, err := protocol.NewReadRequest(request)
+	if err != nil {
+		return protocol.ReadVerification{}, err
+	}
+	portableResult, err := protocol.NewReadResult(result)
+	if err != nil {
+		return protocol.ReadVerification{}, err
+	}
+	return protocol.ReadVerification{Request: portableRequest, Result: portableResult}, nil
+}
+
+func vector(id, operation, backend, category string, verification any, valid bool) (conformance.Vector, error) {
+	raw, err := json.Marshal(verification)
+	if err != nil {
+		return conformance.Vector{}, fmt.Errorf("marshal vector %q verification: %w", id, err)
+	}
+	return conformance.Vector{
+		ID:           id,
+		Operation:    operation,
+		Backend:      backend,
+		Category:     category,
+		Verification: raw,
+		Expected:     conformance.Expected{Valid: valid},
+	}, nil
+}
+
+func tamperResolveEvidence(base conformance.Vector, id, backend string) (conformance.Vector, error) {
+	var value protocol.ResolveVerification
+	if err := json.Unmarshal(base.Verification, &value); err != nil {
+		return conformance.Vector{}, err
+	}
+	if len(value.Result.ProofList.Steps) == 0 || len(value.Result.ProofList.Steps[0].Evidence) == 0 {
+		return conformance.Vector{}, fmt.Errorf("resolve tamper base has no evidence")
+	}
+	tampered, err := tamperSemanticProof(value.Result.ProofList.Steps[0].Evidence)
+	if err != nil {
+		return conformance.Vector{}, fmt.Errorf("tamper resolve evidence: %w", err)
+	}
+	value.Result.ProofList.Steps[0].Evidence = tampered
+	return vector(id, conformance.OperationResolve, backend, "tamper", value, false)
+}
+
+func crossRootResolve(base conformance.Vector, otherRoot cid.Cid, id, backend string) (conformance.Vector, error) {
+	var value protocol.ResolveVerification
+	if err := json.Unmarshal(base.Verification, &value); err != nil {
+		return conformance.Vector{}, err
+	}
+	value.Request.Root = otherRoot.String()
+	value.Result.ProofList.Root = otherRoot
+	value.Result.ProofList.Steps[0].From = otherRoot
+	return vector(id, conformance.OperationResolve, backend, "cross_root", value, false)
+}
+
+func tamperReadProof(base conformance.Vector, id, backend string) (conformance.Vector, error) {
+	var value protocol.ReadVerification
+	if err := json.Unmarshal(base.Verification, &value); err != nil {
+		return conformance.Vector{}, err
+	}
+	if len(value.Result.ProofList.Steps) == 0 || len(value.Result.ProofList.Steps[0].Proof) == 0 {
+		return conformance.Vector{}, fmt.Errorf("read tamper base has no proof")
+	}
+	tampered, err := tamperSemanticProof(value.Result.ProofList.Steps[0].Proof)
+	if err != nil {
+		return conformance.Vector{}, fmt.Errorf("tamper read proof: %w", err)
+	}
+	value.Result.ProofList.Steps[0].Proof = tampered
+	return vector(id, conformance.OperationRead, backend, "tamper", value, false)
+}
+
+func tamperReadTarget(base conformance.Vector, id, backend string) (conformance.Vector, error) {
+	var value protocol.ReadVerification
+	if err := json.Unmarshal(base.Verification, &value); err != nil {
+		return conformance.Vector{}, err
+	}
+	forged, err := rawCID("forged-read-target")
+	if err != nil {
+		return conformance.Vector{}, err
+	}
+	value.Result.Target = forged.String()
+	value.Result.ProofList.Steps[0].Target = forged
+	return vector(id, conformance.OperationRead, backend, "tamper", value, false)
+}
+
+func crossRootRead(base conformance.Vector, otherRoot cid.Cid, id, backend string) (conformance.Vector, error) {
+	var value protocol.ReadVerification
+	if err := json.Unmarshal(base.Verification, &value); err != nil {
+		return conformance.Vector{}, err
+	}
+	value.Request.Root = otherRoot.String()
+	value.Result.ProofList.Root = otherRoot
+	value.Result.ProofList.Steps[0].From = otherRoot
+	return vector(id, conformance.OperationRead, backend, "cross_root", value, false)
+}
+
+func crossKindRead(base conformance.Vector, id, backend string) (conformance.Vector, error) {
+	var value protocol.ReadVerification
+	if err := json.Unmarshal(base.Verification, &value); err != nil {
+		return conformance.Vector{}, err
+	}
+	index := uint64(0)
+	value.Request.Query = protocol.Query{Kind: protocol.QueryListIndex, Index: &index}
+	value.Result.ProofList.Query = "list:0"
+	return vector(id, conformance.OperationRead, backend, "cross_kind", value, false)
+}
+
+func tamperRangeSegments(base conformance.Vector, id, backend string) (conformance.Vector, error) {
+	var value protocol.ReadVerification
+	if err := json.Unmarshal(base.Verification, &value); err != nil {
+		return conformance.Vector{}, err
+	}
+	if len(value.Result.RangeSegments) < 2 {
+		return conformance.Vector{}, fmt.Errorf("range tamper base has fewer than two segments")
+	}
+	value.Result.RangeSegments[0], value.Result.RangeSegments[1] = value.Result.RangeSegments[1], value.Result.RangeSegments[0]
+	return vector(id, conformance.OperationRead, backend, "tamper", value, false)
+}
+
+func malformedBase64(base conformance.Vector, id, backend string) (conformance.Vector, error) {
+	value, err := rawObject(base.Verification)
+	if err != nil {
+		return conformance.Vector{}, err
+	}
+	result, err := objectField(value, "result")
+	if err != nil {
+		return conformance.Vector{}, err
+	}
+	proofList, err := objectField(result, "prooflist")
+	if err != nil {
+		return conformance.Vector{}, err
+	}
+	steps, ok := proofList["steps"].([]any)
+	if !ok || len(steps) == 0 {
+		return conformance.Vector{}, fmt.Errorf("vector %q has no proof steps", base.ID)
+	}
+	step, ok := steps[0].(map[string]any)
+	if !ok {
+		return conformance.Vector{}, fmt.Errorf("vector %q first proof step is not an object", base.ID)
+	}
+	field := "proof"
+	if base.Operation == conformance.OperationResolve {
+		field = "evidence"
+	}
+	step[field] = "not-base64%%%"
+	return vector(id, base.Operation, backend, "malformed_evidence", value, false)
+}
+
+func unknownVerificationField(base conformance.Vector, id, backend string) (conformance.Vector, error) {
+	value, err := rawObject(base.Verification)
+	if err != nil {
+		return conformance.Vector{}, err
+	}
+	value["unexpected"] = true
+	return vector(id, base.Operation, backend, "strict_json", value, false)
+}
+
+func truncatedEvidence(base conformance.Vector, id, backend string) (conformance.Vector, error) {
+	switch base.Operation {
+	case conformance.OperationResolve:
+		var value protocol.ResolveVerification
+		if err := json.Unmarshal(base.Verification, &value); err != nil {
+			return conformance.Vector{}, err
+		}
+		truncated, err := truncateSemanticProof(value.Result.ProofList.Steps[0].Evidence)
+		if err != nil {
+			return conformance.Vector{}, err
+		}
+		value.Result.ProofList.Steps[0].Evidence = truncated
+		return vector(id, base.Operation, backend, "malformed_evidence", value, false)
+	case conformance.OperationRead:
+		var value protocol.ReadVerification
+		if err := json.Unmarshal(base.Verification, &value); err != nil {
+			return conformance.Vector{}, err
+		}
+		truncated, err := truncateSemanticProof(value.Result.ProofList.Steps[0].Proof)
+		if err != nil {
+			return conformance.Vector{}, err
+		}
+		value.Result.ProofList.Steps[0].Proof = truncated
+		return vector(id, base.Operation, backend, "malformed_evidence", value, false)
+	default:
+		return conformance.Vector{}, fmt.Errorf("unsupported operation %q", base.Operation)
+	}
+}
+
+func missingEvidence(base conformance.Vector, id, backend string) (conformance.Vector, error) {
+	switch base.Operation {
+	case conformance.OperationResolve:
+		var value protocol.ResolveVerification
+		if err := json.Unmarshal(base.Verification, &value); err != nil {
+			return conformance.Vector{}, err
+		}
+		value.Result.ProofList.Steps[0].Evidence = nil
+		return vector(id, base.Operation, backend, "malformed_evidence", value, false)
+	case conformance.OperationRead:
+		var value protocol.ReadVerification
+		if err := json.Unmarshal(base.Verification, &value); err != nil {
+			return conformance.Vector{}, err
+		}
+		value.Result.ProofList.Steps[0].Proof = nil
+		return vector(id, base.Operation, backend, "malformed_evidence", value, false)
+	default:
+		return conformance.Vector{}, fmt.Errorf("unsupported operation %q", base.Operation)
+	}
+}
+
+func crossBackendVector(base conformance.Vector, destinationRoot cid.Cid, destinationBackend, sourceBackend string) (conformance.Vector, error) {
+	var value protocol.ReadVerification
+	if err := json.Unmarshal(base.Verification, &value); err != nil {
+		return conformance.Vector{}, err
+	}
+	value.Request.Root = destinationRoot.String()
+	value.Result.ProofList.Root = destinationRoot
+	value.Result.ProofList.Steps[0].From = destinationRoot
+	id := "read." + destinationBackend + ".cross-backend-" + sourceBackend + "-evidence.reject"
+	return vector(id, conformance.OperationRead, destinationBackend, "cross_backend", value, false)
+}
+
+func rawObject(data []byte) (map[string]any, error) {
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func objectField(value map[string]any, name string) (map[string]any, error) {
+	field, ok := value[name].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("field %q is not an object", name)
+	}
+	return field, nil
+}
+
+// tamperSemanticProof preserves the radix proof JSON envelope and the
+// primitive proof framing. Built-in KZG and IPA index proofs both end in the
+// authenticated uint32 index, so changing its final byte remains decodable but
+// makes verification reject the proof/query binding.
+func tamperSemanticProof(proof []byte) ([]byte, error) {
+	return mutateSemanticProof(proof, func(primitive []byte) ([]byte, error) {
+		if len(primitive) < 4 {
+			return nil, fmt.Errorf("primitive proof is too short")
+		}
+		primitive = slices.Clone(primitive)
+		primitive[len(primitive)-1] ^= 0x01
+		return primitive, nil
+	})
+}
+
+func truncateSemanticProof(proof []byte) ([]byte, error) {
+	return mutateSemanticProof(proof, func(primitive []byte) ([]byte, error) {
+		if len(primitive) < 5 {
+			return nil, fmt.Errorf("primitive proof is too short to truncate")
+		}
+		return slices.Clone(primitive[:len(primitive)-1]), nil
+	})
+}
+
+func mutateSemanticProof(proof []byte, mutate func([]byte) ([]byte, error)) ([]byte, error) {
+	envelope, err := rawObject(proof)
+	if err != nil {
+		return nil, fmt.Errorf("decode semantic proof envelope: %w", err)
+	}
+	steps, ok := envelope["steps"].([]any)
+	if !ok || len(steps) == 0 {
+		return nil, fmt.Errorf("semantic proof envelope has no steps")
+	}
+	step, ok := steps[0].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("semantic proof step is not an object")
+	}
+	encoded, ok := step["proof"].(string)
+	if !ok {
+		return nil, fmt.Errorf("semantic proof step has no encoded proof")
+	}
+	primitive, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode primitive proof: %w", err)
+	}
+	primitive, err = mutate(primitive)
+	if err != nil {
+		return nil, err
+	}
+	step["proof"] = base64.StdEncoding.EncodeToString(primitive)
+	tampered, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, fmt.Errorf("encode semantic proof envelope: %w", err)
+	}
+	return tampered, nil
+}
+
+func rawCIDs(prefix string, count int) ([]cid.Cid, error) {
+	out := make([]cid.Cid, count)
+	for i := range out {
+		value, err := rawCID(fmt.Sprintf("%s-%d", prefix, i))
+		if err != nil {
+			return nil, err
+		}
+		out[i] = value
+	}
+	return out, nil
+}
+
+func rawCID(seed string) (cid.Cid, error) {
+	digest, err := mh.Sum([]byte("malt-conformance-v1:"+seed), mh.SHA2_256, -1)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return cid.NewCidV1(cid.Raw, digest), nil
+}

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -1,0 +1,61 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// MaxVerificationJSONBytes bounds portable verifier inputs before JSON
+// decoding. It matches the current transport body ceiling while keeping the
+// protocol decoder independent from HTTP and WASM adapters.
+const MaxVerificationJSONBytes = 96 << 20
+
+// DecodeResolveVerification strictly decodes and validates one portable
+// resolve request/result pair. Unknown fields and trailing JSON values are
+// rejected so every language adapter observes the published schema boundary.
+func DecodeResolveVerification(data []byte) (ResolveVerification, error) {
+	var value ResolveVerification
+	if err := decodeVerificationJSON(data, &value); err != nil {
+		return ResolveVerification{}, fmt.Errorf("decode resolve verification: %w", err)
+	}
+	if err := value.Validate(); err != nil {
+		return ResolveVerification{}, err
+	}
+	return value, nil
+}
+
+// DecodeReadVerification strictly decodes and validates one portable primitive
+// read request/result pair.
+func DecodeReadVerification(data []byte) (ReadVerification, error) {
+	var value ReadVerification
+	if err := decodeVerificationJSON(data, &value); err != nil {
+		return ReadVerification{}, fmt.Errorf("decode read verification: %w", err)
+	}
+	if err := value.Validate(); err != nil {
+		return ReadVerification{}, err
+	}
+	return value, nil
+}
+
+func decodeVerificationJSON(data []byte, target any) error {
+	if len(data) == 0 {
+		return fmt.Errorf("verification JSON is empty")
+	}
+	if len(data) > MaxVerificationJSONBytes {
+		return fmt.Errorf("verification JSON exceeds %d bytes", MaxVerificationJSONBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing JSON value")
+		}
+		return fmt.Errorf("unexpected trailing JSON: %w", err)
+	}
+	return nil
+}

--- a/protocol/decode_test.go
+++ b/protocol/decode_test.go
@@ -1,0 +1,70 @@
+package protocol_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	"github.com/dewebprotocol/malt/protocol"
+)
+
+func TestDecodeResolveVerificationStrict(t *testing.T) {
+	root := protocolTestCID(t, "strict-resolve-root")
+	value := protocol.ResolveVerification{
+		Request: protocol.ResolveRequest{Profile: protocol.ResolveProfile, Root: root.String(), Segments: []string{}},
+		Result: protocol.ResolveResult{
+			Profile: protocol.ResolveProfile,
+			Target:  root.String(),
+			ProofList: prooflist.ProofList{
+				Root:  root,
+				Steps: []prooflist.Step{},
+			},
+		},
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := protocol.DecodeResolveVerification(raw); err != nil {
+		t.Fatalf("DecodeResolveVerification: %v", err)
+	}
+
+	withUnknown := strings.TrimSuffix(string(raw), "}") + `,"unexpected":true}`
+	if _, err := protocol.DecodeResolveVerification([]byte(withUnknown)); err == nil {
+		t.Fatal("DecodeResolveVerification accepted an unknown field")
+	}
+	if _, err := protocol.DecodeResolveVerification(append(raw, []byte("{}")...)); err == nil {
+		t.Fatal("DecodeResolveVerification accepted a trailing JSON value")
+	}
+}
+
+func TestDecodeReadVerificationRejectsUnknownNestedField(t *testing.T) {
+	root := protocolTestCID(t, "strict-read-root")
+	target := protocolTestCID(t, "strict-read-target")
+	raw := []byte(`{
+		"request":{
+			"profile":"malt.read/v0alpha1",
+			"root":"` + root.String() + `",
+			"query":{"kind":"map_key","segments":["name"],"unexpected":true}
+		},
+		"result":{
+			"profile":"malt.read/v0alpha1",
+			"target":"` + target.String() + `",
+			"prooflist":{"root":{"/":"` + root.String() + `"},"steps":[]}
+		}
+	}`)
+	if _, err := protocol.DecodeReadVerification(raw); err == nil {
+		t.Fatal("DecodeReadVerification accepted an unknown nested field")
+	}
+}
+
+func TestDecodeVerificationRejectsEmptyAndOversizedInputs(t *testing.T) {
+	if _, err := protocol.DecodeResolveVerification(nil); err == nil {
+		t.Fatal("DecodeResolveVerification accepted an empty input")
+	}
+	oversized := make([]byte, protocol.MaxVerificationJSONBytes+1)
+	if _, err := protocol.DecodeReadVerification(oversized); err == nil {
+		t.Fatal("DecodeReadVerification accepted an oversized input")
+	}
+}

--- a/scripts/run-verifier-wasm-vectors.mjs
+++ b/scripts/run-verifier-wasm-vectors.mjs
@@ -1,0 +1,115 @@
+import { webcrypto } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const [wasmPath, wasmExecPath, corpusPath] = process.argv.slice(2);
+if (!wasmPath || !wasmExecPath || !corpusPath) {
+  console.error(
+    "usage: node run-verifier-wasm-vectors.mjs <verifier.wasm> <wasm_exec.js> <vectors.json>",
+  );
+  process.exit(2);
+}
+
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto;
+}
+
+await import(pathToFileURL(wasmExecPath).href);
+if (typeof globalThis.Go !== "function") {
+  throw new Error(`${wasmExecPath} did not install the Go WASM runtime`);
+}
+
+const corpus = JSON.parse(await readFile(corpusPath, "utf8"));
+if (!Array.isArray(corpus.vectors) || corpus.vectors.length === 0) {
+  throw new Error(`${corpusPath} does not contain a non-empty vectors array`);
+}
+
+const go = new globalThis.Go();
+const wasm = await readFile(wasmPath);
+const { instance } = await WebAssembly.instantiate(wasm, go.importObject);
+let runtimeFailure;
+void go.run(instance).catch((error) => {
+  runtimeFailure = error;
+});
+
+await waitForVerifierGlobals();
+
+const seen = new Set();
+const failures = [];
+for (const vector of corpus.vectors) {
+  const label = typeof vector.id === "string" ? vector.id : "<missing-id>";
+  try {
+    validateEnvelope(vector, seen);
+    const verify = selectVerifier(vector.operation);
+    const response = JSON.parse(verify(JSON.stringify(vector.verification)));
+    if (typeof response.valid !== "boolean") {
+      throw new Error("verifier response has no boolean valid field");
+    }
+    if (response.valid !== vector.expected.valid) {
+      const diagnostic = response.error ? `: ${response.error}` : "";
+      throw new Error(
+        `expected valid=${vector.expected.valid}, got valid=${response.valid}${diagnostic}`,
+      );
+    }
+  } catch (error) {
+    failures.push(`${label}: ${error instanceof Error ? error.message : error}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`WASM conformance failed (${failures.length}/${corpus.vectors.length}):`);
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`WASM conformance passed (${corpus.vectors.length} vectors)`);
+process.exit(0);
+
+function selectVerifier(operation) {
+  switch (operation) {
+    case "resolve":
+      return globalThis.maltVerifyResolve;
+    case "read":
+      return globalThis.maltVerifyRead;
+    default:
+      throw new Error(`unsupported operation ${JSON.stringify(operation)}`);
+  }
+}
+
+function validateEnvelope(vector, ids) {
+  if (!vector || typeof vector !== "object" || Array.isArray(vector)) {
+    throw new Error("vector is not an object");
+  }
+  if (typeof vector.id !== "string" || vector.id.length === 0) {
+    throw new Error("vector has no non-empty id");
+  }
+  if (ids.has(vector.id)) {
+    throw new Error("duplicate vector id");
+  }
+  ids.add(vector.id);
+  if (!vector.verification || typeof vector.verification !== "object" || Array.isArray(vector.verification)) {
+    throw new Error("verification is not an object");
+  }
+  if (!vector.expected || typeof vector.expected.valid !== "boolean") {
+    throw new Error("expected.valid is not a boolean");
+  }
+}
+
+async function waitForVerifierGlobals() {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (runtimeFailure) {
+      throw new Error(`Go WASM runtime failed: ${runtimeFailure}`);
+    }
+    if (
+      typeof globalThis.maltVerifyResolve === "function" &&
+      typeof globalThis.maltVerifyRead === "function"
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("timed out waiting for MALT verifier globals");
+}

--- a/scripts/test-verifier-wasm-vectors.sh
+++ b/scripts/test-verifier-wasm-vectors.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/malt-wasm-vectors.XXXXXX")
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+sh "$repo_root/scripts/build-verifier-wasm.sh" "$work_dir/verifier"
+node "$repo_root/scripts/run-verifier-wasm-vectors.mjs" \
+  "$work_dir/verifier/malt-verifier.wasm" \
+  "$work_dir/verifier/wasm_exec.js" \
+  "$repo_root/conformance/resolve-read/v1/vectors.json"

--- a/wire/maltcid/codec.go
+++ b/wire/maltcid/codec.go
@@ -237,9 +237,10 @@ func decodeRoot(c cid.Cid) (codecParts, []byte, error) {
 	return parts, decoded.Digest, nil
 }
 
-// EqualCommitment reports whether a and b carry the same commitment bytes.
-// This is useful when comparing typed roots that differ only by semantic codec
-// (e.g., map vs list) but refer to the same primitive commitment.
+// EqualCommitment reports whether a and b use the same commitment backend and
+// carry the same commitment bytes. This permits semantic rewrapping (for
+// example map to list) without treating equal-length values from different
+// backend suites as interchangeable.
 func EqualCommitment(a, b cid.Cid) (bool, error) {
 	ab, err := ExtractCommitment(a)
 	if err != nil {
@@ -248,6 +249,9 @@ func EqualCommitment(a, b cid.Cid) (bool, error) {
 	bb, err := ExtractCommitment(b)
 	if err != nil {
 		return false, err
+	}
+	if BackendKindOf(a) != BackendKindOf(b) {
+		return false, nil
 	}
 	return bytes.Equal(ab, bb), nil
 }

--- a/wire/maltcid/codec.go
+++ b/wire/maltcid/codec.go
@@ -1,12 +1,21 @@
 // Package maltcid defines MALT-specific multicodec constants and CID utilities.
-// MALT uses the Private Use Area (0x300000-0x3FFFFF) for typed structure roots.
+// MALT typed roots use the 0x300000-0x30FFFF slice of the multicodec Private
+// Use Area. The low 16 bits form the locked 0x30VSBB layout:
 //
-// Wire allocation (locked; see Implementation plan Phase 0):
+//	V  = 4-bit MALT wire-format version
+//	S  = 4-bit semantic kind
+//	BB = 8-bit commitment backend suite
 //
-//	malt-map-kzg  = 0x300001
-//	malt-list-kzg = 0x300002
-//	malt-map-ipa  = 0x300003
-//	malt-list-ipa = 0x300004
+// A codec is constructed as:
+//
+//	0x300000 | (version << 12) | (semantic << 8) | backend
+//
+// Current allocations:
+//
+//	malt-map-kzg  = 0x301101
+//	malt-list-kzg = 0x301201
+//	malt-map-ipa  = 0x301102
+//	malt-list-ipa = 0x301202
 package maltcid
 
 import (
@@ -17,12 +26,42 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
-// Typed MALT multicodecs (Private Use Area: 0x300000-0x3FFFFF).
+// MALTVersionID identifies the current typed-root wire layout. It is not a
+// source release or protocol-profile version.
+const MALTVersionID uint8 = 1
+
 const (
-	CodecMaltMapKZG  = 0x300001 // malt-map-kzg
-	CodecMaltListKZG = 0x300002 // malt-list-kzg
-	CodecMaltMapIPA  = 0x300003 // malt-map-ipa
-	CodecMaltListIPA = 0x300004 // malt-list-ipa
+	codecMaltRootBase = 0x300000
+	codecMaltRootMax  = 0x30FFFF
+
+	codecVersionShift  = 12
+	codecSemanticShift = 8
+
+	semanticIDMap  = 0x1
+	semanticIDList = 0x2
+
+	backendIDKZG = 0x01
+	backendIDIPA = 0x02
+)
+
+// Typed MALT multicodecs in the 0x30VSBB layout.
+const (
+	CodecMaltMapKZG = codecMaltRootBase |
+		uint64(MALTVersionID)<<codecVersionShift |
+		semanticIDMap<<codecSemanticShift |
+		backendIDKZG
+	CodecMaltListKZG = codecMaltRootBase |
+		uint64(MALTVersionID)<<codecVersionShift |
+		semanticIDList<<codecSemanticShift |
+		backendIDKZG
+	CodecMaltMapIPA = codecMaltRootBase |
+		uint64(MALTVersionID)<<codecVersionShift |
+		semanticIDMap<<codecSemanticShift |
+		backendIDIPA
+	CodecMaltListIPA = codecMaltRootBase |
+		uint64(MALTVersionID)<<codecVersionShift |
+		semanticIDList<<codecSemanticShift |
+		backendIDIPA
 )
 
 // SemanticKind indicates the structural semantic encoded in the typed CID.
@@ -57,12 +96,21 @@ const (
 	IPACommitmentSize = 32 // IPACommitmentSize is the size of an IPA commitment in bytes (32 bytes).
 )
 
+type backendDescriptor struct {
+	id             uint8
+	kind           BackendKind
+	displayName    string
+	commitmentSize int
+}
+
+var backendRegistry = [...]backendDescriptor{
+	{id: backendIDKZG, kind: BackendKindKZG, displayName: "KZG", commitmentSize: KZGCommitmentSize},
+	{id: backendIDIPA, kind: BackendKindIPA, displayName: "IPA", commitmentSize: IPACommitmentSize},
+}
+
 // NewKZGCid creates a CID from KZG commitment bytes using the malt-map-kzg codec.
 func NewKZGCid(commitment []byte) (cid.Cid, error) {
-	if len(commitment) != KZGCommitmentSize {
-		return cid.Cid{}, fmt.Errorf("invalid KZG commitment size: %d, expected %d", len(commitment), KZGCommitmentSize)
-	}
-	return newMaltCid(CodecMaltMapKZG, commitment)
+	return NewTypedCID(SemanticKindMap, BackendKindKZG, commitment)
 }
 
 // NewMapKZGCid is an alias for [NewKZGCid].
@@ -72,18 +120,12 @@ func NewMapKZGCid(commitment []byte) (cid.Cid, error) {
 
 // NewListKZGCid creates a CID from KZG commitment bytes using the malt-list-kzg codec.
 func NewListKZGCid(commitment []byte) (cid.Cid, error) {
-	if len(commitment) != KZGCommitmentSize {
-		return cid.Cid{}, fmt.Errorf("invalid KZG commitment size: %d, expected %d", len(commitment), KZGCommitmentSize)
-	}
-	return newMaltCid(CodecMaltListKZG, commitment)
+	return NewTypedCID(SemanticKindList, BackendKindKZG, commitment)
 }
 
 // NewIPACid creates a CID from IPA commitment bytes using the malt-map-ipa codec.
 func NewIPACid(commitment []byte) (cid.Cid, error) {
-	if len(commitment) != IPACommitmentSize {
-		return cid.Cid{}, fmt.Errorf("invalid IPA commitment size: %d, expected %d", len(commitment), IPACommitmentSize)
-	}
-	return newMaltCid(CodecMaltMapIPA, commitment)
+	return NewTypedCID(SemanticKindMap, BackendKindIPA, commitment)
 }
 
 // NewMapIPACid is an alias for [NewIPACid].
@@ -93,31 +135,22 @@ func NewMapIPACid(commitment []byte) (cid.Cid, error) {
 
 // NewListIPACid creates a CID from IPA commitment bytes using the malt-list-ipa codec.
 func NewListIPACid(commitment []byte) (cid.Cid, error) {
-	if len(commitment) != IPACommitmentSize {
-		return cid.Cid{}, fmt.Errorf("invalid IPA commitment size: %d, expected %d", len(commitment), IPACommitmentSize)
-	}
-	return newMaltCid(CodecMaltListIPA, commitment)
+	return NewTypedCID(SemanticKindList, BackendKindIPA, commitment)
 }
 
 // NewTypedCID constructs a typed MALT CID for the given semantic/backend kinds.
 func NewTypedCID(semantic SemanticKind, backend BackendKind, commitment []byte) (cid.Cid, error) {
-	switch backend {
-	case BackendKindKZG:
-		if semantic == SemanticKindList {
-			return NewListKZGCid(commitment)
-		}
-		if semantic == SemanticKindMap {
-			return NewMapKZGCid(commitment)
-		}
-	case BackendKindIPA:
-		if semantic == SemanticKindList {
-			return NewListIPACid(commitment)
-		}
-		if semantic == SemanticKindMap {
-			return NewMapIPACid(commitment)
-		}
+	codec, descriptor, err := codecFor(semantic, backend)
+	if err != nil {
+		return cid.Undef, err
 	}
-	return cid.Undef, fmt.Errorf("unsupported typed cid kind: semantic=%s backend=%s", semantic, backend)
+	if len(commitment) != descriptor.commitmentSize {
+		return cid.Undef, fmt.Errorf(
+			"invalid %s commitment size: %d, expected %d",
+			descriptor.displayName, len(commitment), descriptor.commitmentSize,
+		)
+	}
+	return newMaltCid(codec, commitment)
 }
 
 // newMaltCid creates a CIDv1 with the given codec and commitment bytes.
@@ -130,38 +163,42 @@ func newMaltCid(codec uint64, commitment []byte) (cid.Cid, error) {
 	return cid.NewCidV1(codec, mhash), nil
 }
 
-// IsMaltCid checks if a CID is a typed MALT structure root (map or list, KZG or IPA).
+// IsMaltCid checks if a CID carries a supported MALT version, semantic kind,
+// backend suite, and combination in the 0x30VSBB root-codec layout, using an
+// identity multihash whose digest has the size required by that backend.
 func IsMaltCid(c cid.Cid) bool {
-	switch c.Prefix().Codec {
-	case CodecMaltMapKZG, CodecMaltListKZG, CodecMaltMapIPA, CodecMaltListIPA:
-		return true
-	default:
-		return false
+	_, _, err := decodeRoot(c)
+	return err == nil
+}
+
+// VersionIDOf returns the encoded MALT wire-format version for a codec in the
+// typed-root subrange. It returns zero for values outside that subrange. A
+// nonzero result does not by itself mean the version is supported; use
+// [IsMaltCid] for complete classification.
+func VersionIDOf(c cid.Cid) uint8 {
+	codec := c.Prefix().Codec
+	if codec < codecMaltRootBase || codec > codecMaltRootMax {
+		return 0
 	}
+	return uint8((codec - codecMaltRootBase) >> codecVersionShift)
 }
 
 // SemanticKindOf returns the semantic kind for a typed MALT CID.
 func SemanticKindOf(c cid.Cid) SemanticKind {
-	switch c.Prefix().Codec {
-	case CodecMaltMapKZG, CodecMaltMapIPA:
-		return SemanticKindMap
-	case CodecMaltListKZG, CodecMaltListIPA:
-		return SemanticKindList
-	default:
+	parts, _, err := decodeRoot(c)
+	if err != nil {
 		return SemanticKindUnknown
 	}
+	return parts.semantic
 }
 
 // BackendKindOf returns the backend kind for a typed MALT CID.
 func BackendKindOf(c cid.Cid) BackendKind {
-	switch c.Prefix().Codec {
-	case CodecMaltMapKZG, CodecMaltListKZG:
-		return BackendKindKZG
-	case CodecMaltMapIPA, CodecMaltListIPA:
-		return BackendKindIPA
-	default:
+	parts, _, err := decodeRoot(c)
+	if err != nil {
 		return BackendKindUnknown
 	}
+	return parts.backend.kind
 }
 
 // GetMaltCodec returns the MALT codec value for a CID.
@@ -175,32 +212,29 @@ func GetMaltCodec(c cid.Cid) uint64 {
 
 // ExtractCommitment extracts the raw commitment bytes from a MALT structure CID.
 func ExtractCommitment(c cid.Cid) ([]byte, error) {
-	if !IsMaltCid(c) {
-		return nil, fmt.Errorf("not a MALT commitment CID: codec=%x", c.Prefix().Codec)
+	_, digest, err := decodeRoot(c)
+	return digest, err
+}
+
+func decodeRoot(c cid.Cid) (codecParts, []byte, error) {
+	parts, ok := decodeCodec(c.Prefix().Codec)
+	if !ok {
+		return codecParts{}, nil, fmt.Errorf("not a MALT commitment CID: codec=%x", c.Prefix().Codec)
 	}
 	decoded, err := mh.Decode(c.Hash())
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode multihash: %w", err)
+		return codecParts{}, nil, fmt.Errorf("failed to decode multihash: %w", err)
 	}
 	if decoded.Code != mh.IDENTITY {
-		return nil, fmt.Errorf("expected identity hash, got code=%x", decoded.Code)
+		return codecParts{}, nil, fmt.Errorf("expected identity hash, got code=%x", decoded.Code)
 	}
-	expectedSize := 0
-	switch BackendKindOf(c) {
-	case BackendKindKZG:
-		expectedSize = KZGCommitmentSize
-	case BackendKindIPA:
-		expectedSize = IPACommitmentSize
-	default:
-		return nil, fmt.Errorf("unsupported MALT commitment backend for codec=%x", c.Prefix().Codec)
-	}
-	if len(decoded.Digest) != expectedSize {
-		return nil, fmt.Errorf(
+	if len(decoded.Digest) != parts.backend.commitmentSize {
+		return codecParts{}, nil, fmt.Errorf(
 			"invalid %s commitment size: %d, expected %d",
-			CodecName(c.Prefix().Codec), len(decoded.Digest), expectedSize,
+			CodecName(c.Prefix().Codec), len(decoded.Digest), parts.backend.commitmentSize,
 		)
 	}
-	return decoded.Digest, nil
+	return parts, decoded.Digest, nil
 }
 
 // EqualCommitment reports whether a and b carry the same commitment bytes.
@@ -220,16 +254,96 @@ func EqualCommitment(a, b cid.Cid) (bool, error) {
 
 // CodecName returns the locked wire name for a typed MALT multicodec.
 func CodecName(codec uint64) string {
-	switch codec {
-	case CodecMaltMapKZG:
-		return "malt-map-kzg"
-	case CodecMaltListKZG:
-		return "malt-list-kzg"
-	case CodecMaltMapIPA:
-		return "malt-map-ipa"
-	case CodecMaltListIPA:
-		return "malt-list-ipa"
-	default:
+	parts, ok := decodeCodec(codec)
+	if !ok {
 		return fmt.Sprintf("unknown-%x", codec)
 	}
+	return fmt.Sprintf("malt-%s-%s", parts.semantic, parts.backend.kind)
+}
+
+type codecParts struct {
+	versionID uint8
+	semantic  SemanticKind
+	backend   backendDescriptor
+}
+
+func codecFor(semantic SemanticKind, backend BackendKind) (uint64, backendDescriptor, error) {
+	semanticID, ok := semanticIDForKind(semantic)
+	if !ok {
+		return 0, backendDescriptor{}, fmt.Errorf("unsupported typed cid semantic kind %q", semantic)
+	}
+	descriptor, ok := backendDescriptorForKind(backend)
+	if !ok {
+		return 0, backendDescriptor{}, fmt.Errorf("unsupported typed cid backend %q", backend)
+	}
+	codec := uint64(codecMaltRootBase) |
+		uint64(MALTVersionID)<<codecVersionShift |
+		uint64(semanticID)<<codecSemanticShift |
+		uint64(descriptor.id)
+	return codec, descriptor, nil
+}
+
+func decodeCodec(codec uint64) (codecParts, bool) {
+	if codec < codecMaltRootBase || codec > codecMaltRootMax {
+		return codecParts{}, false
+	}
+	offset := codec - codecMaltRootBase
+	versionID := uint8(offset >> codecVersionShift)
+	if versionID != MALTVersionID {
+		return codecParts{}, false
+	}
+	semanticID := uint8((offset >> codecSemanticShift) & 0x0F)
+	semantic, ok := semanticKindForID(semanticID)
+	if !ok {
+		return codecParts{}, false
+	}
+	descriptor, ok := backendDescriptorForID(uint8(offset & 0xFF))
+	if !ok {
+		return codecParts{}, false
+	}
+	reconstructed, _, err := codecFor(semantic, descriptor.kind)
+	if err != nil || reconstructed != codec {
+		return codecParts{}, false
+	}
+	return codecParts{versionID: versionID, semantic: semantic, backend: descriptor}, true
+}
+
+func semanticIDForKind(kind SemanticKind) (uint8, bool) {
+	switch kind {
+	case SemanticKindMap:
+		return semanticIDMap, true
+	case SemanticKindList:
+		return semanticIDList, true
+	default:
+		return 0, false
+	}
+}
+
+func semanticKindForID(id uint8) (SemanticKind, bool) {
+	switch id {
+	case semanticIDMap:
+		return SemanticKindMap, true
+	case semanticIDList:
+		return SemanticKindList, true
+	default:
+		return SemanticKindUnknown, false
+	}
+}
+
+func backendDescriptorForKind(kind BackendKind) (backendDescriptor, bool) {
+	for _, descriptor := range backendRegistry {
+		if descriptor.kind == kind {
+			return descriptor, true
+		}
+	}
+	return backendDescriptor{}, false
+}
+
+func backendDescriptorForID(id uint8) (backendDescriptor, bool) {
+	for _, descriptor := range backendRegistry {
+		if descriptor.id == id {
+			return descriptor, true
+		}
+	}
+	return backendDescriptor{}, false
 }

--- a/wire/maltcid/codec_test.go
+++ b/wire/maltcid/codec_test.go
@@ -263,6 +263,24 @@ func TestEqualCommitmentAcrossSemanticCodecs(t *testing.T) {
 	}
 }
 
+func TestEqualCommitmentRejectsDifferentBackends(t *testing.T) {
+	kzgCID, err := maltcid.NewMapKZGCid(make([]byte, maltcid.KZGCommitmentSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipaCID, err := maltcid.NewMapIPACid(make([]byte, maltcid.IPACommitmentSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, err := maltcid.EqualCommitment(kzgCID, ipaCID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("EqualCommitment accepted roots from different backend suites")
+	}
+}
+
 func TestCodecName(t *testing.T) {
 	tests := []struct {
 		codec    uint64

--- a/wire/maltcid/codec_test.go
+++ b/wire/maltcid/codec_test.go
@@ -8,6 +8,97 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
+func TestCodecLayout(t *testing.T) {
+	tests := []struct {
+		name     string
+		codec    uint64
+		version  uint8
+		semantic maltcid.SemanticKind
+		backend  maltcid.BackendKind
+	}{
+		{name: "map_kzg", codec: maltcid.CodecMaltMapKZG, version: 1, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindKZG},
+		{name: "list_kzg", codec: maltcid.CodecMaltListKZG, version: 1, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindKZG},
+		{name: "map_ipa", codec: maltcid.CodecMaltMapIPA, version: 1, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindIPA},
+		{name: "list_ipa", codec: maltcid.CodecMaltListIPA, version: 1, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindIPA},
+	}
+	wantCodecs := map[string]uint64{
+		"map_kzg":  0x301101,
+		"list_kzg": 0x301201,
+		"map_ipa":  0x301102,
+		"list_ipa": 0x301202,
+	}
+	if maltcid.MALTVersionID != 1 {
+		t.Fatalf("MALTVersionID = %d, want 1", maltcid.MALTVersionID)
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.codec != wantCodecs[test.name] {
+				t.Fatalf("codec = %#x, want %#x", test.codec, wantCodecs[test.name])
+			}
+			root := cidWithIdentityDigest(t, test.codec, commitmentSize(test.backend))
+			if !maltcid.IsMaltCid(root) {
+				t.Fatal("IsMaltCid rejected a registered codec")
+			}
+			if got := maltcid.VersionIDOf(root); got != test.version {
+				t.Fatalf("VersionIDOf = %d, want %d", got, test.version)
+			}
+			if got := maltcid.SemanticKindOf(root); got != test.semantic {
+				t.Fatalf("SemanticKindOf = %q, want %q", got, test.semantic)
+			}
+			if got := maltcid.BackendKindOf(root); got != test.backend {
+				t.Fatalf("BackendKindOf = %q, want %q", got, test.backend)
+			}
+		})
+	}
+}
+
+func TestCodecClassificationRejectsUnsupportedFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		codec       uint64
+		versionHint uint8
+	}{
+		{name: "old_flat_map_kzg", codec: 0x300001},
+		{name: "old_flat_list_kzg", codec: 0x300002},
+		{name: "old_flat_map_ipa", codec: 0x300003},
+		{name: "old_flat_list_ipa", codec: 0x300004},
+		{name: "version_zero", codec: 0x300101},
+		{name: "version_two", codec: 0x302101, versionHint: 2},
+		{name: "version_fifteen", codec: 0x30F101, versionHint: 15},
+		{name: "semantic_zero", codec: 0x301001, versionHint: 1},
+		{name: "semantic_unknown", codec: 0x301301, versionHint: 1},
+		{name: "semantic_fifteen", codec: 0x301F01, versionHint: 1},
+		{name: "backend_zero", codec: 0x301100, versionHint: 1},
+		{name: "backend_unknown", codec: 0x301103, versionHint: 1},
+		{name: "backend_255", codec: 0x3011FF, versionHint: 1},
+		{name: "outside_root_subrange", codec: 0x311101},
+		{name: "high_bit_alias", codec: 0x100301101},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := cidWithIdentityDigest(t, test.codec, maltcid.KZGCommitmentSize)
+			if maltcid.IsMaltCid(root) {
+				t.Fatalf("IsMaltCid accepted unsupported codec %#x", test.codec)
+			}
+			if got := maltcid.VersionIDOf(root); got != test.versionHint {
+				t.Fatalf("VersionIDOf = %d, want %d", got, test.versionHint)
+			}
+			if got := maltcid.SemanticKindOf(root); got != maltcid.SemanticKindUnknown {
+				t.Fatalf("SemanticKindOf = %q, want unknown", got)
+			}
+			if got := maltcid.BackendKindOf(root); got != maltcid.BackendKindUnknown {
+				t.Fatalf("BackendKindOf = %q, want unknown", got)
+			}
+			if got := maltcid.GetMaltCodec(root); got != 0 {
+				t.Fatalf("GetMaltCodec = %#x, want 0", got)
+			}
+			if _, err := maltcid.ExtractCommitment(root); err == nil {
+				t.Fatal("ExtractCommitment accepted unsupported codec")
+			}
+		})
+	}
+}
+
 func TestNewKZGCid(t *testing.T) {
 	// Create a valid KZG commitment (48 bytes)
 	commitment := make([]byte, maltcid.KZGCommitmentSize)
@@ -37,6 +128,9 @@ func TestNewKZGCid(t *testing.T) {
 	if !maltcid.IsMaltCid(c) {
 		t.Error("Expected IsMaltCid to return true")
 	}
+	if version := maltcid.VersionIDOf(c); version != maltcid.MALTVersionID {
+		t.Errorf("VersionIDOf = %d, want %d", version, maltcid.MALTVersionID)
+	}
 
 	// Extract commitment
 	extracted, err := maltcid.ExtractCommitment(c)
@@ -62,6 +156,26 @@ func TestNewKZGCidInvalidSize(t *testing.T) {
 	_, err := maltcid.NewKZGCid(commitment)
 	if err == nil {
 		t.Error("Expected error for invalid size")
+	}
+}
+
+func TestNewTypedCIDRejectsUnknownKinds(t *testing.T) {
+	tests := []struct {
+		name     string
+		semantic maltcid.SemanticKind
+		backend  maltcid.BackendKind
+	}{
+		{name: "unknown_semantic", semantic: maltcid.SemanticKindUnknown, backend: maltcid.BackendKindKZG},
+		{name: "unknown_backend", semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindUnknown},
+		{name: "unregistered_semantic", semantic: maltcid.SemanticKind("tree"), backend: maltcid.BackendKindKZG},
+		{name: "unregistered_backend", semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKind("future")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := maltcid.NewTypedCID(test.semantic, test.backend, make([]byte, maltcid.KZGCommitmentSize)); err == nil {
+				t.Fatal("NewTypedCID accepted an unregistered kind")
+			}
+		})
 	}
 }
 
@@ -208,10 +322,55 @@ func TestExtractCommitmentRejectsInvalidDigestSize(t *testing.T) {
 					t.Fatalf("encode identity multihash: %v", err)
 				}
 				malformed := cid.NewCidV1(test.codec, hash)
+				if maltcid.IsMaltCid(malformed) {
+					t.Fatalf("IsMaltCid accepted %d-byte digest, want %d", invalidSize, test.size)
+				}
+				if got := maltcid.SemanticKindOf(malformed); got != maltcid.SemanticKindUnknown {
+					t.Fatalf("SemanticKindOf = %q, want unknown", got)
+				}
+				if got := maltcid.BackendKindOf(malformed); got != maltcid.BackendKindUnknown {
+					t.Fatalf("BackendKindOf = %q, want unknown", got)
+				}
 				if _, err := maltcid.ExtractCommitment(malformed); err == nil {
 					t.Fatalf("ExtractCommitment accepted %d-byte digest, want %d", invalidSize, test.size)
 				}
 			})
 		}
 	}
+}
+
+func TestExtractCommitmentRejectsNonIdentityMultihash(t *testing.T) {
+	hash, err := mh.Sum([]byte("not a raw commitment"), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("create sha2-256 multihash: %v", err)
+	}
+	root := cid.NewCidV1(maltcid.CodecMaltMapKZG, hash)
+	if maltcid.IsMaltCid(root) {
+		t.Fatal("IsMaltCid accepted non-identity multihash")
+	}
+	if got := maltcid.SemanticKindOf(root); got != maltcid.SemanticKindUnknown {
+		t.Fatalf("SemanticKindOf = %q, want unknown", got)
+	}
+	if got := maltcid.BackendKindOf(root); got != maltcid.BackendKindUnknown {
+		t.Fatalf("BackendKindOf = %q, want unknown", got)
+	}
+	if _, err := maltcid.ExtractCommitment(root); err == nil {
+		t.Fatal("ExtractCommitment accepted non-identity multihash")
+	}
+}
+
+func cidWithIdentityDigest(t *testing.T, codec uint64, size int) cid.Cid {
+	t.Helper()
+	hash, err := mh.Encode(make([]byte, size), mh.IDENTITY)
+	if err != nil {
+		t.Fatalf("encode identity multihash: %v", err)
+	}
+	return cid.NewCidV1(codec, hash)
+}
+
+func commitmentSize(backend maltcid.BackendKind) int {
+	if backend == maltcid.BackendKindKZG {
+		return maltcid.KZGCommitmentSize
+	}
+	return maltcid.IPACommitmentSize
 }


### PR DESCRIPTION
## Summary

- add a canonical Resolve/Read v1 corpus with 49 KZG/IPA accept/reject vectors, JSON schemas, and a deterministic reference generator
- run the same checked-in vectors through the native Go verifier and the real Go WASM adapter
- define the typed-root codec as `0x30VSBB`: 4-bit `MALTVersionID` (currently `1`), 4-bit semantic ID, and 8-bit commitment-backend suite ID
- bind each backend ID to its commitment encoding and exact size, and fail closed on unknown fields, legacy flat codecs, non-identity multihashes, or malformed commitment lengths
- regenerate the language-neutral vectors and document that the corpus/profile/version domains are independent

Current typed-root codecs are:

| Semantic | Backend | Codec |
| --- | --- | ---: |
| map | KZG | `0x301101` |
| list | KZG | `0x301201` |
| map | IPA | `0x301102` |
| list | IPA | `0x301202` |

This is an intentional pre-release wire replacement. The former `0x300001` through `0x300004` allocations are rejected; there is no compatibility fallback or data migration path.

The negative matrix covers same-backend root splicing, cross-backend evidence, cross-kind confusion, target/range binding tampering, validly framed primitive-proof tampering, missing/truncated/bad-base64 evidence, and unknown JSON fields. Identity remains an explicit zero-step, backend-independent case.

## Validation

- `git diff --check`
- `gofmt -l .`
- `go test -count=1 ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- `sh scripts/test-verifier-wasm-vectors.sh` — 49 vectors passed
- independent final review: no actionable findings
