### PR TITLE
Classify incomplete list materialization

### DIFF
--- a/auth/arcset/materializer/materializer.go
+++ b/auth/arcset/materializer/materializer.go
@@ -19,9 +19,21 @@ import (
 // ArcSet materialization.
 var ErrNotFound = arcset.ErrNotFound
 
+// ErrIncomplete reports that physical materialization was found for an
+// authenticated object, but it is not sufficient to reconstruct the object
+// named by its root. It is distinct from backend I/O failures so callers can
+// classify absent/incomplete state without hiding retryable storage errors.
+var ErrIncomplete = errors.New("materialized state is incomplete")
+
 // IsNotFound reports whether err represents an absent materialized arc.
 func IsNotFound(err error) bool {
 	return errors.Is(err, ErrNotFound)
+}
+
+// IsIncomplete reports whether err represents incomplete physical state for
+// an authenticated object.
+func IsIncomplete(err error) bool {
+	return errors.Is(err, ErrIncomplete)
 }
 
 // Lookup is the read-only coordinate lookup capability used by semantic

--- a/auth/arcset/materializer/materializer.go
+++ b/auth/arcset/materializer/materializer.go
@@ -19,10 +19,10 @@ import (
 // ArcSet materialization.
 var ErrNotFound = arcset.ErrNotFound
 
-// ErrIncomplete reports that physical materialization was found for an
-// authenticated object, but it is not sufficient to reconstruct the object
-// named by its root. It is distinct from backend I/O failures so callers can
-// classify absent/incomplete state without hiding retryable storage errors.
+// ErrIncomplete reports that physical materialization for an authenticated
+// object is absent, incomplete, or inconsistent with the object named by its
+// root. It is distinct from backend I/O failures so callers can classify
+// unavailable object state without hiding retryable storage errors.
 var ErrIncomplete = errors.New("materialized state is incomplete")
 
 // IsNotFound reports whether err represents an absent materialized arc.

--- a/auth/semantic/list/tree/internal/layout.go
+++ b/auth/semantic/list/tree/internal/layout.go
@@ -179,7 +179,7 @@ func ValidateSlots(scheme commitment.IndexCommitment, root cid.Cid, slots []cid.
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("materialized node state does not match root %s", root.String())
+		return fmt.Errorf("%w: node state does not match root %s", materializer.ErrIncomplete, root.String())
 	}
 	return nil
 }
@@ -195,7 +195,7 @@ func ProveSlot(scheme commitment.IndexCommitment, root cid.Cid, slots []cid.Cid,
 		return nil, nil, err
 	}
 	if !ok {
-		return nil, nil, fmt.Errorf("recomputed node root does not match requested root")
+		return nil, nil, fmt.Errorf("%w: recomputed node root does not match requested root", materializer.ErrIncomplete)
 	}
 	return value, proof, nil
 }

--- a/auth/semantic/list/tree/tree.go
+++ b/auth/semantic/list/tree/tree.go
@@ -141,6 +141,9 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 			return list.Query{}, nil, err
 		}
 		envelope.Steps = append(envelope.Steps, newProofStep(target, proof, slot))
+		if !target.Defined() {
+			return list.Query{}, nil, fmt.Errorf("%w: missing child at level %d digit %d", materializer.ErrIncomplete, level, digit)
+		}
 
 		if level == len(digits)-1 {
 			query.Key, err = target.AsCID()
@@ -149,10 +152,6 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 			}
 			return encodeProof(query, envelope)
 		}
-		if !target.Defined() {
-			return list.Query{}, nil, fmt.Errorf("%w: missing child at level %d digit %d", materializer.ErrIncomplete, level, digit)
-		}
-
 		currentRoot, err = target.AsCID()
 		if err != nil {
 			return list.Query{}, nil, err

--- a/auth/semantic/list/tree/tree.go
+++ b/auth/semantic/list/tree/tree.go
@@ -150,7 +150,7 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 			return encodeProof(query, envelope)
 		}
 		if !target.Defined() {
-			return list.Query{}, nil, fmt.Errorf("missing child at level %d digit %d", level, digit)
+			return list.Query{}, nil, fmt.Errorf("%w: missing child at level %d digit %d", materializer.ErrIncomplete, level, digit)
 		}
 
 		currentRoot, err = target.AsCID()
@@ -997,7 +997,7 @@ func (s *TreeList) validateSlots(root cid.Cid, slots []cid.Cid) error {
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("materialized node state does not match root %s", root.String())
+		return fmt.Errorf("%w: node state does not match root %s", materializer.ErrIncomplete, root.String())
 	}
 	return nil
 }

