### PR TITLE
refactor: remove evaluator timing from radix proof path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+- Remove `radix.ProveTimings` and `(*radix.Map).ProveWithTimings`; evaluator
+  timing no longer runs inside the SDK proof path. This is an intentional
+  pre-v1 Go source break.
 - Remove the unused process-global logger, the former HTTP stat/content query
   path helper, and the stale daemon configuration example. These are
   intentional pre-v1 Go source removals after the Gateway/client split.

--- a/auth/semantic/mapping/radix/radix.go
+++ b/auth/semantic/mapping/radix/radix.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
-	"time"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	materializer "github.com/dewebprotocol/malt/auth/arcset/materializer"
@@ -35,15 +34,6 @@ const (
 type Map struct {
 	commitment   *mapping.Commitment
 	materializer materializer.NodeStore
-}
-
-// ProveTimings separates materialization from commitment-open cost for
-// benchmark reporting. LoadElapsedNS covers ArcSet materializer reads and loaded-node
-// validation; OpenElapsedNS covers only commitment ProveSlot calls.
-type ProveTimings struct {
-	LoadElapsedNS int64
-	OpenElapsedNS int64
-	OpenCount     int
 }
 
 // ErrPathNotFound is retained as a compatibility alias for the semantic-level
@@ -115,20 +105,11 @@ func (s *Map) Commit(ctx context.Context, namespace string, view mapping.View) (
 }
 
 func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arcset.Path) (mapping.Binding, structure.Proof, error) {
-	binding, proof, _, err := s.ProveWithTimings(ctx, namespace, root, key)
-	return binding, proof, err
-}
-
-// ProveWithTimings proves the existing binding for key and returns a timing
-// breakdown suitable for evaluation. The returned proof is identical to Prove;
-// timings do not change verifier semantics.
-func (s *Map) ProveWithTimings(ctx context.Context, namespace string, root cid.Cid, key arcset.Path) (mapping.Binding, structure.Proof, ProveTimings, error) {
-	var timings ProveTimings
 	if !root.Defined() {
-		return mapping.Binding{}, nil, timings, fmt.Errorf("root is undefined")
+		return mapping.Binding{}, nil, fmt.Errorf("root is undefined")
 	}
 	if key.IsEmpty() {
-		return mapping.Binding{}, nil, timings, fmt.Errorf("key is empty")
+		return mapping.Binding{}, nil, fmt.Errorf("key is empty")
 	}
 
 	digest := hashPath(key)
@@ -136,25 +117,20 @@ func (s *Map) ProveWithTimings(ctx context.Context, namespace string, root cid.C
 	envelope := proofEnvelope{}
 
 	for depth := 0; depth < len(digest); depth++ {
-		loadStart := time.Now()
 		slots, err := s.loadValidatedNode(ctx, namespace, currentRoot)
-		timings.LoadElapsedNS += time.Since(loadStart).Nanoseconds()
 		if err != nil {
-			return mapping.Binding{}, nil, timings, err
+			return mapping.Binding{}, nil, err
 		}
 
 		slotIndex := digest[depth]
-		openStart := time.Now()
 		value, proof, err := s.commitment.ProveSlot(currentRoot, slots, uint64(slotIndex))
-		timings.OpenElapsedNS += time.Since(openStart).Nanoseconds()
-		timings.OpenCount++
 		if err != nil {
-			return mapping.Binding{}, nil, timings, err
+			return mapping.Binding{}, nil, err
 		}
 
 		slotCID, err := value.AsCID()
 		if err != nil {
-			return mapping.Binding{}, nil, timings, err
+			return mapping.Binding{}, nil, err
 		}
 		envelope.Steps = append(envelope.Steps, proofStep{
 			Slot:  cidBytes(slotCID),
@@ -162,36 +138,34 @@ func (s *Map) ProveWithTimings(ctx context.Context, namespace string, root cid.C
 		})
 
 		if !slotCID.Defined() {
-			return mapping.Binding{}, nil, timings, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+			return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 		}
 
 		if leafPath, leafValue, ok, err := tryDecodeLeafMarker(slotCID); err != nil {
-			return mapping.Binding{}, nil, timings, err
+			return mapping.Binding{}, nil, err
 		} else if ok {
 			if leafPath != key {
-				return mapping.Binding{}, nil, timings, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+				return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 			}
 			proofBytes, err := json.Marshal(envelope)
 			if err != nil {
-				return mapping.Binding{}, nil, timings, err
+				return mapping.Binding{}, nil, err
 			}
-			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), timings, nil
+			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), nil
 		}
 
 		if bucketRoot, ok, err := tryDecodeBucketRef(slotCID); err != nil {
-			return mapping.Binding{}, nil, timings, err
+			return mapping.Binding{}, nil, err
 		} else if ok {
-			loadStart := time.Now()
 			markers, err := s.loadBucketEntries(ctx, namespace, bucketRoot)
-			timings.LoadElapsedNS += time.Since(loadStart).Nanoseconds()
 			if err != nil {
-				return mapping.Binding{}, nil, timings, err
+				return mapping.Binding{}, nil, err
 			}
 			index := -1
 			for i, marker := range markers {
 				leafPath, _, err := decodeLeafMarker(marker)
 				if err != nil {
-					return mapping.Binding{}, nil, timings, err
+					return mapping.Binding{}, nil, err
 				}
 				if leafPath == key {
 					index = i
@@ -199,32 +173,29 @@ func (s *Map) ProveWithTimings(ctx context.Context, namespace string, root cid.C
 				}
 			}
 			if index < 0 {
-				return mapping.Binding{}, nil, timings, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+				return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 			}
 
-			openStart := time.Now()
 			value, proof, err := s.commitment.ProveSlot(bucketRoot, markers, uint64(index))
-			timings.OpenElapsedNS += time.Since(openStart).Nanoseconds()
-			timings.OpenCount++
 			if err != nil {
-				return mapping.Binding{}, nil, timings, err
+				return mapping.Binding{}, nil, err
 			}
 			_, leafValue, err := decodeLeafMarkerCID(value)
 			if err != nil {
-				return mapping.Binding{}, nil, timings, err
+				return mapping.Binding{}, nil, err
 			}
 			envelope.Bucket = &bucketWitness{Proof: proof}
 			proofBytes, err := json.Marshal(envelope)
 			if err != nil {
-				return mapping.Binding{}, nil, timings, err
+				return mapping.Binding{}, nil, err
 			}
-			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), timings, nil
+			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), nil
 		}
 
 		currentRoot = slotCID
 	}
 
