### PR TITLE
docs: define post-release core boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,29 +10,35 @@ when this checkout is part of the combined MALT workspace.
 ## Core Boundary
 
 - Keep canonical values, segment paths, semantic map/list authentication,
-  commitments, ProofLists, resolve/read/mutation contracts, graph algorithms,
-  portable verification, and transport-neutral schemas here.
+  commitments, ProofLists, resolve/read/mutation/client-root contracts, graph
+  algorithms, portable verification, and transport-neutral schemas here.
 - Core algorithms may consume narrow capabilities under
   `auth/arcset/materializer`, but must not define durable ArcTable, KV, CAS,
   cache, HTTP, daemon, filesystem, UnixFS, Merkle DAG application, tenant,
   publication, or trusted-root policy.
 - Treat every resolver, materializer, cache, and gateway as untrusted execution
   state. Verification is relative to a caller-selected root and query.
-- Mutation receipts contain candidate result roots; they are not portable
-  transition proofs and must not be documented as authenticated updates.
+- Mutation receipts and client-root materialization receipts bind operational
+  outcomes; they are not portable transition, publication, freshness, or trust
+  proofs and must not be documented as authenticated updates.
 
 ## Package Ownership
 
 - The module-root `malt` package owns the minimal in-process semantic facade.
-- `auth/` owns ArcSet values, commitments, semantic structures, ProofLists, and
-  portable proof verification.
+- `auth/` owns ArcSet values, commitments, semantic structures, ProofLists,
+  portable proof verification, and optional request-scoped observation hooks.
+  Observations are diagnostics, never protocol evidence.
 - `graph/` owns application-neutral traversal, runtime composition over injected
   capabilities, and reference writer algorithms.
 - `execution/` owns the untrusted resolve/read/apply facade; it does not make
   client trust decisions or own service state.
-- `mutation/` owns portable semantic mutation values and operational receipts.
+- `mutation/` owns portable semantic mutation values, complete-view client-root
+  values, and operational receipts.
 - `protocol/` and `wire/` own versioned transport-neutral JSON/schema and CID
   projections. Incompatible wire changes require a new profile.
+- `sdk/writer` owns application-neutral complete-view verification and exact
+  client-root computation. It does not own application syntax, durable
+  persistence, publication, synchronization, or trusted-root promotion.
 - `artifact/` and its verifier entry points are frozen v0.0.4 compatibility
   surfaces. Do not add new operations to `malt.artifact/v0alpha2`.
 - `cmd/malt-verifier-wasm` is a portable local-verification build target, not a

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,9 +14,9 @@ application state are outside the trust boundary.
 
 | Layer | Owns | Explicitly excludes |
 | --- | --- | --- |
-| MALT core | arcs/segments, typed roots, commitments, resolve/read/mutation values, ProofList, verification | HTTP, CAS I/O, ArcTable implementation, application syntax, trusted-root policy |
-| Client | application syntax, accepted roots, request construction, local proof and payload-byte verification | proof generation, ArcTable, server policy |
-| Gateway/executor | candidate selection, proof generation, mutation execution, ArcTable/KV/CAS, service policy | the final trust decision |
+| MALT core | arcs/segments, typed roots, commitments, resolve/read/mutation and client-root values, ProofList, verification | HTTP, CAS I/O, ArcTable implementation, application syntax, trusted-root policy |
+| Client | application syntax, accepted roots, request construction, local proof and payload-byte verification, optional client-root computation | proof generation, persistent ArcTable, server policy |
+| Gateway/executor | candidate selection for server-executed mutations, exact client-root replay/materialization, proof generation, ArcTable/KV/CAS, service policy | the final trust decision or substitution of a client-computed root |
 | CAS | immutable CID-addressed bytes | graph semantics and ProofLists |
 
 ## Data flow
@@ -45,12 +45,13 @@ selection. Application policy may impose additional constraints.
 
 ```text
 malt (module facade)
-├── protocol                 serialized resolve/read profiles and schemas
-├── mutation                 portable mutation/receipt values
+├── protocol                 serialized resolve/read and client-root profiles
+├── mutation                 portable mutation/client-root/receipt values
 ├── auth
 │   ├── arcset               canonical arcs and ArcSet views
 │   │   └── materializer     caller-injected load/store capability
 │   ├── commitment           KZG/IPA commitment primitives
+│   ├── observation          optional request-scoped diagnostics
 │   ├── semantic             map/list contracts and algorithms
 │   ├── proof                ProofList and evidence
 │   └── verifier             storage-free portable verifier
@@ -58,6 +59,7 @@ malt (module facade)
 ├── graph                    resolver/writer algorithms
 │   └── runtime              composition over an injected materializer
 ├── sdk/verifier             trusted client facade
+├── sdk/writer               complete-view client-root computation
 ├── wire/maltcid             typed CID rules
 └── artifact                 frozen compatibility profile
 ```
