### PR TITLE
Support backend-isolated browser verification

### DIFF
--- a/cmd/malt-verifier-wasm/README.md
+++ b/cmd/malt-verifier-wasm/README.md
@@ -15,6 +15,21 @@ globalThis.maltVerifyRead(verificationJSON) -> resultJSON
 globalThis.maltVerifyArtifact(requestJSON) -> resultJSON  # v0.0.4 compatibility
 ```
 
+The default module initializes both built-in commitment backends. Browser
+clients that isolate initialization may set one of the following values before
+calling `go.run`:
+
+```js
+globalThis.maltVerifierBackend = 'kzg' // KZG-only verifier
+globalThis.maltVerifierBackend = 'ipa' // IPA-only verifier
+globalThis.maltVerifierBackend = 'all' // default portable verifier
+```
+
+Backend selection still comes from each typed MALT root during verification.
+A backend-specific instance fails closed when evidence requires a backend that
+is not registered. Clients that need cross-backend ProofLists must use the
+default `all` instance.
+
 `maltVerifyResolve` accepts one `malt.resolve/v0alpha1` request/result pair;
 `maltVerifyRead` accepts one `malt.read/v0alpha1` request/result pair. The
 caller constructs the request from its trusted root and intended query before

--- a/cmd/malt-verifier-wasm/main.go
+++ b/cmd/malt-verifier-wasm/main.go
@@ -12,10 +12,16 @@ import (
 	"github.com/dewebprotocol/malt/artifact"
 	"github.com/dewebprotocol/malt/protocol"
 	clientverifier "github.com/dewebprotocol/malt/sdk/verifier"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 )
 
 func main() {
-	verifier, initErr := clientverifier.NewDefault()
+	backend := requestedBackend()
+	verifier, initErr := newVerifier(backend)
+	if initErr != nil {
+		js.Global().Set("maltVerifierInitError", initErr.Error())
+	}
+	js.Global().Set("maltVerifierLoadedBackend", backend)
 	artifactFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
 		if initErr != nil {
 			return encodeResponse(clientverifier.Result{Profile: artifact.Profile, Error: fmt.Sprintf("initialize verifier: %v", initErr)})
@@ -68,6 +74,27 @@ func main() {
 	js.Global().Set("maltVerifyResolve", resolveFunction)
 	js.Global().Set("maltVerifyRead", readFunction)
 	select {}
+}
+
+func requestedBackend() string {
+	value := js.Global().Get("maltVerifierBackend")
+	if value.Type() != js.TypeString || value.String() == "" {
+		return "all"
+	}
+	return value.String()
+}
+
+func newVerifier(backend string) (*clientverifier.Verifier, error) {
+	switch backend {
+	case "all":
+		return clientverifier.NewDefault()
+	case string(maltcid.BackendKindKZG):
+		return clientverifier.NewForBackend(maltcid.BackendKindKZG)
+	case string(maltcid.BackendKindIPA):
+		return clientverifier.NewForBackend(maltcid.BackendKindIPA)
+	default:
+		return nil, fmt.Errorf("unsupported verifier backend %q", backend)
+	}
 }
 
 func encodeResponse(response clientverifier.Result) string {

--- a/scripts/run-verifier-wasm-vectors.mjs
+++ b/scripts/run-verifier-wasm-vectors.mjs
@@ -2,12 +2,15 @@ import { webcrypto } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
-const [wasmPath, wasmExecPath, corpusPath] = process.argv.slice(2);
+const [wasmPath, wasmExecPath, corpusPath, selectedBackend = "all"] = process.argv.slice(2);
 if (!wasmPath || !wasmExecPath || !corpusPath) {
   console.error(
-    "usage: node run-verifier-wasm-vectors.mjs <verifier.wasm> <wasm_exec.js> <vectors.json>",
+    "usage: node run-verifier-wasm-vectors.mjs <verifier.wasm> <wasm_exec.js> <vectors.json> [all|kzg|ipa]",
   );
   process.exit(2);
+}
+if (!["all", "kzg", "ipa"].includes(selectedBackend)) {
+  throw new Error(`unsupported verifier backend ${JSON.stringify(selectedBackend)}`);
 }
 
 if (!globalThis.crypto) {
@@ -24,6 +27,7 @@ if (!Array.isArray(corpus.vectors) || corpus.vectors.length === 0) {
   throw new Error(`${corpusPath} does not contain a non-empty vectors array`);
 }
 
+globalThis.maltVerifierBackend = selectedBackend;
 const go = new globalThis.Go();
 const wasm = await readFile(wasmPath);
 const { instance } = await WebAssembly.instantiate(wasm, go.importObject);
@@ -34,9 +38,15 @@ void go.run(instance).catch((error) => {
 
 await waitForVerifierGlobals();
 
+const vectors =
+  selectedBackend === "all"
+    ? corpus.vectors
+    : corpus.vectors.filter(
+        (vector) => vector.backend === selectedBackend || vector.backend === "none",
+      );
 const seen = new Set();
 const failures = [];
-for (const vector of corpus.vectors) {
+for (const vector of vectors) {
   const label = typeof vector.id === "string" ? vector.id : "<missing-id>";
   try {
     validateEnvelope(vector, seen);
@@ -57,14 +67,14 @@ for (const vector of corpus.vectors) {
 }
 
 if (failures.length > 0) {
-  console.error(`WASM conformance failed (${failures.length}/${corpus.vectors.length}):`);
+  console.error(`WASM ${selectedBackend} conformance failed (${failures.length}/${vectors.length}):`);
   for (const failure of failures) {
     console.error(`- ${failure}`);
   }
   process.exit(1);
 }
 
-console.log(`WASM conformance passed (${corpus.vectors.length} vectors)`);
+console.log(`WASM ${selectedBackend} conformance passed (${vectors.length} vectors)`);
 process.exit(0);
 
 function selectVerifier(operation) {
@@ -98,7 +108,7 @@ function validateEnvelope(vector, ids) {
 }
 
 async function waitForVerifierGlobals() {
-  const deadline = Date.now() + 10_000;
+  const deadline = Date.now() + 90_000;
   while (Date.now() < deadline) {
     if (runtimeFailure) {
       throw new Error(`Go WASM runtime failed: ${runtimeFailure}`);
@@ -107,6 +117,14 @@ async function waitForVerifierGlobals() {
       typeof globalThis.maltVerifyResolve === "function" &&
       typeof globalThis.maltVerifyRead === "function"
     ) {
+      if (globalThis.maltVerifierInitError) {
+        throw new Error(`MALT verifier initialization failed: ${globalThis.maltVerifierInitError}`);
+      }
+      if (globalThis.maltVerifierLoadedBackend !== selectedBackend) {
+        throw new Error(
+          `MALT verifier loaded backend ${JSON.stringify(globalThis.maltVerifierLoadedBackend)}, expected ${JSON.stringify(selectedBackend)}`,
+        );
+      }
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, 10));

--- a/scripts/test-verifier-wasm-vectors.sh
+++ b/scripts/test-verifier-wasm-vectors.sh
@@ -10,3 +10,13 @@ node "$repo_root/scripts/run-verifier-wasm-vectors.mjs" \
   "$work_dir/verifier/malt-verifier.wasm" \
   "$work_dir/verifier/wasm_exec.js" \
   "$repo_root/conformance/resolve-read/v1/vectors.json"
+node "$repo_root/scripts/run-verifier-wasm-vectors.mjs" \
+  "$work_dir/verifier/malt-verifier.wasm" \
+  "$work_dir/verifier/wasm_exec.js" \
+  "$repo_root/conformance/resolve-read/v1/vectors.json" \
+  kzg
+node "$repo_root/scripts/run-verifier-wasm-vectors.mjs" \
+  "$work_dir/verifier/malt-verifier.wasm" \
+  "$work_dir/verifier/wasm_exec.js" \
+  "$repo_root/conformance/resolve-read/v1/vectors.json" \
+  ipa

--- a/sdk/verifier/verifier.go
+++ b/sdk/verifier/verifier.go
@@ -9,9 +9,13 @@ import (
 
 	malt "github.com/dewebprotocol/malt"
 	"github.com/dewebprotocol/malt/artifact"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
 	"github.com/dewebprotocol/malt/auth/proof/prooflist"
 	authverifier "github.com/dewebprotocol/malt/auth/verifier"
 	"github.com/dewebprotocol/malt/protocol"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 )
 
 type Verifier struct {
@@ -52,6 +56,33 @@ func NewDefault() (*Verifier, error) {
 		return nil, err
 	}
 	return &Verifier{proofs: proofs}, nil
+}
+
+// NewForBackend creates a portable verifier with only one built-in commitment
+// backend. It is intended for clients that isolate backend initialization while
+// retaining backend selection from typed roots inside the verifier.
+func NewForBackend(kind maltcid.BackendKind) (*Verifier, error) {
+	var (
+		scheme commitment.IndexVerifier
+		err    error
+	)
+	switch kind {
+	case maltcid.BackendKindKZG:
+		scheme, err = kzg.NewScheme()
+	case maltcid.BackendKindIPA:
+		scheme, err = ipa.NewScheme()
+	default:
+		return nil, fmt.Errorf("unsupported verifier backend %q", kind)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("creating %s verifier backend: %w", kind, err)
+	}
+
+	registry := authverifier.NewBackendRegistry()
+	if err := registry.RegisterScheme(kind, scheme); err != nil {
+		return nil, err
+	}
+	return &Verifier{proofs: authverifier.NewWithRegistry(registry)}, nil
 }
 
 // Verify verifies the frozen malt.artifact/v0alpha2 compatibility envelope.

--- a/sdk/verifier/verifier_test.go
+++ b/sdk/verifier/verifier_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dewebprotocol/malt/artifact"
 	clientverifier "github.com/dewebprotocol/malt/sdk/verifier"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 )
 
 func TestDefaultVerifierAcceptsRootIdentityArtifact(t *testing.T) {
@@ -130,5 +131,19 @@ func TestLocalRequestRejectsArtifactSelectedQuery(t *testing.T) {
 		Artifact: request.Artifact,
 	}); err == nil {
 		t.Fatal("accepted an artifact for a different client-selected query")
+	}
+}
+
+func TestBackendSpecificVerifierRejectsUnsupportedBackend(t *testing.T) {
+	for _, kind := range []maltcid.BackendKind{
+		maltcid.BackendKindKZG,
+		maltcid.BackendKindIPA,
+	} {
+		if _, err := clientverifier.NewForBackend(kind); err != nil {
+			t.Fatalf("NewForBackend(%q): %v", kind, err)
+		}
+	}
+	if _, err := clientverifier.NewForBackend(maltcid.BackendKindUnknown); err == nil {
+		t.Fatal("NewForBackend accepted an unknown backend")
 	}
 }


### PR DESCRIPTION
## Summary

- add a verifier constructor that registers only one built-in commitment backend
- let the browser WASM entrypoint initialize `kzg`, `ipa`, or the default `all` backend set
- extend the WASM conformance runner to exercise all three initialization modes

## Why

The managed Gateway Console needs KZG verification to become available before the more expensive IPA setup finishes. Backend-isolated WASM instances allow KZG to gate readiness while a separate full KZG+IPA instance initializes in a background Worker. Verification still selects the required backend from typed roots and fails closed if an instance does not contain it.

The default `all` behavior remains unchanged and continues to support mixed KZG/IPA ProofLists.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- WASM conformance: `all` (49 vectors)
- WASM conformance: `kzg` (25 vectors)
- WASM conformance: `ipa` (25 vectors)
- `git diff --check origin/main...HEAD`

The corresponding Gateway Console integration will be submitted as a dependent draft PR.