-	return mapping.Binding{}, nil, timings, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+	return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 }
 
 func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, proof structure.Proof) (bool, error) {

--- a/auth/semantic/mapping/radix/radix_test.go
+++ b/auth/semantic/mapping/radix/radix_test.go
@@ -2,21 +2,15 @@ package radix_test
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/binary"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
-	materializer "github.com/dewebprotocol/malt/auth/arcset/materializer"
 	materialmemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
 	"github.com/dewebprotocol/malt/auth/commitment"
 	"github.com/dewebprotocol/malt/auth/commitment/ipa"
 	"github.com/dewebprotocol/malt/auth/commitment/kzg"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
 	mappingradix "github.com/dewebprotocol/malt/auth/semantic/mapping/radix"
-	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -108,46 +102,6 @@ func TestMapCommitProveVerify(t *testing.T) {
 				t.Fatal("expected proof to be path-bound")
 			}
 		})
-	}
-}
-
-func TestProveWithTimingsExcludesArcSetLoadTime(t *testing.T) {
-	ctx := context.Background()
-	base := materialmemory.New(true)
-	loadDelay := 120 * time.Millisecond
-	openDelay := 5 * time.Millisecond
-	table := delayedMaterializer{inner: base, delay: loadDelay}
-	semantic, err := mappingradix.NewMap(fakeTimingScheme{proveDelay: openDelay}, table)
-	if err != nil {
-		t.Fatalf("radix.NewMap failed: %v", err)
-	}
-	view := mapping.NewViewFrom(map[string]cid.Cid{
-		"a": fakeCID("value-a"),
-		"b": fakeCID("value-b"),
-	})
-	root, err := semantic.Commit(ctx, testNamespace+"-timing", view)
-	if err != nil {
-		t.Fatalf("Commit failed: %v", err)
-	}
-
-	binding, proof, timings, err := semantic.ProveWithTimings(ctx, testNamespace+"-timing", root, arcset.CanonicalizePath("b"))
-	if err != nil {
-		t.Fatalf("ProveWithTimings failed: %v", err)
-	}
-	if !binding.Present || !binding.Value.Equals(fakeCID("value-b")) || len(proof) == 0 {
-		t.Fatalf("proof result = binding %+v proof bytes %d", binding, len(proof))
-	}
-	if timings.LoadElapsedNS < int64(loadDelay) {
-		t.Fatalf("LoadElapsedNS = %d, want at least injected load delay %s", timings.LoadElapsedNS, loadDelay)
-	}
-	if timings.OpenElapsedNS <= 0 {
-		t.Fatalf("OpenElapsedNS = %d, want positive open/prove time", timings.OpenElapsedNS)
-	}
-	if timings.OpenElapsedNS >= int64(loadDelay/2) {
-		t.Fatalf("OpenElapsedNS = %d includes too much load delay, want below %s", timings.OpenElapsedNS, loadDelay/2)
-	}
-	if timings.OpenCount != 1 {
-		t.Fatalf("OpenCount = %d, want one radix open at this cardinality", timings.OpenCount)
 	}
 }
 
@@ -244,102 +198,6 @@ func TestMapUpdateReplaceInsertDelete(t *testing.T) {
 			}
 		})
 	}