@@ -133,6 +135,23 @@ separate `StructureCreator` because a new structure has no authenticated base
 root. Legacy `UpdateArc`, `BatchUpdateArcs`, and inspection helpers are exposed
 only through the explicitly named `ReferenceWriter()` capability.
 
+### Client-root computation
+
+The post-release client-root contract lets a trusted writer validate a bounded
+complete `UpdateView`, normalize an output-free `SemanticIntent`, and compute
+one exact `ClientRootBundle` locally. `sdk/writer` owns that
+application-neutral computation. It uses caller-supplied branching
+materialization only for speculative local state and defines no durable
+ArcTable or publication policy.
+
+A service may independently replay and materialize the exact bundle at its
+declared durability boundary, then acknowledge it with a
+`MaterializationReceipt`. That receipt can advance a writer session's retained
+vectors, but it is not a portable state-transition, freshness, publication, or
+trust proof. Initial structure creation remains a separate bootstrap boundary
+because it has no authenticated base root. See the
+[client-root contract](./docs/spec/client-root-contract.md).
+
 ## Verification boundary
 
 Trusted verification packages must remain deterministic and storage-free:
@@ -153,8 +172,13 @@ application-defined ranged segment, against authenticated CIDs.
 
 UnixFS is not a core layout or package. It is a client application profile that
 maps filesystem paths/manifests/chunks into core segment, mutation, resolve,
-and read contracts. Its current implementation lives in `malt-client` and the
-browser client.
+and read contracts. Its native implementation lives in `malt-client`; the
+managed browser application lives in `gateway/console`.
+
+`auth/observation` is an application-neutral, request-scoped diagnostic hook
+used by outer runtimes and evaluators. Observations cannot affect protocol
+results and are never proof evidence. Its current phase vocabulary describes
+SDK execution stages, not a paper result schema or persistence contract.
 
 A future TypeScript SDK may map `.` or `[]` object syntax into the same segment
 arrays. Core does not parse those syntaxes. HTTP may naturally use `/`, while

--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@ line client, daemon, UnixFS model, or website.
 
 [Documentation](./docs/README.md) · [Architecture](./ARCHITECTURE.md) ·
 [Resolve/read contracts](./docs/spec/resolve-read-contracts.md) ·
+[Client-root contract](./docs/spec/client-root-contract.md) ·
 [ProofList](./docs/spec/prooflist-format.md) ·
 [Compatibility](./docs/policy/compatibility.md) ·
 [v0.0.6 release](./docs/releases/v0.0.6.md) · [Roadmap](./ROADMAP.md)
+
+`v0.0.6` is the current tagged release. The client-root profiles and
+`sdk/writer` are experimental post-release contracts on `main`; their `/v1`
+profile suffixes do not declare the Go module or project stable at v1.
 
 ## Boundary
 
@@ -31,6 +36,7 @@ MALT core owns:
 - typed map/list roots and CID rules;
 - map/list commitment, proof, and verification algorithms;
 - `malt.resolve/v0alpha1` and `malt.read/v0alpha1` values and JSON Schemas;
+- complete-view client-root values, schemas, and local candidate computation;
 - ProofList generation/verification semantics;
 - portable mutation and receipt values;
 - untrusted resolve/read/apply composition over caller-injected capabilities;