--- a/auth/semantic/list/tree/tree_test.go
+++ b/auth/semantic/list/tree/tree_test.go
@@ -3,6 +3,7 @@ package tree_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -219,11 +220,77 @@ func TestTreeListRejectsLegacyWidthMaterialization(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewList after restart failed: %v", err)
 			}
-			if _, _, err := restarted.Prove(ctx, namespace, root, 0); err == nil {
-				t.Fatal("Prove should reject legacy-width materialization")
+			if _, _, err := restarted.Prove(ctx, namespace, root, 0); !errors.Is(err, materializer.ErrIncomplete) {
+				t.Fatalf("Prove error = %v, want ErrIncomplete", err)
 			}
 		})
 	}
+}
+
+func TestTreeListReportsIncompleteMaterialization(t *testing.T) {
+	ctx := context.Background()
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			scheme := factory(t)
+			source, _, err := newListWithMaterializer(scheme, materialmemory.New(true))
+			if err != nil {
+				t.Fatal(err)
+			}
+			root, err := source.Commit(ctx, "source-"+name, list.NewViewFromSlice(makeValues(2)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			missing, _, err := newListWithMaterializer(scheme, materialmemory.New(true))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := missing.Prove(ctx, "missing-"+name, root, 0); !errors.Is(err, materializer.ErrIncomplete) {
+				t.Fatalf("Prove error = %v, want ErrIncomplete", err)
+			}
+		})
+	}
+}
+
+func TestTreeListPreservesMaterializerFailure(t *testing.T) {
+	ctx := context.Background()
+	storeErr := errors.New("materializer unavailable")
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			scheme := factory(t)
+			source, _, err := newListWithMaterializer(scheme, materialmemory.New(true))
+			if err != nil {
+				t.Fatal(err)
+			}
+			root, err := source.Commit(ctx, "source-"+name, list.NewViewFromSlice(makeValues(2)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			failing, err := tree.NewList(scheme, failingNodeStore{err: storeErr})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _, err = failing.Prove(ctx, "failing-"+name, root, 0)
+			if !errors.Is(err, storeErr) || errors.Is(err, materializer.ErrIncomplete) {
+				t.Fatalf("Prove error = %v, want original materializer failure only", err)
+			}
+		})
+	}
+}
+
+type failingNodeStore struct {
+	err error
+}
+
+func (s failingNodeStore) Get(context.Context, string, cid.Cid, arcset.Path) (cid.Cid, error) {
+	return cid.Undef, s.err
+}
+
+func (s failingNodeStore) BatchGet(context.Context, string, cid.Cid, []arcset.Path) (map[arcset.Path]cid.Cid, error) {
+	return nil, s.err
+}
+
+func (s failingNodeStore) Update(context.Context, string, cid.Cid, cid.Cid, arcset.ArcSet) error {
+	return s.err
 }
 
 func TestTreeListVerifiesProofWithoutStepSlots(t *testing.T) {

--- a/auth/semantic/list/tree/tree_test.go
+++ b/auth/semantic/list/tree/tree_test.go
@@ -251,6 +251,35 @@ func TestTreeListReportsIncompleteMaterialization(t *testing.T) {
 	}
 }
 
+func TestTreeListRejectsAuthenticatedLengthWithMissingLeaf(t *testing.T) {
+	ctx := context.Background()
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			scheme := factory(t)
+			store := materialmemory.New(true)
+			semantic, _, err := newListWithMaterializer(scheme, store)
+			if err != nil {
+				t.Fatal(err)
+			}
+			slots := layout.EmptyRootSlots()
+			slots[0], err = layout.EncodeNodeMetadata(layout.NodeMetadata{ChildCount: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+			root, err := layout.CommitSlots(scheme, slots)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := layout.StoreSlots(ctx, store, "missing-leaf-"+name, root, slots); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := semantic.Prove(ctx, "missing-leaf-"+name, root, 0); !errors.Is(err, materializer.ErrIncomplete) {
+				t.Fatalf("Prove error = %v, want ErrIncomplete", err)
+			}
+		})
+	}
+}
+
 func TestTreeListPreservesMaterializerFailure(t *testing.T) {
 	ctx := context.Background()
 	storeErr := errors.New("materializer unavailable")


### PR DESCRIPTION
## Summary

- add a typed `materializer.ErrIncomplete` error for absent, partial, or root-inconsistent authenticated object state
- preserve underlying materializer I/O errors instead of conflating them with missing state
- reject authenticated list lengths whose required leaf is undefined

## Why

Managed Gateway Bucket isolation needs to map only genuinely absent/incomplete list state to a not-found result. Retryable storage failures must retain their original error chain and service category.

## Validation

- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- independent review: no actionable findings