-}
-
-type delayedMaterializer struct {
-	inner materializer.Store
-	delay time.Duration
-}
-
-func (d delayedMaterializer) Get(ctx context.Context, namespace string, root cid.Cid, path arcset.Path) (cid.Cid, error) {
-	time.Sleep(d.delay)
-	return d.inner.Get(ctx, namespace, root, path)
-}
-
-func (d delayedMaterializer) BatchGet(ctx context.Context, namespace string, root cid.Cid, paths []arcset.Path) (map[arcset.Path]cid.Cid, error) {
-	time.Sleep(d.delay)
-	return d.inner.BatchGet(ctx, namespace, root, paths)
-}
-
-func (d delayedMaterializer) Update(ctx context.Context, namespace string, newRoot, oldRoot cid.Cid, arcs arcset.ArcSet) error {
-	return d.inner.Update(ctx, namespace, newRoot, oldRoot, arcs)
-}
-
-func (d delayedMaterializer) Snapshot(ctx context.Context, namespace string, root cid.Cid) (arcset.ArcSet, error) {
-	return d.inner.Snapshot(ctx, namespace, root)
-}
-
-func (d delayedMaterializer) Iterate(ctx context.Context, namespace string, root cid.Cid) arcset.Iterator {
-	return d.inner.Iterate(ctx, namespace, root)
-}
-
-type fakeTimingScheme struct {
-	proveDelay time.Duration
-}
-
-func (s fakeTimingScheme) MaxValues() int { return 256 }
-
-func (s fakeTimingScheme) Commit(values []commitment.Cell) (cid.Cid, error) {
-	return fakeCommitRoot(values)
-}
-
-func (s fakeTimingScheme) Prove(values []commitment.Cell, index uint64) (cid.Cid, commitment.Cell, []byte, error) {
-	time.Sleep(s.proveDelay)
-	if index >= uint64(len(values)) {
-		return cid.Undef, nil, nil, fmt.Errorf("index %d out of range", index)
-	}
-	root, err := s.Commit(values)
-	if err != nil {
-		return cid.Undef, nil, nil, err
-	}
-	return root, commitment.NewCell(values[index]), []byte("proof"), nil
-}
-
-func (s fakeTimingScheme) BatchProve(values []commitment.Cell, indices []uint64) (cid.Cid, []commitment.Cell, []byte, error) {
-	root, err := s.Commit(values)
-	if err != nil {
-		return cid.Undef, nil, nil, err
-	}
-	proved := make([]commitment.Cell, len(indices))
-	for i, index := range indices {
-		if index >= uint64(len(values)) {
-			return cid.Undef, nil, nil, fmt.Errorf("index %d out of range", index)
-		}
-		proved[i] = commitment.NewCell(values[index])
-	}
-	return root, proved, []byte("batch-proof"), nil
-}
-
-func (s fakeTimingScheme) VerifyIndex(cid.Cid, uint64, commitment.Cell, []byte) (bool, error) {
-	return true, nil
-}
-
-func (s fakeTimingScheme) BatchVerify(cid.Cid, []uint64, []commitment.Cell, []byte) (bool, error) {
-	return true, nil
-}
-
-func (s fakeTimingScheme) VerifyProof(cid.Cid, commitment.Cell, []byte) (bool, error) {
-	return true, nil
-}
-
-func (s fakeTimingScheme) Replace(values []commitment.Cell, index uint64, _, newValue commitment.Cell) (cid.Cid, error) {
-	next := commitment.CloneCells(values)
-	if index >= uint64(len(next)) {
-		return cid.Undef, fmt.Errorf("index %d out of range", index)
-	}
-	next[index] = commitment.NewCell(newValue)
-	return s.Commit(next)
-}
-
-func fakeCommitRoot(values []commitment.Cell) (cid.Cid, error) {
-	h := sha256.New()
-	var lenBuf [4]byte
-	for _, value := range values {
-		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(value)))
-		h.Write(lenBuf[:])
-		h.Write(value)
-	}
-	return maltcid.NewMapIPACid(h.Sum(nil))
 }
 
 func TestMapUpdateRejectsInconsistentOldValue(t *testing.T) {


### PR DESCRIPTION
## What changed

- remove the evaluator-specific `radix.ProveTimings` type and `(*radix.Map).ProveWithTimings`
- keep the existing proof construction and error paths directly in `Map.Prove`
- document the intentional pre-v1 Go source break in the unreleased changelog

## Why

The repository split left evaluator timing instrumentation in the core SDK proof hot path. That instrumentation added a production API and wall-clock sampling without contributing to proof or verification semantics. Evaluation timing now belongs in `malt-evaluation`, while core exposes only the proof operation.

## Impact

Go callers using the removed timing API must switch to `Map.Prove` and measure externally. Proof bytes, binding results, verification behavior, and wire formats are unchanged.

## Validation

- `git diff --check` and `gofmt -l`
- `go test ./...`
- `go test -race ./auth/semantic/mapping/radix`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- Windows, Darwin, and JS/WASM cross-builds
- fresh independent pre-PR review: no actionable findings