@@ -52,7 +58,7 @@ Those responsibilities are split across independent repositories:
 | [`DeWebProtocol/malt-client`](https://github.com/DeWebProtocol/malt-client) | CLI/daemon plus separate transport, trusted-root policy, UnixFS, payload binding, and Merkle DAG compatibility layers |
 | [`DeWebProtocol/gateway`](https://github.com/DeWebProtocol/gateway) | Untrusted native/compatibility profiles, runtime composition, ArcTable/KV/CAS backends, scope and publication policy |
 | [`DeWebProtocol/malt-evaluation`](https://github.com/DeWebProtocol/malt-evaluation) | Reproducible evaluator, benchmark suites, comparison adapters, plans, and schemas |
-| [`DeWebProtocol/malt-web`](https://github.com/DeWebProtocol/malt-web) | Browser client, local WASM verification, public website and tutorials |
+| [`DeWebProtocol/malt-web`](https://github.com/DeWebProtocol/malt-web) | Public website, tutorials, and browser-local verification tools |
 
 ## Core composition
 
@@ -116,11 +122,13 @@ in the application client.
 | `auth/semantic` | Map/list semantic contracts and reference algorithms |
 | `auth/proof` | ProofList/evidence formats |
 | `auth/verifier` | Storage-free ProofList verification |
-| `protocol` | Versioned serialized resolve/read profiles and schemas |
-| `mutation` | Portable mutation and receipt values |
+| `protocol` | Versioned serialized resolve/read and client-root profiles and schemas |
+| `mutation` | Portable mutation, client-root, and receipt values |
 | `execution` | Untrusted resolve/read/apply composition |
 | `graph` | Resolver, semantic mutation, bootstrap, and explicit reference-writer algorithms over injected capabilities |
 | `sdk/verifier` | Client-facing local verification facade |
+| `sdk/writer` | Complete-view verification and exact client-root computation |
+| `auth/observation` | Optional request-scoped execution diagnostics; never proof evidence |
 | `artifact` | Frozen `malt.artifact/v0alpha2` compatibility decoder/verifier |
 | `cmd/malt-verifier-wasm` | Browser verifier build entry point |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,17 @@ v0.0.6 turns this repository into an SDK-only core:
   materializer capability;
 - keep portable Go/WASM verification independent of execution state;
 - move ArcTable/KV/CAS execution to `gateway`;
-- move trusted roots, CLI/daemon, UnixFS, and payload-byte binding to
-  `malt-client` and Web.
+- move native trusted roots, CLI/daemon, UnixFS, and payload-byte binding to
+  `malt-client`; managed browser application behavior lives in
+  `gateway/console`.
+
+## Post-v0.0.6 main
+
+Current `main` additionally contains the experimental complete-view
+client-root profiles, `sdk/writer` local candidate computation, and optional
+request-scoped phase observations. These contracts are not part of the
+immutable v0.0.6 tag. Before a later release, they need a language-neutral
+accept/reject conformance corpus as well as the checked-in schemas and Go tests.
 
 ## Next core work
 
@@ -33,8 +42,9 @@ v0.0.6 turns this repository into an SDK-only core:
   publication, cache/quota policy, backend availability, and product E2E.
 - `malt-client`: UnixFS CLI/daemon, accepted roots, candidate acceptance,
   local proof verification, and payload-byte validation.
-- `web`: browser application, local WASM verification, and generic
-  resolve/read/CAS composition.
+- `gateway/console`: managed browser account/Bucket application and
+  client-side UnixFS composition.
+- `web`: public explanation, tutorials, and browser-local verification tools.
 - future `malt-ts`: TypeScript object syntax and client ergonomics after core
   conformance is stable.
 

--- a/architecture_test.go
+++ b/architecture_test.go
@@ -63,6 +63,12 @@ func TestProductionImportBoundaries(t *testing.T) {
 			forbidden: []string{"graph", "runtime", "storage", "model", "api", "server", "execution", "logger"},
 		},
 		{
+			name:      "client writer",
+			dir:       filepath.Join(root, "sdk", "writer"),
+			recursive: true,
+			forbidden: []string{"artifact", "execution", "storage", "layout", "model", "api", "server", "logger", "sdk/verifier"},
+		},
+		{
 			name:      "module facade",
 			dir:       root,
 			recursive: false,

--- a/auth/observation/phase.go
+++ b/auth/observation/phase.go
@@ -8,10 +8,14 @@ import (
 	"time"
 )
 
-// Phase names the stable server-side phases used by the paper evaluator.
+// Phase names application-neutral SDK execution stages exposed to optional
+// diagnostics. Evaluators may consume them, but they are not wire profiles,
+// proof evidence, paper result schemas, or persistence contracts.
 type Phase string
 
 const (
+	// PhaseArcTable measures an injected materializer lookup. The diagnostic
+	// label does not define or require a persistent ArcTable implementation.
 	PhaseArcTable        Phase = "arc-table"
 	PhaseMaterialization Phase = "materialization"
 	PhaseOpen            Phase = "open"

--- a/auth/semantic/mapping/radix/observation_test.go
+++ b/auth/semantic/mapping/radix/observation_test.go
@@ -1,6 +1,7 @@
 package radix
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -33,6 +34,10 @@ func TestProveReportsMaterializationOpenAndSerialization(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	baselineBinding, baselineProof, err := semanticMap.Prove(context.Background(), "observation", root, arcset.Path("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	collector := new(phaseCollector)
 	ctx := observation.WithObserver(context.Background(), collector)
 	binding, proof, err := semanticMap.Prove(ctx, "observation", root, arcset.Path("payload"))
@@ -41,6 +46,9 @@ func TestProveReportsMaterializationOpenAndSerialization(t *testing.T) {
 	}
 	if !binding.Value.Equals(target) || len(proof) == 0 {
 		t.Fatalf("binding=%#v proof=%d", binding, len(proof))
+	}
+	if binding.Present != baselineBinding.Present || !binding.Value.Equals(baselineBinding.Value) || !bytes.Equal(proof, baselineProof) {
+		t.Fatalf("observation changed result: baseline=%#v/%x observed=%#v/%x", baselineBinding, baselineProof, binding, proof)
 	}
 	seen := map[observation.Phase]bool{}
 	for _, sample := range collector.samples {

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ with code, tests, schemas, and wire formats. Public
 website pages in `DeWebProtocol/malt-web` may summarize this material, but they
 should link back here for protocol, policy, and compatibility details.
 
-Managed gateway service behavior, including future tenancy, identity, authorization,
+Managed gateway service behavior, including tenancy, identity, authorization,
 root publication, backend orchestration, S3/Filecoin/IPFS deployment policy,
 quota, cache policy, and operations, belongs in `DeWebProtocol/gateway` or
 private deployment overlays. Client/daemon and UnixFS behavior belongs in
@@ -39,6 +39,8 @@ research narrative remain in `DeWebProtocol/documents`.
 ## Specifications
 
 - [Specification index](./spec/README.md)
+- [Resolve and read contracts](./spec/resolve-read-contracts.md)
+- [Client-root contract](./spec/client-root-contract.md)
 
 ## MALT Improvement Proposals
 
@@ -59,8 +61,10 @@ The current public-core contracts are
 [MIP-1012: Segment Path Resolution](./mips/mip-1012-segment-path-resolution.md),
 the final
 [MIP-1013: Client, Gateway, And Core Responsibility Boundary](./mips/mip-1013-client-gateway-core-boundary.md),
-the operation-specific resolve/read profiles introduced by that MIP, and the
-frozen v0.0.4 artifact compatibility profile recorded by
+the operation-specific resolve/read profiles introduced by that MIP, the
+experimental post-v0.0.6
+[client-root contract](./spec/client-root-contract.md), and the frozen v0.0.4
+artifact compatibility profile recorded by
 [MIP-1004](./mips/mip-1004-resolve-prooflist-artifact-schema.md).
 
 ## What Goes Where

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -24,8 +24,8 @@ mechanics:
 - [Semantic model](../spec/semantic.md) for map/list semantics, roots, payloads,
   resolver, writer, and ArcTable boundaries.
 - [ProofList format](../spec/prooflist-format.md) for proof steps, ordering,
-  HTTP proof headers, and range evidence.
-- [HTTP API](../spec/http-api.md) for resolve, content, verify, and mutation
-  routes.
+  serialized evidence, and range evidence.
+- [HTTP routing ownership](../spec/http-api.md) for why service routes,
+  authentication, CORS, and daemon APIs remain outside MALT core.
 - [Commitment model](../spec/commitment.md) for backend proof assumptions.
 - [CID and wire format](../spec/cid-and-wire-format.md) for root encoding.

--- a/docs/policy/compatibility.md
+++ b/docs/policy/compatibility.md
@@ -10,10 +10,17 @@ profiles rejected.
 | Root `malt` typed facade | Experimental |
 | `malt.resolve/v0alpha1` | Profiled; incompatible wire revisions require a new profile |
 | `malt.read/v0alpha1` | Profiled; incompatible wire revisions require a new profile |
+| `malt.update-view/v1` | Experimental post-v0.0.6 complete semantic closure |
+| `stateful-complete-vectors-v1` | Experimental state profile required by the current update-view contract |
+| `malt.semantic-intent/v1` | Experimental post-v0.0.6 output-free update intent |
+| `malt.client-root-bundle/v1` | Experimental post-v0.0.6 exact-root submission; not a transition proof |
+| `malt.materialization-receipt/v1` | Experimental post-v0.0.6 exact-bundle durability acknowledgement |
 | ProofList JSON and proof semantics | Experimental, verifier-facing |
 | Typed MALT root CIDs/codecs | Experimental, verifier-facing |
 | `SegmentPath` projection | `/`-joined UTF-8 segments; experimental |
 | Public Go semantic/materializer interfaces | Experimental source API |
+| `sdk/writer` | Experimental source API for local complete-view client-root computation |
+| `auth/observation` phases | Diagnostic source API; not wire data or proof evidence |
 | `malt.artifact/v0alpha2` | Frozen v0.0.4 compatibility profile |
 | ArcTable/KV/CAS implementations | Outside this module and not a core compatibility surface |
 | CLI, daemon, HTTP routes, UnixFS | Outside this module |
@@ -21,6 +28,11 @@ profiles rejected.
 The frozen artifact profile accepts only its released operation set. New
 integrations use operation-specific resolve/read request/result pairs rather
 than extending that union.
+
+The `/v1` suffixes on the client-root profiles version those serialized
+contracts. They do not mean that MALT, the Go module, or the source APIs have
+reached a stable v1 release. The profiles are present on post-v0.0.6 `main` and
+are not part of the immutable v0.0.6 tag.
 
 ## Pre-v1 changes
 
@@ -32,7 +44,7 @@ documentation in the same PR:
 - ProofList fields, ordering, step kinds, or verification rules;
 - root/CID encoding and commitment backend selection;
 - canonical segment/arc validation;
-- mutation or receipt value semantics;
+- mutation, client-root, or receipt value semantics;
 - payload-binding and measured-list evidence.
 
 Typed-root decoders accept only the current registered `MALTVersionID`,

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -10,10 +10,12 @@ For reader-facing background on hash authentication, Merkle DAGs, and MALT's
 positioning, start with [Concepts](../concepts/README.md). Keep normative
 behavior, wire formats, and proof semantics in this folder.
 
-The current transport-neutral contracts are `malt.resolve/v0alpha1` and
-`malt.read/v0alpha1`. They carry operation-specific results plus ProofList
-evidence. The v0.0.4 `malt.artifact/v0alpha2` profile remains frozen for
-compatibility. See [MIP-1012](../mips/mip-1012-segment-path-resolution.md) and
+The current transport-neutral proof-bearing contracts are
+`malt.resolve/v0alpha1` and `malt.read/v0alpha1`. The post-release client-root
+contracts are `malt.update-view/v1`, `malt.semantic-intent/v1`,
+`malt.client-root-bundle/v1`, and `malt.materialization-receipt/v1`. The
+v0.0.4 `malt.artifact/v0alpha2` profile remains frozen for compatibility. See
+[MIP-1012](../mips/mip-1012-segment-path-resolution.md) and
 [MIP-1013](../mips/mip-1013-client-gateway-core-boundary.md).
 
 ## Documents
@@ -22,12 +24,32 @@ compatibility. See [MIP-1012](../mips/mip-1012-segment-path-resolution.md) and
 - [ProofList format](./prooflist-format.md)
 - [Writer receipts](./writer-receipts.md)
 - [Resolve and read contracts](./resolve-read-contracts.md)
+- [Client-root contract](./client-root-contract.md)
 - [Frozen artifact compatibility profile](./artifacts.md)
 - [Segment paths and resolution](./segment-paths.md)
 - [Commitment model](./commitment.md)
 - [Commitment and proof encoding](./commitment-proof-encoding.md)
 - [CID and wire format](./cid-and-wire-format.md)
 - [Resolve/Read conformance corpus v1](./resolve-read-conformance-v1.md)
+
+## Protocol Schema Index
+
+Every filename returned by `protocol.SchemaNames()` is indexed here:
+
+<!-- schema-catalog:protocol:start -->
+- [`client-root-bundle.schema.json`](../../protocol/schemas/client-root-bundle.schema.json)
+- [`materialization-receipt.schema.json`](../../protocol/schemas/materialization-receipt.schema.json)
+- [`prooflist.schema.json`](../../protocol/schemas/prooflist.schema.json)
+- [`read-request.schema.json`](../../protocol/schemas/read-request.schema.json)
+- [`read-result.schema.json`](../../protocol/schemas/read-result.schema.json)
+- [`read-verification.schema.json`](../../protocol/schemas/read-verification.schema.json)
+- [`resolve-request.schema.json`](../../protocol/schemas/resolve-request.schema.json)
+- [`resolve-result.schema.json`](../../protocol/schemas/resolve-result.schema.json)
+- [`resolve-verification.schema.json`](../../protocol/schemas/resolve-verification.schema.json)
+- [`semantic-intent.schema.json`](../../protocol/schemas/semantic-intent.schema.json)
+- [`update-view.schema.json`](../../protocol/schemas/update-view.schema.json)
+- [`verification-result.schema.json`](../../protocol/schemas/verification-result.schema.json)
+<!-- schema-catalog:protocol:end -->
 
 ## Notes
 

--- a/docs/spec/artifacts.md
+++ b/docs/spec/artifacts.md
@@ -13,9 +13,12 @@ schema and verifiers. Any incompatible extension would require a new profile.
 ## Status
 
 The Go package `github.com/dewebprotocol/malt/artifact`, its schemas under
-`artifact/schemas/`, fixtures under `artifact/testdata/v0alpha2/`, and the
-reference `/v1/artifacts/*` routes remain available for v0.0.4 compatibility.
-They are not the primary contract for new integrations.
+`artifact/schemas/`, and fixtures under `artifact/testdata/v0alpha2/` remain
+available for v0.0.4 compatibility. Core is transport-neutral and no longer
+ships the historical `/v1/artifacts/*` HTTP projection. A gateway that
+deliberately reintroduces those routes owns their registration, access policy,
+and compatibility testing. The artifact profile is not the primary contract
+for new integrations.
 
 The `prove` name in this legacy profile means “execute one primitive typed
 map/list read and return its evidence.” It is not a general semantic operation
@@ -28,7 +31,7 @@ and it does not prove arbitrary resolve or mutation operations.
 | `resolve` | root plus canonical segment path | Return one authenticated path-to-target derivation. An empty path is strict zero-step root identity. |
 | `prove` | root plus `map_key`, `list_index`, or `list_range` query | Return one primitive read result and its evidence. |
 
-The compatibility HTTP projection is:
+The historical compatibility HTTP projection was:
 
 ```text
 POST /v1/artifacts/resolve
@@ -38,6 +41,22 @@ POST /v1/artifacts/verify
 
 Remote verification is diagnostic. A client must bind its independently
 selected trusted root and expected request before accepting the result.
+These route names are historical documentation, not routes provided by this
+module or promised by the current Gateway.
+
+## Embedded Schema Index
+
+Every filename returned by `artifact.SchemaNames()` is indexed here:
+
+<!-- schema-catalog:artifact:start -->
+- [`artifact.schema.json`](../../artifact/schemas/artifact.schema.json)
+- [`local-verify-request.schema.json`](../../artifact/schemas/local-verify-request.schema.json)
+- [`local-verify-result.schema.json`](../../artifact/schemas/local-verify-result.schema.json)
+- [`prove-request.schema.json`](../../artifact/schemas/prove-request.schema.json)
+- [`resolve-request.schema.json`](../../artifact/schemas/resolve-request.schema.json)
+- [`verify-request.schema.json`](../../artifact/schemas/verify-request.schema.json)
+- [`verify-result.schema.json`](../../artifact/schemas/verify-result.schema.json)
+<!-- schema-catalog:artifact:end -->
 
 ## Root Identity Compatibility
 

--- a/docs/spec/client-root-contract.md
+++ b/docs/spec/client-root-contract.md
@@ -1,0 +1,264 @@
+# Client-Root Contract
+
+This document defines the transport-neutral contract for computing one exact
+candidate root from complete, client-verified semantic state. It does not
+define an HTTP route, persistence engine, root-publication policy, or portable
+state-transition proof.
+
+## Status
+
+This is an experimental post-v0.0.6 contract on `main`; it is not part of the
+immutable v0.0.6 release and has not yet been published as v0.0.7. The `/v1`
+suffixes below version the serialized profiles. They do not declare MALT or its
+Go source APIs stable at v1.
+
+## Profiles And Schemas
+
+| Contract | Profile | Schema |
+| --- | --- | --- |
+| complete old-state closure | `malt.update-view/v1` | `update-view.schema.json` |
+| output-free requested change | `malt.semantic-intent/v1` | `semantic-intent.schema.json` |
+| exact locally computed submission | `malt.client-root-bundle/v1` | `client-root-bundle.schema.json` |
+| durable exact-bundle acknowledgement | `malt.materialization-receipt/v1` | `materialization-receipt.schema.json` |
+
+Canonical in-process values live in `mutation`. Their JSON projections and
+checked-in schemas live in `protocol`. The application-neutral computation
+facade lives in `sdk/writer`.
+
+These profiles are experimental pre-v1 contracts. Unknown profiles and values
+that cannot be normalized to a valid canonical form must be rejected. An
+incompatible wire revision requires a new profile identifier.
+
+## Lifecycle And State Boundaries
+
+```text
+caller-selected accepted base root
+  -> caller-bounded, untrusted complete UpdateView
+  -> locally verified complete semantic vectors
+  -> application-produced SemanticIntent
+  -> locally computed transition outputs and candidate root
+  -> exact ClientRootBundle
+  -> service accepts that exact candidate or rejects the bundle
+  -> exact MaterializationReceipt
+  -> writer session may retain the candidate as its next working base
+  -> optional publication and client trust promotion remain separate
+```
+
+`sdk/writer.Session.Load` verifies the complete view before installing it.
+`Prepare` computes a candidate without advancing retained state.
+`AcceptReceipt` advances only that SDK writer session after validating an exact
+receipt for the sealed prepared result. It does not modify an application's
+accepted-root store or perform publication.
+
+## Complete Update View
+
+`UpdateView` is the complete old semantic closure required to compute an
+update locally:
+
+- `base_root` is selected by the client;
+- every typed MALT object reachable from that root occurs exactly once;
+- every object contains its complete canonical logical vector and commit
+  descriptor;
+- object IDs and roots are unique, and objects are canonicalized by object ID;
+- semantic child target kinds must agree with their typed MALT CIDs;
+- unrelated objects, missing semantic children, cycles, excessive depth, and
+  root/kind/backend mismatches are rejected; and
+- positive object, total-entry, and depth bounds are part of the returned view
+  and its digest.
+
+Receiving an update view does not make it trusted. `sdk/writer` normalizes the
+view, recomputes every declared object root with the backend encoded in that
+root CID, and only then returns a `VerifiedUpdateView`.
+
+The current state profile is `stateful-complete-vectors-v1`. Partial deltas,
+server-selected snapshots, and proofs of only the changed coordinates cannot
+be substituted for this complete-view contract.
+
+Transport-specific clients should choose acceptable bounds before requesting a
+view and require the response to preserve them. Core validates the bounds
+carried by the value; it does not define the request route or transport policy.
+The independent wire ceilings below apply even if a returned view declares
+larger values.
+
+## Semantic Intent
+
+`SemanticIntent` describes the requested semantic change without supplying the
+candidate root. Each transition:
+
+- names the old or newly created logical object;
+- declares map/list kind and commitment backend;
+- carries canonical before/after changes;
+- may consume the output of another transition by ID; and
+- declares the expected number of parent uses.
+
+Each existing or newly created object ID may occur in at most one transition.
+Normalization checks before-images against the verified view; rejects duplicate
+coordinates, no-op changes, target relabeling, missing outputs, cycles, orphan
+outputs, and use-count mismatches; and produces a deterministic
+child-before-parent order. The designated top transition must update the
+base-root object and have zero parent uses. The client, not the service,
+computes its root.
+
+Application syntax and provenance are outside this value. A UnixFS client, an
+object client, or another application translates its own change into the same
+canonical intent without placing Unix paths, source objects, or evaluation
+metadata in this Core profile.
+
+## Canonical Ordering And Digests
+
+Conversions to Core values and canonical constructors normalize ordering before
+semantic validation and digest computation. Newly emitted wire values therefore
+use:
+
+- update-view objects are ordered lexicographically by `object_id`;
+- each object's ArcSet uses its canonical coordinate order;
+- changes within a transition are ordered by canonical coordinate bytes;
+- transitions use deterministic child-before-parent topological order, with
+  lexicographic transition ID breaking ties;
+- bundle outputs are ordered by `transition_id`; and
+- payload CIDs are unique and ordered by raw CID bytes.
+
+The three digests are SHA-256 over canonical binary values, not hashes of JSON
+text. Implementations use these encoding primitives:
+
+| Value | Encoding |
+| --- | --- |
+| byte string or UTF-8 string | unsigned 64-bit big-endian byte length, then bytes |
+| CID | the preceding byte-string encoding of the CID's raw bytes; an undefined CID encodes as an empty byte string |
+| unsigned 32/64-bit integer | fixed-width big-endian |
+| optional target | one byte `0` when absent; otherwise `1`, target-kind string, then CID |
+| commit descriptor | one byte `0` for default; otherwise `1`, `total_size` uint64, then `chunk_size` uint64 |
+
+`UpdateView.Digest` writes, in order: profile, state profile, base CID,
+`max_objects`, `max_total_entries`, `max_depth`, object count, then for each
+canonical object its ID, root CID, kind, canonical `ArcSet.MarshalBinary`
+bytes, and commit descriptor.
+
+`SemanticIntent.Digest` requires an intent already returned by
+`NormalizeSemanticIntent`; it has no update-view argument and does not itself
+normalize or validate before-images. It writes: profile, base CID, top output
+ID, transition count, then for each canonical transition its ID, object ID,
+old-root CID, kind, backend, commit descriptor, expected-use count, change
+count, and each change's coordinate bytes, before target, after target, output
+ID, and output kind. A digest caller must still bind the intent to its update
+view; the intent digest alone does not authenticate before-images.
+
+`ClientRootBundle.Digest` writes: profile, operation ID, the 32-byte view and
+intent digests as length-prefixed byte strings, candidate CID, canonical output
+count and output pairs, then canonical payload-CID count and values. On the
+wire, all three digests are exactly 64 lowercase hexadecimal characters.
+
+## Exact Client-Root Bundle
+
+`sdk/writer.Runtime.ComputeBundle` applies a normalized intent to a verified
+view and returns:
+
+- every intermediate transition output;
+- the designated candidate root;
+- the exact set of literal payload CIDs introduced by the intent;
+- deterministic SHA-256 digests of the canonical view and intent; and
+- an operation ID and one canonical `ClientRootBundle` binding all of those
+  values.
+
+The bundle contains exactly one output for every transition. Each output's
+typed root kind and commitment backend must match its transition, and the
+bundle candidate must equal the designated top transition output. Its payload
+set must equal the unique literal non-MALT CAS post-images introduced by the
+intent. A service may reject the bundle, but it must not replace the candidate
+with a different root while claiming to accept that bundle.
+
+Payload CIDs in the bundle support service-side availability checks. Their
+presence does not prove that payload bytes are durable, published, fresh, or
+authorized for another reader.
+
+## Strict JSON Decoding And Limits
+
+The client-root JSON decoders reject:
+
+- unknown, duplicate, missing, or `null` fields at every nested level;
+- malformed explicit optional-value discriminators;
+- trailing JSON values;
+- noncanonical CID, coordinate, target-kind, digest, and profile values; and
+- semantic values that satisfy JSON Schema shape but violate the Core
+  invariants above.
+
+All JSON DTO fields are required. Optional semantic values use explicit
+`present` or `absent` state objects rather than omitted properties or JSON
+`null`.
+
+Before structural validation, every client-root document is limited to 64 MiB.
+The wire contract additionally caps:
+
+| Resource | Maximum |
+| --- | ---: |
+| objects | 65,536 |
+| total entries | 1,048,576 |
+| semantic depth | 65,536 |
+| transitions | 65,536 |
+| changes | 1,048,576 |
+| payload CIDs | 1,048,576 |
+| encoded CID string | 4,096 bytes |
+
+The positive bounds inside an `UpdateView` may be lower than those hard
+ceilings. Both the declared bounds and the independent wire ceilings are
+enforced.
+
+## Service Replay And Receipt
+
+A service claiming exact-bundle replay and materialization must independently:
+
+1. validate the complete update view and its declared old roots;
+2. recompute the normalized intent and every transition output;
+3. require the replayed candidate to equal the submitted candidate;
+4. check the required payload CIDs at its declared durability boundary;
+5. complete every write named by its documented durability boundary without
+   acknowledging a partial exact bundle; and
+6. return a `MaterializationReceipt` only after that declared durable boundary
+   succeeds.
+
+Core defines the receipt value and its binding to one exact canonical bundle,
+not the service's transaction, idempotency, persistence, or HTTP mechanism.
+`durable_boundary` is a service-defined non-empty identifier; it is not a
+portable proof that an arbitrary remote system actually completed those
+writes.
+
+A valid receipt binds:
+
+- the operation ID;
+- base and candidate roots;
+- the canonical bundle digest; and
+- the service-declared durable boundary.
+
+Receipt validation requires the exact operation ID, base root, candidate root,
+canonical bundle digest, and a non-empty durable-boundary identifier. It does
+not independently inspect the service's storage.
+
+## Explicit Non-Claims
+
+An `UpdateView`, `ClientRootBundle`, writer computation result, or
+`MaterializationReceipt` is not:
+
+- a cryptographic state-transition or delta proof;
+- proof that the service published the candidate as a named root or head;
+- proof of freshness, rollback resistance, or multi-writer ordering;
+- proof that another client should trust the candidate;
+- authorization to read or write the associated data; or
+- a substitute for local verification of later resolve/read results.
+
+Trusted-root promotion remains client policy. Publication, head arbitration,
+authorization, persistence, and application synchronization remain outside
+MALT core.
+
+## Creation Boundary
+
+The client-root contract updates an existing accepted top root. Creating an
+initial semantic structure has no authenticated base root and therefore uses a
+separate application or service bootstrap capability. Such a capability must
+not be exposed as part of the portable client-root profiles.
+
+## Related Documents
+
+- [Resolve and read contracts](./resolve-read-contracts.md)
+- [Writer receipts](./writer-receipts.md)
+- [CID and wire format](./cid-and-wire-format.md)
+- [Compatibility policy](../policy/compatibility.md)

--- a/schema_documentation_test.go
+++ b/schema_documentation_test.go
@@ -1,0 +1,84 @@
+package malt_test
+
+import (
+	"os"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/dewebprotocol/malt/artifact"
+	"github.com/dewebprotocol/malt/protocol"
+)
+
+var documentedSchemaName = regexp.MustCompile("`([a-z0-9-]+\\.schema\\.json)`")
+
+func TestEmbeddedSchemaCatalogsMatchDocumentation(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		marker string
+		want   []string
+	}{
+		{
+			name:   "protocol",
+			path:   "docs/spec/README.md",
+			marker: "protocol",
+			want:   protocol.SchemaNames(),
+		},
+		{
+			name:   "artifact",
+			path:   "docs/spec/artifacts.md",
+			marker: "artifact",
+			want:   artifact.SchemaNames(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := readDocumentedSchemaCatalog(t, test.path, test.marker)
+			want := append([]string(nil), test.want...)
+			sort.Strings(want)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("%s schema catalog mismatch\n got: %v\nwant: %v", test.path, got, want)
+			}
+		})
+	}
+}
+
+func readDocumentedSchemaCatalog(t *testing.T, path, marker string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	startMarker := "<!-- schema-catalog:" + marker + ":start -->"
+	endMarker := "<!-- schema-catalog:" + marker + ":end -->"
+	document := string(data)
+	if strings.Count(document, startMarker) != 1 || strings.Count(document, endMarker) != 1 {
+		t.Fatalf("%s must contain exactly one %q and one %q marker", path, startMarker, endMarker)
+	}
+	start := strings.Index(document, startMarker) + len(startMarker)
+	end := strings.Index(document, endMarker)
+	if end <= start {
+		t.Fatalf("%s has an invalid %s schema catalog marker order", path, marker)
+	}
+
+	matches := documentedSchemaName.FindAllStringSubmatch(document[start:end], -1)
+	if len(matches) == 0 {
+		t.Fatalf("%s %s schema catalog is empty", path, marker)
+	}
+	names := make([]string, 0, len(matches))
+	seen := make(map[string]struct{}, len(matches))
+	for _, match := range matches {
+		name := match[1]
+		if _, exists := seen[name]; exists {
+			t.Fatalf("%s %s schema catalog repeats %q", path, marker, name)
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
## Summary

- define the transport-neutral post-v0.0.6 client-root contract, including canonical ordering, digest encoding, strict decoding, resource ceilings, receipt binding, and explicit non-claims
- align Core ownership across AGENTS, README, architecture, roadmap, concepts, and compatibility docs
- document the complete protocol and frozen artifact schema catalogs and enforce exact parity in tests
- clarify that observation phases are diagnostics and add an output-equivalence regression test
- add an import-boundary guard for `sdk/writer`

## Boundary decisions

- Core owns client-root values and local exact candidate computation, but no HTTP route, persistence, publication, synchronization, or trust promotion
- materialization receipts are not portable state-transition, publication, freshness, or trust proofs
- the old `/v1/artifacts/*` projection is historical; Core retains only the frozen decoder/verifier, schemas, and fixtures
- the public website is documentation/verifier tooling; the managed browser application belongs to `gateway/console`

## Validation

- `git diff --check origin/main`
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go build -buildvcs=false ./...`
- independent fresh-agent review: no actionable findings