### PR TITLE
Add verified client-root and evaluation phase contracts

### DIFF
--- a/auth/arcset/canonical.go
+++ b/auth/arcset/canonical.go
@@ -13,6 +13,8 @@ import (
 const (
 	canonicalEncodingMagic   = "MARC"
 	canonicalEncodingVersion = byte(1)
+	canonicalDeltaMagic      = "MDLT"
+	canonicalDeltaVersion    = byte(1)
 )
 
 var (
@@ -120,6 +122,13 @@ func NewListCoordinate(index int64) (CanonicalCoordinate, error) {
 		return CanonicalCoordinate{}, ErrInvalidListCoordinate
 	}
 	return newListCoordinate(uint64(index)), nil
+}
+
+// NewListCoordinateUint64 encodes the full non-negative list-index domain.
+// It complements NewListCoordinate for wire decoders and APIs whose index is
+// already represented as uint64.
+func NewListCoordinateUint64(index uint64) CanonicalCoordinate {
+	return newListCoordinate(index)
 }
 
 func newListCoordinate(index uint64) CanonicalCoordinate {
@@ -393,6 +402,75 @@ func (s *CanonicalArcSet) MarshalBinary() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// MarshalBinary encodes a canonical arc delta deterministically. The encoding
+// is suitable for digest inputs and portable writer contracts; callers must
+// still validate the surrounding base object and dependency graph.
+func (d *CanonicalArcDelta) MarshalBinary() ([]byte, error) {
+	if d == nil {
+		return nil, errors.New("canonical arc delta is nil")
+	}
+	if err := validateKind(d.kind); err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(canonicalDeltaMagic)
+	buf.WriteByte(canonicalDeltaVersion)
+	writeBytes(&buf, []byte(d.kind))
+	writeUint32(&buf, uint32(len(d.changes)))
+	for _, change := range d.changes {
+		writeBytes(&buf, change.Coordinate.bytes)
+		writeOptionalTarget(&buf, change.Before)
+		writeOptionalTarget(&buf, change.After)
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalCanonicalArcDelta decodes the deterministic canonical delta
+// encoding and re-runs all canonical ordering, coordinate, target, duplicate,
+// and no-op validation.
+func UnmarshalCanonicalArcDelta(data []byte) (*CanonicalArcDelta, error) {
+	decoder := canonicalDecoder{data: data}
+	if string(decoder.readFixed(len(canonicalDeltaMagic))) != canonicalDeltaMagic {
+		return nil, errors.New("invalid canonical arc delta encoding")
+	}
+	version := decoder.readByte()
+	if version != canonicalDeltaVersion {
+		return nil, fmt.Errorf("unsupported canonical arc delta encoding version %d", version)
+	}
+
+	kind := Kind(decoder.readBytesAsString())
+	count := decoder.readUint32()
+	changes := make([]ArcChange, 0, count)
+	for i := uint32(0); i < count; i++ {
+		coordBytes := decoder.readBytes()
+		before := decoder.readOptionalTarget()
+		after := decoder.readOptionalTarget()
+		changes = append(changes, ArcChange{
+			Coordinate: coordinateFromEncodedBytes(kind, coordBytes),
+			Before:     before,
+			After:      after,
+		})
+	}
+	if decoder.err != nil {
+		return nil, decoder.err
+	}
+	if decoder.pos != len(decoder.data) {
+		return nil, errors.New("canonical arc delta encoding has trailing bytes")
+	}
+	return NewCanonicalArcDelta(kind, changes)
+}
+
+func writeOptionalTarget(buf *bytes.Buffer, target *TargetRef) {
+	if target == nil {
+		buf.WriteByte(0)
+		return
+	}
+	buf.WriteByte(1)
+	writeBytes(buf, []byte(target.kind))
+	writeBytes(buf, target.target.Bytes())
+}
+
 // UnmarshalCanonicalArcSet decodes a deterministic canonical arc set encoding.
 func UnmarshalCanonicalArcSet(data []byte) (*CanonicalArcSet, error) {
 	decoder := canonicalDecoder{data: data}
@@ -627,6 +705,33 @@ type canonicalDecoder struct {
 	data []byte
 	pos  int
 	err  error
+}
+
+func (d *canonicalDecoder) readOptionalTarget() *TargetRef {
+	present := d.readByte()
+	if d.err != nil {
+		return nil
+	}
+	switch present {
+	case 0:
+		return nil
+	case 1:
+		kind := TargetKind(d.readBytesAsString())
+		cidBytes := d.readBytes()
+		if d.err != nil {
+			return nil
+		}
+		target, err := cid.Cast(cidBytes)
+		if err != nil {
+			d.err = err
+			return nil
+		}
+		value := NewTargetRef(kind, target)
+		return &value
+	default:
+		d.err = fmt.Errorf("invalid optional target marker %d", present)
+		return nil
+	}
 }
 
 func (d *canonicalDecoder) readFixed(n int) []byte {

--- a/auth/arcset/canonical.go
+++ b/auth/arcset/canonical.go
@@ -441,6 +441,9 @@ func UnmarshalCanonicalArcDelta(data []byte) (*CanonicalArcDelta, error) {
 
 	kind := Kind(decoder.readBytesAsString())
 	count := decoder.readUint32()
+	if !decoder.requireCollectionBytes(count, 6, "canonical arc delta changes") {
+		return nil, decoder.err
+	}
 	changes := make([]ArcChange, 0, count)
 	for i := uint32(0); i < count; i++ {
 		coordBytes := decoder.readBytes()
@@ -484,6 +487,9 @@ func UnmarshalCanonicalArcSet(data []byte) (*CanonicalArcSet, error) {
 
 	kind := Kind(decoder.readBytesAsString())
 	count := decoder.readUint32()
+	if !decoder.requireCollectionBytes(count, 12, "canonical arc set entries") {
+		return nil, decoder.err
+	}
 	entries := make([]ArcEntry, 0, count)
 	for i := uint32(0); i < count; i++ {
 		coordBytes := decoder.readBytes()
@@ -732,6 +738,18 @@ func (d *canonicalDecoder) readOptionalTarget() *TargetRef {
 		d.err = fmt.Errorf("invalid optional target marker %d", present)
 		return nil
 	}
+}
+
+func (d *canonicalDecoder) requireCollectionBytes(count uint32, minimumBytesPerItem uint64, label string) bool {
+	if d.err != nil {
+		return false
+	}
+	remaining := len(d.data) - d.pos
+	if uint64(count)*minimumBytesPerItem > uint64(remaining) {
+		d.err = fmt.Errorf("%s count %d exceeds remaining encoded bytes", label, count)
+		return false
+	}
+	return true
 }
 
 func (d *canonicalDecoder) readFixed(n int) []byte {

--- a/auth/arcset/canonical_delta_encoding_test.go
+++ b/auth/arcset/canonical_delta_encoding_test.go
@@ -1,0 +1,100 @@
+package arcset
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestCanonicalArcDeltaBinaryRoundTrip(t *testing.T) {
+	before := NewCASTarget(deltaTestCID(t, "before"))
+	after := NewMapTarget(deltaTestCID(t, "after"))
+	insert := NewListTarget(deltaTestCID(t, "insert"))
+	delta, err := NewCanonicalArcDelta(KindMap, []ArcChange{
+		{Coordinate: mustMapCoordinate(t, "z"), Before: &before, After: &after},
+		{Coordinate: mustMapCoordinate(t, "a"), After: &insert},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encoded, err := delta.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := UnmarshalCanonicalArcDelta(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reencoded, err := decoded.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(encoded, reencoded) {
+		t.Fatalf("delta encoding changed after round trip\nfirst:  %x\nsecond: %x", encoded, reencoded)
+	}
+	changes := decoded.Changes()
+	if len(changes) != 2 || changes[0].Coordinate.String() != "a" || changes[0].Before != nil || changes[0].After == nil {
+		t.Fatalf("decoded changes = %#v", changes)
+	}
+}
+
+func TestCanonicalArcDeltaBinaryRejectsTampering(t *testing.T) {
+	target := NewCASTarget(deltaTestCID(t, "target"))
+	delta, err := NewCanonicalArcDelta(KindMap, []ArcChange{{
+		Coordinate: mustMapCoordinate(t, "name"),
+		After:      &target,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := delta.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "truncated", data: encoded[:len(encoded)-1]},
+		{name: "trailing", data: append(append([]byte(nil), encoded...), 0)},
+		{name: "wrong magic", data: append([]byte("XXXX"), encoded[4:]...)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := UnmarshalCanonicalArcDelta(test.data); err == nil {
+				t.Fatal("tampered delta encoding was accepted")
+			}
+		})
+	}
+
+	badMarker := append([]byte(nil), encoded...)
+	// MARC/MDLT header + version + kind length/kind + count + coordinate
+	// length/coordinate places the first optional target marker here.
+	marker := bytes.Index(badMarker, []byte("name")) + len("name")
+	badMarker[marker] = 2
+	if _, err := UnmarshalCanonicalArcDelta(badMarker); err == nil || errors.Is(err, nil) {
+		t.Fatal("invalid optional target marker was accepted")
+	}
+}
+
+func mustMapCoordinate(t *testing.T, value string) CanonicalCoordinate {
+	t.Helper()
+	coordinate, err := NewMapCoordinate(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return coordinate
+}
+
+func deltaTestCID(t *testing.T, value string) cid.Cid {
+	t.Helper()
+	hash, err := mh.Sum([]byte(value), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cid.NewCidV1(cid.Raw, hash)
+}

--- a/auth/arcset/canonical_delta_encoding_test.go
+++ b/auth/arcset/canonical_delta_encoding_test.go
@@ -2,6 +2,7 @@ package arcset
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"testing"
 
@@ -78,6 +79,25 @@ func TestCanonicalArcDeltaBinaryRejectsTampering(t *testing.T) {
 	badMarker[marker] = 2
 	if _, err := UnmarshalCanonicalArcDelta(badMarker); err == nil || errors.Is(err, nil) {
 		t.Fatal("invalid optional target marker was accepted")
+	}
+}
+
+func TestCanonicalDecodersRejectImpossibleCountsBeforeAllocation(t *testing.T) {
+	encodeHeader := func(magic string, version byte, kind Kind) []byte {
+		var buffer bytes.Buffer
+		buffer.WriteString(magic)
+		buffer.WriteByte(version)
+		writeBytes(&buffer, []byte(kind))
+		var count [4]byte
+		binary.BigEndian.PutUint32(count[:], ^uint32(0))
+		buffer.Write(count[:])
+		return buffer.Bytes()
+	}
+	if _, err := UnmarshalCanonicalArcDelta(encodeHeader(canonicalDeltaMagic, canonicalDeltaVersion, KindMap)); err == nil {
+		t.Fatal("delta decoder accepted an impossible collection count")
+	}
+	if _, err := UnmarshalCanonicalArcSet(encodeHeader(canonicalEncodingMagic, canonicalEncodingVersion, KindMap)); err == nil {
+		t.Fatal("arc-set decoder accepted an impossible collection count")
 	}
 }
 

--- a/auth/commitment/commitment.go
+++ b/auth/commitment/commitment.go
@@ -43,6 +43,22 @@ type IndexProver interface {
 	Replace(values []Cell, index uint64, oldValue, newValue Cell) (cid.Cid, error)
 }
 
+// IndexOpening is an opaque, prepared witness for one committed vector. Root
+// returns the commitment computed while the witness was prepared. Open
+// generates an index proof without recomputing that commitment.
+type IndexOpening interface {
+	Root() cid.Cid
+	Open(index uint64) (value Cell, proof []byte, err error)
+}
+
+// IndexOpener is the optional execution capability for separating commitment
+// preparation from proof generation. Preparing an opening computes and binds
+// the root once; callers must keep PrepareOpening outside an independently
+// measured Open interval.
+type IndexOpener interface {
+	PrepareOpening(values []Cell) (IndexOpening, error)
+}
+
 // IndexCommitment is the full execution backend. Client verification code
 // should depend on IndexVerifier instead.
 type IndexCommitment interface {

--- a/auth/commitment/ipa/ipa.go
+++ b/auth/commitment/ipa/ipa.go
@@ -38,6 +38,8 @@ type Scheme struct {
 	ipaConfig *ipa.IPAConfig
 }
 
+var _ commitment.IndexOpener = (*Scheme)(nil)
+
 // NewScheme creates a new IPA commitment scheme.
 func NewScheme() (*Scheme, error) {
 	ipaConfig, err := ipa.NewIPASettings()
@@ -71,6 +73,31 @@ func (s *Scheme) Prove(values []commitment.Cell, index uint64) (cid.Cid, commitm
 	}
 	value, proof, err := s.proveValuesIndex(comm, values, index)
 	return comm, value, proof, err
+}
+
+type opening struct {
+	scheme *Scheme
+	root   cid.Cid
+	values []commitment.Cell
+}
+
+// PrepareOpening computes a commitment once and returns an opaque witness
+// whose Open method reuses that commitment in the IPA transcript.
+func (s *Scheme) PrepareOpening(values []commitment.Cell) (commitment.IndexOpening, error) {
+	root, err := s.commitValues(values)
+	if err != nil {
+		return nil, err
+	}
+	return &opening{scheme: s, root: root, values: commitment.CloneCells(values)}, nil
+}
+
+func (o *opening) Root() cid.Cid { return o.root }
+
+func (o *opening) Open(index uint64) (commitment.Cell, []byte, error) {
+	if index >= uint64(len(o.values)) {
+		return nil, nil, fmt.Errorf("index %d out of range", index)
+	}
+	return o.scheme.proveValuesIndex(o.root, o.values, index)
 }
 
 // BatchProve proves multiple stable indices with one batch proof payload.

--- a/auth/commitment/ipa/ipa_test.go
+++ b/auth/commitment/ipa/ipa_test.go
@@ -92,6 +92,48 @@ func TestIPAProveIsStateless(t *testing.T) {
 	}
 }
 
+func TestIPAPreparedOpeningBindsRootAndClonesWitness(t *testing.T) {
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme failed: %v", err)
+	}
+	values := []commitment.Cell{
+		commitment.NewCell([]byte("slot0")),
+		commitment.NewCell([]byte("slot1")),
+	}
+	wantRoot, err := scheme.Commit(values)
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	prepared, err := scheme.PrepareOpening(values)
+	if err != nil {
+		t.Fatalf("PrepareOpening failed: %v", err)
+	}
+	if !prepared.Root().Equals(wantRoot) {
+		t.Fatalf("prepared root %s, want %s", prepared.Root(), wantRoot)
+	}
+
+	values[1] = commitment.NewCell([]byte("attacker replacement"))
+	value, proof, err := prepared.Open(1)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	if value.Equal(values[1]) {
+		t.Fatal("prepared opening retained caller-owned mutable witness")
+	}
+	ok, err := scheme.VerifyIndex(prepared.Root(), 1, value, proof)
+	if err != nil || !ok {
+		t.Fatalf("VerifyIndex = %v, %v; want true, nil", ok, err)
+	}
+	otherRoot, err := scheme.Commit(values)
+	if err != nil {
+		t.Fatalf("Commit(other) failed: %v", err)
+	}
+	if ok, err := scheme.VerifyIndex(otherRoot, 1, value, proof); err == nil && ok {
+		t.Fatal("prepared proof verified against a mismatched root")
+	}
+}
+
 func TestIPAReplaceIsStateless(t *testing.T) {
 	scheme, err := ipa.NewScheme()
 	if err != nil {

--- a/auth/commitment/kzg/kzg.go
+++ b/auth/commitment/kzg/kzg.go
@@ -34,6 +34,8 @@ type Scheme struct {
 	domainPoints []gokzg4844.Scalar
 }
 
+var _ commitment.IndexOpener = (*Scheme)(nil)
+
 // NewScheme creates a new KZG commitment scheme.
 func NewScheme() (*Scheme, error) {
 	context, err := gokzg4844.NewContext4096Secure()
@@ -72,6 +74,31 @@ func (s *Scheme) Prove(values []commitment.Cell, index uint64) (cid.Cid, commitm
 	}
 	value, proof, err := s.proveValuesIndex(values, index)
 	return comm, value, proof, err
+}
+
+type opening struct {
+	scheme *Scheme
+	root   cid.Cid
+	values []commitment.Cell
+}
+
+// PrepareOpening computes a commitment once and returns an opaque witness
+// whose Open method never calls BlobToKZGCommitment.
+func (s *Scheme) PrepareOpening(values []commitment.Cell) (commitment.IndexOpening, error) {
+	root, err := s.commitValues(values)
+	if err != nil {
+		return nil, err
+	}
+	return &opening{scheme: s, root: root, values: commitment.CloneCells(values)}, nil
+}
+
+func (o *opening) Root() cid.Cid { return o.root }
+
+func (o *opening) Open(index uint64) (commitment.Cell, []byte, error) {
+	if index >= uint64(len(o.values)) {
+		return nil, nil, fmt.Errorf("index %d out of range", index)
+	}
+	return o.scheme.proveValuesIndex(o.values, index)
 }
 
 func (s *Scheme) proveValuesIndex(values []commitment.Cell, index uint64) (commitment.Cell, []byte, error) {

--- a/auth/commitment/kzg/kzg_test.go
+++ b/auth/commitment/kzg/kzg_test.go
@@ -52,6 +52,49 @@ func TestKZGProveIsStateless(t *testing.T) {
 	}
 }
 
+func TestKZGPreparedOpeningBindsRootAndClonesWitness(t *testing.T) {
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme failed: %v", err)
+	}
+	values := []commitment.Cell{
+		commitment.NewCell([]byte("slot0")),
+		commitment.NewCell([]byte("slot1")),
+	}
+	wantRoot, err := scheme.Commit(values)
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	prepared, err := scheme.PrepareOpening(values)
+	if err != nil {
+		t.Fatalf("PrepareOpening failed: %v", err)
+	}
+	if !prepared.Root().Equals(wantRoot) {
+		t.Fatalf("prepared root %s, want %s", prepared.Root(), wantRoot)
+	}
+
+	// Mutating the caller-owned witness cannot relabel the prepared root.
+	values[1] = commitment.NewCell([]byte("attacker replacement"))
+	value, proof, err := prepared.Open(1)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	if value.Equal(values[1]) {
+		t.Fatal("prepared opening retained caller-owned mutable witness")
+	}
+	ok, err := scheme.VerifyIndex(prepared.Root(), 1, value, proof)
+	if err != nil || !ok {
+		t.Fatalf("VerifyIndex = %v, %v; want true, nil", ok, err)
+	}
+	otherRoot, err := scheme.Commit(values)
+	if err != nil {
+		t.Fatalf("Commit(other) failed: %v", err)
+	}
+	if ok, err := scheme.VerifyIndex(otherRoot, 1, value, proof); err == nil && ok {
+		t.Fatal("prepared proof verified against a mismatched root")
+	}
+}
+
 func TestKZGBatchProveIsStateless(t *testing.T) {
 	scheme, err := kzg.NewScheme()
 	if err != nil {

--- a/auth/observation/phase.go
+++ b/auth/observation/phase.go
@@ -1,0 +1,72 @@
+// Package observation provides request-scoped, optional execution phase
+// observations. Observations are diagnostics only: they are never proof
+// evidence and cannot affect protocol results.
+package observation
+
+import (
+	"context"
+	"time"
+)
+
+// Phase names the stable server-side phases used by the paper evaluator.
+type Phase string
+
+const (
+	PhaseArcTable        Phase = "arc-table"
+	PhaseMaterialization Phase = "materialization"
+	PhaseOpen            Phase = "open"
+	PhaseSerialization   Phase = "serialization"
+)
+
+// Sample is one completed phase observation. Operations counts logical calls;
+// Items and Bytes describe materialized or serialized data when known.
+type Sample struct {
+	Phase      Phase
+	DurationNS uint64
+	Operations uint64
+	Items      uint64
+	Bytes      uint64
+}
+
+// Observer consumes synchronous request-scoped samples. Implementations must
+// not retain or mutate protocol inputs.
+type Observer interface {
+	ObservePhase(Sample)
+}
+
+type contextKey struct{}
+
+// WithObserver attaches an optional observer to ctx.
+func WithObserver(ctx context.Context, observer Observer) context.Context {
+	if observer == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, contextKey{}, observer)
+}
+
+// Start begins a phase span. The returned closure is allocation-free when no
+// observer is attached and may be called exactly once with observed volume.
+func Start(ctx context.Context, phase Phase) func(operations, items, bytes uint64) {
+	observer, _ := ctx.Value(contextKey{}).(Observer)
+	if observer == nil {
+		return func(uint64, uint64, uint64) {}
+	}
+	started := time.Now()
+	return func(operations, items, bytes uint64) {
+		duration := time.Since(started)
+		var nanos uint64
+		if duration > 0 {
+			nanos = uint64(duration)
+		}
+		observer.ObservePhase(Sample{Phase: phase, DurationNS: nanos, Operations: operations, Items: items, Bytes: bytes})
+	}
+}
+
+// Record adds a phase sample measured by an outer boundary such as wire
+// serialization.
+func Record(ctx context.Context, sample Sample) {
+	observer, _ := ctx.Value(contextKey{}).(Observer)
+	if observer != nil {
+		observer.ObservePhase(sample)
+	}
+}

--- a/auth/observation/phase.go
+++ b/auth/observation/phase.go
@@ -44,6 +44,13 @@ func WithObserver(ctx context.Context, observer Observer) context.Context {
 	return context.WithValue(ctx, contextKey{}, observer)
 }
 
+// Enabled reports whether ctx carries a phase observer. Hot paths use this to
+// avoid computing optional volume diagnostics when observations are disabled.
+func Enabled(ctx context.Context) bool {
+	observer, _ := ctx.Value(contextKey{}).(Observer)
+	return observer != nil
+}
+
 // Start begins a phase span. The returned closure is allocation-free when no
 // observer is attached and may be called exactly once with observed volume.
 func Start(ctx context.Context, phase Phase) func(operations, items, bytes uint64) {

--- a/auth/observation/phase_test.go
+++ b/auth/observation/phase_test.go
@@ -1,0 +1,22 @@
+package observation
+
+import (
+	"context"
+	"testing"
+)
+
+type collector struct{ samples []Sample }
+
+func (c *collector) ObservePhase(sample Sample) { c.samples = append(c.samples, sample) }
+
+func TestRequestScopedObservation(t *testing.T) {
+	value := new(collector)
+	ctx := WithObserver(context.Background(), value)
+	done := Start(ctx, PhaseOpen)
+	done(2, 3, 4)
+	Record(ctx, Sample{Phase: PhaseSerialization, DurationNS: 5, Operations: 1, Bytes: 6})
+	if len(value.samples) != 2 || value.samples[0].Phase != PhaseOpen || value.samples[0].Operations != 2 || value.samples[0].Items != 3 || value.samples[0].Bytes != 4 || value.samples[1].DurationNS != 5 {
+		t.Fatalf("samples = %#v", value.samples)
+	}
+	Start(context.Background(), PhaseArcTable)(1, 1, 1)
+}

--- a/auth/observation/phase_test.go
+++ b/auth/observation/phase_test.go
@@ -12,6 +12,9 @@ func (c *collector) ObservePhase(sample Sample) { c.samples = append(c.samples, 
 func TestRequestScopedObservation(t *testing.T) {
 	value := new(collector)
 	ctx := WithObserver(context.Background(), value)
+	if !Enabled(ctx) || Enabled(context.Background()) {
+		t.Fatal("observer enabled state does not follow request context")
+	}
 	done := Start(ctx, PhaseOpen)
 	done(2, 3, 4)
 	Record(ctx, Sample{Phase: PhaseSerialization, DurationNS: 5, Operations: 1, Bytes: 6})

--- a/auth/semantic/mapping/radix/observation_test.go
+++ b/auth/semantic/mapping/radix/observation_test.go
@@ -1,0 +1,66 @@
+package radix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materializermemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/observation"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+type phaseCollector struct{ samples []observation.Sample }
+
+func (c *phaseCollector) ObservePhase(sample observation.Sample) {
+	c.samples = append(c.samples, sample)
+}
+
+func TestProveReportsMaterializationOpenAndSerialization(t *testing.T) {
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	semanticMap, err := NewMap(scheme, materializermemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := observedRawCID(t, []byte("target"))
+	root, err := semanticMap.Commit(t.Context(), "observation", mapping.NewViewFrom(map[string]cid.Cid{"payload": target}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	collector := new(phaseCollector)
+	ctx := observation.WithObserver(context.Background(), collector)
+	binding, proof, err := semanticMap.Prove(ctx, "observation", root, arcset.Path("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !binding.Value.Equals(target) || len(proof) == 0 {
+		t.Fatalf("binding=%#v proof=%d", binding, len(proof))
+	}
+	seen := map[observation.Phase]bool{}
+	for _, sample := range collector.samples {
+		seen[sample.Phase] = true
+		if sample.Operations == 0 {
+			t.Fatalf("empty observation sample = %#v", sample)
+		}
+	}
+	for _, phase := range []observation.Phase{observation.PhaseMaterialization, observation.PhaseOpen, observation.PhaseSerialization} {
+		if !seen[phase] {
+			t.Fatalf("missing phase %q in %#v", phase, collector.samples)
+		}
+	}
+}
+
+func observedRawCID(t *testing.T, data []byte) cid.Cid {
+	t.Helper()
+	digest, err := mh.Sum(data, mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cid.NewCidV1(cid.Raw, digest)
+}

--- a/auth/semantic/mapping/radix/radix.go
+++ b/auth/semantic/mapping/radix/radix.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dewebprotocol/malt/auth/arcset"
 	materializer "github.com/dewebprotocol/malt/auth/arcset/materializer"
 	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/observation"
 	"github.com/dewebprotocol/malt/auth/semantic"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
 	cid "github.com/ipfs/go-cid"
@@ -117,13 +118,17 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 	envelope := proofEnvelope{}
 
 	for depth := 0; depth < len(digest); depth++ {
+		finishMaterialization := observation.Start(ctx, observation.PhaseMaterialization)
 		slots, err := s.loadValidatedNode(ctx, namespace, currentRoot)
+		finishMaterialization(1, uint64(len(slots)), cidVectorBytes(slots))
 		if err != nil {
 			return mapping.Binding{}, nil, err
 		}
 
 		slotIndex := digest[depth]
+		finishOpen := observation.Start(ctx, observation.PhaseOpen)
 		value, proof, err := s.commitment.ProveSlot(currentRoot, slots, uint64(slotIndex))
+		finishOpen(1, 1, uint64(len(proof)))
 		if err != nil {
 			return mapping.Binding{}, nil, err
 		}
@@ -147,7 +152,9 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 			if leafPath != key {
 				return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 			}
+			finishSerialization := observation.Start(ctx, observation.PhaseSerialization)
 			proofBytes, err := json.Marshal(envelope)
+			finishSerialization(1, uint64(len(envelope.Steps)), uint64(len(proofBytes)))
 			if err != nil {
 				return mapping.Binding{}, nil, err
 			}
@@ -157,7 +164,9 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 		if bucketRoot, ok, err := tryDecodeBucketRef(slotCID); err != nil {
 			return mapping.Binding{}, nil, err
 		} else if ok {
+			finishMaterialization := observation.Start(ctx, observation.PhaseMaterialization)
 			markers, err := s.loadBucketEntries(ctx, namespace, bucketRoot)
+			finishMaterialization(1, uint64(len(markers)), cidVectorBytes(markers))
 			if err != nil {
 				return mapping.Binding{}, nil, err
 			}
@@ -176,7 +185,9 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 				return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 			}
 
+			finishOpen := observation.Start(ctx, observation.PhaseOpen)
 			value, proof, err := s.commitment.ProveSlot(bucketRoot, markers, uint64(index))
+			finishOpen(1, 1, uint64(len(proof)))
 			if err != nil {
 				return mapping.Binding{}, nil, err
 			}
@@ -185,7 +196,9 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 				return mapping.Binding{}, nil, err
 			}
 			envelope.Bucket = &bucketWitness{Proof: proof}
+			finishSerialization := observation.Start(ctx, observation.PhaseSerialization)
 			proofBytes, err := json.Marshal(envelope)
+			finishSerialization(1, uint64(len(envelope.Steps))+1, uint64(len(proofBytes)))
 			if err != nil {
 				return mapping.Binding{}, nil, err
 			}
@@ -1143,6 +1156,16 @@ func cellsFromCIDs(values []cid.Cid) []commitment.Cell {
 
 func cloneCIDs(values []cid.Cid) []cid.Cid {
 	return append([]cid.Cid(nil), values...)
+}
+
+func cidVectorBytes(values []cid.Cid) uint64 {
+	var total uint64
+	for _, value := range values {
+		if value.Defined() {
+			total += uint64(len(value.Bytes()))
+		}
+	}
+	return total
 }
 
 func cidEqual(a, b cid.Cid) bool {

--- a/auth/semantic/mapping/radix/radix.go
+++ b/auth/semantic/mapping/radix/radix.go
@@ -120,7 +120,11 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 	for depth := 0; depth < len(digest); depth++ {
 		finishMaterialization := observation.Start(ctx, observation.PhaseMaterialization)
 		slots, err := s.loadValidatedNode(ctx, namespace, currentRoot)
-		finishMaterialization(1, uint64(len(slots)), cidVectorBytes(slots))
+		var materializedBytes uint64
+		if observation.Enabled(ctx) {
+			materializedBytes = cidVectorBytes(slots)
+		}
+		finishMaterialization(1, uint64(len(slots)), materializedBytes)
 		if err != nil {
 			return mapping.Binding{}, nil, err
 		}
@@ -166,7 +170,11 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 		} else if ok {
 			finishMaterialization := observation.Start(ctx, observation.PhaseMaterialization)
 			markers, err := s.loadBucketEntries(ctx, namespace, bucketRoot)
-			finishMaterialization(1, uint64(len(markers)), cidVectorBytes(markers))
+			var materializedBytes uint64
+			if observation.Enabled(ctx) {
+				materializedBytes = cidVectorBytes(markers)
+			}
+			finishMaterialization(1, uint64(len(markers)), materializedBytes)
 			if err != nil {
 				return mapping.Binding{}, nil, err
 			}
@@ -1162,7 +1170,7 @@ func cidVectorBytes(values []cid.Cid) uint64 {
 	var total uint64
 	for _, value := range values {
 		if value.Defined() {
-			total += uint64(len(value.Bytes()))
+			total += uint64(value.ByteLen())
 		}
 	}
 	return total

--- a/graph/resolver/step/explicit/explicit.go
+++ b/graph/resolver/step/explicit/explicit.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/auth/observation"
 	"github.com/dewebprotocol/malt/auth/proof/evidence"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
 	"github.com/dewebprotocol/malt/graph/resolver/step"
@@ -66,7 +67,13 @@ func (r *Resolver) Resolve(ctx context.Context, root cid.Cid, path arcset.Path) 
 	for i := len(segments); i > 0; i-- {
 		candidatePath := arcset.Path(strings.Join(segments[:i], "/"))
 
+		finishLookup := observation.Start(ctx, observation.PhaseArcTable)
 		target, err := r.materializer.Get(ctx, r.namespace, root, candidatePath)
+		var targetBytes uint64
+		if target.Defined() {
+			targetBytes = uint64(len(target.Bytes()))
+		}
+		finishLookup(1, 1, targetBytes)
 		if err == nil {
 			// Found a match, generate proof
 			binding, proof, err := r.semantic.Prove(ctx, r.namespace, root, candidatePath)

--- a/graph/resolver/step/explicit/explicit.go
+++ b/graph/resolver/step/explicit/explicit.go
@@ -70,8 +70,8 @@ func (r *Resolver) Resolve(ctx context.Context, root cid.Cid, path arcset.Path) 
 		finishLookup := observation.Start(ctx, observation.PhaseArcTable)
 		target, err := r.materializer.Get(ctx, r.namespace, root, candidatePath)
 		var targetBytes uint64
-		if target.Defined() {
-			targetBytes = uint64(len(target.Bytes()))
+		if observation.Enabled(ctx) && target.Defined() {
+			targetBytes = uint64(target.ByteLen())
 		}
 		finishLookup(1, 1, targetBytes)
 		if err == nil {

--- a/mutation/client_root.go
+++ b/mutation/client_root.go
@@ -177,6 +177,11 @@ func NormalizeUpdateView(view UpdateView) (UpdateView, error) {
 		if object.Entries == nil || object.Entries.Kind() != object.Kind {
 			return UpdateView{}, fmt.Errorf("%w: object %q vector/kind mismatch", ErrInvalidUpdateView, object.ObjectID)
 		}
+		for _, entry := range object.Entries.Entries() {
+			if !clientRootTargetKindMatchesCID(entry.Target) {
+				return UpdateView{}, fmt.Errorf("%w: object %q target kind does not match CID semantics at %q", ErrInvalidUpdateView, object.ObjectID, entry.Coordinate.String())
+			}
+		}
 		if object.Commit.FixedList != nil && object.Kind != arcset.KindList {
 			return UpdateView{}, fmt.Errorf("%w: object %q has map fixed-list descriptor", ErrInvalidUpdateView, object.ObjectID)
 		}
@@ -409,6 +414,12 @@ func normalizeIntentTransition(transition IntentTransition, object UpdateObject)
 		}
 		if change.After != nil && change.OutputID != "" {
 			return IntentTransition{}, fmt.Errorf("%w: transition %q coordinate %q has both literal and output post-image", ErrInvalidSemanticIntent, transition.ID, change.Coordinate.String())
+		}
+		if change.Before != nil && !clientRootTargetKindMatchesCID(*change.Before) {
+			return IntentTransition{}, fmt.Errorf("%w: transition %q before target kind/CID mismatch at %q", ErrInvalidSemanticIntent, transition.ID, change.Coordinate.String())
+		}
+		if change.After != nil && !clientRootTargetKindMatchesCID(*change.After) {
+			return IntentTransition{}, fmt.Errorf("%w: transition %q after target kind/CID mismatch at %q", ErrInvalidSemanticIntent, transition.ID, change.Coordinate.String())
 		}
 		if change.OutputID != "" {
 			if !validClientRootID(change.OutputID) || change.OutputKind != arcset.TargetKindMap && change.OutputKind != arcset.TargetKindList {
@@ -664,6 +675,24 @@ func semanticTargetKind(target arcset.TargetRef) (arcset.Kind, bool) {
 		return arcset.KindList, true
 	default:
 		return "", false
+	}
+}
+
+// clientRootTargetKindMatchesCID prevents an untrusted update view from
+// relabeling a typed semantic child as opaque CAS data (and thereby escaping
+// closure validation), or from relabeling an ordinary payload as a semantic
+// child. Unknown/CAS remain valid spellings only for non-MALT payload CIDs.
+func clientRootTargetKindMatchesCID(target arcset.TargetRef) bool {
+	semantic := maltcid.SemanticKindOf(target.CID())
+	switch target.Kind() {
+	case arcset.TargetKindMap:
+		return semantic == maltcid.SemanticKindMap
+	case arcset.TargetKindList:
+		return semantic == maltcid.SemanticKindList
+	case arcset.TargetKindCAS, arcset.TargetKindUnknown:
+		return semantic == maltcid.SemanticKindUnknown
+	default:
+		return false
 	}
 }
 

--- a/mutation/client_root.go
+++ b/mutation/client_root.go
@@ -1,0 +1,733 @@
+package mutation
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+)
+
+const (
+	UpdateViewProfile              = "malt.update-view/v1"
+	SemanticIntentProfile          = "malt.semantic-intent/v1"
+	ClientRootBundleProfile        = "malt.client-root-bundle/v1"
+	MaterializationReceiptProfile  = "malt.materialization-receipt/v1"
+	StatefulCompleteVectorsProfile = "stateful-complete-vectors-v1"
+)
+
+var (
+	ErrInvalidUpdateView       = errors.New("invalid update view")
+	ErrIncompleteUpdateView    = errors.New("incomplete update view")
+	ErrUpdateViewCycle         = errors.New("update view cycle")
+	ErrInvalidSemanticIntent   = errors.New("invalid semantic intent")
+	ErrIntentDependencyCycle   = errors.New("intent dependency cycle")
+	ErrIntentMultiplicity      = errors.New("intent output multiplicity mismatch")
+	ErrInvalidClientRootBundle = errors.New("invalid client root bundle")
+	ErrBundleDigestMismatch    = errors.New("client root bundle digest mismatch")
+	ErrBundleCandidateMismatch = errors.New("client root candidate mismatch")
+	clientRootIDPattern        = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,127}$`)
+)
+
+// UpdateViewBounds is part of the authenticated client-writer request. It
+// prevents an untrusted service from expanding a small mutation into an
+// unbounded state download.
+type UpdateViewBounds struct {
+	MaxObjects      uint32
+	MaxTotalEntries uint64
+	MaxDepth        uint32
+}
+
+// UpdateView is the complete old semantic closure needed to verify and update
+// one accepted root locally. Objects are ordered by ObjectID in canonical
+// form. Every typed MALT child reachable from BaseRoot must occur exactly once;
+// unrelated objects are rejected.
+type UpdateView struct {
+	Profile      string
+	StateProfile string
+	BaseRoot     cid.Cid
+	Bounds       UpdateViewBounds
+	Objects      []UpdateObject
+}
+
+// UpdateObject binds a stable operation-local ID to one complete canonical
+// logical vector and its current typed semantic root.
+type UpdateObject struct {
+	ObjectID string
+	Root     cid.Cid
+	Kind     arcset.Kind
+	Entries  *arcset.CanonicalArcSet
+	Commit   CommitDescriptor
+}
+
+// SemanticIntent is output-free: child results are referenced by transition
+// ID and no candidate root is supplied until local computation finishes.
+type SemanticIntent struct {
+	Profile     string
+	BaseRoot    cid.Cid
+	Transitions []IntentTransition
+	TopOutputID string
+}
+
+// IntentTransition describes one object update. OldRoot may be undefined only
+// for a newly-created object. ExpectedUses declares how many parent coordinates
+// consume this transition's output; the designated top output has zero uses.
+type IntentTransition struct {
+	ID           string
+	ObjectID     string
+	OldRoot      cid.Cid
+	Kind         arcset.Kind
+	Backend      maltcid.BackendKind
+	Changes      []IntentChange
+	Commit       CommitDescriptor
+	ExpectedUses uint32
+}
+
+// IntentChange selects either a literal post-image target or the output of a
+// child transition. A nil After and empty OutputID is a deletion. Exactly one
+// of After and OutputID may be present.
+type IntentChange struct {
+	Coordinate arcset.CanonicalCoordinate
+	Before     *arcset.TargetRef
+	After      *arcset.TargetRef
+	OutputID   string
+	OutputKind arcset.TargetKind
+}
+
+// TransitionOutput binds one normalized transition to the exact root computed
+// locally. Outputs are ordered by transition ID in a client-root bundle.
+type TransitionOutput struct {
+	TransitionID string
+	Root         cid.Cid
+}
+
+// ClientRootBundle is the exact-root submission. It binds the complete view,
+// normalized intent, every intermediate root, referenced payloads, and the
+// designated candidate. A Gateway may accept this candidate or reject it; it
+// must not substitute a different root.
+type ClientRootBundle struct {
+	Profile      string
+	OperationID  string
+	View         UpdateView
+	Intent       SemanticIntent
+	Outputs      []TransitionOutput
+	Candidate    cid.Cid
+	PayloadCIDs  []cid.Cid
+	ViewDigest   [32]byte
+	IntentDigest [32]byte
+}
+
+// MaterializationReceipt is a durable acknowledgement of one exact bundle.
+// Publication and client trust acceptance remain separate policies.
+type MaterializationReceipt struct {
+	Profile         string
+	OperationID     string
+	BaseRoot        cid.Cid
+	Candidate       cid.Cid
+	BundleDigest    [32]byte
+	DurableBoundary string
+}
+
+// NormalizeUpdateView validates a view and returns a deep canonical copy.
+func NormalizeUpdateView(view UpdateView) (UpdateView, error) {
+	if view.Profile != UpdateViewProfile {
+		return UpdateView{}, fmt.Errorf("%w: profile must be %q", ErrInvalidUpdateView, UpdateViewProfile)
+	}
+	if view.StateProfile != StatefulCompleteVectorsProfile {
+		return UpdateView{}, fmt.Errorf("%w: state profile must be %q", ErrInvalidUpdateView, StatefulCompleteVectorsProfile)
+	}
+	if !view.BaseRoot.Defined() {
+		return UpdateView{}, fmt.Errorf("%w: base root is undefined", ErrInvalidUpdateView)
+	}
+	if view.Bounds.MaxObjects == 0 || view.Bounds.MaxTotalEntries == 0 || view.Bounds.MaxDepth == 0 {
+		return UpdateView{}, fmt.Errorf("%w: all bounds must be positive", ErrInvalidUpdateView)
+	}
+	if len(view.Objects) == 0 || uint64(len(view.Objects)) > uint64(view.Bounds.MaxObjects) {
+		return UpdateView{}, fmt.Errorf("%w: object count %d exceeds bound %d", ErrInvalidUpdateView, len(view.Objects), view.Bounds.MaxObjects)
+	}
+
+	normalized := view
+	normalized.Objects = make([]UpdateObject, len(view.Objects))
+	byID := make(map[string]struct{}, len(view.Objects))
+	byRoot := make(map[string]int, len(view.Objects))
+	var totalEntries uint64
+	for index, object := range view.Objects {
+		if !validClientRootID(object.ObjectID) {
+			return UpdateView{}, fmt.Errorf("%w: invalid object id %q", ErrInvalidUpdateView, object.ObjectID)
+		}
+		if _, exists := byID[object.ObjectID]; exists {
+			return UpdateView{}, fmt.Errorf("%w: duplicate object id %q", ErrInvalidUpdateView, object.ObjectID)
+		}
+		byID[object.ObjectID] = struct{}{}
+		if !object.Root.Defined() || !objectKindMatches(object.Root, object.Kind) {
+			return UpdateView{}, fmt.Errorf("%w: object %q root/kind mismatch", ErrInvalidUpdateView, object.ObjectID)
+		}
+		rootKey := object.Root.KeyString()
+		if _, exists := byRoot[rootKey]; exists {
+			return UpdateView{}, fmt.Errorf("%w: duplicate object root %s", ErrInvalidUpdateView, object.Root)
+		}
+		if object.Entries == nil || object.Entries.Kind() != object.Kind {
+			return UpdateView{}, fmt.Errorf("%w: object %q vector/kind mismatch", ErrInvalidUpdateView, object.ObjectID)
+		}
+		if object.Commit.FixedList != nil && object.Kind != arcset.KindList {
+			return UpdateView{}, fmt.Errorf("%w: object %q has map fixed-list descriptor", ErrInvalidUpdateView, object.ObjectID)
+		}
+		totalEntries += uint64(object.Entries.Len())
+		if totalEntries > view.Bounds.MaxTotalEntries {
+			return UpdateView{}, fmt.Errorf("%w: total entries exceed bound %d", ErrInvalidUpdateView, view.Bounds.MaxTotalEntries)
+		}
+		encoded, err := object.Entries.MarshalBinary()
+		if err != nil {
+			return UpdateView{}, fmt.Errorf("%w: object %q: %v", ErrInvalidUpdateView, object.ObjectID, err)
+		}
+		entries, err := arcset.UnmarshalCanonicalArcSet(encoded)
+		if err != nil {
+			return UpdateView{}, fmt.Errorf("%w: object %q: %v", ErrInvalidUpdateView, object.ObjectID, err)
+		}
+		normalized.Objects[index] = UpdateObject{
+			ObjectID: object.ObjectID,
+			Root:     object.Root,
+			Kind:     object.Kind,
+			Entries:  entries,
+			Commit:   cloneCommitDescriptor(object.Commit),
+		}
+		byRoot[rootKey] = index
+	}
+	slices.SortFunc(normalized.Objects, func(a, b UpdateObject) int {
+		return strings.Compare(a.ObjectID, b.ObjectID)
+	})
+	byRoot = make(map[string]int, len(normalized.Objects))
+	for index, object := range normalized.Objects {
+		byRoot[object.Root.KeyString()] = index
+	}
+	baseIndex, exists := byRoot[view.BaseRoot.KeyString()]
+	if !exists {
+		return UpdateView{}, fmt.Errorf("%w: base root object is missing", ErrIncompleteUpdateView)
+	}
+
+	state := make([]uint8, len(normalized.Objects))
+	visited := 0
+	var visit func(int, uint32) error
+	visit = func(index int, depth uint32) error {
+		if depth > view.Bounds.MaxDepth {
+			return fmt.Errorf("%w: depth exceeds bound %d", ErrInvalidUpdateView, view.Bounds.MaxDepth)
+		}
+		switch state[index] {
+		case 1:
+			return ErrUpdateViewCycle
+		case 2:
+			return nil
+		}
+		state[index] = 1
+		visited++
+		for _, entry := range normalized.Objects[index].Entries.Entries() {
+			childKind, semantic := semanticTargetKind(entry.Target)
+			if !semantic {
+				continue
+			}
+			childIndex, ok := byRoot[entry.Target.CID().KeyString()]
+			if !ok {
+				return fmt.Errorf("%w: object %q references missing %s child %s", ErrIncompleteUpdateView, normalized.Objects[index].ObjectID, childKind, entry.Target.CID())
+			}
+			if normalized.Objects[childIndex].Kind != childKind {
+				return fmt.Errorf("%w: child %s kind mismatch", ErrInvalidUpdateView, entry.Target.CID())
+			}
+			if err := visit(childIndex, depth+1); err != nil {
+				return err
+			}
+		}
+		state[index] = 2
+		return nil
+	}
+	if err := visit(baseIndex, 1); err != nil {
+		return UpdateView{}, err
+	}
+	if visited != len(normalized.Objects) {
+		return UpdateView{}, fmt.Errorf("%w: view contains %d unreachable objects", ErrIncompleteUpdateView, len(normalized.Objects)-visited)
+	}
+	return normalized, nil
+}
+
+// NormalizeSemanticIntent validates an output-free intent against the complete
+// update view and returns child-before-parent deterministic order.
+func NormalizeSemanticIntent(view UpdateView, intent SemanticIntent) (SemanticIntent, error) {
+	normalizedView, err := NormalizeUpdateView(view)
+	if err != nil {
+		return SemanticIntent{}, err
+	}
+	if intent.Profile != SemanticIntentProfile {
+		return SemanticIntent{}, fmt.Errorf("%w: profile must be %q", ErrInvalidSemanticIntent, SemanticIntentProfile)
+	}
+	if !intent.BaseRoot.Equals(normalizedView.BaseRoot) {
+		return SemanticIntent{}, fmt.Errorf("%w: base root does not match update view", ErrInvalidSemanticIntent)
+	}
+	if !validClientRootID(intent.TopOutputID) || len(intent.Transitions) == 0 {
+		return SemanticIntent{}, fmt.Errorf("%w: invalid top output or empty transition set", ErrInvalidSemanticIntent)
+	}
+
+	objects := make(map[string]UpdateObject, len(normalizedView.Objects))
+	for _, object := range normalizedView.Objects {
+		objects[object.ObjectID] = object
+	}
+	transitions := make(map[string]IntentTransition, len(intent.Transitions))
+	objectTransitions := make(map[string]string, len(intent.Transitions))
+	for _, transition := range intent.Transitions {
+		if !validClientRootID(transition.ID) || !validClientRootID(transition.ObjectID) {
+			return SemanticIntent{}, fmt.Errorf("%w: invalid transition/object id", ErrInvalidSemanticIntent)
+		}
+		if _, exists := transitions[transition.ID]; exists {
+			return SemanticIntent{}, fmt.Errorf("%w: duplicate transition id %q", ErrInvalidSemanticIntent, transition.ID)
+		}
+		if prior, exists := objectTransitions[transition.ObjectID]; exists {
+			return SemanticIntent{}, fmt.Errorf("%w: object %q is updated by both %q and %q; merge changes before normalization", ErrInvalidSemanticIntent, transition.ObjectID, prior, transition.ID)
+		}
+		objectTransitions[transition.ObjectID] = transition.ID
+		object, exists := objects[transition.ObjectID]
+		if transition.OldRoot.Defined() {
+			if !exists || !transition.OldRoot.Equals(object.Root) || transition.Kind != object.Kind {
+				return SemanticIntent{}, fmt.Errorf("%w: transition %q old object does not match update view", ErrInvalidSemanticIntent, transition.ID)
+			}
+			if transition.Backend != maltcid.BackendKindOf(transition.OldRoot) {
+				return SemanticIntent{}, fmt.Errorf("%w: transition %q backend does not match old root", ErrInvalidSemanticIntent, transition.ID)
+			}
+		} else if exists {
+			return SemanticIntent{}, fmt.Errorf("%w: transition %q declares an existing object as new", ErrInvalidSemanticIntent, transition.ID)
+		}
+		if transition.Backend != maltcid.BackendKindKZG && transition.Backend != maltcid.BackendKindIPA {
+			return SemanticIntent{}, fmt.Errorf("%w: transition %q has unsupported backend %q", ErrInvalidSemanticIntent, transition.ID, transition.Backend)
+		}
+		if transition.Kind != arcset.KindMap && transition.Kind != arcset.KindList {
+			return SemanticIntent{}, fmt.Errorf("%w: transition %q has invalid kind %q", ErrInvalidSemanticIntent, transition.ID, transition.Kind)
+		}
+		if transition.Commit.FixedList != nil && transition.Kind != arcset.KindList {
+			return SemanticIntent{}, fmt.Errorf("%w: transition %q has map fixed-list descriptor", ErrInvalidSemanticIntent, transition.ID)
+		}
+		normalizedTransition, err := normalizeIntentTransition(transition, object)
+		if err != nil {
+			return SemanticIntent{}, err
+		}
+		transitions[transition.ID] = normalizedTransition
+	}
+	top, exists := transitions[intent.TopOutputID]
+	if !exists || !top.OldRoot.Equals(normalizedView.BaseRoot) || top.ExpectedUses != 0 {
+		return SemanticIntent{}, fmt.Errorf("%w: top output must update the base root and have zero uses", ErrInvalidSemanticIntent)
+	}
+
+	uses := make(map[string]uint32, len(transitions))
+	parents := make(map[string][]string, len(transitions))
+	indegree := make(map[string]int, len(transitions))
+	for id := range transitions {
+		indegree[id] = 0
+	}
+	for parentID, transition := range transitions {
+		for _, change := range transition.Changes {
+			if change.OutputID == "" {
+				continue
+			}
+			child, ok := transitions[change.OutputID]
+			if !ok {
+				return SemanticIntent{}, fmt.Errorf("%w: transition %q references unknown output %q", ErrInvalidSemanticIntent, parentID, change.OutputID)
+			}
+			if child.Kind == arcset.KindMap && change.OutputKind != arcset.TargetKindMap || child.Kind == arcset.KindList && change.OutputKind != arcset.TargetKindList {
+				return SemanticIntent{}, fmt.Errorf("%w: output %q kind mismatch", ErrInvalidSemanticIntent, change.OutputID)
+			}
+			uses[change.OutputID]++
+			parents[change.OutputID] = append(parents[change.OutputID], parentID)
+			indegree[parentID]++
+		}
+	}
+	for id, transition := range transitions {
+		if uses[id] != transition.ExpectedUses {
+			return SemanticIntent{}, fmt.Errorf("%w: output %q declares %d uses, observed %d", ErrIntentMultiplicity, id, transition.ExpectedUses, uses[id])
+		}
+		if id != intent.TopOutputID && uses[id] == 0 {
+			return SemanticIntent{}, fmt.Errorf("%w: output %q is orphaned", ErrInvalidSemanticIntent, id)
+		}
+	}
+
+	ready := make([]string, 0)
+	for id, degree := range indegree {
+		if degree == 0 {
+			ready = append(ready, id)
+		}
+	}
+	sort.Strings(ready)
+	ordered := make([]IntentTransition, 0, len(transitions))
+	for len(ready) > 0 {
+		id := ready[0]
+		ready = ready[1:]
+		ordered = append(ordered, transitions[id])
+		for _, parentID := range parents[id] {
+			indegree[parentID]--
+			if indegree[parentID] == 0 {
+				ready = append(ready, parentID)
+				sort.Strings(ready)
+			}
+		}
+	}
+	if len(ordered) != len(transitions) {
+		return SemanticIntent{}, ErrIntentDependencyCycle
+	}
+	if ordered[len(ordered)-1].ID != intent.TopOutputID {
+		return SemanticIntent{}, fmt.Errorf("%w: dependency graph does not close at top output", ErrInvalidSemanticIntent)
+	}
+	return SemanticIntent{Profile: intent.Profile, BaseRoot: intent.BaseRoot, Transitions: ordered, TopOutputID: intent.TopOutputID}, nil
+}
+
+func normalizeIntentTransition(transition IntentTransition, object UpdateObject) (IntentTransition, error) {
+	if len(transition.Changes) == 0 {
+		return IntentTransition{}, fmt.Errorf("%w: transition %q has no changes", ErrInvalidSemanticIntent, transition.ID)
+	}
+	normalized := transition
+	normalized.Commit = cloneCommitDescriptor(transition.Commit)
+	normalized.Changes = append([]IntentChange(nil), transition.Changes...)
+	slices.SortFunc(normalized.Changes, func(a, b IntentChange) int {
+		return bytes.Compare(a.Coordinate.Bytes(), b.Coordinate.Bytes())
+	})
+	var entries map[string]arcset.TargetRef
+	if object.Entries != nil {
+		entries = make(map[string]arcset.TargetRef, object.Entries.Len())
+		for _, entry := range object.Entries.Entries() {
+			entries[string(entry.Coordinate.Bytes())] = entry.Target
+		}
+	}
+	for index := range normalized.Changes {
+		change := &normalized.Changes[index]
+		if len(change.Coordinate.Bytes()) == 0 {
+			return IntentTransition{}, fmt.Errorf("%w: transition %q has empty coordinate", ErrInvalidSemanticIntent, transition.ID)
+		}
+		if index > 0 && bytes.Equal(normalized.Changes[index-1].Coordinate.Bytes(), change.Coordinate.Bytes()) {
+			return IntentTransition{}, fmt.Errorf("%w: transition %q has duplicate coordinate %q", ErrInvalidSemanticIntent, transition.ID, change.Coordinate.String())
+		}
+		if change.After != nil && change.OutputID != "" {
+			return IntentTransition{}, fmt.Errorf("%w: transition %q coordinate %q has both literal and output post-image", ErrInvalidSemanticIntent, transition.ID, change.Coordinate.String())
+		}
+		if change.OutputID != "" {
+			if !validClientRootID(change.OutputID) || change.OutputKind != arcset.TargetKindMap && change.OutputKind != arcset.TargetKindList {
+				return IntentTransition{}, fmt.Errorf("%w: transition %q has invalid output reference", ErrInvalidSemanticIntent, transition.ID)
+			}
+		} else if change.OutputKind != "" {
+			return IntentTransition{}, fmt.Errorf("%w: transition %q has output kind without output", ErrInvalidSemanticIntent, transition.ID)
+		}
+		current, present := entries[string(change.Coordinate.Bytes())]
+		if change.Before == nil {
+			if present {
+				return IntentTransition{}, fmt.Errorf("%w: transition %q expected coordinate %q absent", ErrInvalidSemanticIntent, transition.ID, change.Coordinate.String())
+			}
+		} else if !present || !targetEqual(*change.Before, current) {
+			return IntentTransition{}, fmt.Errorf("%w: transition %q before-image mismatch at %q", ErrInvalidSemanticIntent, transition.ID, change.Coordinate.String())
+		}
+		if change.After == nil && change.OutputID == "" && change.Before == nil {
+			return IntentTransition{}, fmt.Errorf("%w: transition %q has empty change at %q", ErrInvalidSemanticIntent, transition.ID, change.Coordinate.String())
+		}
+		if change.After != nil && change.Before != nil && targetEqual(*change.After, *change.Before) {
+			return IntentTransition{}, fmt.Errorf("%w: transition %q has no-op at %q", ErrInvalidSemanticIntent, transition.ID, change.Coordinate.String())
+		}
+	}
+	return normalized, nil
+}
+
+// NewClientRootBundle validates and canonicalizes one exact-root submission.
+func NewClientRootBundle(bundle ClientRootBundle) (ClientRootBundle, error) {
+	if bundle.Profile != ClientRootBundleProfile || !validClientRootID(bundle.OperationID) {
+		return ClientRootBundle{}, fmt.Errorf("%w: invalid profile or operation id", ErrInvalidClientRootBundle)
+	}
+	view, err := NormalizeUpdateView(bundle.View)
+	if err != nil {
+		return ClientRootBundle{}, err
+	}
+	intent, err := NormalizeSemanticIntent(view, bundle.Intent)
+	if err != nil {
+		return ClientRootBundle{}, err
+	}
+	viewDigest, err := view.Digest()
+	if err != nil {
+		return ClientRootBundle{}, err
+	}
+	intentDigest, err := intent.Digest()
+	if err != nil {
+		return ClientRootBundle{}, err
+	}
+	if bundle.ViewDigest != viewDigest || bundle.IntentDigest != intentDigest {
+		return ClientRootBundle{}, ErrBundleDigestMismatch
+	}
+
+	outputs := append([]TransitionOutput(nil), bundle.Outputs...)
+	slices.SortFunc(outputs, func(a, b TransitionOutput) int { return strings.Compare(a.TransitionID, b.TransitionID) })
+	if len(outputs) != len(intent.Transitions) {
+		return ClientRootBundle{}, fmt.Errorf("%w: output count mismatch", ErrInvalidClientRootBundle)
+	}
+	transitionIDs := make(map[string]struct{}, len(intent.Transitions))
+	transitionByID := make(map[string]IntentTransition, len(intent.Transitions))
+	for _, transition := range intent.Transitions {
+		transitionIDs[transition.ID] = struct{}{}
+		transitionByID[transition.ID] = transition
+	}
+	var topRoot cid.Cid
+	for index, output := range outputs {
+		if !output.Root.Defined() {
+			return ClientRootBundle{}, fmt.Errorf("%w: output %q root is undefined", ErrInvalidClientRootBundle, output.TransitionID)
+		}
+		if index > 0 && outputs[index-1].TransitionID == output.TransitionID {
+			return ClientRootBundle{}, fmt.Errorf("%w: duplicate output %q", ErrInvalidClientRootBundle, output.TransitionID)
+		}
+		if _, exists := transitionIDs[output.TransitionID]; !exists {
+			return ClientRootBundle{}, fmt.Errorf("%w: unknown output %q", ErrInvalidClientRootBundle, output.TransitionID)
+		}
+		transition := transitionByID[output.TransitionID]
+		if !maltcid.IsMaltCid(output.Root) || maltcid.BackendKindOf(output.Root) != transition.Backend ||
+			transition.Kind == arcset.KindMap && maltcid.SemanticKindOf(output.Root) != maltcid.SemanticKindMap ||
+			transition.Kind == arcset.KindList && maltcid.SemanticKindOf(output.Root) != maltcid.SemanticKindList {
+			return ClientRootBundle{}, fmt.Errorf("%w: output %q root kind/backend mismatch", ErrInvalidClientRootBundle, output.TransitionID)
+		}
+		if output.TransitionID == intent.TopOutputID {
+			topRoot = output.Root
+		}
+	}
+	if !bundle.Candidate.Defined() || !bundle.Candidate.Equals(topRoot) {
+		return ClientRootBundle{}, ErrBundleCandidateMismatch
+	}
+	payloads := append([]cid.Cid(nil), bundle.PayloadCIDs...)
+	slices.SortFunc(payloads, compareCID)
+	for index, payload := range payloads {
+		if !payload.Defined() {
+			return ClientRootBundle{}, fmt.Errorf("%w: undefined payload CID", ErrInvalidClientRootBundle)
+		}
+		if index > 0 && payload.Equals(payloads[index-1]) {
+			return ClientRootBundle{}, fmt.Errorf("%w: duplicate payload CID %s", ErrInvalidClientRootBundle, payload)
+		}
+	}
+	wantPayloads := literalPayloadCIDs(intent)
+	if len(payloads) != len(wantPayloads) {
+		return ClientRootBundle{}, fmt.Errorf("%w: payload CID set does not match literal CAS post-images", ErrInvalidClientRootBundle)
+	}
+	for index := range payloads {
+		if !payloads[index].Equals(wantPayloads[index]) {
+			return ClientRootBundle{}, fmt.Errorf("%w: payload CID set does not match literal CAS post-images", ErrInvalidClientRootBundle)
+		}
+	}
+	bundle.View = view
+	bundle.Intent = intent
+	bundle.Outputs = outputs
+	bundle.PayloadCIDs = payloads
+	return bundle, nil
+}
+
+func literalPayloadCIDs(intent SemanticIntent) []cid.Cid {
+	byKey := make(map[string]cid.Cid)
+	for _, transition := range intent.Transitions {
+		for _, change := range transition.Changes {
+			if change.After == nil {
+				continue
+			}
+			if _, semantic := semanticTargetKind(*change.After); semantic {
+				continue
+			}
+			byKey[change.After.CID().KeyString()] = change.After.CID()
+		}
+	}
+	values := make([]cid.Cid, 0, len(byKey))
+	for _, value := range byKey {
+		values = append(values, value)
+	}
+	slices.SortFunc(values, compareCID)
+	return values
+}
+
+// Validate checks a durable receipt against the exact submitted bundle.
+func (r MaterializationReceipt) Validate(bundle ClientRootBundle) error {
+	canonical, err := NewClientRootBundle(bundle)
+	if err != nil {
+		return err
+	}
+	if r.Profile != MaterializationReceiptProfile || r.OperationID != canonical.OperationID || strings.TrimSpace(r.DurableBoundary) == "" {
+		return fmt.Errorf("invalid materialization receipt metadata")
+	}
+	if !r.BaseRoot.Equals(canonical.View.BaseRoot) || !r.Candidate.Equals(canonical.Candidate) {
+		return fmt.Errorf("materialization receipt root mismatch")
+	}
+	digest, err := canonical.Digest()
+	if err != nil {
+		return err
+	}
+	if r.BundleDigest != digest {
+		return fmt.Errorf("materialization receipt bundle digest mismatch")
+	}
+	return nil
+}
+
+// Digest returns the deterministic SHA-256 digest of a canonical update view.
+func (v UpdateView) Digest() ([32]byte, error) {
+	canonical, err := NormalizeUpdateView(v)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	var encoded bytes.Buffer
+	writeDigestString(&encoded, canonical.Profile)
+	writeDigestString(&encoded, canonical.StateProfile)
+	writeDigestCID(&encoded, canonical.BaseRoot)
+	writeDigestUint32(&encoded, canonical.Bounds.MaxObjects)
+	writeDigestUint64(&encoded, canonical.Bounds.MaxTotalEntries)
+	writeDigestUint32(&encoded, canonical.Bounds.MaxDepth)
+	writeDigestUint32(&encoded, uint32(len(canonical.Objects)))
+	for _, object := range canonical.Objects {
+		writeDigestString(&encoded, object.ObjectID)
+		writeDigestCID(&encoded, object.Root)
+		writeDigestString(&encoded, string(object.Kind))
+		vector, err := object.Entries.MarshalBinary()
+		if err != nil {
+			return [32]byte{}, err
+		}
+		writeDigestBytes(&encoded, vector)
+		writeCommitDescriptor(&encoded, object.Commit)
+	}
+	return sha256.Sum256(encoded.Bytes()), nil
+}
+
+// Digest returns the deterministic SHA-256 digest of a normalized intent.
+func (i SemanticIntent) Digest() ([32]byte, error) {
+	// A digest caller must bind a view separately; ordering and local shape are
+	// still checked here without pretending to revalidate before-images.
+	if i.Profile != SemanticIntentProfile || !i.BaseRoot.Defined() || len(i.Transitions) == 0 || !validClientRootID(i.TopOutputID) {
+		return [32]byte{}, ErrInvalidSemanticIntent
+	}
+	var encoded bytes.Buffer
+	writeDigestString(&encoded, i.Profile)
+	writeDigestCID(&encoded, i.BaseRoot)
+	writeDigestString(&encoded, i.TopOutputID)
+	writeDigestUint32(&encoded, uint32(len(i.Transitions)))
+	for _, transition := range i.Transitions {
+		writeDigestString(&encoded, transition.ID)
+		writeDigestString(&encoded, transition.ObjectID)
+		writeDigestCID(&encoded, transition.OldRoot)
+		writeDigestString(&encoded, string(transition.Kind))
+		writeDigestString(&encoded, string(transition.Backend))
+		writeCommitDescriptor(&encoded, transition.Commit)
+		writeDigestUint32(&encoded, transition.ExpectedUses)
+		writeDigestUint32(&encoded, uint32(len(transition.Changes)))
+		for _, change := range transition.Changes {
+			writeDigestBytes(&encoded, change.Coordinate.Bytes())
+			writeTarget(&encoded, change.Before)
+			writeTarget(&encoded, change.After)
+			writeDigestString(&encoded, change.OutputID)
+			writeDigestString(&encoded, string(change.OutputKind))
+		}
+	}
+	return sha256.Sum256(encoded.Bytes()), nil
+}
+
+// Digest returns the deterministic SHA-256 digest of a canonical bundle.
+func (b ClientRootBundle) Digest() ([32]byte, error) {
+	canonical, err := NewClientRootBundle(b)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	var encoded bytes.Buffer
+	writeDigestString(&encoded, canonical.Profile)
+	writeDigestString(&encoded, canonical.OperationID)
+	writeDigestBytes(&encoded, canonical.ViewDigest[:])
+	writeDigestBytes(&encoded, canonical.IntentDigest[:])
+	writeDigestCID(&encoded, canonical.Candidate)
+	writeDigestUint32(&encoded, uint32(len(canonical.Outputs)))
+	for _, output := range canonical.Outputs {
+		writeDigestString(&encoded, output.TransitionID)
+		writeDigestCID(&encoded, output.Root)
+	}
+	writeDigestUint32(&encoded, uint32(len(canonical.PayloadCIDs)))
+	for _, payload := range canonical.PayloadCIDs {
+		writeDigestCID(&encoded, payload)
+	}
+	return sha256.Sum256(encoded.Bytes()), nil
+}
+
+func semanticTargetKind(target arcset.TargetRef) (arcset.Kind, bool) {
+	switch target.Kind() {
+	case arcset.TargetKindMap:
+		return arcset.KindMap, true
+	case arcset.TargetKindList:
+		return arcset.KindList, true
+	case arcset.TargetKindCAS:
+		return "", false
+	}
+	switch maltcid.SemanticKindOf(target.CID()) {
+	case maltcid.SemanticKindMap:
+		return arcset.KindMap, true
+	case maltcid.SemanticKindList:
+		return arcset.KindList, true
+	default:
+		return "", false
+	}
+}
+
+func cloneCommitDescriptor(value CommitDescriptor) CommitDescriptor {
+	if value.FixedList == nil {
+		return CommitDescriptor{}
+	}
+	fixed := *value.FixedList
+	return CommitDescriptor{FixedList: &fixed}
+}
+
+func targetEqual(a, b arcset.TargetRef) bool {
+	return a.Kind() == b.Kind() && a.CID().Equals(b.CID())
+}
+
+func compareCID(a, b cid.Cid) int {
+	return bytes.Compare(a.Bytes(), b.Bytes())
+}
+
+func validClientRootID(value string) bool {
+	return clientRootIDPattern.MatchString(value)
+}
+
+func writeDigestString(buf *bytes.Buffer, value string) {
+	writeDigestBytes(buf, []byte(value))
+}
+
+func writeDigestBytes(buf *bytes.Buffer, value []byte) {
+	writeDigestUint64(buf, uint64(len(value)))
+	buf.Write(value)
+}
+
+func writeDigestCID(buf *bytes.Buffer, value cid.Cid) {
+	writeDigestBytes(buf, value.Bytes())
+}
+
+func writeDigestUint32(buf *bytes.Buffer, value uint32) {
+	var raw [4]byte
+	binary.BigEndian.PutUint32(raw[:], value)
+	buf.Write(raw[:])
+}
+
+func writeDigestUint64(buf *bytes.Buffer, value uint64) {
+	var raw [8]byte
+	binary.BigEndian.PutUint64(raw[:], value)
+	buf.Write(raw[:])
+}
+
+func writeCommitDescriptor(buf *bytes.Buffer, value CommitDescriptor) {
+	if value.FixedList == nil {
+		buf.WriteByte(0)
+		return
+	}
+	buf.WriteByte(1)
+	writeDigestUint64(buf, value.FixedList.TotalSize)
+	writeDigestUint64(buf, value.FixedList.ChunkSize)
+}
+
+func writeTarget(buf *bytes.Buffer, value *arcset.TargetRef) {
+	if value == nil {
+		buf.WriteByte(0)
+		return
+	}
+	buf.WriteByte(1)
+	writeDigestString(buf, string(value.Kind()))
+	writeDigestCID(buf, value.CID())
+}

--- a/mutation/client_root.go
+++ b/mutation/client_root.go
@@ -2,13 +2,13 @@ package mutation
 
 import (
 	"bytes"
+	"container/heap"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -185,6 +185,9 @@ func NormalizeUpdateView(view UpdateView) (UpdateView, error) {
 		if object.Commit.FixedList != nil && object.Kind != arcset.KindList {
 			return UpdateView{}, fmt.Errorf("%w: object %q has map fixed-list descriptor", ErrInvalidUpdateView, object.ObjectID)
 		}
+		if err := validateFixedListDescriptor(object.Commit, object.Kind, uint64(object.Entries.Len())); err != nil {
+			return UpdateView{}, fmt.Errorf("%w: object %q: %v", ErrInvalidUpdateView, object.ObjectID, err)
+		}
 		totalEntries += uint64(object.Entries.Len())
 		if totalEntries > view.Bounds.MaxTotalEntries {
 			return UpdateView{}, fmt.Errorf("%w: total entries exceed bound %d", ErrInvalidUpdateView, view.Bounds.MaxTotalEntries)
@@ -218,45 +221,77 @@ func NormalizeUpdateView(view UpdateView) (UpdateView, error) {
 		return UpdateView{}, fmt.Errorf("%w: base root object is missing", ErrIncompleteUpdateView)
 	}
 
-	state := make([]uint8, len(normalized.Objects))
-	visited := 0
-	var visit func(int, uint32) error
-	visit = func(index int, depth uint32) error {
-		if depth > view.Bounds.MaxDepth {
-			return fmt.Errorf("%w: depth exceeds bound %d", ErrInvalidUpdateView, view.Bounds.MaxDepth)
-		}
-		switch state[index] {
-		case 1:
-			return ErrUpdateViewCycle
-		case 2:
-			return nil
-		}
-		state[index] = 1
-		visited++
-		for _, entry := range normalized.Objects[index].Entries.Entries() {
+	// Build the semantic DAG once. Reachability, cycle detection, and longest
+	// root-to-leaf depth are then all checked in O(V+E); recursively revisiting
+	// a shared subgraph for every deeper incoming path would make this untrusted
+	// download contract vulnerable to CPU amplification.
+	children := make([][]int, len(normalized.Objects))
+	indegree := make([]uint32, len(normalized.Objects))
+	for index, object := range normalized.Objects {
+		for _, entry := range object.Entries.Entries() {
 			childKind, semantic := semanticTargetKind(entry.Target)
 			if !semantic {
 				continue
 			}
 			childIndex, ok := byRoot[entry.Target.CID().KeyString()]
 			if !ok {
-				return fmt.Errorf("%w: object %q references missing %s child %s", ErrIncompleteUpdateView, normalized.Objects[index].ObjectID, childKind, entry.Target.CID())
+				return UpdateView{}, fmt.Errorf("%w: object %q references missing %s child %s", ErrIncompleteUpdateView, object.ObjectID, childKind, entry.Target.CID())
 			}
 			if normalized.Objects[childIndex].Kind != childKind {
-				return fmt.Errorf("%w: child %s kind mismatch", ErrInvalidUpdateView, entry.Target.CID())
+				return UpdateView{}, fmt.Errorf("%w: child %s kind mismatch", ErrInvalidUpdateView, entry.Target.CID())
 			}
-			if err := visit(childIndex, depth+1); err != nil {
-				return err
+			children[index] = append(children[index], childIndex)
+			indegree[childIndex]++
+		}
+	}
+
+	reachable := make([]bool, len(normalized.Objects))
+	stack := []int{baseIndex}
+	reachable[baseIndex] = true
+	visited := 0
+	for len(stack) > 0 {
+		index := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		visited++
+		for _, childIndex := range children[index] {
+			if !reachable[childIndex] {
+				reachable[childIndex] = true
+				stack = append(stack, childIndex)
 			}
 		}
-		state[index] = 2
-		return nil
-	}
-	if err := visit(baseIndex, 1); err != nil {
-		return UpdateView{}, err
 	}
 	if visited != len(normalized.Objects) {
 		return UpdateView{}, fmt.Errorf("%w: view contains %d unreachable objects", ErrIncompleteUpdateView, len(normalized.Objects)-visited)
+	}
+
+	queue := make([]int, 0, len(normalized.Objects))
+	for index, count := range indegree {
+		if count == 0 {
+			queue = append(queue, index)
+		}
+	}
+	depth := make([]uint32, len(normalized.Objects))
+	depth[baseIndex] = 1
+	processed := 0
+	for head := 0; head < len(queue); head++ {
+		index := queue[head]
+		processed++
+		for _, childIndex := range children[index] {
+			candidateDepth := uint64(depth[index]) + 1
+			if candidateDepth > uint64(view.Bounds.MaxDepth) {
+				return UpdateView{}, fmt.Errorf("%w: depth exceeds bound %d", ErrInvalidUpdateView, view.Bounds.MaxDepth)
+			}
+			if uint32(candidateDepth) > depth[childIndex] {
+				depth[childIndex] = uint32(candidateDepth)
+			}
+			indegree[childIndex]--
+			if indegree[childIndex] == 0 {
+				queue = append(queue, childIndex)
+			}
+		}
+	}
+	if processed != len(normalized.Objects) {
+		return UpdateView{}, ErrUpdateViewCycle
 	}
 	return normalized, nil
 }
@@ -319,6 +354,9 @@ func NormalizeSemanticIntent(view UpdateView, intent SemanticIntent) (SemanticIn
 		if err != nil {
 			return SemanticIntent{}, err
 		}
+		if err := validateTransitionCommit(object, normalizedTransition); err != nil {
+			return SemanticIntent{}, fmt.Errorf("%w: transition %q: %v", ErrInvalidSemanticIntent, transition.ID, err)
+		}
 		transitions[transition.ID] = normalizedTransition
 	}
 	top, exists := transitions[intent.TopOutputID]
@@ -358,23 +396,21 @@ func NormalizeSemanticIntent(view UpdateView, intent SemanticIntent) (SemanticIn
 		}
 	}
 
-	ready := make([]string, 0)
+	ready := make(stringMinHeap, 0)
 	for id, degree := range indegree {
 		if degree == 0 {
 			ready = append(ready, id)
 		}
 	}
-	sort.Strings(ready)
+	heap.Init(&ready)
 	ordered := make([]IntentTransition, 0, len(transitions))
 	for len(ready) > 0 {
-		id := ready[0]
-		ready = ready[1:]
+		id := heap.Pop(&ready).(string)
 		ordered = append(ordered, transitions[id])
 		for _, parentID := range parents[id] {
 			indegree[parentID]--
 			if indegree[parentID] == 0 {
-				ready = append(ready, parentID)
-				sort.Strings(ready)
+				heap.Push(&ready, parentID)
 			}
 		}
 	}
@@ -385,6 +421,25 @@ func NormalizeSemanticIntent(view UpdateView, intent SemanticIntent) (SemanticIn
 		return SemanticIntent{}, fmt.Errorf("%w: dependency graph does not close at top output", ErrInvalidSemanticIntent)
 	}
 	return SemanticIntent{Profile: intent.Profile, BaseRoot: intent.BaseRoot, Transitions: ordered, TopOutputID: intent.TopOutputID}, nil
+}
+
+type stringMinHeap []string
+
+func (values stringMinHeap) Len() int           { return len(values) }
+func (values stringMinHeap) Less(i, j int) bool { return values[i] < values[j] }
+func (values stringMinHeap) Swap(i, j int)      { values[i], values[j] = values[j], values[i] }
+
+func (values *stringMinHeap) Push(value any) {
+	*values = append(*values, value.(string))
+}
+
+func (values *stringMinHeap) Pop() any {
+	old := *values
+	last := len(old) - 1
+	value := old[last]
+	old[last] = ""
+	*values = old[:last]
+	return value
 }
 
 func normalizeIntentTransition(transition IntentTransition, object UpdateObject) (IntentTransition, error) {
@@ -444,6 +499,104 @@ func normalizeIntentTransition(transition IntentTransition, object UpdateObject)
 		}
 	}
 	return normalized, nil
+}
+
+func validateTransitionCommit(object UpdateObject, transition IntentTransition) error {
+	if transition.Kind != arcset.KindList {
+		if transition.Commit.FixedList != nil {
+			return errors.New("map transition has a fixed-list descriptor")
+		}
+		return nil
+	}
+	postCount, err := postTransitionListCount(object, transition)
+	if err != nil {
+		return err
+	}
+	if err := validateFixedListDescriptor(transition.Commit, transition.Kind, postCount); err != nil {
+		return err
+	}
+	if !transition.OldRoot.Defined() {
+		return nil
+	}
+	oldFixed, newFixed := object.Commit.FixedList, transition.Commit.FixedList
+	if (oldFixed == nil) != (newFixed == nil) {
+		return errors.New("list transition changes its plain/fixed representation")
+	}
+	if oldFixed == nil {
+		return nil
+	}
+	if oldFixed.ChunkSize != newFixed.ChunkSize {
+		return errors.New("fixed-list transition changes chunk size")
+	}
+	oldCount := uint64(object.Entries.Len())
+	switch {
+	case postCount < oldCount:
+		return errors.New("fixed-list truncate is unsupported")
+	case postCount == oldCount && oldFixed.TotalSize != newFixed.TotalSize:
+		return errors.New("fixed-list replacement changes total size")
+	case postCount > oldCount && oldFixed.TotalSize%oldFixed.ChunkSize != 0:
+		return errors.New("fixed-list append requires a chunk-aligned old total size")
+	case postCount > oldCount && newFixed.TotalSize <= oldFixed.TotalSize:
+		return errors.New("fixed-list append does not increase total size")
+	}
+	return nil
+}
+
+func postTransitionListCount(object UpdateObject, transition IntentTransition) (uint64, error) {
+	oldEntries := 0
+	if object.Entries != nil {
+		oldEntries = object.Entries.Len()
+	}
+	present := make(map[uint64]struct{}, oldEntries+len(transition.Changes))
+	if object.Entries != nil {
+		for _, entry := range object.Entries.Entries() {
+			raw := entry.Coordinate.Bytes()
+			if len(raw) != 8 {
+				return 0, errors.New("list object contains a non-index coordinate")
+			}
+			present[binary.BigEndian.Uint64(raw)] = struct{}{}
+		}
+	}
+	for _, change := range transition.Changes {
+		raw := change.Coordinate.Bytes()
+		if len(raw) != 8 {
+			return 0, errors.New("list transition contains a non-index coordinate")
+		}
+		index := binary.BigEndian.Uint64(raw)
+		if change.After == nil && change.OutputID == "" {
+			delete(present, index)
+		} else {
+			present[index] = struct{}{}
+		}
+	}
+	count := uint64(len(present))
+	for index := uint64(0); index < count; index++ {
+		if _, ok := present[index]; !ok {
+			return 0, errors.New("list transition creates a sparse post-image")
+		}
+	}
+	return count, nil
+}
+
+func validateFixedListDescriptor(descriptor CommitDescriptor, kind arcset.Kind, count uint64) error {
+	if descriptor.FixedList == nil {
+		return nil
+	}
+	if kind != arcset.KindList {
+		return errors.New("fixed-list descriptor belongs to a non-list object")
+	}
+	fixed := descriptor.FixedList
+	if fixed.ChunkSize == 0 {
+		return errors.New("fixed-list chunk size is zero")
+	}
+	wantCount := fixed.TotalSize / fixed.ChunkSize
+	if fixed.TotalSize%fixed.ChunkSize != 0 {
+		wantCount++
+	}
+	if wantCount != count {
+		return fmt.Errorf("fixed-list descriptor implies %d chunks, vector has %d", wantCount, count)
+	}
+	return nil
 }
 
 // NewClientRootBundle validates and canonicalizes one exact-root submission.

--- a/mutation/client_root_test.go
+++ b/mutation/client_root_test.go
@@ -88,6 +88,50 @@ func TestNormalizeUpdateViewRequiresExactReachabilityClosure(t *testing.T) {
 	}
 }
 
+func TestNormalizeUpdateViewEnforcesMaxDepthAcrossSharedSubgraphs(t *testing.T) {
+	root := typedRoot(t, arcset.KindMap, 10)
+	shared := typedRoot(t, arcset.KindMap, 11)
+	branch := typedRoot(t, arcset.KindMap, 12)
+	leaf := typedRoot(t, arcset.KindMap, 13)
+
+	entries := func(values ...arcset.ArcEntry) *arcset.CanonicalArcSet {
+		t.Helper()
+		set, err := arcset.NewCanonicalArcSet(arcset.KindMap, values)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return set
+	}
+	view := UpdateView{
+		Profile: UpdateViewProfile, StateProfile: StatefulCompleteVectorsProfile,
+		BaseRoot: root,
+		Bounds:   UpdateViewBounds{MaxObjects: 8, MaxTotalEntries: 16, MaxDepth: 3},
+		Objects: []UpdateObject{
+			{ObjectID: "root", Root: root, Kind: arcset.KindMap, Entries: entries(
+				arcset.ArcEntry{Coordinate: mapCoordinate(t, "a-direct"), Target: arcset.NewMapTarget(shared)},
+				arcset.ArcEntry{Coordinate: mapCoordinate(t, "z-branch"), Target: arcset.NewMapTarget(branch)},
+			)},
+			{ObjectID: "shared", Root: shared, Kind: arcset.KindMap, Entries: entries(
+				arcset.ArcEntry{Coordinate: mapCoordinate(t, "leaf"), Target: arcset.NewMapTarget(leaf)},
+			)},
+			{ObjectID: "branch", Root: branch, Kind: arcset.KindMap, Entries: entries(
+				arcset.ArcEntry{Coordinate: mapCoordinate(t, "shared"), Target: arcset.NewMapTarget(shared)},
+			)},
+			{ObjectID: "leaf", Root: leaf, Kind: arcset.KindMap, Entries: entries(
+				arcset.ArcEntry{Coordinate: mapCoordinate(t, "payload"), Target: arcset.NewCASTarget(rawCID(t, "leaf-payload"))},
+			)},
+		},
+	}
+	if _, err := NormalizeUpdateView(view); !errors.Is(err, ErrInvalidUpdateView) {
+		t.Fatalf("shared-subgraph depth error = %v, want ErrInvalidUpdateView", err)
+	}
+
+	view.Bounds.MaxDepth = 4
+	if _, err := NormalizeUpdateView(view); err != nil {
+		t.Fatalf("valid depth-four shared subgraph: %v", err)
+	}
+}
+
 func TestClientRootRejectsTargetKindRelabelingAcrossSemanticBoundary(t *testing.T) {
 	view, intent, _, _, _ := clientRootFixture(t)
 	for index := range view.Objects {
@@ -144,6 +188,81 @@ func TestNormalizeSemanticIntentRejectsMultiplicityBeforeImageAndLastDeltaPatter
 	duplicateObject.Transitions[2].ID = "second-child-delta"
 	if _, err := NormalizeSemanticIntent(view, duplicateObject); !errors.Is(err, ErrInvalidSemanticIntent) {
 		t.Fatalf("duplicate object error = %v, want ErrInvalidSemanticIntent", err)
+	}
+}
+
+func TestNormalizeSemanticIntentPreservesFixedListRepresentationAndMetadata(t *testing.T) {
+	root := typedRoot(t, arcset.KindList, 70)
+	oldPayload := arcset.NewCASTarget(rawCID(t, "old-fixed-chunk"))
+	newPayload := arcset.NewCASTarget(rawCID(t, "new-fixed-chunk"))
+	entries, err := arcset.NewCanonicalArcSet(arcset.KindList, []arcset.ArcEntry{{
+		Coordinate: listCoordinate(0), Target: oldPayload,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := UpdateView{
+		Profile: UpdateViewProfile, StateProfile: StatefulCompleteVectorsProfile, BaseRoot: root,
+		Bounds: UpdateViewBounds{MaxObjects: 2, MaxTotalEntries: 8, MaxDepth: 2},
+		Objects: []UpdateObject{{
+			ObjectID: "fixed-file", Root: root, Kind: arcset.KindList, Entries: entries,
+			Commit: CommitDescriptor{FixedList: &FixedListCommit{ChunkSize: 4, TotalSize: 4}},
+		}},
+	}
+	base := SemanticIntent{
+		Profile: SemanticIntentProfile, BaseRoot: root, TopOutputID: "fixed-output",
+		Transitions: []IntentTransition{{
+			ID: "fixed-output", ObjectID: "fixed-file", OldRoot: root, Kind: arcset.KindList,
+			Backend: maltcid.BackendKindKZG,
+			Commit:  CommitDescriptor{FixedList: &FixedListCommit{ChunkSize: 4, TotalSize: 4}},
+			Changes: []IntentChange{{Coordinate: listCoordinate(0), Before: &oldPayload, After: &newPayload}},
+		}},
+	}
+	if _, err := NormalizeSemanticIntent(view, base); err != nil {
+		t.Fatalf("valid fixed replacement: %v", err)
+	}
+	for name, mutate := range map[string]func(*SemanticIntent){
+		"missing descriptor": func(value *SemanticIntent) { value.Transitions[0].Commit = CommitDescriptor{} },
+		"changed chunk size": func(value *SemanticIntent) { value.Transitions[0].Commit.FixedList.ChunkSize = 8 },
+		"changed total size": func(value *SemanticIntent) { value.Transitions[0].Commit.FixedList.TotalSize = 3 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := base
+			candidate.Transitions = cloneIntentTransitions(base.Transitions)
+			fixed := *base.Transitions[0].Commit.FixedList
+			candidate.Transitions[0].Commit.FixedList = &fixed
+			mutate(&candidate)
+			if _, err := NormalizeSemanticIntent(view, candidate); !errors.Is(err, ErrInvalidSemanticIntent) {
+				t.Fatalf("error = %v, want ErrInvalidSemanticIntent", err)
+			}
+		})
+	}
+
+	appendIntent := base
+	appendIntent.Transitions = cloneIntentTransitions(base.Transitions)
+	appendFixed := *base.Transitions[0].Commit.FixedList
+	appendFixed.TotalSize = 8
+	appendIntent.Transitions[0].Commit.FixedList = &appendFixed
+	appendIntent.Transitions[0].Changes = []IntentChange{{Coordinate: listCoordinate(1), After: &newPayload}}
+	if _, err := NormalizeSemanticIntent(view, appendIntent); err != nil {
+		t.Fatalf("valid fixed append: %v", err)
+	}
+	appendIntent.Transitions[0].Commit.FixedList.TotalSize = 4
+	if _, err := NormalizeSemanticIntent(view, appendIntent); !errors.Is(err, ErrInvalidSemanticIntent) {
+		t.Fatalf("non-growing append error = %v", err)
+	}
+
+	partialView := view
+	partialView.Objects = append([]UpdateObject(nil), view.Objects...)
+	partialFixed := *view.Objects[0].Commit.FixedList
+	partialFixed.TotalSize = 3
+	partialView.Objects[0].Commit.FixedList = &partialFixed
+	partialAppend := appendIntent
+	partialAppend.Transitions = cloneIntentTransitions(appendIntent.Transitions)
+	partialAppend.Transitions[0].OldRoot = partialView.BaseRoot
+	partialAppend.Transitions[0].Commit.FixedList.TotalSize = 5
+	if _, err := NormalizeSemanticIntent(partialView, partialAppend); !errors.Is(err, ErrInvalidSemanticIntent) {
+		t.Fatalf("partial-old append error = %v, want ErrInvalidSemanticIntent", err)
 	}
 }
 
@@ -306,6 +425,10 @@ func mapCoordinate(t *testing.T, value string) arcset.CanonicalCoordinate {
 		t.Fatal(err)
 	}
 	return coordinate
+}
+
+func listCoordinate(index uint64) arcset.CanonicalCoordinate {
+	return arcset.NewListCoordinateUint64(index)
 }
 
 func typedRoot(t *testing.T, kind arcset.Kind, seed byte) cid.Cid {

--- a/mutation/client_root_test.go
+++ b/mutation/client_root_test.go
@@ -1,0 +1,327 @@
+package mutation
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestClientRootBundleCanonicalizesAndBindsExactTopOutput(t *testing.T) {
+	view, intent, childOutput, topOutput, payload := clientRootFixture(t)
+	viewDigest, err := view.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	normalizedIntent, err := NormalizeSemanticIntent(view, intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intentDigest, err := normalizedIntent.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bundle, err := NewClientRootBundle(ClientRootBundle{
+		Profile:      ClientRootBundleProfile,
+		OperationID:  "operation-1",
+		View:         view,
+		Intent:       intent,
+		Outputs:      []TransitionOutput{topOutput, childOutput},
+		Candidate:    topOutput.Root,
+		PayloadCIDs:  []cid.Cid{payload},
+		ViewDigest:   viewDigest,
+		IntentDigest: intentDigest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bundle.Intent.Transitions[0].ID != "child-output" || bundle.Intent.Transitions[1].ID != "top-output" {
+		t.Fatalf("transition order = %q, %q", bundle.Intent.Transitions[0].ID, bundle.Intent.Transitions[1].ID)
+	}
+	if bundle.Outputs[0].TransitionID != "child-output" || bundle.Outputs[1].TransitionID != "top-output" {
+		t.Fatalf("output order = %#v", bundle.Outputs)
+	}
+	digest, err := bundle.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := MaterializationReceipt{
+		Profile:         MaterializationReceiptProfile,
+		OperationID:     bundle.OperationID,
+		BaseRoot:        bundle.View.BaseRoot,
+		Candidate:       bundle.Candidate,
+		BundleDigest:    digest,
+		DurableBoundary: "embedded-transaction-commit-v1",
+	}
+	if err := receipt.Validate(bundle); err != nil {
+		t.Fatalf("receipt validation: %v", err)
+	}
+}
+
+func TestNormalizeUpdateViewRequiresExactReachabilityClosure(t *testing.T) {
+	view, _, _, _, _ := clientRootFixture(t)
+
+	missing := view
+	missing.Objects = append([]UpdateObject(nil), view.Objects[:1]...)
+	if _, err := NormalizeUpdateView(missing); !errors.Is(err, ErrIncompleteUpdateView) {
+		t.Fatalf("missing child error = %v, want ErrIncompleteUpdateView", err)
+	}
+
+	extraRoot := typedRoot(t, arcset.KindMap, 90)
+	extraEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
+		Coordinate: mapCoordinate(t, "payload"),
+		Target:     arcset.NewCASTarget(rawCID(t, "extra-payload")),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	extra := view
+	extra.Objects = append(append([]UpdateObject(nil), view.Objects...), UpdateObject{
+		ObjectID: "extra", Root: extraRoot, Kind: arcset.KindMap, Entries: extraEntries,
+	})
+	if _, err := NormalizeUpdateView(extra); !errors.Is(err, ErrIncompleteUpdateView) {
+		t.Fatalf("extra object error = %v, want ErrIncompleteUpdateView", err)
+	}
+}
+
+func TestNormalizeSemanticIntentRejectsMultiplicityBeforeImageAndLastDeltaPatterns(t *testing.T) {
+	view, intent, _, _, _ := clientRootFixture(t)
+
+	wrongMultiplicity := intent
+	wrongMultiplicity.Transitions = cloneIntentTransitions(intent.Transitions)
+	wrongMultiplicity.Transitions[1].ExpectedUses = 2
+	if _, err := NormalizeSemanticIntent(view, wrongMultiplicity); !errors.Is(err, ErrIntentMultiplicity) {
+		t.Fatalf("multiplicity error = %v, want ErrIntentMultiplicity", err)
+	}
+
+	wrongBefore := intent
+	wrongBefore.Transitions = cloneIntentTransitions(intent.Transitions)
+	wrong := arcset.NewCASTarget(rawCID(t, "wrong-before"))
+	wrongBefore.Transitions[1].Changes[0].Before = &wrong
+	if _, err := NormalizeSemanticIntent(view, wrongBefore); !errors.Is(err, ErrInvalidSemanticIntent) {
+		t.Fatalf("before-image error = %v, want ErrInvalidSemanticIntent", err)
+	}
+
+	duplicateObject := intent
+	duplicateObject.Transitions = append(cloneIntentTransitions(intent.Transitions), intent.Transitions[0])
+	duplicateObject.Transitions[2].ID = "second-child-delta"
+	if _, err := NormalizeSemanticIntent(view, duplicateObject); !errors.Is(err, ErrInvalidSemanticIntent) {
+		t.Fatalf("duplicate object error = %v, want ErrInvalidSemanticIntent", err)
+	}
+}
+
+func TestClientRootBundleRejectsDigestAndCandidateSubstitution(t *testing.T) {
+	view, intent, childOutput, topOutput, payload := clientRootFixture(t)
+	viewDigest, err := view.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	normalizedIntent, err := NormalizeSemanticIntent(view, intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intentDigest, err := normalizedIntent.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := ClientRootBundle{
+		Profile: ClientRootBundleProfile, OperationID: "operation-2", View: view, Intent: intent,
+		Outputs: []TransitionOutput{childOutput, topOutput}, Candidate: topOutput.Root,
+		PayloadCIDs: []cid.Cid{payload}, ViewDigest: viewDigest, IntentDigest: intentDigest,
+	}
+
+	tamperedDigest := base
+	tamperedDigest.IntentDigest[0] ^= 0xff
+	if _, err := NewClientRootBundle(tamperedDigest); !errors.Is(err, ErrBundleDigestMismatch) {
+		t.Fatalf("digest error = %v, want ErrBundleDigestMismatch", err)
+	}
+
+	substituted := base
+	substituted.Candidate = typedRoot(t, arcset.KindMap, 99)
+	if _, err := NewClientRootBundle(substituted); !errors.Is(err, ErrBundleCandidateMismatch) {
+		t.Fatalf("candidate error = %v, want ErrBundleCandidateMismatch", err)
+	}
+}
+
+func TestClientRootBundleRejectsOutputKindBackendAndPayloadSetSubstitution(t *testing.T) {
+	view, intent, childOutput, topOutput, payload := clientRootFixture(t)
+	viewDigest, err := view.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	normalizedIntent, err := NormalizeSemanticIntent(view, intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intentDigest, err := normalizedIntent.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := ClientRootBundle{
+		Profile: ClientRootBundleProfile, OperationID: "operation-hostile", View: view, Intent: intent,
+		Outputs: []TransitionOutput{childOutput, topOutput}, Candidate: topOutput.Root,
+		PayloadCIDs: []cid.Cid{payload}, ViewDigest: viewDigest, IntentDigest: intentDigest,
+	}
+
+	wrongKind := base
+	wrongKind.Outputs = append([]TransitionOutput(nil), base.Outputs...)
+	wrongKind.Outputs[0].Root = typedRoot(t, arcset.KindList, 31)
+	if _, err := NewClientRootBundle(wrongKind); !errors.Is(err, ErrInvalidClientRootBundle) {
+		t.Fatalf("wrong output kind error = %v, want ErrInvalidClientRootBundle", err)
+	}
+
+	wrongBackend := base
+	wrongBackend.Outputs = append([]TransitionOutput(nil), base.Outputs...)
+	wrongBackend.Outputs[0].Root = typedIPARoot(t, arcset.KindMap, 41)
+	if _, err := NewClientRootBundle(wrongBackend); !errors.Is(err, ErrInvalidClientRootBundle) {
+		t.Fatalf("wrong output backend error = %v, want ErrInvalidClientRootBundle", err)
+	}
+
+	missingPayload := base
+	missingPayload.PayloadCIDs = nil
+	if _, err := NewClientRootBundle(missingPayload); !errors.Is(err, ErrInvalidClientRootBundle) {
+		t.Fatalf("missing payload error = %v, want ErrInvalidClientRootBundle", err)
+	}
+
+	extraPayload := base
+	extraPayload.PayloadCIDs = []cid.Cid{payload, rawCID(t, "unreferenced-payload")}
+	if _, err := NewClientRootBundle(extraPayload); !errors.Is(err, ErrInvalidClientRootBundle) {
+		t.Fatalf("extra payload error = %v, want ErrInvalidClientRootBundle", err)
+	}
+}
+
+func clientRootFixture(t *testing.T) (UpdateView, SemanticIntent, TransitionOutput, TransitionOutput, cid.Cid) {
+	t.Helper()
+	oldPayload := rawCID(t, "old-payload")
+	newPayload := rawCID(t, "new-payload")
+	childRoot := typedRoot(t, arcset.KindMap, 1)
+	parentRoot := typedRoot(t, arcset.KindMap, 2)
+	childNewRoot := typedRoot(t, arcset.KindMap, 3)
+	parentNewRoot := typedRoot(t, arcset.KindMap, 4)
+
+	childEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
+		Coordinate: mapCoordinate(t, "payload"),
+		Target:     arcset.NewCASTarget(oldPayload),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
+		Coordinate: mapCoordinate(t, "child"),
+		Target:     arcset.NewMapTarget(childRoot),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := UpdateView{
+		Profile: UpdateViewProfile, StateProfile: StatefulCompleteVectorsProfile,
+		BaseRoot: parentRoot,
+		Bounds:   UpdateViewBounds{MaxObjects: 8, MaxTotalEntries: 64, MaxDepth: 8},
+		// Deliberately reversed: normalization owns canonical object order.
+		Objects: []UpdateObject{
+			{ObjectID: "parent", Root: parentRoot, Kind: arcset.KindMap, Entries: parentEntries},
+			{ObjectID: "child", Root: childRoot, Kind: arcset.KindMap, Entries: childEntries},
+		},
+	}
+	oldPayloadTarget := arcset.NewCASTarget(oldPayload)
+	newPayloadTarget := arcset.NewCASTarget(newPayload)
+	childTarget := arcset.NewMapTarget(childRoot)
+	intent := SemanticIntent{
+		Profile: SemanticIntentProfile, BaseRoot: parentRoot, TopOutputID: "top-output",
+		// Deliberately parent-first: normalization must schedule bottom-up.
+		Transitions: []IntentTransition{
+			{
+				ID: "top-output", ObjectID: "parent", OldRoot: parentRoot, Kind: arcset.KindMap, Backend: maltcid.BackendKindKZG,
+				ExpectedUses: 0,
+				Changes: []IntentChange{{
+					Coordinate: mapCoordinate(t, "child"), Before: &childTarget,
+					OutputID: "child-output", OutputKind: arcset.TargetKindMap,
+				}},
+			},
+			{
+				ID: "child-output", ObjectID: "child", OldRoot: childRoot, Kind: arcset.KindMap, Backend: maltcid.BackendKindKZG,
+				ExpectedUses: 1,
+				Changes: []IntentChange{{
+					Coordinate: mapCoordinate(t, "payload"), Before: &oldPayloadTarget, After: &newPayloadTarget,
+				}},
+			},
+		},
+	}
+	return view, intent,
+		TransitionOutput{TransitionID: "child-output", Root: childNewRoot},
+		TransitionOutput{TransitionID: "top-output", Root: parentNewRoot},
+		newPayload
+}
+
+func cloneIntentTransitions(values []IntentTransition) []IntentTransition {
+	out := make([]IntentTransition, len(values))
+	copy(out, values)
+	for index := range out {
+		out[index].Changes = append([]IntentChange(nil), values[index].Changes...)
+	}
+	return out
+}
+
+func mapCoordinate(t *testing.T, value string) arcset.CanonicalCoordinate {
+	t.Helper()
+	coordinate, err := arcset.NewMapCoordinate(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return coordinate
+}
+
+func typedRoot(t *testing.T, kind arcset.Kind, seed byte) cid.Cid {
+	t.Helper()
+	commitment := make([]byte, maltcid.KZGCommitmentSize)
+	for index := range commitment {
+		commitment[index] = seed + byte(index)
+	}
+	var (
+		root cid.Cid
+		err  error
+	)
+	if kind == arcset.KindMap {
+		root, err = maltcid.NewMapKZGCid(commitment)
+	} else {
+		root, err = maltcid.NewListKZGCid(commitment)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func typedIPARoot(t *testing.T, kind arcset.Kind, seed byte) cid.Cid {
+	t.Helper()
+	commitment := make([]byte, maltcid.IPACommitmentSize)
+	for index := range commitment {
+		commitment[index] = seed + byte(index)
+	}
+	var (
+		root cid.Cid
+		err  error
+	)
+	if kind == arcset.KindMap {
+		root, err = maltcid.NewMapIPACid(commitment)
+	} else {
+		root, err = maltcid.NewListIPACid(commitment)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func rawCID(t *testing.T, value string) cid.Cid {
+	t.Helper()
+	hash, err := mh.Sum([]byte(value), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cid.NewCidV1(cid.Raw, hash)
+}

--- a/mutation/client_root_test.go
+++ b/mutation/client_root_test.go
@@ -88,6 +88,39 @@ func TestNormalizeUpdateViewRequiresExactReachabilityClosure(t *testing.T) {
 	}
 }
 
+func TestClientRootRejectsTargetKindRelabelingAcrossSemanticBoundary(t *testing.T) {
+	view, intent, _, _, _ := clientRootFixture(t)
+	for index := range view.Objects {
+		if view.Objects[index].ObjectID != "parent" {
+			continue
+		}
+		entries := view.Objects[index].Entries.Entries()
+		entries[0].Target = arcset.NewCASTarget(entries[0].Target.CID())
+		relabeled, err := arcset.NewCanonicalArcSet(arcset.KindMap, entries)
+		if err != nil {
+			t.Fatal(err)
+		}
+		view.Objects[index].Entries = relabeled
+	}
+	if _, err := NormalizeUpdateView(view); !errors.Is(err, ErrInvalidUpdateView) {
+		t.Fatalf("semantic child relabel error = %v, want ErrInvalidUpdateView", err)
+	}
+
+	view, intent, _, _, _ = clientRootFixture(t)
+	intent.Transitions = cloneIntentTransitions(intent.Transitions)
+	for transitionIndex := range intent.Transitions {
+		if intent.Transitions[transitionIndex].ID != "child-output" {
+			continue
+		}
+		payload := intent.Transitions[transitionIndex].Changes[0].After.CID()
+		wrong := arcset.NewMapTarget(payload)
+		intent.Transitions[transitionIndex].Changes[0].After = &wrong
+	}
+	if _, err := NormalizeSemanticIntent(view, intent); !errors.Is(err, ErrInvalidSemanticIntent) {
+		t.Fatalf("payload relabel error = %v, want ErrInvalidSemanticIntent", err)
+	}
+}
+
 func TestNormalizeSemanticIntentRejectsMultiplicityBeforeImageAndLastDeltaPatterns(t *testing.T) {
 	view, intent, _, _, _ := clientRootFixture(t)
 

--- a/protocol/client_root.go
+++ b/protocol/client_root.go
@@ -1,0 +1,806 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/mutation"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+)
+
+const (
+	// Client-root wire profiles are aliases of the transport-neutral core
+	// profiles. Keeping the literals owned by mutation prevents profile drift
+	// between in-process and serialized contracts.
+	UpdateViewProfile             = mutation.UpdateViewProfile
+	SemanticIntentProfile         = mutation.SemanticIntentProfile
+	ClientRootBundleProfile       = mutation.ClientRootBundleProfile
+	MaterializationReceiptProfile = mutation.MaterializationReceiptProfile
+
+	StatefulCompleteVectorsProfile = mutation.StatefulCompleteVectorsProfile
+
+	PresenceAbsent  Presence = "absent"
+	PresencePresent Presence = "present"
+
+	CommitModeDefault   CommitMode = "default"
+	CommitModeFixedList CommitMode = "fixed_list"
+
+	// These hard limits bound allocations and graph walks independently from
+	// caller-supplied update-view bounds. They are wire safety ceilings, not
+	// benchmark workload defaults.
+	MaxClientRootObjects     = 1 << 16
+	MaxClientRootEntries     = 1 << 20
+	MaxClientRootDepth       = 1 << 16
+	MaxClientRootTransitions = 1 << 16
+	MaxClientRootChanges     = 1 << 20
+	MaxClientRootPayloadCIDs = 1 << 20
+	MaxClientRootCIDBytes    = 4096
+)
+
+// Presence makes optional wire values explicit. An absent value has empty
+// companion fields; a present value must carry all companion fields.
+type Presence string
+
+// CommitMode distinguishes the default semantic commit from the measured
+// fixed-list commit without relying on a nullable object.
+type CommitMode string
+
+// UpdateView is the JSON projection of mutation.UpdateView.
+type UpdateView struct {
+	Profile      string           `json:"profile"`
+	StateProfile string           `json:"state_profile"`
+	BaseRoot     string           `json:"base_root"`
+	Bounds       UpdateViewBounds `json:"bounds"`
+	Objects      []UpdateObject   `json:"objects"`
+}
+
+type UpdateViewBounds struct {
+	MaxObjects      uint32 `json:"max_objects"`
+	MaxTotalEntries uint64 `json:"max_total_entries"`
+	MaxDepth        uint32 `json:"max_depth"`
+}
+
+type UpdateObject struct {
+	ObjectID string           `json:"object_id"`
+	Root     string           `json:"root"`
+	Kind     arcset.Kind      `json:"kind"`
+	Entries  []ArcEntry       `json:"entries"`
+	Commit   CommitDescriptor `json:"commit"`
+}
+
+// ArcEntry binds one explicitly typed coordinate to one explicitly typed CID.
+type ArcEntry struct {
+	Coordinate Coordinate `json:"coordinate"`
+	Target     Target     `json:"target"`
+}
+
+// Coordinate always serializes all fields. For a map coordinate, MapPath is
+// canonical and ListIndex is zero. For a list coordinate, MapPath is empty and
+// ListIndex is the full uint64 index. Kind is checked against the containing
+// object rather than inferred from either zero value.
+type Coordinate struct {
+	Kind      arcset.Kind `json:"kind"`
+	MapPath   string      `json:"map_path"`
+	ListIndex uint64      `json:"list_index"`
+}
+
+// Target carries both the semantic target kind and a canonical CID string.
+type Target struct {
+	Kind arcset.TargetKind `json:"kind"`
+	CID  string            `json:"cid"`
+}
+
+// OptionalTarget encodes absence without JSON null. When State is absent,
+// Kind and CID must both be empty.
+type OptionalTarget struct {
+	State Presence          `json:"state"`
+	Kind  arcset.TargetKind `json:"kind"`
+	CID   string            `json:"cid"`
+}
+
+// OptionalCID encodes an undefined core CID without an empty-string inference.
+type OptionalCID struct {
+	State Presence `json:"state"`
+	CID   string   `json:"cid"`
+}
+
+// CommitDescriptor always carries mode and numeric fields. Default commits
+// require both numeric fields to be zero; fixed-list commits require a positive
+// chunk size and carry the exact total size, including zero for an empty list.
+type CommitDescriptor struct {
+	Mode      CommitMode `json:"mode"`
+	TotalSize uint64     `json:"total_size"`
+	ChunkSize uint64     `json:"chunk_size"`
+}
+
+// SemanticIntent is the JSON projection of mutation.SemanticIntent.
+type SemanticIntent struct {
+	Profile     string             `json:"profile"`
+	BaseRoot    string             `json:"base_root"`
+	Transitions []IntentTransition `json:"transitions"`
+	TopOutputID string             `json:"top_output_id"`
+}
+
+type IntentTransition struct {
+	ID           string              `json:"id"`
+	ObjectID     string              `json:"object_id"`
+	OldRoot      OptionalCID         `json:"old_root"`
+	Kind         arcset.Kind         `json:"kind"`
+	Backend      maltcid.BackendKind `json:"backend"`
+	Changes      []IntentChange      `json:"changes"`
+	Commit       CommitDescriptor    `json:"commit"`
+	ExpectedUses uint32              `json:"expected_uses"`
+}
+
+type IntentChange struct {
+	Coordinate Coordinate     `json:"coordinate"`
+	Before     OptionalTarget `json:"before"`
+	After      OptionalTarget `json:"after"`
+	Output     OptionalOutput `json:"output"`
+}
+
+// OptionalOutput makes a child-transition dependency explicit. An absent
+// output has empty ID and Kind; a present output is restricted to map/list.
+type OptionalOutput struct {
+	State Presence          `json:"state"`
+	ID    string            `json:"id"`
+	Kind  arcset.TargetKind `json:"kind"`
+}
+
+type TransitionOutput struct {
+	TransitionID string `json:"transition_id"`
+	Root         string `json:"root"`
+}
+
+// ClientRootBundle binds the complete view and intent to exact local outputs.
+// Digests are canonical lowercase, fixed-width SHA-256 hex strings.
+type ClientRootBundle struct {
+	Profile      string             `json:"profile"`
+	OperationID  string             `json:"operation_id"`
+	View         UpdateView         `json:"view"`
+	Intent       SemanticIntent     `json:"intent"`
+	Outputs      []TransitionOutput `json:"outputs"`
+	Candidate    string             `json:"candidate"`
+	PayloadCIDs  []string           `json:"payload_cids"`
+	ViewDigest   string             `json:"view_digest"`
+	IntentDigest string             `json:"intent_digest"`
+}
+
+type MaterializationReceipt struct {
+	Profile         string `json:"profile"`
+	OperationID     string `json:"operation_id"`
+	BaseRoot        string `json:"base_root"`
+	Candidate       string `json:"candidate"`
+	BundleDigest    string `json:"bundle_digest"`
+	DurableBoundary string `json:"durable_boundary"`
+}
+
+// NewUpdateView returns the canonical wire projection of one complete view.
+func NewUpdateView(value mutation.UpdateView) (UpdateView, error) {
+	canonical, err := mutation.NormalizeUpdateView(value)
+	if err != nil {
+		return UpdateView{}, err
+	}
+	objects := make([]UpdateObject, len(canonical.Objects))
+	for objectIndex, object := range canonical.Objects {
+		entries := object.Entries.Entries()
+		wireEntries := make([]ArcEntry, len(entries))
+		for entryIndex, entry := range entries {
+			coordinate, err := coordinateFromCore(object.Kind, entry.Coordinate)
+			if err != nil {
+				return UpdateView{}, fmt.Errorf("object %q entry %d: %w", object.ObjectID, entryIndex, err)
+			}
+			wireEntries[entryIndex] = ArcEntry{
+				Coordinate: coordinate,
+				Target:     targetFromCore(entry.Target),
+			}
+		}
+		wireCommit := commitFromCore(object.Commit)
+		if _, err := wireCommit.core(object.Kind); err != nil {
+			return UpdateView{}, fmt.Errorf("object %q commit: %w", object.ObjectID, err)
+		}
+		objects[objectIndex] = UpdateObject{
+			ObjectID: object.ObjectID,
+			Root:     object.Root.String(),
+			Kind:     object.Kind,
+			Entries:  wireEntries,
+			Commit:   wireCommit,
+		}
+	}
+	result := UpdateView{
+		Profile:      canonical.Profile,
+		StateProfile: canonical.StateProfile,
+		BaseRoot:     canonical.BaseRoot.String(),
+		Bounds: UpdateViewBounds{
+			MaxObjects:      canonical.Bounds.MaxObjects,
+			MaxTotalEntries: canonical.Bounds.MaxTotalEntries,
+			MaxDepth:        canonical.Bounds.MaxDepth,
+		},
+		Objects: objects,
+	}
+	if err := validateWireLimits(result); err != nil {
+		return UpdateView{}, err
+	}
+	return result, nil
+}
+
+// Core validates and converts a wire update view to its canonical core value.
+func (v UpdateView) Core() (mutation.UpdateView, error) {
+	if err := validateWireLimits(v); err != nil {
+		return mutation.UpdateView{}, err
+	}
+	baseRoot, err := parseCanonicalCID(v.BaseRoot, "update view base_root")
+	if err != nil {
+		return mutation.UpdateView{}, err
+	}
+	objects := make([]mutation.UpdateObject, len(v.Objects))
+	for objectIndex, object := range v.Objects {
+		root, err := parseCanonicalCID(object.Root, fmt.Sprintf("update object %d root", objectIndex))
+		if err != nil {
+			return mutation.UpdateView{}, err
+		}
+		entries := make([]arcset.ArcEntry, len(object.Entries))
+		seen := make(map[string]struct{}, len(object.Entries))
+		for entryIndex, entry := range object.Entries {
+			coordinate, err := entry.Coordinate.core(object.Kind)
+			if err != nil {
+				return mutation.UpdateView{}, fmt.Errorf("update object %q entry %d: %w", object.ObjectID, entryIndex, err)
+			}
+			key := string(coordinate.Bytes())
+			if _, exists := seen[key]; exists {
+				return mutation.UpdateView{}, fmt.Errorf("update object %q has duplicate coordinate %q", object.ObjectID, entry.Coordinate.debugString())
+			}
+			seen[key] = struct{}{}
+			target, err := entry.Target.core()
+			if err != nil {
+				return mutation.UpdateView{}, fmt.Errorf("update object %q entry %d: %w", object.ObjectID, entryIndex, err)
+			}
+			entries[entryIndex] = arcset.ArcEntry{Coordinate: coordinate, Target: target}
+		}
+		canonicalEntries, err := arcset.NewCanonicalArcSet(object.Kind, entries)
+		if err != nil {
+			return mutation.UpdateView{}, fmt.Errorf("update object %q entries: %w", object.ObjectID, err)
+		}
+		commit, err := object.Commit.core(object.Kind)
+		if err != nil {
+			return mutation.UpdateView{}, fmt.Errorf("update object %q commit: %w", object.ObjectID, err)
+		}
+		objects[objectIndex] = mutation.UpdateObject{
+			ObjectID: object.ObjectID,
+			Root:     root,
+			Kind:     object.Kind,
+			Entries:  canonicalEntries,
+			Commit:   commit,
+		}
+	}
+	return mutation.NormalizeUpdateView(mutation.UpdateView{
+		Profile:      v.Profile,
+		StateProfile: v.StateProfile,
+		BaseRoot:     baseRoot,
+		Bounds: mutation.UpdateViewBounds{
+			MaxObjects:      v.Bounds.MaxObjects,
+			MaxTotalEntries: v.Bounds.MaxTotalEntries,
+			MaxDepth:        v.Bounds.MaxDepth,
+		},
+		Objects: objects,
+	})
+}
+
+func (v UpdateView) Validate() error {
+	_, err := v.Core()
+	return err
+}
+
+// NewSemanticIntent returns the canonical child-before-parent wire projection.
+func NewSemanticIntent(view mutation.UpdateView, value mutation.SemanticIntent) (SemanticIntent, error) {
+	canonical, err := mutation.NormalizeSemanticIntent(view, value)
+	if err != nil {
+		return SemanticIntent{}, err
+	}
+	if len(canonical.Transitions) > MaxClientRootTransitions {
+		return SemanticIntent{}, fmt.Errorf("semantic intent transition count exceeds %d", MaxClientRootTransitions)
+	}
+	transitions := make([]IntentTransition, len(canonical.Transitions))
+	totalChanges := 0
+	for transitionIndex, transition := range canonical.Transitions {
+		totalChanges += len(transition.Changes)
+		if totalChanges > MaxClientRootChanges {
+			return SemanticIntent{}, fmt.Errorf("semantic intent changes exceed %d", MaxClientRootChanges)
+		}
+		changes := make([]IntentChange, len(transition.Changes))
+		for changeIndex, change := range transition.Changes {
+			coordinate, err := coordinateFromCore(transition.Kind, change.Coordinate)
+			if err != nil {
+				return SemanticIntent{}, fmt.Errorf("transition %q change %d: %w", transition.ID, changeIndex, err)
+			}
+			changes[changeIndex] = IntentChange{
+				Coordinate: coordinate,
+				Before:     optionalTargetFromCore(change.Before),
+				After:      optionalTargetFromCore(change.After),
+				Output:     optionalOutputFromCore(change.OutputID, change.OutputKind),
+			}
+		}
+		wireCommit := commitFromCore(transition.Commit)
+		if _, err := wireCommit.core(transition.Kind); err != nil {
+			return SemanticIntent{}, fmt.Errorf("transition %q commit: %w", transition.ID, err)
+		}
+		transitions[transitionIndex] = IntentTransition{
+			ID:           transition.ID,
+			ObjectID:     transition.ObjectID,
+			OldRoot:      optionalCIDFromCore(transition.OldRoot),
+			Kind:         transition.Kind,
+			Backend:      transition.Backend,
+			Changes:      changes,
+			Commit:       wireCommit,
+			ExpectedUses: transition.ExpectedUses,
+		}
+	}
+	return SemanticIntent{
+		Profile:     canonical.Profile,
+		BaseRoot:    canonical.BaseRoot.String(),
+		Transitions: transitions,
+		TopOutputID: canonical.TopOutputID,
+	}, nil
+}
+
+// Core validates and converts a wire intent against its complete update view.
+func (i SemanticIntent) Core(view mutation.UpdateView) (mutation.SemanticIntent, error) {
+	if len(i.Transitions) == 0 || len(i.Transitions) > MaxClientRootTransitions {
+		return mutation.SemanticIntent{}, fmt.Errorf("semantic intent transition count %d is outside 1..%d", len(i.Transitions), MaxClientRootTransitions)
+	}
+	baseRoot, err := parseCanonicalCID(i.BaseRoot, "semantic intent base_root")
+	if err != nil {
+		return mutation.SemanticIntent{}, err
+	}
+	transitions := make([]mutation.IntentTransition, len(i.Transitions))
+	totalChanges := 0
+	for transitionIndex, transition := range i.Transitions {
+		totalChanges += len(transition.Changes)
+		if totalChanges > MaxClientRootChanges {
+			return mutation.SemanticIntent{}, fmt.Errorf("semantic intent changes exceed %d", MaxClientRootChanges)
+		}
+		oldRoot, err := transition.OldRoot.core(fmt.Sprintf("transition %q old_root", transition.ID))
+		if err != nil {
+			return mutation.SemanticIntent{}, err
+		}
+		commit, err := transition.Commit.core(transition.Kind)
+		if err != nil {
+			return mutation.SemanticIntent{}, fmt.Errorf("transition %q commit: %w", transition.ID, err)
+		}
+		changes := make([]mutation.IntentChange, len(transition.Changes))
+		for changeIndex, change := range transition.Changes {
+			coordinate, err := change.Coordinate.core(transition.Kind)
+			if err != nil {
+				return mutation.SemanticIntent{}, fmt.Errorf("transition %q change %d: %w", transition.ID, changeIndex, err)
+			}
+			before, err := change.Before.core(fmt.Sprintf("transition %q change %d before", transition.ID, changeIndex))
+			if err != nil {
+				return mutation.SemanticIntent{}, err
+			}
+			after, err := change.After.core(fmt.Sprintf("transition %q change %d after", transition.ID, changeIndex))
+			if err != nil {
+				return mutation.SemanticIntent{}, err
+			}
+			outputID, outputKind, err := change.Output.core()
+			if err != nil {
+				return mutation.SemanticIntent{}, fmt.Errorf("transition %q change %d output: %w", transition.ID, changeIndex, err)
+			}
+			changes[changeIndex] = mutation.IntentChange{
+				Coordinate: coordinate,
+				Before:     before,
+				After:      after,
+				OutputID:   outputID,
+				OutputKind: outputKind,
+			}
+		}
+		transitions[transitionIndex] = mutation.IntentTransition{
+			ID:           transition.ID,
+			ObjectID:     transition.ObjectID,
+			OldRoot:      oldRoot,
+			Kind:         transition.Kind,
+			Backend:      transition.Backend,
+			Changes:      changes,
+			Commit:       commit,
+			ExpectedUses: transition.ExpectedUses,
+		}
+	}
+	return mutation.NormalizeSemanticIntent(view, mutation.SemanticIntent{
+		Profile:     i.Profile,
+		BaseRoot:    baseRoot,
+		Transitions: transitions,
+		TopOutputID: i.TopOutputID,
+	})
+}
+
+func (i SemanticIntent) Validate(view mutation.UpdateView) error {
+	_, err := i.Core(view)
+	return err
+}
+
+// NewClientRootBundle returns the canonical JSON projection of an exact-root
+// bundle after all view, dependency, digest, output, and candidate checks.
+func NewClientRootBundle(value mutation.ClientRootBundle) (ClientRootBundle, error) {
+	canonical, err := mutation.NewClientRootBundle(value)
+	if err != nil {
+		return ClientRootBundle{}, err
+	}
+	if len(canonical.Outputs) > MaxClientRootTransitions {
+		return ClientRootBundle{}, fmt.Errorf("client-root output count exceeds %d", MaxClientRootTransitions)
+	}
+	if len(canonical.PayloadCIDs) > MaxClientRootPayloadCIDs {
+		return ClientRootBundle{}, fmt.Errorf("client-root payload CID count exceeds %d", MaxClientRootPayloadCIDs)
+	}
+	view, err := NewUpdateView(canonical.View)
+	if err != nil {
+		return ClientRootBundle{}, err
+	}
+	intent, err := NewSemanticIntent(canonical.View, canonical.Intent)
+	if err != nil {
+		return ClientRootBundle{}, err
+	}
+	outputs := make([]TransitionOutput, len(canonical.Outputs))
+	for index, output := range canonical.Outputs {
+		outputs[index] = TransitionOutput{TransitionID: output.TransitionID, Root: output.Root.String()}
+	}
+	payloads := make([]string, len(canonical.PayloadCIDs))
+	for index, payload := range canonical.PayloadCIDs {
+		payloads[index] = payload.String()
+	}
+	return ClientRootBundle{
+		Profile:      canonical.Profile,
+		OperationID:  canonical.OperationID,
+		View:         view,
+		Intent:       intent,
+		Outputs:      outputs,
+		Candidate:    canonical.Candidate.String(),
+		PayloadCIDs:  payloads,
+		ViewDigest:   hex.EncodeToString(canonical.ViewDigest[:]),
+		IntentDigest: hex.EncodeToString(canonical.IntentDigest[:]),
+	}, nil
+}
+
+// Core validates and converts a wire bundle to its canonical core value.
+func (b ClientRootBundle) Core() (mutation.ClientRootBundle, error) {
+	if len(b.Outputs) == 0 || len(b.Outputs) > MaxClientRootTransitions {
+		return mutation.ClientRootBundle{}, fmt.Errorf("client-root output count %d is outside 1..%d", len(b.Outputs), MaxClientRootTransitions)
+	}
+	if len(b.PayloadCIDs) > MaxClientRootPayloadCIDs {
+		return mutation.ClientRootBundle{}, fmt.Errorf("client-root payload CID count exceeds %d", MaxClientRootPayloadCIDs)
+	}
+	view, err := b.View.Core()
+	if err != nil {
+		return mutation.ClientRootBundle{}, err
+	}
+	intent, err := b.Intent.Core(view)
+	if err != nil {
+		return mutation.ClientRootBundle{}, err
+	}
+	outputs := make([]mutation.TransitionOutput, len(b.Outputs))
+	for index, output := range b.Outputs {
+		root, err := parseCanonicalCID(output.Root, fmt.Sprintf("output %q root", output.TransitionID))
+		if err != nil {
+			return mutation.ClientRootBundle{}, err
+		}
+		outputs[index] = mutation.TransitionOutput{TransitionID: output.TransitionID, Root: root}
+	}
+	candidate, err := parseCanonicalCID(b.Candidate, "client-root candidate")
+	if err != nil {
+		return mutation.ClientRootBundle{}, err
+	}
+	payloads := make([]cid.Cid, len(b.PayloadCIDs))
+	for index, raw := range b.PayloadCIDs {
+		payloads[index], err = parseCanonicalCID(raw, fmt.Sprintf("payload_cids[%d]", index))
+		if err != nil {
+			return mutation.ClientRootBundle{}, err
+		}
+	}
+	viewDigest, err := parseDigest(b.ViewDigest, "view_digest")
+	if err != nil {
+		return mutation.ClientRootBundle{}, err
+	}
+	intentDigest, err := parseDigest(b.IntentDigest, "intent_digest")
+	if err != nil {
+		return mutation.ClientRootBundle{}, err
+	}
+	return mutation.NewClientRootBundle(mutation.ClientRootBundle{
+		Profile:      b.Profile,
+		OperationID:  b.OperationID,
+		View:         view,
+		Intent:       intent,
+		Outputs:      outputs,
+		Candidate:    candidate,
+		PayloadCIDs:  payloads,
+		ViewDigest:   viewDigest,
+		IntentDigest: intentDigest,
+	})
+}
+
+func (b ClientRootBundle) Validate() error {
+	_, err := b.Core()
+	return err
+}
+
+// NewMaterializationReceipt returns a wire receipt only after checking that it
+// acknowledges the exact submitted bundle.
+func NewMaterializationReceipt(value mutation.MaterializationReceipt, bundle mutation.ClientRootBundle) (MaterializationReceipt, error) {
+	if err := value.Validate(bundle); err != nil {
+		return MaterializationReceipt{}, err
+	}
+	return MaterializationReceipt{
+		Profile:         value.Profile,
+		OperationID:     value.OperationID,
+		BaseRoot:        value.BaseRoot.String(),
+		Candidate:       value.Candidate.String(),
+		BundleDigest:    hex.EncodeToString(value.BundleDigest[:]),
+		DurableBoundary: value.DurableBoundary,
+	}, nil
+}
+
+// Core validates a wire receipt against the exact submitted bundle.
+func (r MaterializationReceipt) Core(bundle mutation.ClientRootBundle) (mutation.MaterializationReceipt, error) {
+	baseRoot, err := parseCanonicalCID(r.BaseRoot, "materialization receipt base_root")
+	if err != nil {
+		return mutation.MaterializationReceipt{}, err
+	}
+	candidate, err := parseCanonicalCID(r.Candidate, "materialization receipt candidate")
+	if err != nil {
+		return mutation.MaterializationReceipt{}, err
+	}
+	digest, err := parseDigest(r.BundleDigest, "bundle_digest")
+	if err != nil {
+		return mutation.MaterializationReceipt{}, err
+	}
+	value := mutation.MaterializationReceipt{
+		Profile:         r.Profile,
+		OperationID:     r.OperationID,
+		BaseRoot:        baseRoot,
+		Candidate:       candidate,
+		BundleDigest:    digest,
+		DurableBoundary: r.DurableBoundary,
+	}
+	if err := value.Validate(bundle); err != nil {
+		return mutation.MaterializationReceipt{}, err
+	}
+	return value, nil
+}
+
+func (r MaterializationReceipt) Validate(bundle mutation.ClientRootBundle) error {
+	_, err := r.Core(bundle)
+	return err
+}
+
+func validateWireLimits(v UpdateView) error {
+	if v.Bounds.MaxObjects == 0 || v.Bounds.MaxObjects > MaxClientRootObjects {
+		return fmt.Errorf("update view max_objects must be in 1..%d", MaxClientRootObjects)
+	}
+	if v.Bounds.MaxTotalEntries == 0 || v.Bounds.MaxTotalEntries > MaxClientRootEntries {
+		return fmt.Errorf("update view max_total_entries must be in 1..%d", MaxClientRootEntries)
+	}
+	if v.Bounds.MaxDepth == 0 || v.Bounds.MaxDepth > MaxClientRootDepth {
+		return fmt.Errorf("update view max_depth must be in 1..%d", MaxClientRootDepth)
+	}
+	if len(v.Objects) == 0 || len(v.Objects) > MaxClientRootObjects || uint64(len(v.Objects)) > uint64(v.Bounds.MaxObjects) {
+		return fmt.Errorf("update view object count %d exceeds bounds", len(v.Objects))
+	}
+	var entries uint64
+	for _, object := range v.Objects {
+		entries += uint64(len(object.Entries))
+		if entries > MaxClientRootEntries || entries > v.Bounds.MaxTotalEntries {
+			return fmt.Errorf("update view entry count exceeds bounds")
+		}
+	}
+	return nil
+}
+
+func coordinateFromCore(kind arcset.Kind, value arcset.CanonicalCoordinate) (Coordinate, error) {
+	raw := value.Bytes()
+	switch kind {
+	case arcset.KindMap:
+		canonical, err := arcset.NewMapCoordinate(string(raw))
+		if err != nil || !bytes.Equal(canonical.Bytes(), raw) {
+			return Coordinate{}, fmt.Errorf("invalid canonical map coordinate")
+		}
+		return Coordinate{Kind: kind, MapPath: string(raw)}, nil
+	case arcset.KindList:
+		if len(raw) != 8 {
+			return Coordinate{}, fmt.Errorf("invalid canonical list coordinate")
+		}
+		return Coordinate{Kind: kind, ListIndex: binary.BigEndian.Uint64(raw)}, nil
+	default:
+		return Coordinate{}, fmt.Errorf("unsupported coordinate kind %q", kind)
+	}
+}
+
+func (c Coordinate) core(containingKind arcset.Kind) (arcset.CanonicalCoordinate, error) {
+	if c.Kind != containingKind {
+		return arcset.CanonicalCoordinate{}, fmt.Errorf("coordinate kind %q does not match containing kind %q", c.Kind, containingKind)
+	}
+	switch c.Kind {
+	case arcset.KindMap:
+		if c.MapPath == "" || c.ListIndex != 0 {
+			return arcset.CanonicalCoordinate{}, fmt.Errorf("map coordinate must carry only map_path")
+		}
+		coordinate, err := arcset.NewMapCoordinate(c.MapPath)
+		if err != nil {
+			return arcset.CanonicalCoordinate{}, err
+		}
+		if coordinate.String() != c.MapPath {
+			return arcset.CanonicalCoordinate{}, fmt.Errorf("map coordinate is not canonical")
+		}
+		return coordinate, nil
+	case arcset.KindList:
+		if c.MapPath != "" {
+			return arcset.CanonicalCoordinate{}, fmt.Errorf("list coordinate must carry only list_index")
+		}
+		return arcset.NewListCoordinateUint64(c.ListIndex), nil
+	default:
+		return arcset.CanonicalCoordinate{}, fmt.Errorf("unsupported coordinate kind %q", c.Kind)
+	}
+}
+
+func (c Coordinate) debugString() string {
+	if c.Kind == arcset.KindList {
+		return fmt.Sprintf("%d", c.ListIndex)
+	}
+	return c.MapPath
+}
+
+func targetFromCore(value arcset.TargetRef) Target {
+	return Target{Kind: value.Kind(), CID: value.CID().String()}
+}
+
+func (t Target) core() (arcset.TargetRef, error) {
+	if !knownTargetKind(t.Kind) {
+		return arcset.TargetRef{}, fmt.Errorf("unsupported target kind %q", t.Kind)
+	}
+	target, err := parseCanonicalCID(t.CID, "target CID")
+	if err != nil {
+		return arcset.TargetRef{}, err
+	}
+	return arcset.NewTargetRef(t.Kind, target), nil
+}
+
+func optionalTargetFromCore(value *arcset.TargetRef) OptionalTarget {
+	if value == nil {
+		return OptionalTarget{State: PresenceAbsent}
+	}
+	return OptionalTarget{State: PresencePresent, Kind: value.Kind(), CID: value.CID().String()}
+}
+
+func (t OptionalTarget) core(field string) (*arcset.TargetRef, error) {
+	switch t.State {
+	case PresenceAbsent:
+		if t.Kind != "" || t.CID != "" {
+			return nil, fmt.Errorf("%s absent target has companion fields", field)
+		}
+		return nil, nil
+	case PresencePresent:
+		target, err := (Target{Kind: t.Kind, CID: t.CID}).core()
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", field, err)
+		}
+		return &target, nil
+	default:
+		return nil, fmt.Errorf("%s has unsupported presence %q", field, t.State)
+	}
+}
+
+func optionalCIDFromCore(value cid.Cid) OptionalCID {
+	if !value.Defined() {
+		return OptionalCID{State: PresenceAbsent}
+	}
+	return OptionalCID{State: PresencePresent, CID: value.String()}
+}
+
+func (c OptionalCID) core(field string) (cid.Cid, error) {
+	switch c.State {
+	case PresenceAbsent:
+		if c.CID != "" {
+			return cid.Undef, fmt.Errorf("%s absent CID is nonempty", field)
+		}
+		return cid.Undef, nil
+	case PresencePresent:
+		return parseCanonicalCID(c.CID, field)
+	default:
+		return cid.Undef, fmt.Errorf("%s has unsupported presence %q", field, c.State)
+	}
+}
+
+func optionalOutputFromCore(id string, kind arcset.TargetKind) OptionalOutput {
+	if id == "" {
+		return OptionalOutput{State: PresenceAbsent}
+	}
+	return OptionalOutput{State: PresencePresent, ID: id, Kind: kind}
+}
+
+func (o OptionalOutput) core() (string, arcset.TargetKind, error) {
+	switch o.State {
+	case PresenceAbsent:
+		if o.ID != "" || o.Kind != "" {
+			return "", "", fmt.Errorf("absent output has companion fields")
+		}
+		return "", "", nil
+	case PresencePresent:
+		if o.ID == "" || o.Kind != arcset.TargetKindMap && o.Kind != arcset.TargetKindList {
+			return "", "", fmt.Errorf("present output must carry id and map/list kind")
+		}
+		return o.ID, o.Kind, nil
+	default:
+		return "", "", fmt.Errorf("unsupported output presence %q", o.State)
+	}
+}
+
+func commitFromCore(value mutation.CommitDescriptor) CommitDescriptor {
+	if value.FixedList == nil {
+		return CommitDescriptor{Mode: CommitModeDefault}
+	}
+	return CommitDescriptor{
+		Mode:      CommitModeFixedList,
+		TotalSize: value.FixedList.TotalSize,
+		ChunkSize: value.FixedList.ChunkSize,
+	}
+}
+
+func (c CommitDescriptor) core(kind arcset.Kind) (mutation.CommitDescriptor, error) {
+	switch c.Mode {
+	case CommitModeDefault:
+		if c.TotalSize != 0 || c.ChunkSize != 0 {
+			return mutation.CommitDescriptor{}, fmt.Errorf("default commit has fixed-list fields")
+		}
+		return mutation.CommitDescriptor{}, nil
+	case CommitModeFixedList:
+		if kind != arcset.KindList {
+			return mutation.CommitDescriptor{}, fmt.Errorf("fixed-list commit requires list kind")
+		}
+		if c.ChunkSize == 0 {
+			return mutation.CommitDescriptor{}, fmt.Errorf("fixed-list chunk_size must be positive")
+		}
+		return mutation.CommitDescriptor{FixedList: &mutation.FixedListCommit{
+			TotalSize: c.TotalSize,
+			ChunkSize: c.ChunkSize,
+		}}, nil
+	default:
+		return mutation.CommitDescriptor{}, fmt.Errorf("unsupported commit mode %q", c.Mode)
+	}
+}
+
+func parseCanonicalCID(raw, field string) (cid.Cid, error) {
+	if raw == "" || len(raw) > MaxClientRootCIDBytes {
+		return cid.Undef, fmt.Errorf("%s length is outside 1..%d", field, MaxClientRootCIDBytes)
+	}
+	value, err := cid.Decode(raw)
+	if err != nil {
+		return cid.Undef, fmt.Errorf("invalid %s: %w", field, err)
+	}
+	if value.String() != raw {
+		return cid.Undef, fmt.Errorf("%s is not in canonical CID string form", field)
+	}
+	return value, nil
+}
+
+func parseDigest(raw, field string) ([32]byte, error) {
+	if len(raw) != 64 || strings.ToLower(raw) != raw {
+		return [32]byte{}, fmt.Errorf("%s must be 64 lowercase hexadecimal characters", field)
+	}
+	decoded, err := hex.DecodeString(raw)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("invalid %s: %w", field, err)
+	}
+	var value [32]byte
+	copy(value[:], decoded)
+	return value, nil
+}
+
+func knownTargetKind(kind arcset.TargetKind) bool {
+	switch kind {
+	case arcset.TargetKindUnknown, arcset.TargetKindCAS, arcset.TargetKindMap, arcset.TargetKindList:
+		return true
+	default:
+		return false
+	}
+}

--- a/protocol/client_root_decode.go
+++ b/protocol/client_root_decode.go
@@ -1,0 +1,270 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/dewebprotocol/malt/mutation"
+)
+
+// MaxClientRootJSONBytes bounds every client-writer JSON document before
+// decoding. The semantic collection ceilings in client_root.go apply after
+// structural decoding and before core graph validation.
+const MaxClientRootJSONBytes = 64 << 20
+
+// DecodeUpdateView strictly decodes and validates one complete update view.
+func DecodeUpdateView(data []byte) (UpdateView, error) {
+	var value UpdateView
+	if err := decodeClientRootJSON(data, &value); err != nil {
+		return UpdateView{}, fmt.Errorf("decode update view: %w", err)
+	}
+	if err := value.Validate(); err != nil {
+		return UpdateView{}, err
+	}
+	return value, nil
+}
+
+// DecodeSemanticIntent strictly decodes and validates one intent against the
+// caller-selected complete update view.
+func DecodeSemanticIntent(data []byte, view mutation.UpdateView) (SemanticIntent, error) {
+	var value SemanticIntent
+	if err := decodeClientRootJSON(data, &value); err != nil {
+		return SemanticIntent{}, fmt.Errorf("decode semantic intent: %w", err)
+	}
+	if err := value.Validate(view); err != nil {
+		return SemanticIntent{}, err
+	}
+	return value, nil
+}
+
+// DecodeClientRootBundle strictly decodes and validates one exact-root bundle.
+func DecodeClientRootBundle(data []byte) (ClientRootBundle, error) {
+	var value ClientRootBundle
+	if err := decodeClientRootJSON(data, &value); err != nil {
+		return ClientRootBundle{}, fmt.Errorf("decode client-root bundle: %w", err)
+	}
+	if err := value.Validate(); err != nil {
+		return ClientRootBundle{}, err
+	}
+	return value, nil
+}
+
+// DecodeMaterializationReceipt strictly decodes a receipt and checks it against
+// the exact submitted bundle.
+func DecodeMaterializationReceipt(data []byte, bundle mutation.ClientRootBundle) (MaterializationReceipt, error) {
+	var value MaterializationReceipt
+	if err := decodeClientRootJSON(data, &value); err != nil {
+		return MaterializationReceipt{}, fmt.Errorf("decode materialization receipt: %w", err)
+	}
+	if err := value.Validate(bundle); err != nil {
+		return MaterializationReceipt{}, err
+	}
+	return value, nil
+}
+
+func decodeClientRootJSON(data []byte, target any) error {
+	if len(data) == 0 {
+		return fmt.Errorf("client-root JSON is empty")
+	}
+	if len(data) > MaxClientRootJSONBytes {
+		return fmt.Errorf("client-root JSON exceeds %d bytes", MaxClientRootJSONBytes)
+	}
+	targetType := reflect.TypeOf(target)
+	if targetType.Kind() != reflect.Pointer || targetType.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("client-root decode target must point to a struct")
+	}
+	if err := validateRequiredJSONShape(data, targetType.Elem()); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing JSON value")
+		}
+		return fmt.Errorf("unexpected trailing JSON: %w", err)
+	}
+	return nil
+}
+
+// validateRequiredJSONShape performs a streaming structural pass before typed
+// decoding. In addition to unknown fields, it rejects duplicate fields, nulls,
+// and missing required fields at every nested level. All client-root DTO fields
+// are deliberately required; optional semantic values use explicit presence
+// discriminators instead of optional JSON properties.
+func validateRequiredJSONShape(data []byte, targetType reflect.Type) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	if err := validateJSONToken(decoder, token, targetType, "$", true); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing JSON value")
+		}
+		return fmt.Errorf("unexpected trailing JSON: %w", err)
+	}
+	return nil
+}
+
+func validateJSONToken(decoder *json.Decoder, token json.Token, targetType reflect.Type, path string, required bool) error {
+	for targetType.Kind() == reflect.Pointer {
+		targetType = targetType.Elem()
+	}
+	if token == nil {
+		if required {
+			return fmt.Errorf("%s must not be null", path)
+		}
+		return nil
+	}
+	switch targetType.Kind() {
+	case reflect.Struct:
+		delim, ok := token.(json.Delim)
+		if !ok || delim != '{' {
+			return fmt.Errorf("%s must be an object", path)
+		}
+		fields := jsonStructFields(targetType)
+		seen := make(map[string]struct{}, len(fields))
+		for decoder.More() {
+			nameToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			name, ok := nameToken.(string)
+			if !ok {
+				return fmt.Errorf("%s has a non-string field name", path)
+			}
+			field, exists := fields[name]
+			if !exists {
+				return fmt.Errorf("%s has unknown field %q", path, name)
+			}
+			if _, exists := seen[name]; exists {
+				return fmt.Errorf("%s has duplicate field %q", path, name)
+			}
+			seen[name] = struct{}{}
+			valueToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if err := validateJSONToken(decoder, valueToken, field.typ, path+"."+name, !field.optional); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim('}') {
+			return fmt.Errorf("%s has an invalid object terminator", path)
+		}
+		for name, field := range fields {
+			if _, exists := seen[name]; !exists && !field.optional {
+				return fmt.Errorf("%s is missing required field %q", path, name)
+			}
+		}
+		return nil
+	case reflect.Slice, reflect.Array:
+		delim, ok := token.(json.Delim)
+		if !ok || delim != '[' {
+			return fmt.Errorf("%s must be an array", path)
+		}
+		index := 0
+		maxItems := maxClientRootSliceItems(targetType)
+		for decoder.More() {
+			if maxItems > 0 && index >= maxItems {
+				return fmt.Errorf("%s exceeds %d items", path, maxItems)
+			}
+			valueToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if err := validateJSONToken(decoder, valueToken, targetType.Elem(), fmt.Sprintf("%s[%d]", path, index), true); err != nil {
+				return err
+			}
+			index++
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim(']') {
+			return fmt.Errorf("%s has an invalid array terminator", path)
+		}
+		return nil
+	case reflect.String:
+		if _, ok := token.(string); !ok {
+			return fmt.Errorf("%s must be a string", path)
+		}
+		return nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if _, ok := token.(json.Number); !ok {
+			return fmt.Errorf("%s must be an unsigned integer", path)
+		}
+		return nil
+	case reflect.Bool:
+		if _, ok := token.(bool); !ok {
+			return fmt.Errorf("%s must be a boolean", path)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%s has unsupported decoder type %s", path, targetType)
+	}
+}
+
+func maxClientRootSliceItems(targetType reflect.Type) int {
+	if targetType.Kind() == reflect.Array {
+		return targetType.Len()
+	}
+	switch targetType.Elem() {
+	case reflect.TypeFor[UpdateObject]():
+		return MaxClientRootObjects
+	case reflect.TypeFor[ArcEntry]():
+		return MaxClientRootEntries
+	case reflect.TypeFor[IntentTransition]():
+		return MaxClientRootTransitions
+	case reflect.TypeFor[IntentChange]():
+		return MaxClientRootChanges
+	case reflect.TypeFor[TransitionOutput]():
+		return MaxClientRootTransitions
+	case reflect.TypeFor[string]():
+		return MaxClientRootPayloadCIDs
+	default:
+		return 0
+	}
+}
+
+type jsonStructField struct {
+	typ      reflect.Type
+	optional bool
+}
+
+func jsonStructFields(targetType reflect.Type) map[string]jsonStructField {
+	fields := make(map[string]jsonStructField, targetType.NumField())
+	for index := 0; index < targetType.NumField(); index++ {
+		field := targetType.Field(index)
+		if !field.IsExported() {
+			continue
+		}
+		tag := field.Tag.Get("json")
+		name, options, _ := strings.Cut(tag, ",")
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = field.Name
+		}
+		fields[name] = jsonStructField{typ: field.Type, optional: strings.Contains(options, "omitempty")}
+	}
+	return fields
+}

--- a/protocol/client_root_test.go
+++ b/protocol/client_root_test.go
@@ -1,0 +1,521 @@
+package protocol_test
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/mutation"
+	"github.com/dewebprotocol/malt/protocol"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+)
+
+func TestClientRootWireRoundTripsCoreValues(t *testing.T) {
+	bundle, receipt := protocolClientRootFixture(t)
+	wireBundle, err := protocol.NewClientRootBundle(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(wireBundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := protocol.DecodeClientRootBundle(raw)
+	if err != nil {
+		t.Fatalf("DecodeClientRootBundle: %v", err)
+	}
+	if !reflect.DeepEqual(decoded, wireBundle) {
+		t.Fatalf("decoded wire bundle differs\n got: %#v\nwant: %#v", decoded, wireBundle)
+	}
+	coreBundle, err := decoded.Core()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDigest, err := bundle.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotDigest, err := coreBundle.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotDigest != wantDigest {
+		t.Fatalf("bundle digest = %x, want %x", gotDigest, wantDigest)
+	}
+
+	wireView, err := protocol.NewUpdateView(bundle.View)
+	if err != nil {
+		t.Fatal(err)
+	}
+	viewRaw, err := json.Marshal(wireView)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := protocol.DecodeUpdateView(viewRaw); err != nil {
+		t.Fatalf("DecodeUpdateView: %v", err)
+	}
+	wireIntent, err := protocol.NewSemanticIntent(bundle.View, bundle.Intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intentRaw, err := json.Marshal(wireIntent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := protocol.DecodeSemanticIntent(intentRaw, bundle.View); err != nil {
+		t.Fatalf("DecodeSemanticIntent: %v", err)
+	}
+
+	wireReceipt, err := protocol.NewMaterializationReceipt(receipt, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptRaw, err := json.Marshal(wireReceipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decodedReceipt, err := protocol.DecodeMaterializationReceipt(receiptRaw, bundle)
+	if err != nil {
+		t.Fatalf("DecodeMaterializationReceipt: %v", err)
+	}
+	coreReceipt, err := decodedReceipt.Core(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if coreReceipt.BundleDigest != receipt.BundleDigest || !coreReceipt.Candidate.Equals(receipt.Candidate) {
+		t.Fatalf("receipt = %#v, want %#v", coreReceipt, receipt)
+	}
+}
+
+func TestUpdateViewWireRoundTripsFullUint64ListCoordinate(t *testing.T) {
+	root := protocolTypedRoot(t, arcset.KindList, 31)
+	target := protocolTestCID(t, "uint64-list-target")
+	entries, err := arcset.NewCanonicalArcSet(arcset.KindList, []arcset.ArcEntry{{
+		Coordinate: arcset.NewListCoordinateUint64(math.MaxUint64),
+		Target:     arcset.NewCASTarget(target),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := mutation.UpdateView{
+		Profile:      mutation.UpdateViewProfile,
+		StateProfile: mutation.StatefulCompleteVectorsProfile,
+		BaseRoot:     root,
+		Bounds:       mutation.UpdateViewBounds{MaxObjects: 1, MaxTotalEntries: 1, MaxDepth: 1},
+		Objects: []mutation.UpdateObject{{
+			ObjectID: "root", Root: root, Kind: arcset.KindList, Entries: entries,
+		}},
+	}
+	wire, err := protocol.NewUpdateView(view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := wire.Objects[0].Entries[0].Coordinate.ListIndex; got != math.MaxUint64 {
+		t.Fatalf("wire list index = %d, want %d", got, uint64(math.MaxUint64))
+	}
+	decoded, err := wire.Core()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := decoded.Objects[0].Entries.Entries()[0].Coordinate.Bytes()
+	if len(raw) != 8 || binary.BigEndian.Uint64(raw) != math.MaxUint64 {
+		t.Fatalf("decoded coordinate = %x", raw)
+	}
+}
+
+func TestClientRootDecodeRejectsUnknownDuplicateMissingNullTrailingAndOversized(t *testing.T) {
+	bundle, _ := protocolClientRootFixture(t)
+	wire, err := protocol.NewClientRootBundle(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatal(err)
+	}
+	object["unexpected"] = true
+	assertBundleDecodeFails(t, object)
+
+	duplicate := `{"profile":"` + protocol.ClientRootBundleProfile + `","profile":` + strings.TrimPrefix(string(raw), `{"profile":`)
+	if _, err := protocol.DecodeClientRootBundle([]byte(duplicate)); err == nil || !strings.Contains(err.Error(), "duplicate field") {
+		t.Fatalf("duplicate-field error = %v", err)
+	}
+
+	missing := cloneJSONMap(t, raw)
+	view := missing["view"].(map[string]any)
+	objects := view["objects"].([]any)
+	commit := objects[0].(map[string]any)["commit"].(map[string]any)
+	delete(commit, "total_size")
+	assertBundleDecodeFails(t, missing)
+
+	nullValue := cloneJSONMap(t, raw)
+	nullValue["payload_cids"] = nil
+	assertBundleDecodeFails(t, nullValue)
+
+	if _, err := protocol.DecodeClientRootBundle(append(raw, []byte(`{}`)...)); err == nil {
+		t.Fatal("DecodeClientRootBundle accepted trailing JSON")
+	}
+	oversized := make([]byte, protocol.MaxClientRootJSONBytes+1)
+	if _, err := protocol.DecodeUpdateView(oversized); err == nil {
+		t.Fatal("DecodeUpdateView accepted oversized JSON")
+	}
+}
+
+func TestClientRootWireRejectsHostileDigestRootKindCoordinateDuplicateAndDependency(t *testing.T) {
+	bundle, _ := protocolClientRootFixture(t)
+	base, err := protocol.NewClientRootBundle(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*protocol.ClientRootBundle)
+	}{
+		{
+			name: "wrong digest",
+			mutate: func(value *protocol.ClientRootBundle) {
+				value.ViewDigest = "0" + value.ViewDigest[1:]
+				if value.ViewDigest == base.ViewDigest {
+					value.ViewDigest = "1" + value.ViewDigest[1:]
+				}
+			},
+		},
+		{
+			name: "wrong root",
+			mutate: func(value *protocol.ClientRootBundle) {
+				index := wireObjectIndex(t, value, "child")
+				value.View.Objects[index].Root = protocolTypedRoot(t, arcset.KindList, 99).String()
+			},
+		},
+		{
+			name: "wrong target kind",
+			mutate: func(value *protocol.ClientRootBundle) {
+				index := wireObjectIndex(t, value, "parent")
+				value.View.Objects[index].Entries[0].Target.Kind = arcset.TargetKindList
+			},
+		},
+		{
+			name: "noncanonical coordinate",
+			mutate: func(value *protocol.ClientRootBundle) {
+				index := wireObjectIndex(t, value, "child")
+				value.View.Objects[index].Entries[0].Coordinate.MapPath = "payload//nested"
+			},
+		},
+		{
+			name: "duplicate coordinate",
+			mutate: func(value *protocol.ClientRootBundle) {
+				index := wireObjectIndex(t, value, "child")
+				entry := value.View.Objects[index].Entries[0]
+				value.View.Objects[index].Entries = append(value.View.Objects[index].Entries, entry)
+			},
+		},
+		{
+			name: "missing dependency",
+			mutate: func(value *protocol.ClientRootBundle) {
+				index := wireTransitionIndex(t, value, "top-output")
+				value.Intent.Transitions[index].Changes[0].Output.ID = "missing-output"
+			},
+		},
+		{
+			name: "wrong output semantic kind",
+			mutate: func(value *protocol.ClientRootBundle) {
+				index := wireOutputIndex(t, value, "child-output")
+				value.Outputs[index].Root = protocolTypedRoot(t, arcset.KindList, 88).String()
+			},
+		},
+		{
+			name: "wrong output backend",
+			mutate: func(value *protocol.ClientRootBundle) {
+				index := wireOutputIndex(t, value, "child-output")
+				value.Outputs[index].Root = protocolIPARoot(t, arcset.KindMap, 77).String()
+			},
+		},
+		{
+			name: "missing literal payload",
+			mutate: func(value *protocol.ClientRootBundle) {
+				value.PayloadCIDs = []string{}
+			},
+		},
+		{
+			name: "extra literal payload",
+			mutate: func(value *protocol.ClientRootBundle) {
+				value.PayloadCIDs = append(value.PayloadCIDs, protocolTestCID(t, "extra-wire-payload").String())
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value := cloneWireBundle(t, base)
+			test.mutate(&value)
+			if _, err := value.Core(); err == nil {
+				t.Fatalf("Core accepted hostile %s", test.name)
+			}
+		})
+	}
+}
+
+func TestMaterializationReceiptWireRejectsWrongDigest(t *testing.T) {
+	bundle, receipt := protocolClientRootFixture(t)
+	wire, err := protocol.NewMaterializationReceipt(receipt, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire.BundleDigest = strings.Repeat("0", 64)
+	if wire.BundleDigest == strings.Repeat("0", 64) && receipt.BundleDigest == [32]byte{} {
+		t.Fatal("fixture unexpectedly has zero bundle digest")
+	}
+	if _, err := wire.Core(bundle); err == nil {
+		t.Fatal("receipt accepted wrong bundle digest")
+	}
+}
+
+func TestClientRootSchemasAreEmbedded(t *testing.T) {
+	want := map[string]bool{
+		"update-view.schema.json":             false,
+		"semantic-intent.schema.json":         false,
+		"client-root-bundle.schema.json":      false,
+		"materialization-receipt.schema.json": false,
+	}
+	for _, name := range protocol.SchemaNames() {
+		if _, ok := want[name]; ok {
+			want[name] = true
+			data, err := protocol.Schema(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var schema map[string]any
+			if err := json.Unmarshal(data, &schema); err != nil {
+				t.Fatalf("schema %s: %v", name, err)
+			}
+			if schema["$id"] == nil {
+				t.Fatalf("schema %s has no $id", name)
+			}
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("SchemaNames does not include %s", name)
+		}
+	}
+}
+
+func protocolClientRootFixture(t *testing.T) (mutation.ClientRootBundle, mutation.MaterializationReceipt) {
+	t.Helper()
+	oldPayload := protocolTestCID(t, "protocol-old-payload")
+	newPayload := protocolTestCID(t, "protocol-new-payload")
+	childRoot := protocolTypedRoot(t, arcset.KindMap, 1)
+	parentRoot := protocolTypedRoot(t, arcset.KindList, 2)
+	childNewRoot := protocolTypedRoot(t, arcset.KindMap, 3)
+	parentNewRoot := protocolTypedRoot(t, arcset.KindList, 4)
+
+	childEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
+		Coordinate: protocolMapCoordinate(t, "payload"),
+		Target:     arcset.NewCASTarget(oldPayload),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentEntries, err := arcset.NewCanonicalArcSet(arcset.KindList, []arcset.ArcEntry{{
+		Coordinate: arcset.NewListCoordinateUint64(0),
+		Target:     arcset.NewMapTarget(childRoot),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixed := mutation.CommitDescriptor{FixedList: &mutation.FixedListCommit{TotalSize: 8, ChunkSize: 8}}
+	view := mutation.UpdateView{
+		Profile:      mutation.UpdateViewProfile,
+		StateProfile: mutation.StatefulCompleteVectorsProfile,
+		BaseRoot:     parentRoot,
+		Bounds:       mutation.UpdateViewBounds{MaxObjects: 8, MaxTotalEntries: 64, MaxDepth: 8},
+		Objects: []mutation.UpdateObject{
+			{ObjectID: "parent", Root: parentRoot, Kind: arcset.KindList, Entries: parentEntries, Commit: fixed},
+			{ObjectID: "child", Root: childRoot, Kind: arcset.KindMap, Entries: childEntries},
+		},
+	}
+	oldPayloadTarget := arcset.NewCASTarget(oldPayload)
+	newPayloadTarget := arcset.NewCASTarget(newPayload)
+	childTarget := arcset.NewMapTarget(childRoot)
+	intent := mutation.SemanticIntent{
+		Profile: mutation.SemanticIntentProfile, BaseRoot: parentRoot, TopOutputID: "top-output",
+		Transitions: []mutation.IntentTransition{
+			{
+				ID: "top-output", ObjectID: "parent", OldRoot: parentRoot, Kind: arcset.KindList,
+				Backend: maltcid.BackendKindKZG, Commit: fixed,
+				Changes: []mutation.IntentChange{{
+					Coordinate: arcset.NewListCoordinateUint64(0), Before: &childTarget,
+					OutputID: "child-output", OutputKind: arcset.TargetKindMap,
+				}},
+			},
+			{
+				ID: "child-output", ObjectID: "child", OldRoot: childRoot, Kind: arcset.KindMap,
+				Backend: maltcid.BackendKindKZG, ExpectedUses: 1,
+				Changes: []mutation.IntentChange{{
+					Coordinate: protocolMapCoordinate(t, "payload"), Before: &oldPayloadTarget, After: &newPayloadTarget,
+				}},
+			},
+		},
+	}
+	viewDigest, err := view.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	normalizedIntent, err := mutation.NormalizeSemanticIntent(view, intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intentDigest, err := normalizedIntent.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := mutation.NewClientRootBundle(mutation.ClientRootBundle{
+		Profile: mutation.ClientRootBundleProfile, OperationID: "operation-1", View: view, Intent: intent,
+		Outputs: []mutation.TransitionOutput{
+			{TransitionID: "top-output", Root: parentNewRoot},
+			{TransitionID: "child-output", Root: childNewRoot},
+		},
+		Candidate: parentNewRoot, PayloadCIDs: []cid.Cid{newPayload},
+		ViewDigest: viewDigest, IntentDigest: intentDigest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundleDigest, err := bundle.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := mutation.MaterializationReceipt{
+		Profile: mutation.MaterializationReceiptProfile, OperationID: bundle.OperationID,
+		BaseRoot: bundle.View.BaseRoot, Candidate: bundle.Candidate, BundleDigest: bundleDigest,
+		DurableBoundary: "embedded-transaction-commit-v1",
+	}
+	return bundle, receipt
+}
+
+func protocolTypedRoot(t *testing.T, kind arcset.Kind, seed byte) cid.Cid {
+	t.Helper()
+	commitment := make([]byte, maltcid.KZGCommitmentSize)
+	for index := range commitment {
+		commitment[index] = seed + byte(index)
+	}
+	var (
+		root cid.Cid
+		err  error
+	)
+	if kind == arcset.KindMap {
+		root, err = maltcid.NewMapKZGCid(commitment)
+	} else {
+		root, err = maltcid.NewListKZGCid(commitment)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func protocolIPARoot(t *testing.T, kind arcset.Kind, seed byte) cid.Cid {
+	t.Helper()
+	commitment := make([]byte, maltcid.IPACommitmentSize)
+	for index := range commitment {
+		commitment[index] = seed + byte(index)
+	}
+	var (
+		root cid.Cid
+		err  error
+	)
+	if kind == arcset.KindMap {
+		root, err = maltcid.NewMapIPACid(commitment)
+	} else {
+		root, err = maltcid.NewListIPACid(commitment)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func protocolMapCoordinate(t *testing.T, value string) arcset.CanonicalCoordinate {
+	t.Helper()
+	coordinate, err := arcset.NewMapCoordinate(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return coordinate
+}
+
+func cloneWireBundle(t *testing.T, value protocol.ClientRootBundle) protocol.ClientRootBundle {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cloned protocol.ClientRootBundle
+	if err := json.Unmarshal(raw, &cloned); err != nil {
+		t.Fatal(err)
+	}
+	return cloned
+}
+
+func wireObjectIndex(t *testing.T, value *protocol.ClientRootBundle, id string) int {
+	t.Helper()
+	for index, object := range value.View.Objects {
+		if object.ObjectID == id {
+			return index
+		}
+	}
+	t.Fatalf("wire object %q not found", id)
+	return -1
+}
+
+func wireTransitionIndex(t *testing.T, value *protocol.ClientRootBundle, id string) int {
+	t.Helper()
+	for index, transition := range value.Intent.Transitions {
+		if transition.ID == id {
+			return index
+		}
+	}
+	t.Fatalf("wire transition %q not found", id)
+	return -1
+}
+
+func wireOutputIndex(t *testing.T, value *protocol.ClientRootBundle, id string) int {
+	t.Helper()
+	for index, output := range value.Outputs {
+		if output.TransitionID == id {
+			return index
+		}
+	}
+	t.Fatalf("wire output %q not found", id)
+	return -1
+}
+
+func cloneJSONMap(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func assertBundleDecodeFails(t *testing.T, value any) {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := protocol.DecodeClientRootBundle(raw); err == nil {
+		t.Fatalf("DecodeClientRootBundle accepted hostile JSON: %s", raw)
+	}
+}

--- a/protocol/schemas/client-root-bundle.schema.json
+++ b/protocol/schemas/client-root-bundle.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/client-root-bundle/v1/client-root-bundle.schema.json",
+  "title": "MALT Client Root Bundle v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "operation_id", "view", "intent", "outputs", "candidate", "payload_cids", "view_digest", "intent_digest"],
+  "properties": {
+    "profile": {"const": "malt.client-root-bundle/v1"},
+    "operation_id": {"$ref": "#/$defs/id"},
+    "view": {"$ref": "https://deweb.world/schemas/malt/update-view/v1/update-view.schema.json"},
+    "intent": {"$ref": "https://deweb.world/schemas/malt/semantic-intent/v1/semantic-intent.schema.json"},
+    "outputs": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 65536,
+      "items": {"$ref": "#/$defs/output"}
+    },
+    "candidate": {"$ref": "#/$defs/cid"},
+    "payload_cids": {
+      "type": "array",
+      "maxItems": 1048576,
+      "items": {"$ref": "#/$defs/cid"}
+    },
+    "view_digest": {"$ref": "#/$defs/digest"},
+    "intent_digest": {"$ref": "#/$defs/digest"}
+  },
+  "$defs": {
+    "cid": {"type": "string", "minLength": 1, "maxLength": 4096},
+    "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"},
+    "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transition_id", "root"],
+      "properties": {
+        "transition_id": {"$ref": "#/$defs/id"},
+        "root": {"$ref": "#/$defs/cid"}
+      }
+    }
+  }
+}

--- a/protocol/schemas/materialization-receipt.schema.json
+++ b/protocol/schemas/materialization-receipt.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/materialization-receipt/v1/materialization-receipt.schema.json",
+  "title": "MALT Materialization Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "operation_id", "base_root", "candidate", "bundle_digest", "durable_boundary"],
+  "properties": {
+    "profile": {"const": "malt.materialization-receipt/v1"},
+    "operation_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"},
+    "base_root": {"type": "string", "minLength": 1, "maxLength": 4096},
+    "candidate": {"type": "string", "minLength": 1, "maxLength": 4096},
+    "bundle_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "durable_boundary": {"type": "string", "minLength": 1}
+  }
+}

--- a/protocol/schemas/semantic-intent.schema.json
+++ b/protocol/schemas/semantic-intent.schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/semantic-intent/v1/semantic-intent.schema.json",
+  "title": "MALT Semantic Intent v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "base_root", "transitions", "top_output_id"],
+  "properties": {
+    "profile": {"const": "malt.semantic-intent/v1"},
+    "base_root": {"$ref": "#/$defs/cid"},
+    "transitions": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 65536,
+      "items": {"$ref": "#/$defs/transition"}
+    },
+    "top_output_id": {"$ref": "#/$defs/id"}
+  },
+  "$defs": {
+    "cid": {"type": "string", "minLength": 1, "maxLength": 4096},
+    "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"},
+    "coordinate": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "map_path", "list_index"],
+          "properties": {
+            "kind": {"const": "map"},
+            "map_path": {"type": "string", "minLength": 1},
+            "list_index": {"const": 0}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "map_path", "list_index"],
+          "properties": {
+            "kind": {"const": "list"},
+            "map_path": {"const": ""},
+            "list_index": {"type": "integer", "minimum": 0}
+          }
+        }
+      ]
+    },
+    "optional_cid": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "cid"],
+          "properties": {"state": {"const": "absent"}, "cid": {"const": ""}}
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "cid"],
+          "properties": {"state": {"const": "present"}, "cid": {"$ref": "#/$defs/cid"}}
+        }
+      ]
+    },
+    "optional_target": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "kind", "cid"],
+          "properties": {
+            "state": {"const": "absent"},
+            "kind": {"const": ""},
+            "cid": {"const": ""}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "kind", "cid"],
+          "properties": {
+            "state": {"const": "present"},
+            "kind": {"enum": ["unknown", "cas", "map", "list"]},
+            "cid": {"$ref": "#/$defs/cid"}
+          }
+        }
+      ]
+    },
+    "optional_output": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "id", "kind"],
+          "properties": {
+            "state": {"const": "absent"},
+            "id": {"const": ""},
+            "kind": {"const": ""}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "id", "kind"],
+          "properties": {
+            "state": {"const": "present"},
+            "id": {"$ref": "#/$defs/id"},
+            "kind": {"enum": ["map", "list"]}
+          }
+        }
+      ]
+    },
+    "commit": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "total_size", "chunk_size"],
+          "properties": {
+            "mode": {"const": "default"},
+            "total_size": {"const": 0},
+            "chunk_size": {"const": 0}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "total_size", "chunk_size"],
+          "properties": {
+            "mode": {"const": "fixed_list"},
+            "total_size": {"type": "integer", "minimum": 0},
+            "chunk_size": {"type": "integer", "minimum": 1}
+          }
+        }
+      ]
+    },
+    "change": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["coordinate", "before", "after", "output"],
+      "properties": {
+        "coordinate": {"$ref": "#/$defs/coordinate"},
+        "before": {"$ref": "#/$defs/optional_target"},
+        "after": {"$ref": "#/$defs/optional_target"},
+        "output": {"$ref": "#/$defs/optional_output"}
+      }
+    },
+    "transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "object_id", "old_root", "kind", "backend", "changes", "commit", "expected_uses"],
+      "properties": {
+        "id": {"$ref": "#/$defs/id"},
+        "object_id": {"$ref": "#/$defs/id"},
+        "old_root": {"$ref": "#/$defs/optional_cid"},
+        "kind": {"enum": ["map", "list"]},
+        "backend": {"enum": ["kzg", "ipa"]},
+        "changes": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1048576,
+          "items": {"$ref": "#/$defs/change"}
+        },
+        "commit": {"$ref": "#/$defs/commit"},
+        "expected_uses": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/protocol/schemas/update-view.schema.json
+++ b/protocol/schemas/update-view.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/update-view/v1/update-view.schema.json",
+  "title": "MALT Complete Update View v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "state_profile", "base_root", "bounds", "objects"],
+  "properties": {
+    "profile": {"const": "malt.update-view/v1"},
+    "state_profile": {"const": "stateful-complete-vectors-v1"},
+    "base_root": {"$ref": "#/$defs/cid"},
+    "bounds": {"$ref": "#/$defs/bounds"},
+    "objects": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 65536,
+      "items": {"$ref": "#/$defs/object"}
+    }
+  },
+  "$defs": {
+    "cid": {"type": "string", "minLength": 1, "maxLength": 4096},
+    "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"},
+    "bounds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_objects", "max_total_entries", "max_depth"],
+      "properties": {
+        "max_objects": {"type": "integer", "minimum": 1, "maximum": 65536},
+        "max_total_entries": {"type": "integer", "minimum": 1, "maximum": 1048576},
+        "max_depth": {"type": "integer", "minimum": 1, "maximum": 65536}
+      }
+    },
+    "coordinate": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "map_path", "list_index"],
+          "properties": {
+            "kind": {"const": "map"},
+            "map_path": {"type": "string", "minLength": 1},
+            "list_index": {"const": 0}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "map_path", "list_index"],
+          "properties": {
+            "kind": {"const": "list"},
+            "map_path": {"const": ""},
+            "list_index": {"type": "integer", "minimum": 0}
+          }
+        }
+      ]
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "cid"],
+      "properties": {
+        "kind": {"enum": ["unknown", "cas", "map", "list"]},
+        "cid": {"$ref": "#/$defs/cid"}
+      }
+    },
+    "commit": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "total_size", "chunk_size"],
+          "properties": {
+            "mode": {"const": "default"},
+            "total_size": {"const": 0},
+            "chunk_size": {"const": 0}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "total_size", "chunk_size"],
+          "properties": {
+            "mode": {"const": "fixed_list"},
+            "total_size": {"type": "integer", "minimum": 0},
+            "chunk_size": {"type": "integer", "minimum": 1}
+          }
+        }
+      ]
+    },
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["coordinate", "target"],
+      "properties": {
+        "coordinate": {"$ref": "#/$defs/coordinate"},
+        "target": {"$ref": "#/$defs/target"}
+      }
+    },
+    "object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["object_id", "root", "kind", "entries", "commit"],
+      "properties": {
+        "object_id": {"$ref": "#/$defs/id"},
+        "root": {"$ref": "#/$defs/cid"},
+        "kind": {"enum": ["map", "list"]},
+        "entries": {
+          "type": "array",
+          "maxItems": 1048576,
+          "items": {"$ref": "#/$defs/entry"}
+        },
+        "commit": {"$ref": "#/$defs/commit"}
+      }
+    }
+  }
+}

--- a/sdk/writer/session.go
+++ b/sdk/writer/session.go
@@ -84,17 +84,57 @@ func (s *Session) AcceptReceipt(receipt mutation.MaterializationReceipt, prepare
 	if !s.loaded {
 		return fmt.Errorf("client writer session has no update view")
 	}
-	if !prepared.Bundle.View.BaseRoot.Equals(s.current.View.BaseRoot) {
+	current, currentDigest, err := validateVerifiedUpdateView(s.runtime, s.current)
+	if err != nil {
+		return fmt.Errorf("retained update view: %w", err)
+	}
+	if prepared.seal.runtime != s.runtime {
+		return fmt.Errorf("prepared result does not belong to this client writer runtime")
+	}
+	bundleDigest, err := prepared.Bundle.Digest()
+	if err != nil || bundleDigest != prepared.seal.bundleDigest {
+		return fmt.Errorf("prepared client-root bundle seal mismatch")
+	}
+	next, err := mutation.NormalizeUpdateView(prepared.NextView)
+	if err != nil {
+		return fmt.Errorf("prepared next view is invalid: %w", err)
+	}
+	nextDigest, err := next.Digest()
+	if err != nil || nextDigest != prepared.seal.nextViewDigest {
+		return fmt.Errorf("prepared next-view seal mismatch")
+	}
+	if !prepared.Bundle.View.BaseRoot.Equals(current.BaseRoot) {
 		return fmt.Errorf("prepared bundle base is stale")
+	}
+	if prepared.Bundle.ViewDigest != currentDigest {
+		return fmt.Errorf("prepared bundle update view is stale")
 	}
 	if err := receipt.Validate(prepared.Bundle); err != nil {
 		return err
 	}
-	if !prepared.NextView.BaseRoot.Equals(prepared.Bundle.Candidate) {
+	if !next.BaseRoot.Equals(prepared.Bundle.Candidate) {
 		return fmt.Errorf("prepared next view does not match candidate")
 	}
-	s.current = VerifiedUpdateView{View: prepared.NextView}
+	s.current = VerifiedUpdateView{View: next, runtime: s.runtime, digest: nextDigest}
 	return nil
+}
+
+func validateVerifiedUpdateView(runtime *Runtime, verified VerifiedUpdateView) (mutation.UpdateView, [32]byte, error) {
+	if runtime == nil || verified.runtime != runtime {
+		return mutation.UpdateView{}, [32]byte{}, fmt.Errorf("verified update view belongs to a different runtime")
+	}
+	canonical, err := mutation.NormalizeUpdateView(verified.View)
+	if err != nil {
+		return mutation.UpdateView{}, [32]byte{}, err
+	}
+	digest, err := canonical.Digest()
+	if err != nil {
+		return mutation.UpdateView{}, [32]byte{}, err
+	}
+	if digest != verified.digest {
+		return mutation.UpdateView{}, [32]byte{}, fmt.Errorf("verified update view seal mismatch")
+	}
+	return canonical, digest, nil
 }
 
 // Audit recomputes the retained complete vectors. Evaluators use this after a

--- a/sdk/writer/session.go
+++ b/sdk/writer/session.go
@@ -1,0 +1,117 @@
+package writer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/dewebprotocol/malt/mutation"
+	cid "github.com/ipfs/go-cid"
+)
+
+// Session retains verified complete vectors and semantic materialization across
+// mutations. Preparing a candidate never advances the session; only an exact
+// durable receipt can advance it. Client trust promotion remains a separate
+// higher-level policy.
+type Session struct {
+	mu      sync.Mutex
+	runtime *Runtime
+	loaded  bool
+	current VerifiedUpdateView
+}
+
+func NewSession(runtime *Runtime) (*Session, error) {
+	if runtime == nil {
+		return nil, fmt.Errorf("client writer runtime is nil")
+	}
+	return &Session{runtime: runtime}, nil
+}
+
+// Load verifies and installs the accepted-root update view for this session.
+func (s *Session) Load(ctx context.Context, view mutation.UpdateView) error {
+	if s == nil {
+		return fmt.Errorf("client writer session is nil")
+	}
+	verified, err := s.runtime.VerifyUpdateView(ctx, view)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.current = verified
+	s.loaded = true
+	return nil
+}
+
+// BaseRoot returns the currently retained accepted base. It is unchanged by
+// Prepare and changes only after AcceptReceipt succeeds.
+func (s *Session) BaseRoot() cid.Cid {
+	if s == nil {
+		return cid.Undef
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.loaded {
+		return cid.Undef
+	}
+	return s.current.View.BaseRoot
+}
+
+// Prepare computes a candidate against the session's current accepted base.
+func (s *Session) Prepare(ctx context.Context, operationID string, intent mutation.SemanticIntent) (ComputeResult, error) {
+	if s == nil {
+		return ComputeResult{}, fmt.Errorf("client writer session is nil")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.loaded {
+		return ComputeResult{}, fmt.Errorf("client writer session has no update view")
+	}
+	if !intent.BaseRoot.Equals(s.current.View.BaseRoot) {
+		return ComputeResult{}, fmt.Errorf("intent base %s is stale; current base is %s", intent.BaseRoot, s.current.View.BaseRoot)
+	}
+	return s.runtime.ComputeBundle(ctx, operationID, s.current, intent)
+}
+
+// AcceptReceipt verifies a service's exact durable acknowledgement and only
+// then advances retained writer state to the prepared next view.
+func (s *Session) AcceptReceipt(receipt mutation.MaterializationReceipt, prepared ComputeResult) error {
+	if s == nil {
+		return fmt.Errorf("client writer session is nil")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.loaded {
+		return fmt.Errorf("client writer session has no update view")
+	}
+	if !prepared.Bundle.View.BaseRoot.Equals(s.current.View.BaseRoot) {
+		return fmt.Errorf("prepared bundle base is stale")
+	}
+	if err := receipt.Validate(prepared.Bundle); err != nil {
+		return err
+	}
+	if !prepared.NextView.BaseRoot.Equals(prepared.Bundle.Candidate) {
+		return fmt.Errorf("prepared next view does not match candidate")
+	}
+	s.current = VerifiedUpdateView{View: prepared.NextView}
+	return nil
+}
+
+// Audit recomputes the retained complete vectors. Evaluators use this after a
+// long-lived measured session; a failure invalidates the whole run.
+func (s *Session) Audit(ctx context.Context) error {
+	if s == nil {
+		return fmt.Errorf("client writer session is nil")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.loaded {
+		return fmt.Errorf("client writer session has no update view")
+	}
+	verified, err := s.runtime.VerifyUpdateView(ctx, s.current.View)
+	if err != nil {
+		return err
+	}
+	s.current = verified
+	return nil
+}

--- a/sdk/writer/writer.go
+++ b/sdk/writer/writer.go
@@ -34,7 +34,9 @@ type Runtime struct {
 // VerifiedUpdateView is a normalized view whose complete logical vectors have
 // independently recomputed every declared old root in this runtime.
 type VerifiedUpdateView struct {
-	View mutation.UpdateView
+	View    mutation.UpdateView
+	runtime *Runtime
+	digest  [32]byte
 }
 
 // ComputeResult carries both the exact submission bundle and the complete next
@@ -43,19 +45,30 @@ type ComputeResult struct {
 	Bundle   mutation.ClientRootBundle
 	NextView mutation.UpdateView
 	Metrics  ComputeMetrics
+	seal     computeResultSeal
+}
+
+type computeResultSeal struct {
+	runtime        *Runtime
+	bundleDigest   [32]byte
+	nextViewDigest [32]byte
 }
 
 // ComputeMetrics separates the client-local phases required by writer
 // evaluation. Durations cover only local SDK work; payload hashing/upload,
 // network submission, Gateway replay, and persistence stay caller-owned.
+// CommitmentUpdateNS is a nested subphase of RootComputationNS and must not be
+// added to it in a stacked breakdown. All other fields are disjoint phases.
 type ComputeMetrics struct {
-	ViewNormalizationNS   uint64 `json:"view_normalization_ns"`
-	IntentNormalizationNS uint64 `json:"intent_normalization_ns"`
-	DigestNS              uint64 `json:"digest_ns"`
-	RootComputationNS     uint64 `json:"root_computation_ns"`
-	BundleValidationNS    uint64 `json:"bundle_validation_ns"`
-	NextViewNS            uint64 `json:"next_view_ns"`
-	TotalNS               uint64 `json:"total_ns"`
+	ViewNormalizationNS    uint64 `json:"view_normalization_ns"`
+	IntentNormalizationNS  uint64 `json:"intent_normalization_ns"`
+	DigestNS               uint64 `json:"digest_ns"`
+	CommitmentUpdateNS     uint64 `json:"commitment_update_ns"`
+	RootComputationNS      uint64 `json:"root_computation_ns"`
+	ExpectedRootEncodingNS uint64 `json:"expected_root_encoding_ns"`
+	BundleValidationNS     uint64 `json:"bundle_validation_ns"`
+	NextViewNS             uint64 `json:"next_view_ns"`
+	TotalNS                uint64 `json:"total_ns"`
 }
 
 // NewRuntime creates a client writer over the narrow materializer capability.
@@ -64,6 +77,10 @@ type ComputeMetrics struct {
 func NewRuntime(store materializer.MutableStore, schemes map[maltcid.BackendKind]commitment.IndexCommitment) (*Runtime, error) {
 	if store == nil {
 		return nil, fmt.Errorf("client writer materializer is nil")
+	}
+	branching, ok := store.(materializer.BranchingStore)
+	if !ok || !branching.SupportsConcurrentBranches() {
+		return nil, fmt.Errorf("client writer requires a branching materializer for speculative candidates")
 	}
 	if len(schemes) == 0 {
 		return nil, fmt.Errorf("client writer has no commitment backends")
@@ -128,7 +145,11 @@ func (r *Runtime) VerifyUpdateView(ctx context.Context, view mutation.UpdateView
 			return VerifiedUpdateView{}, fmt.Errorf("seed update object %q: %w", object.ObjectID, err)
 		}
 	}
-	return VerifiedUpdateView{View: canonical}, nil
+	digest, err := canonical.Digest()
+	if err != nil {
+		return VerifiedUpdateView{}, fmt.Errorf("digest verified update view: %w", err)
+	}
+	return VerifiedUpdateView{View: canonical, runtime: r, digest: digest}, nil
 }
 
 // ComputeBundle applies a normalized intent bottom-up and returns the exact
@@ -156,6 +177,9 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 	viewDigest, err := view.Digest()
 	if err != nil {
 		return ComputeResult{}, err
+	}
+	if verified.runtime != r || verified.digest != viewDigest {
+		return ComputeResult{}, fmt.Errorf("verified update view seal does not match this runtime or its canonical contents")
 	}
 	intentDigest, err := normalized.Digest()
 	if err != nil {
@@ -187,6 +211,7 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 		if err != nil {
 			return ComputeResult{}, fmt.Errorf("transition %q delta: %w", transition.ID, err)
 		}
+		commitmentStarted := time.Now()
 		receipt, err := graph.Writer().Apply(ctx, objectScope(transition.ObjectID), mutation.SemanticMutation{
 			BaseRoot: view.BaseRoot,
 			Deltas: []mutation.ArcSetDelta{{
@@ -199,6 +224,11 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 		if err != nil {
 			return ComputeResult{}, fmt.Errorf("compute transition %q: %w", transition.ID, err)
 		}
+		commitmentDuration := writerDurationNS(time.Since(commitmentStarted))
+		if ^uint64(0)-metrics.CommitmentUpdateNS < commitmentDuration {
+			return ComputeResult{}, fmt.Errorf("client writer commitment timing overflow")
+		}
+		metrics.CommitmentUpdateNS += commitmentDuration
 		if maltcid.BackendKindOf(receipt.NewRoot) != transition.Backend {
 			return ComputeResult{}, fmt.Errorf("compute transition %q returned backend %q, want %q", transition.ID, maltcid.BackendKindOf(receipt.NewRoot), transition.Backend)
 		}
@@ -224,6 +254,12 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 	slices.SortFunc(payloads, func(a, b cid.Cid) int { return stringCompareBytes(a.Bytes(), b.Bytes()) })
 	metrics.RootComputationNS = writerDurationNS(time.Since(phaseStart))
 	phaseStart = time.Now()
+	expectedRoot := candidate.String()
+	if expectedRoot == "" {
+		return ComputeResult{}, fmt.Errorf("client writer candidate root encoding is empty")
+	}
+	metrics.ExpectedRootEncodingNS = writerDurationNS(time.Since(phaseStart))
+	phaseStart = time.Now()
 	bundle, err := mutation.NewClientRootBundle(mutation.ClientRootBundle{
 		Profile:      mutation.ClientRootBundleProfile,
 		OperationID:  operationID,
@@ -238,15 +274,26 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 	if err != nil {
 		return ComputeResult{}, err
 	}
+	bundleDigest, err := bundle.Digest()
+	if err != nil {
+		return ComputeResult{}, fmt.Errorf("seal client-root bundle: %w", err)
+	}
 	metrics.BundleValidationNS = writerDurationNS(time.Since(phaseStart))
 	phaseStart = time.Now()
 	next, err := nextReachableView(view, candidate, objects)
 	if err != nil {
 		return ComputeResult{}, err
 	}
+	nextViewDigest, err := next.Digest()
+	if err != nil {
+		return ComputeResult{}, fmt.Errorf("seal retained next view: %w", err)
+	}
 	metrics.NextViewNS = writerDurationNS(time.Since(phaseStart))
 	metrics.TotalNS = writerDurationNS(time.Since(totalStart))
-	return ComputeResult{Bundle: bundle, NextView: next, Metrics: metrics}, nil
+	return ComputeResult{
+		Bundle: bundle, NextView: next, Metrics: metrics,
+		seal: computeResultSeal{runtime: r, bundleDigest: bundleDigest, nextViewDigest: nextViewDigest},
+	}, nil
 }
 
 func commitCompleteObject(ctx context.Context, graph *runtimegraph.RuntimeGraph, scope string, object mutation.UpdateObject) (cid.Cid, error) {
@@ -342,9 +389,27 @@ func applyCompleteVector(current *arcset.CanonicalArcSet, kind arcset.Kind, chan
 }
 
 func nextReachableView(previous mutation.UpdateView, candidate cid.Cid, objects map[string]mutation.UpdateObject) (mutation.UpdateView, error) {
-	byRoot := make(map[string]mutation.UpdateObject, len(objects))
+	ordered := make([]mutation.UpdateObject, 0, len(objects))
 	for _, object := range objects {
-		byRoot[object.Root.KeyString()] = object
+		ordered = append(ordered, object)
+	}
+	slices.SortFunc(ordered, func(a, b mutation.UpdateObject) int {
+		switch {
+		case a.ObjectID < b.ObjectID:
+			return -1
+		case a.ObjectID > b.ObjectID:
+			return 1
+		default:
+			return 0
+		}
+	})
+	byRoot := make(map[string]mutation.UpdateObject, len(objects))
+	for _, object := range ordered {
+		rootKey := object.Root.KeyString()
+		if existing, ok := byRoot[rootKey]; ok {
+			return mutation.UpdateView{}, fmt.Errorf("retained objects %q and %q converge to root %s", existing.ObjectID, object.ObjectID, object.Root)
+		}
+		byRoot[rootKey] = object
 	}
 	rootObject, ok := byRoot[candidate.KeyString()]
 	if !ok {

--- a/sdk/writer/writer.go
+++ b/sdk/writer/writer.go
@@ -1,0 +1,398 @@
+// Package writer implements the application-neutral client-root computation
+// path. It verifies a bounded complete update view, normalizes an output-free
+// dependency graph, computes every changed semantic object bottom-up, and
+// returns an exact client-root bundle. Persistence, publication, and trust
+// promotion remain outside this package.
+package writer
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"slices"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materializer "github.com/dewebprotocol/malt/auth/arcset/materializer"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/semantic/list"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	runtimegraph "github.com/dewebprotocol/malt/graph/runtime"
+	"github.com/dewebprotocol/malt/mutation"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+)
+
+// Runtime owns backend implementations and caller-supplied in-memory or
+// persistent-free materialization used for local computation. The materializer
+// is not an ArcTable and no result is durable until a service accepts it.
+type Runtime struct {
+	store  materializer.MutableStore
+	graphs map[maltcid.BackendKind]*runtimegraph.RuntimeGraph
+}
+
+// VerifiedUpdateView is a normalized view whose complete logical vectors have
+// independently recomputed every declared old root in this runtime.
+type VerifiedUpdateView struct {
+	View mutation.UpdateView
+}
+
+// ComputeResult carries both the exact submission bundle and the complete next
+// view retained by a long-lived client session.
+type ComputeResult struct {
+	Bundle   mutation.ClientRootBundle
+	NextView mutation.UpdateView
+}
+
+// NewRuntime creates a client writer over the narrow materializer capability.
+// Callers normally provide the branching in-memory reference materializer;
+// SDK code does not choose persistence policy.
+func NewRuntime(store materializer.MutableStore, schemes map[maltcid.BackendKind]commitment.IndexCommitment) (*Runtime, error) {
+	if store == nil {
+		return nil, fmt.Errorf("client writer materializer is nil")
+	}
+	if len(schemes) == 0 {
+		return nil, fmt.Errorf("client writer has no commitment backends")
+	}
+	runtime := &Runtime{store: store, graphs: make(map[maltcid.BackendKind]*runtimegraph.RuntimeGraph, len(schemes))}
+	for _, backend := range []maltcid.BackendKind{maltcid.BackendKindKZG, maltcid.BackendKindIPA} {
+		scheme, ok := schemes[backend]
+		if !ok {
+			continue
+		}
+		if scheme == nil {
+			return nil, fmt.Errorf("client writer %s backend is nil", backend)
+		}
+		graph, err := runtimegraph.NewGraph(
+			"client-root-"+string(backend),
+			store,
+			runtimegraph.WithCommitmentBackend(backend, scheme),
+			runtimegraph.WithDefaultCommitmentBackend(backend),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create client writer %s backend: %w", backend, err)
+		}
+		runtime.graphs[backend] = graph
+	}
+	if len(runtime.graphs) != len(schemes) {
+		return nil, fmt.Errorf("client writer schemes contain an unsupported backend")
+	}
+	return runtime, nil
+}
+
+// VerifyUpdateView recomputes every complete logical vector and seeds the
+// local semantic materialization required for subsequent incremental updates.
+func (r *Runtime) VerifyUpdateView(ctx context.Context, view mutation.UpdateView) (VerifiedUpdateView, error) {
+	if r == nil {
+		return VerifiedUpdateView{}, fmt.Errorf("client writer runtime is nil")
+	}
+	canonical, err := mutation.NormalizeUpdateView(view)
+	if err != nil {
+		return VerifiedUpdateView{}, err
+	}
+	for _, object := range canonical.Objects {
+		if err := ctx.Err(); err != nil {
+			return VerifiedUpdateView{}, err
+		}
+		backend := maltcid.BackendKindOf(object.Root)
+		graph, ok := r.graphs[backend]
+		if !ok {
+			return VerifiedUpdateView{}, fmt.Errorf("update object %q requires unavailable backend %q", object.ObjectID, backend)
+		}
+		recomputed, err := commitCompleteObject(ctx, graph, objectScope(object.ObjectID), object)
+		if err != nil {
+			return VerifiedUpdateView{}, fmt.Errorf("verify update object %q: %w", object.ObjectID, err)
+		}
+		if !recomputed.Equals(object.Root) {
+			return VerifiedUpdateView{}, fmt.Errorf("verify update object %q: recomputed root %s does not match declared root %s", object.ObjectID, recomputed, object.Root)
+		}
+		logical, err := completeObjectArcSet(object)
+		if err != nil {
+			return VerifiedUpdateView{}, fmt.Errorf("verify update object %q: %w", object.ObjectID, err)
+		}
+		if err := r.store.Update(ctx, objectScope(object.ObjectID), recomputed, cid.Undef, logical); err != nil {
+			return VerifiedUpdateView{}, fmt.Errorf("seed update object %q: %w", object.ObjectID, err)
+		}
+	}
+	return VerifiedUpdateView{View: canonical}, nil
+}
+
+// ComputeBundle applies a normalized intent bottom-up and returns the exact
+// candidate plus every intermediate output. Literal CAS post-images are
+// collected into PayloadCIDs for service-side existence checks.
+func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verified VerifiedUpdateView, intent mutation.SemanticIntent) (ComputeResult, error) {
+	if r == nil {
+		return ComputeResult{}, fmt.Errorf("client writer runtime is nil")
+	}
+	view, err := mutation.NormalizeUpdateView(verified.View)
+	if err != nil {
+		return ComputeResult{}, err
+	}
+	normalized, err := mutation.NormalizeSemanticIntent(view, intent)
+	if err != nil {
+		return ComputeResult{}, err
+	}
+	viewDigest, err := view.Digest()
+	if err != nil {
+		return ComputeResult{}, err
+	}
+	intentDigest, err := normalized.Digest()
+	if err != nil {
+		return ComputeResult{}, err
+	}
+
+	objects := make(map[string]mutation.UpdateObject, len(view.Objects)+len(normalized.Transitions))
+	for _, object := range view.Objects {
+		objects[object.ObjectID] = object
+	}
+	outputRoots := make(map[string]cid.Cid, len(normalized.Transitions))
+	outputs := make([]mutation.TransitionOutput, 0, len(normalized.Transitions))
+	payloadSet := make(map[string]cid.Cid)
+	for _, transition := range normalized.Transitions {
+		if err := ctx.Err(); err != nil {
+			return ComputeResult{}, err
+		}
+		graph, ok := r.graphs[transition.Backend]
+		if !ok {
+			return ComputeResult{}, fmt.Errorf("transition %q requires unavailable backend %q", transition.ID, transition.Backend)
+		}
+		changes, err := resolveChanges(transition, outputRoots, payloadSet)
+		if err != nil {
+			return ComputeResult{}, err
+		}
+		delta, err := arcset.NewCanonicalArcDelta(transition.Kind, changes)
+		if err != nil {
+			return ComputeResult{}, fmt.Errorf("transition %q delta: %w", transition.ID, err)
+		}
+		receipt, err := graph.Writer().Apply(ctx, objectScope(transition.ObjectID), mutation.SemanticMutation{
+			BaseRoot: view.BaseRoot,
+			Deltas: []mutation.ArcSetDelta{{
+				Object:  transition.OldRoot,
+				Kind:    transition.Kind,
+				Changes: delta,
+				Commit:  transition.Commit,
+			}},
+		})
+		if err != nil {
+			return ComputeResult{}, fmt.Errorf("compute transition %q: %w", transition.ID, err)
+		}
+		if maltcid.BackendKindOf(receipt.NewRoot) != transition.Backend {
+			return ComputeResult{}, fmt.Errorf("compute transition %q returned backend %q, want %q", transition.ID, maltcid.BackendKindOf(receipt.NewRoot), transition.Backend)
+		}
+		outputRoots[transition.ID] = receipt.NewRoot
+		outputs = append(outputs, mutation.TransitionOutput{TransitionID: transition.ID, Root: receipt.NewRoot})
+		postEntries, err := applyCompleteVector(objects[transition.ObjectID].Entries, transition.Kind, changes)
+		if err != nil {
+			return ComputeResult{}, fmt.Errorf("retain transition %q: %w", transition.ID, err)
+		}
+		objects[transition.ObjectID] = mutation.UpdateObject{
+			ObjectID: transition.ObjectID,
+			Root:     receipt.NewRoot,
+			Kind:     transition.Kind,
+			Entries:  postEntries,
+			Commit:   transition.Commit,
+		}
+	}
+	candidate := outputRoots[normalized.TopOutputID]
+	payloads := make([]cid.Cid, 0, len(payloadSet))
+	for _, payload := range payloadSet {
+		payloads = append(payloads, payload)
+	}
+	slices.SortFunc(payloads, func(a, b cid.Cid) int { return stringCompareBytes(a.Bytes(), b.Bytes()) })
+	bundle, err := mutation.NewClientRootBundle(mutation.ClientRootBundle{
+		Profile:      mutation.ClientRootBundleProfile,
+		OperationID:  operationID,
+		View:         view,
+		Intent:       normalized,
+		Outputs:      outputs,
+		Candidate:    candidate,
+		PayloadCIDs:  payloads,
+		ViewDigest:   viewDigest,
+		IntentDigest: intentDigest,
+	})
+	if err != nil {
+		return ComputeResult{}, err
+	}
+	next, err := nextReachableView(view, candidate, objects)
+	if err != nil {
+		return ComputeResult{}, err
+	}
+	return ComputeResult{Bundle: bundle, NextView: next}, nil
+}
+
+func commitCompleteObject(ctx context.Context, graph *runtimegraph.RuntimeGraph, scope string, object mutation.UpdateObject) (cid.Cid, error) {
+	switch object.Kind {
+	case arcset.KindMap:
+		entries := make(map[arcset.Path]cid.Cid, object.Entries.Len())
+		for _, entry := range object.Entries.Entries() {
+			entries[arcset.CanonicalizePath(entry.Coordinate.String())] = entry.Target.CID()
+		}
+		return graph.Semantic().Commit(ctx, scope, mapping.NewViewFromPaths(entries))
+	case arcset.KindList:
+		values, err := listValues(object.Entries)
+		if err != nil {
+			return cid.Undef, err
+		}
+		if object.Commit.FixedList == nil {
+			return graph.ListSemantic().Commit(ctx, scope, list.NewViewFromSlice(values))
+		}
+		fixed, ok := graph.ListSemantic().(list.FixedWidthCommitter)
+		if !ok {
+			return cid.Undef, fmt.Errorf("list backend does not support fixed-width commits")
+		}
+		return fixed.CommitFixed(ctx, scope, values, object.Commit.FixedList.ChunkSize, object.Commit.FixedList.TotalSize)
+	default:
+		return cid.Undef, fmt.Errorf("unsupported object kind %q", object.Kind)
+	}
+}
+
+func completeObjectArcSet(object mutation.UpdateObject) (arcset.ArcSet, error) {
+	values := make(map[arcset.Path]cid.Cid, object.Entries.Len())
+	for _, entry := range object.Entries.Entries() {
+		var path arcset.Path
+		switch object.Kind {
+		case arcset.KindMap:
+			path = arcset.CanonicalizePath(entry.Coordinate.String())
+		case arcset.KindList:
+			path = arcset.CanonicalizePath(entry.Coordinate.String())
+		default:
+			return nil, fmt.Errorf("unsupported object kind %q", object.Kind)
+		}
+		values[path] = entry.Target.CID()
+	}
+	return arcset.NewArcSetFromPaths(values)
+}
+
+func resolveChanges(transition mutation.IntentTransition, outputs map[string]cid.Cid, payloads map[string]cid.Cid) ([]arcset.ArcChange, error) {
+	changes := make([]arcset.ArcChange, len(transition.Changes))
+	for index, change := range transition.Changes {
+		resolved := arcset.ArcChange{Coordinate: change.Coordinate, Before: change.Before, After: change.After}
+		if change.OutputID != "" {
+			root, ok := outputs[change.OutputID]
+			if !ok {
+				return nil, fmt.Errorf("transition %q consumes unavailable output %q", transition.ID, change.OutputID)
+			}
+			var target arcset.TargetRef
+			switch change.OutputKind {
+			case arcset.TargetKindMap:
+				target = arcset.NewMapTarget(root)
+			case arcset.TargetKindList:
+				target = arcset.NewListTarget(root)
+			default:
+				return nil, fmt.Errorf("transition %q has invalid output kind %q", transition.ID, change.OutputKind)
+			}
+			resolved.After = &target
+		} else if change.After != nil && !isSemanticTarget(*change.After) {
+			payloads[change.After.CID().KeyString()] = change.After.CID()
+		}
+		changes[index] = resolved
+	}
+	return changes, nil
+}
+
+func applyCompleteVector(current *arcset.CanonicalArcSet, kind arcset.Kind, changes []arcset.ArcChange) (*arcset.CanonicalArcSet, error) {
+	entries := make(map[string]arcset.ArcEntry)
+	if current != nil {
+		for _, entry := range current.Entries() {
+			entries[string(entry.Coordinate.Bytes())] = entry
+		}
+	}
+	for _, change := range changes {
+		key := string(change.Coordinate.Bytes())
+		if change.After == nil {
+			delete(entries, key)
+			continue
+		}
+		entries[key] = arcset.ArcEntry{Coordinate: change.Coordinate, Target: *change.After}
+	}
+	values := make([]arcset.ArcEntry, 0, len(entries))
+	for _, entry := range entries {
+		values = append(values, entry)
+	}
+	return arcset.NewCanonicalArcSet(kind, values)
+}
+
+func nextReachableView(previous mutation.UpdateView, candidate cid.Cid, objects map[string]mutation.UpdateObject) (mutation.UpdateView, error) {
+	byRoot := make(map[string]mutation.UpdateObject, len(objects))
+	for _, object := range objects {
+		byRoot[object.Root.KeyString()] = object
+	}
+	rootObject, ok := byRoot[candidate.KeyString()]
+	if !ok {
+		return mutation.UpdateView{}, fmt.Errorf("candidate root has no retained complete vector")
+	}
+	reachable := make(map[string]mutation.UpdateObject)
+	var visit func(mutation.UpdateObject) error
+	visit = func(object mutation.UpdateObject) error {
+		if _, seen := reachable[object.ObjectID]; seen {
+			return nil
+		}
+		reachable[object.ObjectID] = object
+		for _, entry := range object.Entries.Entries() {
+			if !isSemanticTarget(entry.Target) {
+				continue
+			}
+			child, exists := byRoot[entry.Target.CID().KeyString()]
+			if !exists {
+				return fmt.Errorf("retained object %q references missing child %s", object.ObjectID, entry.Target.CID())
+			}
+			if err := visit(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := visit(rootObject); err != nil {
+		return mutation.UpdateView{}, err
+	}
+	next := mutation.UpdateView{
+		Profile: previous.Profile, StateProfile: previous.StateProfile,
+		BaseRoot: candidate, Bounds: previous.Bounds,
+		Objects: make([]mutation.UpdateObject, 0, len(reachable)),
+	}
+	for _, object := range reachable {
+		next.Objects = append(next.Objects, object)
+	}
+	return mutation.NormalizeUpdateView(next)
+}
+
+func listValues(entries *arcset.CanonicalArcSet) ([]cid.Cid, error) {
+	values := make([]cid.Cid, entries.Len())
+	for index, entry := range entries.Entries() {
+		raw := entry.Coordinate.Bytes()
+		if len(raw) != 8 || binary.BigEndian.Uint64(raw) != uint64(index) {
+			return nil, fmt.Errorf("list vector is sparse or out of order at %q", entry.Coordinate.String())
+		}
+		values[index] = entry.Target.CID()
+	}
+	return values, nil
+}
+
+func isSemanticTarget(target arcset.TargetRef) bool {
+	if target.Kind() == arcset.TargetKindMap || target.Kind() == arcset.TargetKindList {
+		return true
+	}
+	return maltcid.SemanticKindOf(target.CID()) != maltcid.SemanticKindUnknown
+}
+
+func objectScope(objectID string) string {
+	return "client-root/v1/" + objectID
+}
+
+func stringCompareBytes(a, b []byte) int {
+	for index := 0; index < len(a) && index < len(b); index++ {
+		if a[index] < b[index] {
+			return -1
+		}
+		if a[index] > b[index] {
+			return 1
+		}
+	}
+	switch {
+	case len(a) < len(b):
+		return -1
+	case len(a) > len(b):
+		return 1
+	default:
+		return 0
+	}
+}

--- a/sdk/writer/writer.go
+++ b/sdk/writer/writer.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	materializer "github.com/dewebprotocol/malt/auth/arcset/materializer"
@@ -41,6 +42,20 @@ type VerifiedUpdateView struct {
 type ComputeResult struct {
 	Bundle   mutation.ClientRootBundle
 	NextView mutation.UpdateView
+	Metrics  ComputeMetrics
+}
+
+// ComputeMetrics separates the client-local phases required by writer
+// evaluation. Durations cover only local SDK work; payload hashing/upload,
+// network submission, Gateway replay, and persistence stay caller-owned.
+type ComputeMetrics struct {
+	ViewNormalizationNS   uint64 `json:"view_normalization_ns"`
+	IntentNormalizationNS uint64 `json:"intent_normalization_ns"`
+	DigestNS              uint64 `json:"digest_ns"`
+	RootComputationNS     uint64 `json:"root_computation_ns"`
+	BundleValidationNS    uint64 `json:"bundle_validation_ns"`
+	NextViewNS            uint64 `json:"next_view_ns"`
+	TotalNS               uint64 `json:"total_ns"`
 }
 
 // NewRuntime creates a client writer over the narrow materializer capability.
@@ -120,17 +135,24 @@ func (r *Runtime) VerifyUpdateView(ctx context.Context, view mutation.UpdateView
 // candidate plus every intermediate output. Literal CAS post-images are
 // collected into PayloadCIDs for service-side existence checks.
 func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verified VerifiedUpdateView, intent mutation.SemanticIntent) (ComputeResult, error) {
+	totalStart := time.Now()
 	if r == nil {
 		return ComputeResult{}, fmt.Errorf("client writer runtime is nil")
 	}
+	metrics := ComputeMetrics{}
+	phaseStart := time.Now()
 	view, err := mutation.NormalizeUpdateView(verified.View)
 	if err != nil {
 		return ComputeResult{}, err
 	}
+	metrics.ViewNormalizationNS = writerDurationNS(time.Since(phaseStart))
+	phaseStart = time.Now()
 	normalized, err := mutation.NormalizeSemanticIntent(view, intent)
 	if err != nil {
 		return ComputeResult{}, err
 	}
+	metrics.IntentNormalizationNS = writerDurationNS(time.Since(phaseStart))
+	phaseStart = time.Now()
 	viewDigest, err := view.Digest()
 	if err != nil {
 		return ComputeResult{}, err
@@ -139,7 +161,9 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 	if err != nil {
 		return ComputeResult{}, err
 	}
+	metrics.DigestNS = writerDurationNS(time.Since(phaseStart))
 
+	phaseStart = time.Now()
 	objects := make(map[string]mutation.UpdateObject, len(view.Objects)+len(normalized.Transitions))
 	for _, object := range view.Objects {
 		objects[object.ObjectID] = object
@@ -198,6 +222,8 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 		payloads = append(payloads, payload)
 	}
 	slices.SortFunc(payloads, func(a, b cid.Cid) int { return stringCompareBytes(a.Bytes(), b.Bytes()) })
+	metrics.RootComputationNS = writerDurationNS(time.Since(phaseStart))
+	phaseStart = time.Now()
 	bundle, err := mutation.NewClientRootBundle(mutation.ClientRootBundle{
 		Profile:      mutation.ClientRootBundleProfile,
 		OperationID:  operationID,
@@ -212,11 +238,15 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 	if err != nil {
 		return ComputeResult{}, err
 	}
+	metrics.BundleValidationNS = writerDurationNS(time.Since(phaseStart))
+	phaseStart = time.Now()
 	next, err := nextReachableView(view, candidate, objects)
 	if err != nil {
 		return ComputeResult{}, err
 	}
-	return ComputeResult{Bundle: bundle, NextView: next}, nil
+	metrics.NextViewNS = writerDurationNS(time.Since(phaseStart))
+	metrics.TotalNS = writerDurationNS(time.Since(totalStart))
+	return ComputeResult{Bundle: bundle, NextView: next, Metrics: metrics}, nil
 }
 
 func commitCompleteObject(ctx context.Context, graph *runtimegraph.RuntimeGraph, scope string, object mutation.UpdateObject) (cid.Cid, error) {
@@ -395,4 +425,11 @@ func stringCompareBytes(a, b []byte) int {
 	default:
 		return 0
 	}
+}
+
+func writerDurationNS(value time.Duration) uint64 {
+	if value <= 0 {
+		return 0
+	}
+	return uint64(value)
 }

--- a/sdk/writer/writer_test.go
+++ b/sdk/writer/writer_test.go
@@ -1,0 +1,272 @@
+package writer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materializermemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	mappingradix "github.com/dewebprotocol/malt/auth/semantic/mapping/radix"
+	"github.com/dewebprotocol/malt/mutation"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestComputeBundleMatchesIndependentFullRebuildAndRetainsNextView(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, intent, expectedCandidate, newPayload := mapWriterFixture(t, ctx, scheme)
+	runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, err := runtime.VerifyUpdateView(ctx, view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := runtime.ComputeBundle(ctx, "map-replace-1", verified, intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Bundle.Candidate.Equals(expectedCandidate) {
+		t.Fatalf("candidate = %s, want independent full rebuild %s", result.Bundle.Candidate, expectedCandidate)
+	}
+	if len(result.Bundle.Outputs) != 2 || result.Bundle.Outputs[0].TransitionID != "child-output" || result.Bundle.Outputs[1].TransitionID != "top-output" {
+		t.Fatalf("outputs = %#v", result.Bundle.Outputs)
+	}
+	if len(result.Bundle.PayloadCIDs) != 1 || !result.Bundle.PayloadCIDs[0].Equals(newPayload) {
+		t.Fatalf("payload CIDs = %#v", result.Bundle.PayloadCIDs)
+	}
+	if !result.NextView.BaseRoot.Equals(result.Bundle.Candidate) {
+		t.Fatalf("next view base = %s, candidate = %s", result.NextView.BaseRoot, result.Bundle.Candidate)
+	}
+
+	// A fresh runtime must independently accept the retained complete vectors;
+	// this prevents a session-only materialization cache from hiding bad roots.
+	fresh, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fresh.VerifyUpdateView(ctx, result.NextView); err != nil {
+		t.Fatalf("verify retained next view: %v", err)
+	}
+}
+
+func TestVerifyUpdateViewRejectsUntrustedVectorForDeclaredRoot(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, _, _, _ := mapWriterFixture(t, ctx, scheme)
+	wrongPayload := arcset.NewCASTarget(writerRawCID(t, "tampered"))
+	tamperedEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
+		Coordinate: writerMapCoordinate(t, "payload"), Target: wrongPayload,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := range view.Objects {
+		if view.Objects[index].ObjectID == "child" {
+			view.Objects[index].Entries = tamperedEntries
+		}
+	}
+	runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.VerifyUpdateView(ctx, view); err == nil {
+		t.Fatal("tampered complete vector was accepted")
+	}
+}
+
+func TestComputeBundleRejectsDependencyTamperingBeforeComputation(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, intent, _, _ := mapWriterFixture(t, ctx, scheme)
+	for index := range intent.Transitions {
+		if intent.Transitions[index].ID == "child-output" {
+			intent.Transitions[index].ExpectedUses = 2
+		}
+	}
+	runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, err := runtime.VerifyUpdateView(ctx, view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.ComputeBundle(ctx, "tampered-dependency", verified, intent); !errors.Is(err, mutation.ErrIntentMultiplicity) {
+		t.Fatalf("error = %v, want ErrIntentMultiplicity", err)
+	}
+}
+
+func TestSessionAdvancesOnlyAfterExactDurableReceipt(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, intent, _, _ := mapWriterFixture(t, ctx, scheme)
+	runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := NewSession(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := session.Load(ctx, view); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := session.Prepare(ctx, "session-map-replace", intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !session.BaseRoot().Equals(view.BaseRoot) {
+		t.Fatal("preparing a candidate advanced the accepted session base")
+	}
+	digest, err := prepared.Bundle.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := mutation.MaterializationReceipt{
+		Profile: mutation.MaterializationReceiptProfile, OperationID: prepared.Bundle.OperationID,
+		BaseRoot: prepared.Bundle.View.BaseRoot, Candidate: view.BaseRoot,
+		BundleDigest: digest, DurableBoundary: "embedded-transaction-commit-v1",
+	}
+	if err := session.AcceptReceipt(wrong, prepared); err == nil {
+		t.Fatal("session accepted a substituted receipt candidate")
+	}
+	if !session.BaseRoot().Equals(view.BaseRoot) {
+		t.Fatal("rejected receipt advanced the accepted session base")
+	}
+	correct := wrong
+	correct.Candidate = prepared.Bundle.Candidate
+	if err := session.AcceptReceipt(correct, prepared); err != nil {
+		t.Fatal(err)
+	}
+	if !session.BaseRoot().Equals(prepared.Bundle.Candidate) {
+		t.Fatalf("session base = %s, want %s", session.BaseRoot(), prepared.Bundle.Candidate)
+	}
+	if err := session.Audit(ctx); err != nil {
+		t.Fatalf("final session audit: %v", err)
+	}
+}
+
+func mapWriterFixture(t *testing.T, ctx context.Context, scheme *kzg.Scheme) (mutation.UpdateView, mutation.SemanticIntent, cid.Cid, cid.Cid) {
+	t.Helper()
+	oldPayload := writerRawCID(t, "old-payload")
+	newPayload := writerRawCID(t, "new-payload")
+	oldStore := materializermemory.New(true)
+	oldMap, err := mappingradix.NewMap(scheme, oldStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	childRoot, err := oldMap.Commit(ctx, "child", mapping.NewViewFrom(map[string]cid.Cid{"payload": oldPayload}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentRoot, err := oldMap.Commit(ctx, "parent", mapping.NewViewFrom(map[string]cid.Cid{"child": childRoot}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newStore := materializermemory.New(true)
+	newMap, err := mappingradix.NewMap(scheme, newStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newChildRoot, err := newMap.Commit(ctx, "child", mapping.NewViewFrom(map[string]cid.Cid{"payload": newPayload}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCandidate, err := newMap.Commit(ctx, "parent", mapping.NewViewFrom(map[string]cid.Cid{"child": newChildRoot}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	childEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
+		Coordinate: writerMapCoordinate(t, "payload"), Target: arcset.NewCASTarget(oldPayload),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
+		Coordinate: writerMapCoordinate(t, "child"), Target: arcset.NewMapTarget(childRoot),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := mutation.UpdateView{
+		Profile: mutation.UpdateViewProfile, StateProfile: mutation.StatefulCompleteVectorsProfile,
+		BaseRoot: parentRoot, Bounds: mutation.UpdateViewBounds{MaxObjects: 8, MaxTotalEntries: 64, MaxDepth: 8},
+		Objects: []mutation.UpdateObject{
+			{ObjectID: "parent", Root: parentRoot, Kind: arcset.KindMap, Entries: parentEntries},
+			{ObjectID: "child", Root: childRoot, Kind: arcset.KindMap, Entries: childEntries},
+		},
+	}
+	oldPayloadTarget := arcset.NewCASTarget(oldPayload)
+	newPayloadTarget := arcset.NewCASTarget(newPayload)
+	oldChildTarget := arcset.NewMapTarget(childRoot)
+	intent := mutation.SemanticIntent{
+		Profile: mutation.SemanticIntentProfile, BaseRoot: parentRoot, TopOutputID: "top-output",
+		Transitions: []mutation.IntentTransition{
+			{
+				ID: "top-output", ObjectID: "parent", OldRoot: parentRoot, Kind: arcset.KindMap, Backend: maltcid.BackendKindKZG,
+				Changes: []mutation.IntentChange{{
+					Coordinate: writerMapCoordinate(t, "child"), Before: &oldChildTarget,
+					OutputID: "child-output", OutputKind: arcset.TargetKindMap,
+				}},
+			},
+			{
+				ID: "child-output", ObjectID: "child", OldRoot: childRoot, Kind: arcset.KindMap, Backend: maltcid.BackendKindKZG,
+				ExpectedUses: 1,
+				Changes: []mutation.IntentChange{{
+					Coordinate: writerMapCoordinate(t, "payload"), Before: &oldPayloadTarget, After: &newPayloadTarget,
+				}},
+			},
+		},
+	}
+	return view, intent, expectedCandidate, newPayload
+}
+
+func writerMapCoordinate(t *testing.T, value string) arcset.CanonicalCoordinate {
+	t.Helper()
+	coordinate, err := arcset.NewMapCoordinate(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return coordinate
+}
+
+func writerRawCID(t *testing.T, value string) cid.Cid {
+	t.Helper()
+	hash, err := mh.Sum([]byte(value), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cid.NewCidV1(cid.Raw, hash)
+}

--- a/sdk/writer/writer_test.go
+++ b/sdk/writer/writer_test.go
@@ -50,6 +50,9 @@ func TestComputeBundleMatchesIndependentFullRebuildAndRetainsNextView(t *testing
 	if !result.NextView.BaseRoot.Equals(result.Bundle.Candidate) {
 		t.Fatalf("next view base = %s, candidate = %s", result.NextView.BaseRoot, result.Bundle.Candidate)
 	}
+	if result.Metrics.TotalNS < result.Metrics.RootComputationNS || result.Metrics.TotalNS == 0 {
+		t.Fatalf("compute metrics = %#v", result.Metrics)
+	}
 
 	// A fresh runtime must independently accept the retained complete vectors;
 	// this prevents a session-only materialization cache from hiding bad roots.

--- a/sdk/writer/writer_test.go
+++ b/sdk/writer/writer_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/dewebprotocol/malt/auth/arcset"
 	materializermemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
 	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
 	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	listtree "github.com/dewebprotocol/malt/auth/semantic/list/tree"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
 	mappingradix "github.com/dewebprotocol/malt/auth/semantic/mapping/radix"
 	"github.com/dewebprotocol/malt/mutation"
@@ -50,7 +52,9 @@ func TestComputeBundleMatchesIndependentFullRebuildAndRetainsNextView(t *testing
 	if !result.NextView.BaseRoot.Equals(result.Bundle.Candidate) {
 		t.Fatalf("next view base = %s, candidate = %s", result.NextView.BaseRoot, result.Bundle.Candidate)
 	}
-	if result.Metrics.TotalNS < result.Metrics.RootComputationNS || result.Metrics.TotalNS == 0 {
+	if result.Metrics.TotalNS < result.Metrics.RootComputationNS || result.Metrics.TotalNS == 0 ||
+		result.Metrics.CommitmentUpdateNS == 0 || result.Metrics.CommitmentUpdateNS > result.Metrics.RootComputationNS ||
+		result.Metrics.ExpectedRootEncodingNS == 0 {
 		t.Fatalf("compute metrics = %#v", result.Metrics)
 	}
 
@@ -64,6 +68,137 @@ func TestComputeBundleMatchesIndependentFullRebuildAndRetainsNextView(t *testing
 	}
 	if _, err := fresh.VerifyUpdateView(ctx, result.NextView); err != nil {
 		t.Fatalf("verify retained next view: %v", err)
+	}
+}
+
+func TestNewRuntimeRequiresBranchingMaterializer(t *testing.T) {
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewRuntime(materializermemory.New(false), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	}); err == nil {
+		t.Fatal("non-branching speculative client writer was accepted")
+	}
+}
+
+func TestNextReachableViewRejectsDistinctObjectsConvergingToOneRoot(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, _, _, _ := mapWriterFixture(t, ctx, scheme)
+	objects := make(map[string]mutation.UpdateObject, len(view.Objects))
+	for _, object := range view.Objects {
+		objects[object.ObjectID] = object
+	}
+	child := objects["child"]
+	child.Root = view.BaseRoot
+	objects[child.ObjectID] = child
+
+	if _, err := nextReachableView(view, view.BaseRoot, objects); err == nil {
+		t.Fatal("distinct retained objects converging to one root were accepted")
+	}
+}
+
+func TestFixedListReplaceAndAppendRetainVerifiableMetadataAcrossBackends(t *testing.T) {
+	for _, backend := range []maltcid.BackendKind{maltcid.BackendKindKZG, maltcid.BackendKindIPA} {
+		t.Run(string(backend), func(t *testing.T) {
+			var (
+				scheme commitment.IndexCommitment
+				err    error
+			)
+			if backend == maltcid.BackendKindKZG {
+				scheme, err = kzg.NewScheme()
+			} else {
+				scheme, err = ipa.NewScheme()
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, operation := range []string{"replace", "append"} {
+				t.Run(operation, func(t *testing.T) {
+					ctx := context.Background()
+					oldValues := []cid.Cid{writerRawCID(t, "fixed-a"), writerRawCID(t, "fixed-b")}
+					oldStore := materializermemory.New(true)
+					semantic, err := listtree.NewList(scheme, oldStore)
+					if err != nil {
+						t.Fatal(err)
+					}
+					root, err := semantic.CommitFixed(ctx, "fixed-file", oldValues, 4, 8)
+					if err != nil {
+						t.Fatal(err)
+					}
+					entries, err := arcset.NewCanonicalArcSet(arcset.KindList, []arcset.ArcEntry{
+						{Coordinate: arcset.NewListCoordinateUint64(0), Target: arcset.NewCASTarget(oldValues[0])},
+						{Coordinate: arcset.NewListCoordinateUint64(1), Target: arcset.NewCASTarget(oldValues[1])},
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					view := mutation.UpdateView{
+						Profile: mutation.UpdateViewProfile, StateProfile: mutation.StatefulCompleteVectorsProfile,
+						BaseRoot: root, Bounds: mutation.UpdateViewBounds{MaxObjects: 2, MaxTotalEntries: 8, MaxDepth: 2},
+						Objects: []mutation.UpdateObject{{ObjectID: "fixed-file", Root: root, Kind: arcset.KindList, Entries: entries,
+							Commit: mutation.CommitDescriptor{FixedList: &mutation.FixedListCommit{ChunkSize: 4, TotalSize: 8}}}},
+					}
+					newValue := writerRawCID(t, "fixed-"+operation)
+					intent := mutation.SemanticIntent{
+						Profile: mutation.SemanticIntentProfile, BaseRoot: root, TopOutputID: "fixed-output",
+						Transitions: []mutation.IntentTransition{{
+							ID: "fixed-output", ObjectID: "fixed-file", OldRoot: root, Kind: arcset.KindList, Backend: backend,
+							Commit: mutation.CommitDescriptor{FixedList: &mutation.FixedListCommit{ChunkSize: 4, TotalSize: 8}},
+						}},
+					}
+					nextValues := append([]cid.Cid(nil), oldValues...)
+					if operation == "replace" {
+						before, after := arcset.NewCASTarget(oldValues[0]), arcset.NewCASTarget(newValue)
+						intent.Transitions[0].Changes = []mutation.IntentChange{{Coordinate: arcset.NewListCoordinateUint64(0), Before: &before, After: &after}}
+						nextValues[0] = newValue
+					} else {
+						after := arcset.NewCASTarget(newValue)
+						intent.Transitions[0].Commit.FixedList.TotalSize = 12
+						intent.Transitions[0].Changes = []mutation.IntentChange{{Coordinate: arcset.NewListCoordinateUint64(2), After: &after}}
+						nextValues = append(nextValues, newValue)
+					}
+
+					runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{backend: scheme})
+					if err != nil {
+						t.Fatal(err)
+					}
+					verified, err := runtime.VerifyUpdateView(ctx, view)
+					if err != nil {
+						t.Fatal(err)
+					}
+					result, err := runtime.ComputeBundle(ctx, "fixed-"+operation, verified, intent)
+					if err != nil {
+						t.Fatal(err)
+					}
+					expectedStore := materializermemory.New(true)
+					expectedSemantic, err := listtree.NewList(scheme, expectedStore)
+					if err != nil {
+						t.Fatal(err)
+					}
+					expectedTotal := uint64(len(nextValues) * 4)
+					expected, err := expectedSemantic.CommitFixed(ctx, "fixed-file", nextValues, 4, expectedTotal)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !result.Bundle.Candidate.Equals(expected) {
+						t.Fatalf("candidate = %s, want %s", result.Bundle.Candidate, expected)
+					}
+					fresh, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{backend: scheme})
+					if err != nil {
+						t.Fatal(err)
+					}
+					if _, err := fresh.VerifyUpdateView(ctx, result.NextView); err != nil {
+						t.Fatalf("verify retained fixed-list view: %v", err)
+					}
+				})
+			}
+		})
 	}
 }
 
@@ -94,6 +229,44 @@ func TestVerifyUpdateViewRejectsUntrustedVectorForDeclaredRoot(t *testing.T) {
 	}
 	if _, err := runtime.VerifyUpdateView(ctx, view); err == nil {
 		t.Fatal("tampered complete vector was accepted")
+	}
+}
+
+func TestComputeBundleRejectsMutationOfVerifiedUpdateView(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, intent, _, _ := mapWriterFixture(t, ctx, scheme)
+	runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, err := runtime.VerifyUpdateView(ctx, view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := range verified.View.Objects {
+		if verified.View.Objects[index].ObjectID != "child" {
+			continue
+		}
+		entries := verified.View.Objects[index].Entries.Entries()
+		for entryIndex := range entries {
+			if entries[entryIndex].Coordinate.String() == "untouched" {
+				entries[entryIndex].Target = arcset.NewCASTarget(writerRawCID(t, "forged-unmeasured-binding"))
+			}
+		}
+		tampered, err := arcset.NewCanonicalArcSet(arcset.KindMap, entries)
+		if err != nil {
+			t.Fatal(err)
+		}
+		verified.View.Objects[index].Entries = tampered
+	}
+	if _, err := runtime.ComputeBundle(ctx, "mutated-verified-view", verified, intent); err == nil {
+		t.Fatal("mutation of a verified update view bypassed its runtime seal")
 	}
 }
 
@@ -166,6 +339,13 @@ func TestSessionAdvancesOnlyAfterExactDurableReceipt(t *testing.T) {
 	if !session.BaseRoot().Equals(view.BaseRoot) {
 		t.Fatal("rejected receipt advanced the accepted session base")
 	}
+	reprepared, err := session.Prepare(ctx, "session-map-replace-retry", intent)
+	if err != nil {
+		t.Fatalf("prepare after rejected receipt: %v", err)
+	}
+	if !reprepared.Bundle.Candidate.Equals(prepared.Bundle.Candidate) {
+		t.Fatalf("retry candidate = %s, want %s", reprepared.Bundle.Candidate, prepared.Bundle.Candidate)
+	}
 	correct := wrong
 	correct.Candidate = prepared.Bundle.Candidate
 	if err := session.AcceptReceipt(correct, prepared); err != nil {
@@ -179,6 +359,99 @@ func TestSessionAdvancesOnlyAfterExactDurableReceipt(t *testing.T) {
 	}
 }
 
+func TestSessionRejectsMutationOfPreparedNextView(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, intent, _, _ := mapWriterFixture(t, ctx, scheme)
+	runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := NewSession(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := session.Load(ctx, view); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := session.Prepare(ctx, "session-seal", intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundleDigest, err := prepared.Bundle.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := mutation.MaterializationReceipt{
+		Profile: mutation.MaterializationReceiptProfile, OperationID: prepared.Bundle.OperationID,
+		BaseRoot: prepared.Bundle.View.BaseRoot, Candidate: prepared.Bundle.Candidate,
+		BundleDigest: bundleDigest, DurableBoundary: "embedded-transaction-commit-v1",
+	}
+	for index := range prepared.NextView.Objects {
+		if prepared.NextView.Objects[index].ObjectID == "child" {
+			prepared.NextView.Objects[index].Root = writerRawCID(t, "forged-next-root")
+		}
+	}
+	if err := session.AcceptReceipt(receipt, prepared); err == nil {
+		t.Fatal("session accepted a mutated prepared next view")
+	}
+	if !session.BaseRoot().Equals(view.BaseRoot) {
+		t.Fatal("rejected prepared result advanced the session")
+	}
+}
+
+func TestSessionRejectsPreparedResultAfterSameRootViewReload(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, intent, _, _ := mapWriterFixture(t, ctx, scheme)
+	runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := NewSession(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := session.Load(ctx, view); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := session.Prepare(ctx, "session-stale-view", intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundleDigest, err := prepared.Bundle.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := mutation.MaterializationReceipt{
+		Profile: mutation.MaterializationReceiptProfile, OperationID: prepared.Bundle.OperationID,
+		BaseRoot: prepared.Bundle.View.BaseRoot, Candidate: prepared.Bundle.Candidate,
+		BundleDigest: bundleDigest, DurableBoundary: "embedded-transaction-commit-v1",
+	}
+
+	reloaded := view
+	reloaded.Bounds.MaxObjects++
+	if err := session.Load(ctx, reloaded); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.AcceptReceipt(receipt, prepared); err == nil {
+		t.Fatal("session accepted a result prepared against a different same-root view")
+	}
+	if !session.BaseRoot().Equals(view.BaseRoot) {
+		t.Fatal("rejected stale prepared result advanced the session")
+	}
+}
+
 func mapWriterFixture(t *testing.T, ctx context.Context, scheme *kzg.Scheme) (mutation.UpdateView, mutation.SemanticIntent, cid.Cid, cid.Cid) {
 	t.Helper()
 	oldPayload := writerRawCID(t, "old-payload")
@@ -188,7 +461,8 @@ func mapWriterFixture(t *testing.T, ctx context.Context, scheme *kzg.Scheme) (mu
 	if err != nil {
 		t.Fatal(err)
 	}
-	childRoot, err := oldMap.Commit(ctx, "child", mapping.NewViewFrom(map[string]cid.Cid{"payload": oldPayload}))
+	untouchedPayload := writerRawCID(t, "untouched-payload")
+	childRoot, err := oldMap.Commit(ctx, "child", mapping.NewViewFrom(map[string]cid.Cid{"payload": oldPayload, "untouched": untouchedPayload}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +476,7 @@ func mapWriterFixture(t *testing.T, ctx context.Context, scheme *kzg.Scheme) (mu
 	if err != nil {
 		t.Fatal(err)
 	}
-	newChildRoot, err := newMap.Commit(ctx, "child", mapping.NewViewFrom(map[string]cid.Cid{"payload": newPayload}))
+	newChildRoot, err := newMap.Commit(ctx, "child", mapping.NewViewFrom(map[string]cid.Cid{"payload": newPayload, "untouched": untouchedPayload}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,9 +485,10 @@ func mapWriterFixture(t *testing.T, ctx context.Context, scheme *kzg.Scheme) (mu
 		t.Fatal(err)
 	}
 
-	childEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
-		Coordinate: writerMapCoordinate(t, "payload"), Target: arcset.NewCASTarget(oldPayload),
-	}})
+	childEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{
+		{Coordinate: writerMapCoordinate(t, "payload"), Target: arcset.NewCASTarget(oldPayload)},
+		{Coordinate: writerMapCoordinate(t, "untouched"), Target: arcset.NewCASTarget(untouchedPayload)},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What changed

- add a bounded, canonical client-root update-view / semantic-intent / exact-bundle protocol
- add an SDK writer and long-lived session that independently verifies old roots, computes candidate roots locally, and advances only after an exact durable receipt
- add deterministic phase observations for read and write evaluation
- add prepared KZG/IPA index openings so Open is measured independently from Commit
- harden decoder allocation bounds, shared-DAG depth validation, session seals, fixed-list append continuity, and convergent post-root handling

## Why

Paper Section 5 RQ1/RQ2/RQ4 needs a real current-core measurement boundary: verified reads with phase decomposition, complete client-side Root generation, and commitment backend phases. The previous evaluator registration had no executable client-root contract.

## Dependency

This PR is stacked on #175 so the paper-evaluation boundary and the incomplete-list-materialization correctness fix share one Core head. Merge #175 first, then retarget this PR to `main`.

## Validation

- `git range-diff` confirms all five original evaluation/client-root commits are patch-equivalent after stacking on #175
- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go build -buildvcs=false ./...`
- targeted race tests for the changed client-root, commitment, materializer, and list paths
- fresh independent review after the rebase: no actionable findings

This PR implements the executable boundary only. It does not contain paper performance results or make candidate roots portable transition proofs.
