### PR TITLE
Use 4096-slot KZG semantic nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Align the default Make target and CI build gate with the SDK-only package
   tree.
+- Use all 4096 KZG positions for semantic map and list nodes. KZG maps now
+  consume SHA-256 keys in 12-bit radix digits and KZG lists branch over 4095
+  content slots; the fixed 256-position IPA suite retains 8-bit map digits and
+  255 list content slots.
+- Advance typed MALT roots to `MALTVersionID=2`. Experimental version-1 roots
+  and their materialized node state must be rebuilt; current decoders reject
+  them rather than interpreting them with the new geometry.
 
 ### Removed
 

--- a/auth/semantic/list/tree/internal/layout.go
+++ b/auth/semantic/list/tree/internal/layout.go
@@ -4,37 +4,17 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"math"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
 	materializer "github.com/dewebprotocol/malt/auth/arcset/materializer"
 	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
 
 const (
-	// DefaultFanout is the default commitment width for list nodes.
-	// The current KZG backend supports 256 slots per commitment, so this
-	// value is fixed to 256.
-	DefaultFanout = 256
-
-	// BranchingFactor is the number of content slots per committed list node.
-	//
-	// Slot 0 in every list node is reserved for authenticated node metadata, so
-	// all nodes expose (DefaultFanout-1) content slots.
-	//
-	// Root and non-root nodes share the same branching factor.
-	BranchingFactor = DefaultFanout - 1
-
-	// RootWidth is the fixed slot width for the committed root node.
-	// Slot 0 is the authenticated node metadata marker.
-	RootWidth = DefaultFanout
-
-	// NodeWidth is the fixed slot width for all committed non-root nodes.
-	NodeWidth = DefaultFanout
-
 	nodeMetaPrefix = "malt:list:node-meta:"
 )
 
@@ -49,26 +29,27 @@ type NodeMetadata struct {
 	ChunkSize  uint64
 }
 
-// ValidateCommitment checks whether the supplied index commitment can support
-// the list layout.
-func ValidateCommitment(scheme commitment.IndexCommitment) error {
+// ValidateCommitment returns the list geometry selected by the supplied
+// commitment suite.
+func ValidateCommitment(scheme commitment.IndexCommitment) (nodegeometry.Geometry, error) {
 	if scheme == nil {
-		return fmt.Errorf("index commitment is nil")
+		return nodegeometry.Geometry{}, fmt.Errorf("index commitment is nil")
 	}
-	if scheme.MaxValues() < RootWidth {
-		return fmt.Errorf("index commitment capacity %d is smaller than required root width %d", scheme.MaxValues(), RootWidth)
+	geometry, err := nodegeometry.ForCapacity(scheme.MaxValues())
+	if err != nil {
+		return nodegeometry.Geometry{}, fmt.Errorf("selecting list node geometry: %w", err)
 	}
-	return nil
+	return geometry, nil
 }
 
 // EmptyRootSlots allocates a zero-initialized root slot vector.
-func EmptyRootSlots() []cid.Cid {
-	return make([]cid.Cid, RootWidth)
+func EmptyRootSlots(geometry nodegeometry.Geometry) []cid.Cid {
+	return make([]cid.Cid, geometry.NodeWidth())
 }
 
 // EmptyNodeSlots allocates a zero-initialized non-root slot vector.
-func EmptyNodeSlots() []cid.Cid {
-	return make([]cid.Cid, NodeWidth)
+func EmptyNodeSlots(geometry nodegeometry.Geometry) []cid.Cid {
+	return make([]cid.Cid, geometry.NodeWidth())
 }
 
 // ContentSlots returns the data-bearing portion of a slot vector.
@@ -263,59 +244,16 @@ func DecodeNodeMetadata(marker cid.Cid) (NodeMetadata, error) {
 }
 
 // RequiredHeight returns the minimal non-root height required for length values.
-func RequiredHeight(length uint64) int {
-	if length <= uint64(BranchingFactor) {
-		return 0
-	}
-
-	capacity := uint64(BranchingFactor)
-	height := 0
-	for capacity < length {
-		height++
-		if capacity > math.MaxUint64/uint64(BranchingFactor) {
-			return height
-		}
-		capacity *= uint64(BranchingFactor)
-	}
-	return height
+func RequiredHeight(geometry nodegeometry.Geometry, length uint64) int {
+	return geometry.RequiredListHeight(length)
 }
 
 // SubtreeCapacity returns how many values fit under a node of the given height.
-func SubtreeCapacity(height int) (uint64, error) {
-	if height < 0 {
-		return 0, fmt.Errorf("height must be non-negative")
-	}
-
-	capacity := uint64(BranchingFactor)
-	for i := 0; i < height; i++ {
-		if capacity > math.MaxUint64/uint64(BranchingFactor) {
-			return 0, fmt.Errorf("list capacity overflow at height %d", height)
-		}
-		capacity *= uint64(BranchingFactor)
-	}
-	return capacity, nil
+func SubtreeCapacity(geometry nodegeometry.Geometry, height int) (uint64, error) {
+	return geometry.ListSubtreeCapacity(height)
 }
 
-// IndexDigits decomposes an index into base-BranchingFactor digits for the target height.
-func IndexDigits(index uint64, height int) ([]int, error) {
-	if height < 0 {
-		return nil, fmt.Errorf("height must be non-negative")
-	}
-
-	digits := make([]int, height+1)
-	remaining := index
-	for level := 0; level <= height; level++ {
-		exp := height - level
-		if exp == 0 {
-			digits[level] = int(remaining)
-			continue
-		}
-		chunk, err := SubtreeCapacity(exp - 1)
-		if err != nil {
-			return nil, err
-		}
-		digits[level] = int(remaining / chunk)
-		remaining %= chunk
-	}
-	return digits, nil
+// IndexDigits decomposes an index into base-branching-factor digits for the target height.
+func IndexDigits(geometry nodegeometry.Geometry, index uint64, height int) ([]int, error) {
+	return geometry.ListIndexDigits(index, height)
 }

--- a/auth/semantic/list/tree/tree.go
+++ b/auth/semantic/list/tree/tree.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dewebprotocol/malt/auth/semantic"
 	"github.com/dewebprotocol/malt/auth/semantic/list"
 	"github.com/dewebprotocol/malt/auth/semantic/list/tree/internal"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 )
@@ -24,6 +25,7 @@ import (
 type TreeList struct {
 	commitment   *list.Commitment
 	materializer materializer.NodeStore
+	geometry     nodegeometry.Geometry
 }
 
 type proofEnvelope struct {
@@ -49,7 +51,8 @@ type rangeIndexProof struct {
 }
 
 func NewList(scheme commitment.IndexCommitment, materializer materializer.NodeStore) (*TreeList, error) {
-	if err := layout.ValidateCommitment(scheme); err != nil {
+	geometry, err := layout.ValidateCommitment(scheme)
+	if err != nil {
 		return nil, err
 	}
 	if materializer == nil {
@@ -64,6 +67,7 @@ func NewList(scheme commitment.IndexCommitment, materializer materializer.NodeSt
 	return &TreeList{
 		commitment:   commitmentHandler,
 		materializer: materializer,
+		geometry:     geometry,
 	}, nil
 }
 
@@ -77,7 +81,7 @@ func (s *TreeList) Commit(ctx context.Context, namespace string, view list.View)
 	if err != nil {
 		return cid.Undef, err
 	}
-	return s.buildPlainFromValues(ctx, namespace, values, layout.RequiredHeight(uint64(len(values))))
+	return s.buildPlainFromValues(ctx, namespace, values, layout.RequiredHeight(s.geometry, uint64(len(values))))
 }
 
 // CommitFixed commits fixed-width measured list chunks. The resulting root
@@ -96,7 +100,7 @@ func (s *TreeList) CommitFixed(ctx context.Context, namespace string, chunks []c
 		}
 	}
 	values := append([]cid.Cid(nil), chunks...)
-	return s.buildMeasuredFromValues(ctx, namespace, values, layout.RequiredHeight(uint64(len(values))), 0, chunkSize, totalSize)
+	return s.buildMeasuredFromValues(ctx, namespace, values, layout.RequiredHeight(s.geometry, uint64(len(values))), 0, chunkSize, totalSize)
 }
 
 func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, index uint64) (list.Query, structure.Proof, error) {
@@ -113,7 +117,7 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 	envelope := proofEnvelope{MetadataProof: metadataProof}
 	if target, err := metadataTarget.AsCID(); err != nil {
 		return list.Query{}, nil, err
-	} else if needsExplicitMetadataTarget(target, length) {
+	} else if s.needsExplicitMetadataTarget(target, length) {
 		envelope.MetadataTarget = metadataTarget.Bytes()
 	}
 
@@ -122,8 +126,8 @@ func (s *TreeList) Prove(ctx context.Context, namespace string, root cid.Cid, in
 		return encodeProof(query, envelope)
 	}
 
-	height := layout.RequiredHeight(length)
-	digits, err := layout.IndexDigits(index, height)
+	height := layout.RequiredHeight(s.geometry, length)
+	digits, err := layout.IndexDigits(s.geometry, index, height)
 	if err != nil {
 		return list.Query{}, nil, err
 	}
@@ -174,7 +178,7 @@ func (s *TreeList) Verify(root cid.Cid, index uint64, expected list.Query, proof
 		return false, fmt.Errorf("missing metadata proof")
 	}
 
-	metadataTarget, err := metadataTargetForVerify(expected.Length, envelope.MetadataTarget)
+	metadataTarget, err := s.metadataTargetForVerify(expected.Length, envelope.MetadataTarget)
 	if err != nil {
 		return false, err
 	}
@@ -193,12 +197,12 @@ func (s *TreeList) Verify(root cid.Cid, index uint64, expected list.Query, proof
 		return false, nil
 	}
 
-	height := layout.RequiredHeight(expected.Length)
+	height := layout.RequiredHeight(s.geometry, expected.Length)
 	if len(envelope.Steps) != height+1 {
 		return false, nil
 	}
 
-	digits, err := layout.IndexDigits(index, height)
+	digits, err := layout.IndexDigits(s.geometry, index, height)
 	if err != nil {
 		return false, err
 	}
@@ -353,7 +357,7 @@ func (s *TreeList) Replace(ctx context.Context, namespace string, root cid.Cid, 
 	if index >= length {
 		return cid.Undef, fmt.Errorf("index %d out of range", index)
 	}
-	return s.replaceAt(ctx, namespace, root, true, layout.RequiredHeight(length), index, oldKey, newKey)
+	return s.replaceAt(ctx, namespace, root, true, layout.RequiredHeight(s.geometry, length), index, oldKey, newKey)
 }
 
 func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, key cid.Cid) (cid.Cid, uint64, error) {
@@ -370,8 +374,8 @@ func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, k
 
 	newIndex := length
 	newLength := length + 1
-	oldHeight := layout.RequiredHeight(length)
-	newHeight := layout.RequiredHeight(newLength)
+	oldHeight := layout.RequiredHeight(s.geometry, length)
+	newHeight := layout.RequiredHeight(s.geometry, newLength)
 
 	if newHeight > oldHeight {
 		grownRoot, err := s.growRoot(ctx, namespace, root, oldHeight, length)
@@ -379,7 +383,7 @@ func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, k
 			return cid.Undef, 0, err
 		}
 
-		nextRootSlots := layout.EmptyRootSlots()
+		nextRootSlots := layout.EmptyRootSlots(s.geometry)
 		rootMarker, err := plainNodeMetadata(newHeight, newLength)
 		if err != nil {
 			return cid.Undef, 0, err
@@ -388,7 +392,7 @@ func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, k
 		content := layout.ContentSlots(nextRootSlots, true)
 		content[0] = grownRoot
 
-		childSpan, err := layout.SubtreeCapacity(newHeight - 1)
+		childSpan, err := layout.SubtreeCapacity(s.geometry, newHeight-1)
 		if err != nil {
 			return cid.Undef, 0, err
 		}
@@ -421,7 +425,7 @@ func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, k
 		return newRoot, newIndex, err
 	}
 
-	childSpan, err := layout.SubtreeCapacity(oldHeight - 1)
+	childSpan, err := layout.SubtreeCapacity(s.geometry, oldHeight-1)
 	if err != nil {
 		return cid.Undef, 0, err
 	}
@@ -471,11 +475,11 @@ func (s *TreeList) AppendFixed(ctx context.Context, namespace string, root cid.C
 	}
 
 	newIndex := length
-	oldHeight := layout.RequiredHeight(length)
-	newHeight := layout.RequiredHeight(newLength)
+	oldHeight := layout.RequiredHeight(s.geometry, length)
+	newHeight := layout.RequiredHeight(s.geometry, newLength)
 
 	if newHeight > oldHeight {
-		nextRootSlots := layout.EmptyRootSlots()
+		nextRootSlots := layout.EmptyRootSlots(s.geometry)
 		rootMarker, err := measuredNodeMetadata(newHeight, newLength, 0, meta.ChunkSize, totalSize)
 		if err != nil {
 			return cid.Undef, 0, err
@@ -484,7 +488,7 @@ func (s *TreeList) AppendFixed(ctx context.Context, namespace string, root cid.C
 		content := layout.ContentSlots(nextRootSlots, true)
 		content[0] = root
 
-		childSpan, err := layout.SubtreeCapacity(newHeight - 1)
+		childSpan, err := layout.SubtreeCapacity(s.geometry, newHeight-1)
 		if err != nil {
 			return cid.Undef, 0, err
 		}
@@ -518,7 +522,7 @@ func (s *TreeList) AppendFixed(ctx context.Context, namespace string, root cid.C
 		return newRoot, newIndex, err
 	}
 
-	childSpan, err := layout.SubtreeCapacity(oldHeight - 1)
+	childSpan, err := layout.SubtreeCapacity(s.geometry, oldHeight-1)
 	if err != nil {
 		return cid.Undef, 0, err
 	}
@@ -556,8 +560,8 @@ func (s *TreeList) Truncate(ctx context.Context, namespace string, root cid.Cid,
 		return s.commitEmptyRoot(ctx, namespace)
 	}
 
-	oldHeight := layout.RequiredHeight(oldLen)
-	newHeight := layout.RequiredHeight(newLen)
+	oldHeight := layout.RequiredHeight(s.geometry, oldLen)
+	newHeight := layout.RequiredHeight(s.geometry, newLen)
 	return s.rebuildPrefix(ctx, namespace, root, true, oldHeight, true, newHeight, newLen)
 }
 
@@ -572,7 +576,7 @@ func (s *TreeList) buildPlainFromValues(ctx context.Context, namespace string, v
 	if err != nil {
 		return cid.Undef, err
 	}
-	slots := layout.EmptyRootSlots()
+	slots := layout.EmptyRootSlots(s.geometry)
 	slots[0] = marker
 	content := layout.ContentSlots(slots, true)
 	if height == 0 {
@@ -580,7 +584,7 @@ func (s *TreeList) buildPlainFromValues(ctx context.Context, namespace string, v
 		return s.commitSlots(ctx, namespace, slots)
 	}
 
-	childSpan, err := layout.SubtreeCapacity(height - 1)
+	childSpan, err := layout.SubtreeCapacity(s.geometry, height-1)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -617,7 +621,7 @@ func (s *TreeList) buildMeasuredFromValues(ctx context.Context, namespace string
 	if err != nil {
 		return cid.Undef, err
 	}
-	slots := layout.EmptyRootSlots()
+	slots := layout.EmptyRootSlots(s.geometry)
 	slots[0] = marker
 	content := layout.ContentSlots(slots, true)
 	if height == 0 {
@@ -625,7 +629,7 @@ func (s *TreeList) buildMeasuredFromValues(ctx context.Context, namespace string
 		return s.commitSlots(ctx, namespace, slots)
 	}
 
-	childSpan, err := layout.SubtreeCapacity(height - 1)
+	childSpan, err := layout.SubtreeCapacity(s.geometry, height-1)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -684,9 +688,9 @@ func (s *TreeList) rebuildPrefix(
 
 	var nextSlots []cid.Cid
 	if targetRoot {
-		nextSlots = layout.EmptyRootSlots()
+		nextSlots = layout.EmptyRootSlots(s.geometry)
 	} else {
-		nextSlots = layout.EmptyNodeSlots()
+		nextSlots = layout.EmptyNodeSlots(s.geometry)
 	}
 	marker, err := plainNodeMetadata(targetHeight, keepLen)
 	if err != nil {
@@ -703,7 +707,7 @@ func (s *TreeList) rebuildPrefix(
 		return s.commitSlots(ctx, namespace, nextSlots)
 	}
 
-	childSpan, err := layout.SubtreeCapacity(targetHeight - 1)
+	childSpan, err := layout.SubtreeCapacity(s.geometry, targetHeight-1)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -766,7 +770,7 @@ func (s *TreeList) replaceAt(
 		return s.commitSlots(ctx, namespace, nextSlots)
 	}
 
-	childSpan, err := layout.SubtreeCapacity(height - 1)
+	childSpan, err := layout.SubtreeCapacity(s.geometry, height-1)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -811,7 +815,7 @@ func (s *TreeList) appendInto(ctx context.Context, namespace string, root cid.Ci
 		return s.commitSlots(ctx, namespace, nextSlots)
 	}
 
-	childSpan, err := layout.SubtreeCapacity(height - 1)
+	childSpan, err := layout.SubtreeCapacity(s.geometry, height-1)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -838,7 +842,7 @@ func (s *TreeList) appendInto(ctx context.Context, namespace string, root cid.Ci
 
 func (s *TreeList) buildSparseSubtree(ctx context.Context, namespace string, height int, index uint64, key cid.Cid) (cid.Cid, error) {
 	if height == 0 {
-		slots := layout.EmptyNodeSlots()
+		slots := layout.EmptyNodeSlots(s.geometry)
 		marker, err := plainNodeMetadata(height, index+1)
 		if err != nil {
 			return cid.Undef, err
@@ -852,14 +856,14 @@ func (s *TreeList) buildSparseSubtree(ctx context.Context, namespace string, hei
 		return s.commitSlots(ctx, namespace, slots)
 	}
 
-	childSpan, err := layout.SubtreeCapacity(height - 1)
+	childSpan, err := layout.SubtreeCapacity(s.geometry, height-1)
 	if err != nil {
 		return cid.Undef, err
 	}
 	digit := int(index / childSpan)
 	localIndex := index % childSpan
 
-	slots := layout.EmptyNodeSlots()
+	slots := layout.EmptyNodeSlots(s.geometry)
 	marker, err := plainNodeMetadata(height, index+1)
 	if err != nil {
 		return cid.Undef, err
@@ -898,7 +902,7 @@ func (s *TreeList) appendFixedInto(ctx context.Context, namespace string, root c
 		return s.commitSlots(ctx, namespace, nextSlots)
 	}
 
-	childSpan, err := layout.SubtreeCapacity(height - 1)
+	childSpan, err := layout.SubtreeCapacity(s.geometry, height-1)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -917,7 +921,7 @@ func (s *TreeList) appendFixedInto(ctx context.Context, namespace string, root c
 }
 
 func (s *TreeList) buildMeasuredSparseSubtree(ctx context.Context, namespace string, height int, index, startIndex uint64, key cid.Cid, chunkSize, totalSize uint64) (cid.Cid, error) {
-	slots := layout.EmptyNodeSlots()
+	slots := layout.EmptyNodeSlots(s.geometry)
 	marker, err := measuredNodeMetadata(height, index+1, startIndex, chunkSize, totalSize)
 	if err != nil {
 		return cid.Undef, err
@@ -933,7 +937,7 @@ func (s *TreeList) buildMeasuredSparseSubtree(ctx context.Context, namespace str
 		return s.commitSlots(ctx, namespace, slots)
 	}
 
-	childSpan, err := layout.SubtreeCapacity(height - 1)
+	childSpan, err := layout.SubtreeCapacity(s.geometry, height-1)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -948,7 +952,7 @@ func (s *TreeList) buildMeasuredSparseSubtree(ctx context.Context, namespace str
 }
 
 func (s *TreeList) commitEmptyRoot(ctx context.Context, namespace string) (cid.Cid, error) {
-	slots := layout.EmptyRootSlots()
+	slots := layout.EmptyRootSlots(s.geometry)
 	lengthMarker, err := plainNodeMetadata(0, 0)
 	if err != nil {
 		return cid.Undef, err
@@ -970,11 +974,7 @@ func (s *TreeList) loadRoot(ctx context.Context, namespace string, root cid.Cid)
 }
 
 func (s *TreeList) loadNode(ctx context.Context, namespace string, root cid.Cid, isRoot bool) ([]cid.Cid, error) {
-	width := layout.NodeWidth
-	if isRoot {
-		width = layout.RootWidth
-	}
-	slots, err := layout.LoadSlots(ctx, s.materializer, namespace, root, width)
+	slots, err := layout.LoadSlots(ctx, s.materializer, namespace, root, s.geometry.NodeWidth())
 	if err != nil {
 		return nil, err
 	}
@@ -1025,7 +1025,7 @@ func (s *TreeList) commitSlots(ctx context.Context, namespace string, slots []ci
 
 func (s *TreeList) verifyMetadataSlot(root cid.Cid, meta layout.NodeMetadata, proof []byte) (bool, error) {
 	target, err := nodeMetadataCell(layout.NodeMetadata{
-		Height:     uint64(layout.RequiredHeight(meta.ChildCount)),
+		Height:     uint64(layout.RequiredHeight(s.geometry, meta.ChildCount)),
 		ChildCount: meta.ChildCount,
 		TotalSize:  meta.TotalSize,
 		ChunkSize:  meta.ChunkSize,
@@ -1122,9 +1122,9 @@ func contentSlotsForVerify(step proofStep, isRoot bool, digit int) ([]uint64, er
 	return []uint64{provedSlot}, nil
 }
 
-func needsExplicitMetadataTarget(marker cid.Cid, length uint64) bool {
+func (s *TreeList) needsExplicitMetadataTarget(marker cid.Cid, length uint64) bool {
 	plainMarker, err := layout.EncodeNodeMetadata(layout.NodeMetadata{
-		Height:     uint64(layout.RequiredHeight(length)),
+		Height:     uint64(layout.RequiredHeight(s.geometry, length)),
 		ChildCount: length,
 	})
 	if err != nil {
@@ -1133,10 +1133,10 @@ func needsExplicitMetadataTarget(marker cid.Cid, length uint64) bool {
 	return !marker.Equals(plainMarker)
 }
 
-func metadataTargetForVerify(expectedLength uint64, explicit []byte) (commitment.Cell, error) {
+func (s *TreeList) metadataTargetForVerify(expectedLength uint64, explicit []byte) (commitment.Cell, error) {
 	if len(explicit) == 0 {
 		return nodeMetadataCell(layout.NodeMetadata{
-			Height:     uint64(layout.RequiredHeight(expectedLength)),
+			Height:     uint64(layout.RequiredHeight(s.geometry, expectedLength)),
 			ChildCount: expectedLength,
 		})
 	}

--- a/auth/semantic/list/tree/tree_test.go
+++ b/auth/semantic/list/tree/tree_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dewebprotocol/malt/auth/semantic/list"
 	"github.com/dewebprotocol/malt/auth/semantic/list/tree"
 	"github.com/dewebprotocol/malt/auth/semantic/list/tree/internal"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
@@ -80,6 +81,54 @@ func newListWithMaterializer(scheme commitment.IndexCommitment, store *materialm
 	return semantic, store, nil
 }
 
+func geometryForScheme(t *testing.T, scheme commitment.IndexVerifier) nodegeometry.Geometry {
+	t.Helper()
+	geometry, err := nodegeometry.ForCapacity(scheme.MaxValues())
+	if err != nil {
+		t.Fatalf("nodegeometry.ForCapacity(%d): %v", scheme.MaxValues(), err)
+	}
+	return geometry
+}
+
+func TestTreeListBackendGeometryBoundaries(t *testing.T) {
+	wantGeometry := map[string]struct {
+		nodeWidth int
+		branching int
+	}{
+		"ipa": {nodeWidth: 256, branching: 255},
+		"kzg": {nodeWidth: 4096, branching: 4095},
+	}
+
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			geometry := geometryForScheme(t, factory(t))
+			want := wantGeometry[name]
+			if got := geometry.NodeWidth(); got != want.nodeWidth {
+				t.Fatalf("node width = %d, want %d", got, want.nodeWidth)
+			}
+			if got := geometry.ListBranchingFactor(); got != want.branching {
+				t.Fatalf("branching factor = %d, want %d", got, want.branching)
+			}
+			if got := len(layout.EmptyRootSlots(geometry)); got != want.nodeWidth {
+				t.Fatalf("root slots = %d, want %d", got, want.nodeWidth)
+			}
+			if got := layout.RequiredHeight(geometry, uint64(want.branching)); got != 0 {
+				t.Fatalf("height at %d values = %d, want 0", want.branching, got)
+			}
+			if got := layout.RequiredHeight(geometry, uint64(want.branching+1)); got != 1 {
+				t.Fatalf("height at %d values = %d, want 1", want.branching+1, got)
+			}
+			digits, err := layout.IndexDigits(geometry, uint64(want.branching), 1)
+			if err != nil {
+				t.Fatalf("IndexDigits at boundary: %v", err)
+			}
+			if len(digits) != 2 || digits[0] != 1 || digits[1] != 0 {
+				t.Fatalf("digits at index %d = %v, want [1 0]", want.branching, digits)
+			}
+		})
+	}
+}
+
 func assertVerifiedQuery(t *testing.T, semantic *tree.TreeList, namespace string, root cid.Cid, index uint64, expected list.Query) {
 	t.Helper()
 
@@ -127,10 +176,11 @@ func stripProofStepSlots(t *testing.T, proof []byte) []byte {
 func commitLegacyWidthNode(t *testing.T, ctx context.Context, scheme commitment.IndexCommitment, e materializer.Store, namespace string, values []cid.Cid) cid.Cid {
 	t.Helper()
 
-	if len(values) > layout.BranchingFactor {
-		t.Fatalf("legacy width helper supports at most %d values", layout.BranchingFactor)
+	geometry := geometryForScheme(t, scheme)
+	if len(values) > geometry.ListBranchingFactor() {
+		t.Fatalf("legacy width helper supports at most %d values", geometry.ListBranchingFactor())
 	}
-	slots := make([]cid.Cid, layout.BranchingFactor)
+	slots := make([]cid.Cid, geometry.ListBranchingFactor())
 	copy(slots, values)
 	return commitTestSlots(t, ctx, scheme, e, namespace, slots)
 }
@@ -203,7 +253,7 @@ func TestTreeListSemanticProofsAndRestart(t *testing.T) {
 
 func TestTreeListRejectsLegacyWidthMaterialization(t *testing.T) {
 	ctx := context.Background()
-	values := makeValues(layout.BranchingFactor)
+	values := makeValues(2)
 
 	for name, factory := range listSchemes() {
 		t.Run(name, func(t *testing.T) {
@@ -261,7 +311,8 @@ func TestTreeListRejectsAuthenticatedLengthWithMissingLeaf(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			slots := layout.EmptyRootSlots()
+			geometry := geometryForScheme(t, scheme)
+			slots := layout.EmptyRootSlots(geometry)
 			slots[0], err = layout.EncodeNodeMetadata(layout.NodeMetadata{ChildCount: 1})
 			if err != nil {
 				t.Fatal(err)
@@ -325,7 +376,7 @@ func (s failingNodeStore) Update(context.Context, string, cid.Cid, cid.Cid, arcs
 func TestTreeListVerifiesProofWithoutStepSlots(t *testing.T) {
 	ctx := context.Background()
 	values := makeValues(300)
-	index := uint64(layout.BranchingFactor)
+	index := uint64(1)
 
 	for name, factory := range listSchemes() {
 		t.Run(name, func(t *testing.T) {
@@ -356,13 +407,15 @@ func TestTreeListVerifiesProofWithoutStepSlots(t *testing.T) {
 
 func TestTreeListAppendIntoChildUpdatesSlotZeroMetadata(t *testing.T) {
 	ctx := context.Background()
-	values := makeValues(300)
 
 	for name, factory := range listSchemes() {
 		t.Run(name, func(t *testing.T) {
 			kv := materialmemory.New(true)
 			namespace := "tree-child-append-" + name
 			scheme := factory(t)
+			geometry := geometryForScheme(t, scheme)
+			branching := geometry.ListBranchingFactor()
+			values := makeValues(branching + 1)
 			restarted, e, err := newListWithMaterializer(scheme, kv)
 			if err != nil {
 				t.Fatalf("newListWithMaterializer failed: %v", err)
@@ -384,8 +437,8 @@ func TestTreeListAppendIntoChildUpdatesSlotZeroMetadata(t *testing.T) {
 				Key:    values[0],
 				Length: uint64(len(values) + 1),
 			})
-			assertVerifiedQuery(t, restarted, namespace, appendedRoot, uint64(layout.BranchingFactor), list.Query{
-				Key:    values[layout.BranchingFactor],
+			assertVerifiedQuery(t, restarted, namespace, appendedRoot, uint64(branching), list.Query{
+				Key:    values[branching],
 				Length: uint64(len(values) + 1),
 			})
 			assertVerifiedQuery(t, restarted, namespace, appendedRoot, appendedIndex, list.Query{
@@ -397,7 +450,7 @@ func TestTreeListAppendIntoChildUpdatesSlotZeroMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("fetch second child root: %v", err)
 			}
-			secondChildSlots, err := layout.LoadSlots(ctx, e, namespace, secondChildRoot, layout.NodeWidth)
+			secondChildSlots, err := layout.LoadSlots(ctx, e, namespace, secondChildRoot, geometry.NodeWidth())
 			if err != nil {
 				t.Fatalf("load second child slots: %v", err)
 			}
@@ -405,8 +458,8 @@ func TestTreeListAppendIntoChildUpdatesSlotZeroMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("decode second child metadata: %v", err)
 			}
-			if meta.ChildCount != uint64(len(values)+1-layout.BranchingFactor) {
-				t.Fatalf("second child count = %d, want %d", meta.ChildCount, len(values)+1-layout.BranchingFactor)
+			if meta.ChildCount != uint64(len(values)+1-branching) {
+				t.Fatalf("second child count = %d, want %d", meta.ChildCount, len(values)+1-branching)
 			}
 		})
 	}
@@ -414,13 +467,15 @@ func TestTreeListAppendIntoChildUpdatesSlotZeroMetadata(t *testing.T) {
 
 func TestTreeListChildNodesCarryAuthenticatedMetadata(t *testing.T) {
 	ctx := context.Background()
-	values := makeValues(300)
 
 	for name, factory := range listSchemes() {
 		t.Run(name, func(t *testing.T) {
 			kv := materialmemory.New(true)
 			namespace := "tree-child-meta-" + name
 			scheme := factory(t)
+			geometry := geometryForScheme(t, scheme)
+			branching := geometry.ListBranchingFactor()
+			values := makeValues(branching + 1)
 			semantic, e, err := newListWithMaterializer(scheme, kv)
 			if err != nil {
 				t.Fatalf("newListWithMaterializer failed: %v", err)
@@ -435,7 +490,7 @@ func TestTreeListChildNodesCarryAuthenticatedMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("fetch first child root: %v", err)
 			}
-			childSlots, err := layout.LoadSlots(ctx, e, namespace, childRoot, layout.NodeWidth)
+			childSlots, err := layout.LoadSlots(ctx, e, namespace, childRoot, geometry.NodeWidth())
 			if err != nil {
 				t.Fatalf("load child slots: %v", err)
 			}
@@ -443,8 +498,8 @@ func TestTreeListChildNodesCarryAuthenticatedMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("decode child metadata: %v", err)
 			}
-			if childMeta.ChildCount != uint64(layout.BranchingFactor) {
-				t.Fatalf("child length = %d, want %d", childMeta.ChildCount, layout.BranchingFactor)
+			if childMeta.ChildCount != uint64(branching) {
+				t.Fatalf("child length = %d, want %d", childMeta.ChildCount, branching)
 			}
 			if !childSlots[1].Equals(values[0]) {
 				t.Fatalf("child logical index 0 stored at slot 1 = %s, want %s", childSlots[1], values[0])
@@ -455,15 +510,17 @@ func TestTreeListChildNodesCarryAuthenticatedMetadata(t *testing.T) {
 
 func TestTreeListMeasuredChildNodesCarryRangeMetadata(t *testing.T) {
 	ctx := context.Background()
-	chunks := makeValues(300)
 	chunkSize := uint64(4)
-	totalSize := uint64(len(chunks)-1)*chunkSize + 3
 
 	for name, factory := range listSchemes() {
 		t.Run(name, func(t *testing.T) {
 			kv := materialmemory.New(true)
 			namespace := "tree-child-range-meta-" + name
 			scheme := factory(t)
+			geometry := geometryForScheme(t, scheme)
+			branching := geometry.ListBranchingFactor()
+			chunks := makeValues(branching + 1)
+			totalSize := uint64(len(chunks)-1)*chunkSize + 3
 			semantic, e, err := newListWithMaterializer(scheme, kv)
 			if err != nil {
 				t.Fatalf("newListWithMaterializer failed: %v", err)
@@ -478,7 +535,7 @@ func TestTreeListMeasuredChildNodesCarryRangeMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("fetch first child root: %v", err)
 			}
-			firstChildSlots, err := layout.LoadSlots(ctx, e, namespace, firstChildRoot, layout.NodeWidth)
+			firstChildSlots, err := layout.LoadSlots(ctx, e, namespace, firstChildRoot, geometry.NodeWidth())
 			if err != nil {
 				t.Fatalf("load first child slots: %v", err)
 			}
@@ -486,15 +543,15 @@ func TestTreeListMeasuredChildNodesCarryRangeMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("decode first child fixed metadata: %v", err)
 			}
-			if firstMeta.ChildCount != uint64(layout.BranchingFactor) || firstMeta.TotalSize != uint64(layout.BranchingFactor)*chunkSize || firstMeta.ChunkSize != chunkSize {
-				t.Fatalf("first child metadata = %+v, want count=%d total=%d chunk=%d", firstMeta, layout.BranchingFactor, uint64(layout.BranchingFactor)*chunkSize, chunkSize)
+			if firstMeta.ChildCount != uint64(branching) || firstMeta.TotalSize != uint64(branching)*chunkSize || firstMeta.ChunkSize != chunkSize {
+				t.Fatalf("first child metadata = %+v, want count=%d total=%d chunk=%d", firstMeta, branching, uint64(branching)*chunkSize, chunkSize)
 			}
 
 			secondChildRoot, err := e.Get(ctx, namespace, cid.Undef, layout.NodeSlotPath(root, 2))
 			if err != nil {
 				t.Fatalf("fetch second child root: %v", err)
 			}
-			secondChildSlots, err := layout.LoadSlots(ctx, e, namespace, secondChildRoot, layout.NodeWidth)
+			secondChildSlots, err := layout.LoadSlots(ctx, e, namespace, secondChildRoot, geometry.NodeWidth())
 			if err != nil {
 				t.Fatalf("load second child slots: %v", err)
 			}
@@ -502,12 +559,12 @@ func TestTreeListMeasuredChildNodesCarryRangeMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("decode second child fixed metadata: %v", err)
 			}
-			wantSecondSize := totalSize - uint64(layout.BranchingFactor)*chunkSize
-			if secondMeta.ChildCount != uint64(len(chunks)-layout.BranchingFactor) || secondMeta.TotalSize != wantSecondSize || secondMeta.ChunkSize != chunkSize {
-				t.Fatalf("second child metadata = %+v, want count=%d total=%d chunk=%d", secondMeta, len(chunks)-layout.BranchingFactor, wantSecondSize, chunkSize)
+			wantSecondSize := totalSize - uint64(branching)*chunkSize
+			if secondMeta.ChildCount != uint64(len(chunks)-branching) || secondMeta.TotalSize != wantSecondSize || secondMeta.ChunkSize != chunkSize {
+				t.Fatalf("second child metadata = %+v, want count=%d total=%d chunk=%d", secondMeta, len(chunks)-branching, wantSecondSize, chunkSize)
 			}
-			if !secondChildSlots[1].Equals(chunks[layout.BranchingFactor]) {
-				t.Fatalf("second child logical index 0 stored at slot 1 = %s, want %s", secondChildSlots[1], chunks[layout.BranchingFactor])
+			if !secondChildSlots[1].Equals(chunks[branching]) {
+				t.Fatalf("second child logical index 0 stored at slot 1 = %s, want %s", secondChildSlots[1], chunks[branching])
 			}
 		})
 	}
@@ -751,13 +808,15 @@ func TestTreeListRejectsUndefinedCommittedKeys(t *testing.T) {
 
 func TestTreeListRejectsCorruptedMaterialization(t *testing.T) {
 	ctx := context.Background()
-	values := makeValues(300)
 
 	for name, factory := range listSchemes() {
 		t.Run(name, func(t *testing.T) {
 			kv := materialmemory.New(true)
 			namespace := "tree-corrupt-" + name
 			scheme := factory(t)
+			geometry := geometryForScheme(t, scheme)
+			branching := geometry.ListBranchingFactor()
+			values := makeValues(branching + 1)
 			semantic, e, err := newListWithMaterializer(scheme, kv)
 			if err != nil {
 				t.Fatalf("newListWithMaterializer failed: %v", err)
@@ -780,7 +839,7 @@ func TestTreeListRejectsCorruptedMaterialization(t *testing.T) {
 				t.Fatalf("failed to corrupt child materialization: %v", err)
 			}
 
-			if _, err := semantic.Replace(ctx, namespace, root, 256, values[256], newPayloadCID([]byte("replacement"))); err == nil {
+			if _, err := semantic.Replace(ctx, namespace, root, uint64(branching), values[branching], newPayloadCID([]byte("replacement"))); err == nil {
 				t.Fatal("Replace should reject corrupted child materialization")
 			}
 		})

--- a/auth/semantic/mapping/radix/radix.go
+++ b/auth/semantic/mapping/radix/radix.go
@@ -20,13 +20,12 @@ import (
 	"github.com/dewebprotocol/malt/auth/observation"
 	"github.com/dewebprotocol/malt/auth/semantic"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
 
 const (
-	fanout = 256
-
 	leafPrefix        = "malt:map:radix:leaf:v1:"
 	bucketRefPrefix   = "malt:map:radix:bucket:v1:"
 	bucketCountPrefix = "malt:map:radix:bucket-count:v1:"
@@ -35,6 +34,7 @@ const (
 type Map struct {
 	commitment   *mapping.Commitment
 	materializer materializer.NodeStore
+	geometry     nodegeometry.Geometry
 }
 
 // ErrPathNotFound is retained as a compatibility alias for the semantic-level
@@ -80,8 +80,9 @@ func NewMap(scheme commitment.IndexCommitment, e materializer.NodeStore) (*Map, 
 	if e == nil {
 		return nil, fmt.Errorf("materializer is nil")
 	}
-	if scheme.MaxValues() < fanout {
-		return nil, fmt.Errorf("index commitment capacity %d is smaller than radix fanout %d", scheme.MaxValues(), fanout)
+	geometry, err := nodegeometry.ForCapacity(scheme.MaxValues())
+	if err != nil {
+		return nil, fmt.Errorf("selecting radix geometry: %w", err)
 	}
 
 	commitmentHandler, err := mapping.NewCommitment(scheme)
@@ -89,7 +90,7 @@ func NewMap(scheme commitment.IndexCommitment, e materializer.NodeStore) (*Map, 
 		return nil, fmt.Errorf("failed to create map commitment: %w", err)
 	}
 
-	return &Map{commitment: commitmentHandler, materializer: e}, nil
+	return &Map{commitment: commitmentHandler, materializer: e, geometry: geometry}, nil
 }
 
 // Commitment returns the underlying commitment primitives.
@@ -117,7 +118,7 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 	currentRoot := root
 	envelope := proofEnvelope{}
 
-	for depth := 0; depth < len(digest); depth++ {
+	for depth := 0; depth < s.geometry.MapDepth(len(digest)); depth++ {
 		finishMaterialization := observation.Start(ctx, observation.PhaseMaterialization)
 		slots, err := s.loadValidatedNode(ctx, namespace, currentRoot)
 		var materializedBytes uint64
@@ -129,9 +130,12 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 			return mapping.Binding{}, nil, err
 		}
 
-		slotIndex := digest[depth]
+		slotIndex, ok := s.geometry.MapDigit(digest[:], depth)
+		if !ok {
+			return mapping.Binding{}, nil, fmt.Errorf("invalid radix depth %d", depth)
+		}
 		finishOpen := observation.Start(ctx, observation.PhaseOpen)
-		value, proof, err := s.commitment.ProveSlot(currentRoot, slots, uint64(slotIndex))
+		value, proof, err := s.commitment.ProveSlot(currentRoot, slots, slotIndex)
 		finishOpen(1, 1, uint64(len(proof)))
 		if err != nil {
 			return mapping.Binding{}, nil, err
@@ -239,7 +243,7 @@ func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, pr
 	}
 
 	digest := hashPath(key)
-	if len(envelope.Steps) > len(digest) {
+	if len(envelope.Steps) > s.geometry.MapDepth(len(digest)) {
 		return false, fmt.Errorf("proof has too many radix steps")
 	}
 	currentRoot := root
@@ -257,7 +261,11 @@ func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, pr
 			}
 		}
 
-		ok, err := s.commitment.VerifySlot(currentRoot, uint64(digest[depth]), commitment.CellFromCID(slotCID), step.Proof)
+		slotIndex, ok := s.geometry.MapDigit(digest[:], depth)
+		if !ok {
+			return false, fmt.Errorf("invalid radix depth %d", depth)
+		}
+		ok, err = s.commitment.VerifySlot(currentRoot, slotIndex, commitment.CellFromCID(slotCID), step.Proof)
 		if err != nil || !ok {
 			return ok, err
 		}
@@ -332,7 +340,10 @@ func (s *Map) updateWithoutPersist(ctx context.Context, namespace string, root c
 	}
 
 	digest := hashPath(key)
-	slotIndex := digest[0]
+	slotIndex, ok := s.geometry.MapDigit(digest[:], 0)
+	if !ok {
+		return cid.Undef, nil, nil, fmt.Errorf("missing root radix digit")
+	}
 	nextSlot, nodes, buckets, err := s.updateSubtreeWithoutPersist(ctx, namespace, rootSlots[slotIndex], digest, 1, key, oldValue, newValue)
 	if err != nil {
 		return cid.Undef, nil, nil, err
@@ -369,7 +380,10 @@ func (s *Map) updateWithoutPersistCached(ctx context.Context, namespace string, 
 	}
 
 	digest := hashPath(key)
-	slotIndex := digest[0]
+	slotIndex, ok := s.geometry.MapDigit(digest[:], 0)
+	if !ok {
+		return cid.Undef, nil, nil, fmt.Errorf("missing root radix digit")
+	}
 	nextSlot, nodes, buckets, err := s.updateSubtreeWithoutPersistCached(ctx, namespace, rootSlots[slotIndex], digest, 1, key, oldValue, newValue, nodeCache)
 	if err != nil {
 		return cid.Undef, nil, nil, err
@@ -447,7 +461,7 @@ func (s *Map) updateSubtreeWithoutPersistCached(
 		return s.updateBucketWithoutPersist(ctx, namespace, bucketRoot, key, oldValue, newValue)
 	}
 
-	if depth >= len(digest) {
+	if depth >= s.geometry.MapDepth(len(digest)) {
 		return cid.Undef, nil, nil, fmt.Errorf("unexpected radix depth overflow")
 	}
 
@@ -464,7 +478,10 @@ func (s *Map) updateSubtreeWithoutPersistCached(
 		}
 	}
 
-	slotIndex := digest[depth]
+	slotIndex, ok := s.geometry.MapDigit(digest[:], depth)
+	if !ok {
+		return cid.Undef, nil, nil, fmt.Errorf("invalid radix depth %d", depth)
+	}
 	nextSlot, nodes, buckets, err := s.updateSubtreeWithoutPersistCached(ctx, namespace, slots[slotIndex], digest, depth+1, key, oldValue, newValue, nodeCache)
 	if err != nil {
 		return cid.Undef, nil, nil, err
@@ -600,7 +617,7 @@ func (s *Map) updateSubtreeWithoutPersist(
 		return s.updateBucketWithoutPersist(ctx, namespace, bucketRoot, key, oldValue, newValue)
 	}
 
-	if depth >= len(digest) {
+	if depth >= s.geometry.MapDepth(len(digest)) {
 		return cid.Undef, nil, nil, fmt.Errorf("unexpected radix depth overflow")
 	}
 
@@ -609,7 +626,10 @@ func (s *Map) updateSubtreeWithoutPersist(
 		return cid.Undef, nil, nil, err
 	}
 
-	slotIndex := digest[depth]
+	slotIndex, ok := s.geometry.MapDigit(digest[:], depth)
+	if !ok {
+		return cid.Undef, nil, nil, fmt.Errorf("invalid radix depth %d", depth)
+	}
 	nextSlot, nodes, buckets, err := s.updateSubtreeWithoutPersist(ctx, namespace, slots[slotIndex], digest, depth+1, key, oldValue, newValue)
 	if err != nil {
 		return cid.Undef, nil, nil, err
@@ -780,8 +800,12 @@ func (s *Map) updateBucket(ctx context.Context, namespace string, bucketRoot cid
 }
 
 func (s *Map) commitRoot(ctx context.Context, namespace string, bindings []leafBinding) (cid.Cid, error) {
-	slots := make([]cid.Cid, fanout)
-	for slotIndex, group := range groupBindings(bindings, 0) {
+	slots := make([]cid.Cid, s.geometry.NodeWidth())
+	grouped, err := s.groupBindings(bindings, 0)
+	if err != nil {
+		return cid.Undef, err
+	}
+	for slotIndex, group := range grouped {
 		child, err := s.buildSubtree(ctx, namespace, group, 1)
 		if err != nil {
 			return cid.Undef, err
@@ -801,7 +825,7 @@ func (s *Map) buildSubtreeWithoutPersist(ctx context.Context, namespace string, 
 		return leafCID, nil, nil, err
 	}
 
-	if depth >= sha256.Size || allSameDigest(bindings) {
+	if depth >= s.geometry.MapDepth(sha256.Size) || allSameDigest(bindings) {
 		markers := make([]cid.Cid, len(bindings))
 		for i, binding := range bindings {
 			marker, err := encodeLeafMarker(binding.path, binding.value)
@@ -813,11 +837,15 @@ func (s *Map) buildSubtreeWithoutPersist(ctx context.Context, namespace string, 
 		return s.commitBucketMarkersWithoutPersist(ctx, namespace, markers)
 	}
 
-	slots := make([]cid.Cid, fanout)
+	slots := make([]cid.Cid, s.geometry.NodeWidth())
 	var allNodes []pendingNode
 	var allBuckets []pendingBucket
 
-	for slotIndex, group := range groupBindings(bindings, depth) {
+	grouped, err := s.groupBindings(bindings, depth)
+	if err != nil {
+		return cid.Undef, nil, nil, err
+	}
+	for slotIndex, group := range grouped {
 		child, nodes, buckets, err := s.buildSubtreeWithoutPersist(ctx, namespace, group, depth+1)
 		if err != nil {
 			return cid.Undef, nil, nil, err
@@ -844,7 +872,7 @@ func (s *Map) buildSubtree(ctx context.Context, namespace string, bindings []lea
 		return encodeLeafMarker(bindings[0].path, bindings[0].value)
 	}
 
-	if depth >= sha256.Size || allSameDigest(bindings) {
+	if depth >= s.geometry.MapDepth(sha256.Size) || allSameDigest(bindings) {
 		markers := make([]cid.Cid, len(bindings))
 		for i, binding := range bindings {
 			marker, err := encodeLeafMarker(binding.path, binding.value)
@@ -856,8 +884,12 @@ func (s *Map) buildSubtree(ctx context.Context, namespace string, bindings []lea
 		return s.commitBucketMarkers(ctx, namespace, markers)
 	}
 
-	slots := make([]cid.Cid, fanout)
-	for slotIndex, group := range groupBindings(bindings, depth) {
+	slots := make([]cid.Cid, s.geometry.NodeWidth())
+	grouped, err := s.groupBindings(bindings, depth)
+	if err != nil {
+		return cid.Undef, err
+	}
+	for slotIndex, group := range grouped {
 		child, err := s.buildSubtree(ctx, namespace, group, depth+1)
 		if err != nil {
 			return cid.Undef, err
@@ -1026,12 +1058,16 @@ func extractBindings(view mapping.View) ([]leafBinding, error) {
 	return bindings, nil
 }
 
-func groupBindings(bindings []leafBinding, depth int) map[byte][]leafBinding {
-	grouped := make(map[byte][]leafBinding)
+func (s *Map) groupBindings(bindings []leafBinding, depth int) (map[uint64][]leafBinding, error) {
+	grouped := make(map[uint64][]leafBinding)
 	for _, binding := range bindings {
-		grouped[binding.digest[depth]] = append(grouped[binding.digest[depth]], binding)
+		digit, ok := s.geometry.MapDigit(binding.digest[:], depth)
+		if !ok {
+			return nil, fmt.Errorf("invalid radix depth %d", depth)
+		}
+		grouped[digit] = append(grouped[digit], binding)
 	}
-	return grouped
+	return grouped, nil
 }
 
 func allSameDigest(bindings []leafBinding) bool {
@@ -1071,16 +1107,16 @@ func (s *Map) loadValidatedNode(ctx context.Context, namespace string, root cid.
 }
 
 func (s *Map) loadNodeSlots(ctx context.Context, namespace string, root cid.Cid) ([]cid.Cid, error) {
-	paths := make([]arcset.Path, fanout)
-	for i := 0; i < fanout; i++ {
-		paths[i] = nodeSlotPath(root, byte(i))
+	paths := make([]arcset.Path, s.geometry.NodeWidth())
+	for i := range paths {
+		paths[i] = nodeSlotPath(root, uint64(i))
 	}
 	found, err := s.materializer.BatchGet(ctx, namespace, cid.Undef, paths)
 	if err != nil {
 		return nil, err
 	}
 
-	slots := make([]cid.Cid, fanout)
+	slots := make([]cid.Cid, s.geometry.NodeWidth())
 	for i, path := range paths {
 		if target, ok := found[path]; ok {
 			slots[i] = target
@@ -1095,7 +1131,7 @@ func (s *Map) storeNodeSlots(ctx context.Context, namespace string, root cid.Cid
 		if !slot.Defined() {
 			continue
 		}
-		arcs[nodeSlotPath(root, byte(i))] = slot
+		arcs[nodeSlotPath(root, uint64(i))] = slot
 	}
 	if len(arcs) == 0 {
 		return nil
@@ -1190,7 +1226,7 @@ func cidBytes(value cid.Cid) []byte {
 	return value.Bytes()
 }
 
-func nodeSlotPath(root cid.Cid, slot byte) arcset.Path {
+func nodeSlotPath(root cid.Cid, slot uint64) arcset.Path {
 	return arcset.CanonicalizePath(fmt.Sprintf("runtime/map/radix/nodes/%s/slots/%d", root.String(), slot))
 }
 

--- a/auth/semantic/mapping/radix/radix_test.go
+++ b/auth/semantic/mapping/radix/radix_test.go
@@ -2,6 +2,9 @@ package radix_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -60,6 +63,56 @@ func fakeCID(seed string) cid.Cid {
 	return cid.NewCidV1(cid.Raw, sum)
 }
 
+func firstKZGDigit(path string) uint16 {
+	digest := sha256.Sum256([]byte(arcset.CanonicalizePath(path).String()))
+	return uint16(digest[0])<<4 | uint16(digest[1]>>4)
+}
+
+func secondKZGDigit(path string) uint16 {
+	digest := sha256.Sum256([]byte(arcset.CanonicalizePath(path).String()))
+	return uint16(digest[1]&0x0f)<<8 | uint16(digest[2])
+}
+
+func findPathsWithAliasedLowByte(t *testing.T) (string, string) {
+	t.Helper()
+	seen := make(map[byte]struct {
+		path  string
+		digit uint16
+	})
+	for i := 0; i < 1<<16; i++ {
+		path := fmt.Sprintf("high-slot-%d", i)
+		digit := firstKZGDigit(path)
+		if digit <= 255 {
+			continue
+		}
+		key := byte(digit)
+		if previous, ok := seen[key]; ok && previous.digit != digit {
+			return previous.path, path
+		}
+		seen[key] = struct {
+			path  string
+			digit uint16
+		}{path: path, digit: digit}
+	}
+	t.Fatal("could not find high-slot paths with aliased low bytes")
+	return "", ""
+}
+
+func findPathsWithSharedFirstKZGDigit(t *testing.T) (string, string) {
+	t.Helper()
+	seen := make(map[uint16]string)
+	for i := 0; i < 1<<16; i++ {
+		path := fmt.Sprintf("shared-prefix-%d", i)
+		first := firstKZGDigit(path)
+		if previous, ok := seen[first]; ok && secondKZGDigit(previous) != secondKZGDigit(path) {
+			return previous, path
+		}
+		seen[first] = path
+	}
+	t.Fatal("could not find paths with a shared first KZG digit")
+	return "", ""
+}
+
 func TestMapCommitProveVerify(t *testing.T) {
 	ctx := context.Background()
 	view := mapping.NewViewFrom(map[string]cid.Cid{
@@ -102,6 +155,156 @@ func TestMapCommitProveVerify(t *testing.T) {
 				t.Fatal("expected proof to be path-bound")
 			}
 		})
+	}
+}
+
+func TestKZGMapUsesFullTwelveBitSlots(t *testing.T) {
+	ctx := context.Background()
+	namespace := "map-radix-kzg-high-slots"
+	store := materialmemory.New(true)
+	semantic := newMap(t, mappingSchemes()["kzg"], store)
+
+	first, second := findPathsWithAliasedLowByte(t)
+	firstDigit := firstKZGDigit(first)
+	secondDigit := firstKZGDigit(second)
+	if firstDigit <= 255 || secondDigit <= 255 {
+		t.Fatalf("test paths do not use high slots: %d, %d", firstDigit, secondDigit)
+	}
+	if firstDigit == secondDigit || byte(firstDigit) != byte(secondDigit) {
+		t.Fatalf("test paths do not exercise byte aliasing: %d, %d", firstDigit, secondDigit)
+	}
+
+	values := map[string]cid.Cid{
+		first:  fakeCID("high-slot-first"),
+		second: fakeCID("high-slot-second"),
+	}
+	root, err := semantic.Commit(ctx, namespace, mapping.NewViewFrom(values))
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	for path, want := range values {
+		digit := firstKZGDigit(path)
+		materializedPath := arcset.CanonicalizePath(fmt.Sprintf(
+			"runtime/map/radix/nodes/%s/slots/%d", root.String(), digit,
+		))
+		if _, err := store.Get(ctx, namespace, cid.Undef, materializedPath); err != nil {
+			t.Fatalf("slot %d was not materialized at its full-width path: %v", digit, err)
+		}
+		binding, proof, err := semantic.Prove(ctx, namespace, root, arcset.CanonicalizePath(path))
+		if err != nil {
+			t.Fatalf("Prove(%q) failed: %v", path, err)
+		}
+		if !binding.Value.Equals(want) {
+			t.Fatalf("Prove(%q) value = %s, want %s", path, binding.Value, want)
+		}
+		ok, err := semantic.Verify(root, arcset.CanonicalizePath(path), binding, proof)
+		if err != nil || !ok {
+			t.Fatalf("Verify(%q) = %v, %v", path, ok, err)
+		}
+	}
+
+	replacement := fakeCID("high-slot-first-replaced")
+	updatedRoot, err := semantic.Update(
+		ctx,
+		namespace,
+		root,
+		arcset.CanonicalizePath(first),
+		values[first],
+		replacement,
+	)
+	if err != nil {
+		t.Fatalf("Update high-slot key failed: %v", err)
+	}
+	values[first] = replacement
+	expectedRoot, err := semantic.Commit(ctx, namespace, mapping.NewViewFrom(values))
+	if err != nil {
+		t.Fatalf("Commit updated view failed: %v", err)
+	}
+	if !updatedRoot.Equals(expectedRoot) {
+		t.Fatalf("updated root = %s, want fresh root %s", updatedRoot, expectedRoot)
+	}
+}
+
+func TestKZGMapConsumesSecondTwelveBitDigit(t *testing.T) {
+	ctx := context.Background()
+	namespace := "map-radix-kzg-two-level"
+	semantic := newMap(t, mappingSchemes()["kzg"], nil)
+	first, second := findPathsWithSharedFirstKZGDigit(t)
+
+	values := map[string]cid.Cid{
+		first:  fakeCID("shared-prefix-first"),
+		second: fakeCID("shared-prefix-second"),
+	}
+	root, err := semantic.Commit(ctx, namespace, mapping.NewViewFrom(values))
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	for path, want := range values {
+		binding, proof, err := semantic.Prove(ctx, namespace, root, arcset.CanonicalizePath(path))
+		if err != nil {
+			t.Fatalf("Prove(%q) failed: %v", path, err)
+		}
+		var envelope struct {
+			Steps []json.RawMessage `json:"steps"`
+		}
+		if err := json.Unmarshal(proof, &envelope); err != nil {
+			t.Fatalf("decode proof: %v", err)
+		}
+		if len(envelope.Steps) != 2 {
+			t.Fatalf("proof for %q has %d steps, want 2", path, len(envelope.Steps))
+		}
+		if !binding.Value.Equals(want) {
+			t.Fatalf("Prove(%q) value = %s, want %s", path, binding.Value, want)
+		}
+		ok, err := semantic.Verify(root, arcset.CanonicalizePath(path), binding, proof)
+		if err != nil || !ok {
+			t.Fatalf("Verify(%q) = %v, %v", path, ok, err)
+		}
+	}
+
+	binding, proof, err := semantic.Prove(ctx, namespace, root, arcset.CanonicalizePath(first))
+	if err != nil {
+		t.Fatalf("Prove for depth-bound test failed: %v", err)
+	}
+	var oversized struct {
+		Steps  []json.RawMessage `json:"steps"`
+		Bucket json.RawMessage   `json:"bucket,omitempty"`
+	}
+	if err := json.Unmarshal(proof, &oversized); err != nil {
+		t.Fatalf("decode proof for depth-bound test: %v", err)
+	}
+	for len(oversized.Steps) < 23 {
+		oversized.Steps = append(oversized.Steps, oversized.Steps[0])
+	}
+	oversizedProof, err := json.Marshal(oversized)
+	if err != nil {
+		t.Fatalf("encode oversized proof: %v", err)
+	}
+	if ok, err := semantic.Verify(root, arcset.CanonicalizePath(first), binding, oversizedProof); err == nil || ok {
+		t.Fatalf("Verify accepted 23-step KZG radix proof: ok=%v err=%v", ok, err)
+	}
+
+	replacement := fakeCID("shared-prefix-first-replaced")
+	updatedRoot, err := semantic.Update(
+		ctx,
+		namespace,
+		root,
+		arcset.CanonicalizePath(first),
+		values[first],
+		replacement,
+	)
+	if err != nil {
+		t.Fatalf("Update shared-prefix key failed: %v", err)
+	}
+	values[first] = replacement
+	expectedRoot, err := semantic.Commit(ctx, namespace, mapping.NewViewFrom(values))
+	if err != nil {
+		t.Fatalf("Commit updated shared-prefix view failed: %v", err)
+	}
+	if !updatedRoot.Equals(expectedRoot) {
+		t.Fatalf("updated shared-prefix root = %s, want fresh root %s", updatedRoot, expectedRoot)
 	}
 }
 

--- a/auth/semantic/nodegeometry/geometry.go
+++ b/auth/semantic/nodegeometry/geometry.go
@@ -1,0 +1,171 @@
+// Package nodegeometry defines the backend-sized physical node geometry shared
+// by semantic producers and storage-free verifiers.
+package nodegeometry
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/dewebprotocol/malt/wire/maltcid"
+)
+
+const (
+	// IPANodeWidth is the physical node width of the current IPA suite.
+	IPANodeWidth = 256
+	// KZGNodeWidth is the physical node width of the current KZG suite.
+	KZGNodeWidth = 4096
+)
+
+// Geometry describes the physical node width and map radix associated with one
+// commitment backend suite.
+type Geometry struct {
+	nodeWidth    int
+	mapRadixBits int
+}
+
+// ForCapacity returns the semantic geometry locked to a registered commitment
+// suite's maximum vector capacity.
+func ForCapacity(capacity int) (Geometry, error) {
+	switch capacity {
+	case IPANodeWidth:
+		return Geometry{nodeWidth: IPANodeWidth, mapRadixBits: 8}, nil
+	case KZGNodeWidth:
+		return Geometry{nodeWidth: KZGNodeWidth, mapRadixBits: 12}, nil
+	default:
+		return Geometry{}, fmt.Errorf("unsupported commitment capacity %d", capacity)
+	}
+}
+
+// ForBackend returns the semantic geometry locked to a typed-root commitment
+// backend suite.
+func ForBackend(kind maltcid.BackendKind) (Geometry, error) {
+	switch kind {
+	case maltcid.BackendKindIPA:
+		return ForCapacity(IPANodeWidth)
+	case maltcid.BackendKindKZG:
+		return ForCapacity(KZGNodeWidth)
+	default:
+		return Geometry{}, fmt.Errorf("unsupported commitment backend %q", kind)
+	}
+}
+
+// NodeWidth returns the number of physical commitment slots in every semantic
+// map or list node.
+func (g Geometry) NodeWidth() int {
+	return g.nodeWidth
+}
+
+// MapRadixBits returns the number of digest bits consumed by one map level.
+func (g Geometry) MapRadixBits() int {
+	return g.mapRadixBits
+}
+
+// MapDepth returns the number of radix digits needed to consume byteLength
+// bytes. The final digit is right-padded with zero bits when necessary.
+func (g Geometry) MapDepth(byteLength int) int {
+	if byteLength <= 0 || g.mapRadixBits <= 0 {
+		return 0
+	}
+	return (byteLength*8 + g.mapRadixBits - 1) / g.mapRadixBits
+}
+
+// MapDigit reads one radix digit from a big-endian bit stream. If the final
+// digit is partial, its remaining low bits are zero-filled.
+func (g Geometry) MapDigit(digest []byte, depth int) (uint64, bool) {
+	if depth < 0 || depth >= g.MapDepth(len(digest)) {
+		return 0, false
+	}
+
+	startBit := depth * g.mapRadixBits
+	var digit uint64
+	for offset := 0; offset < g.mapRadixBits; offset++ {
+		digit <<= 1
+		bit := startBit + offset
+		if bit >= len(digest)*8 {
+			continue
+		}
+		digit |= uint64((digest[bit/8] >> (7 - uint(bit%8))) & 1)
+	}
+	return digit, true
+}
+
+// ListBranchingFactor returns the number of data-bearing slots in a list node.
+// Slot zero is reserved for authenticated metadata.
+func (g Geometry) ListBranchingFactor() int {
+	if g.nodeWidth <= 0 {
+		return 0
+	}
+	return g.nodeWidth - 1
+}
+
+// RequiredListHeight returns the minimal non-root height required for length
+// values.
+func (g Geometry) RequiredListHeight(length uint64) int {
+	branching := uint64(g.ListBranchingFactor())
+	if branching == 0 || length <= branching {
+		return 0
+	}
+
+	capacity := branching
+	height := 0
+	for capacity < length {
+		height++
+		if capacity > math.MaxUint64/branching {
+			return height
+		}
+		capacity *= branching
+	}
+	return height
+}
+
+// ListSubtreeCapacity returns how many values fit under a list node of height.
+func (g Geometry) ListSubtreeCapacity(height int) (uint64, error) {
+	if height < 0 {
+		return 0, fmt.Errorf("height must be non-negative")
+	}
+	branching := uint64(g.ListBranchingFactor())
+	if branching == 0 {
+		return 0, fmt.Errorf("list branching factor is zero")
+	}
+
+	capacity := branching
+	for i := 0; i < height; i++ {
+		if capacity > math.MaxUint64/branching {
+			return 0, fmt.Errorf("list capacity overflow at height %d", height)
+		}
+		capacity *= branching
+	}
+	return capacity, nil
+}
+
+// ListIndexDigits decomposes an index into base-branching-factor digits for
+// the target list height.
+func (g Geometry) ListIndexDigits(index uint64, height int) ([]int, error) {
+	if height < 0 {
+		return nil, fmt.Errorf("height must be non-negative")
+	}
+
+	digits := make([]int, height+1)
+	remaining := index
+	for level := 0; level <= height; level++ {
+		exp := height - level
+		if exp == 0 {
+			if remaining >= uint64(g.ListBranchingFactor()) {
+				return nil, fmt.Errorf("index digit %d exceeds branching factor %d", remaining, g.ListBranchingFactor())
+			}
+			digits[level] = int(remaining)
+			continue
+		}
+		chunk, err := g.ListSubtreeCapacity(exp - 1)
+		if err != nil {
+			return nil, err
+		}
+		digit := remaining / chunk
+		if digit >= uint64(g.ListBranchingFactor()) {
+			return nil, fmt.Errorf("index digit %d exceeds branching factor %d", digit, g.ListBranchingFactor())
+		}
+		digits[level] = int(digit)
+		remaining %= chunk
+	}
+	return digits, nil
+}

--- a/auth/semantic/nodegeometry/geometry_test.go
+++ b/auth/semantic/nodegeometry/geometry_test.go
@@ -1,0 +1,173 @@
+package nodegeometry
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/dewebprotocol/malt/wire/maltcid"
+)
+
+func TestForCapacity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		capacity      int
+		width         int
+		radixBits     int
+		mapDepth      int
+		listBranching int
+	}{
+		{capacity: IPANodeWidth, width: 256, radixBits: 8, mapDepth: 32, listBranching: 255},
+		{capacity: KZGNodeWidth, width: 4096, radixBits: 12, mapDepth: 22, listBranching: 4095},
+	}
+	for _, test := range tests {
+		geometry, err := ForCapacity(test.capacity)
+		if err != nil {
+			t.Fatalf("ForCapacity(%d): %v", test.capacity, err)
+		}
+		if got := geometry.NodeWidth(); got != test.width {
+			t.Fatalf("ForCapacity(%d).NodeWidth() = %d, want %d", test.capacity, got, test.width)
+		}
+		if got := geometry.MapRadixBits(); got != test.radixBits {
+			t.Fatalf("ForCapacity(%d).MapRadixBits() = %d, want %d", test.capacity, got, test.radixBits)
+		}
+		if got := geometry.MapDepth(32); got != test.mapDepth {
+			t.Fatalf("ForCapacity(%d).MapDepth(32) = %d, want %d", test.capacity, got, test.mapDepth)
+		}
+		if got := geometry.ListBranchingFactor(); got != test.listBranching {
+			t.Fatalf("ForCapacity(%d).ListBranchingFactor() = %d, want %d", test.capacity, got, test.listBranching)
+		}
+	}
+	if _, err := ForCapacity(1024); err == nil {
+		t.Fatal("ForCapacity accepted an unregistered capacity")
+	}
+}
+
+func TestForBackend(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		kind  maltcid.BackendKind
+		width int
+	}{
+		{kind: maltcid.BackendKindIPA, width: IPANodeWidth},
+		{kind: maltcid.BackendKindKZG, width: KZGNodeWidth},
+	}
+	for _, test := range tests {
+		geometry, err := ForBackend(test.kind)
+		if err != nil {
+			t.Fatalf("ForBackend(%q): %v", test.kind, err)
+		}
+		if got := geometry.NodeWidth(); got != test.width {
+			t.Fatalf("ForBackend(%q).NodeWidth() = %d, want %d", test.kind, got, test.width)
+		}
+	}
+	if _, err := ForBackend(maltcid.BackendKindUnknown); err == nil {
+		t.Fatal("ForBackend accepted an unknown backend")
+	}
+}
+
+func TestKZGMapDigitsUseBigEndianTwelveBitStream(t *testing.T) {
+	t.Parallel()
+
+	geometry, err := ForCapacity(KZGNodeWidth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := make([]byte, 32)
+	digest[0] = 0xab
+	digest[1] = 0xcd
+	digest[2] = 0xef
+	digest[30] = 0x12
+	digest[31] = 0x34
+
+	tests := []struct {
+		depth int
+		want  uint64
+	}{
+		{depth: 0, want: 0xabc},
+		{depth: 1, want: 0xdef},
+		{depth: 20, want: 0x123},
+		{depth: 21, want: 0x400},
+	}
+	for _, test := range tests {
+		got, ok := geometry.MapDigit(digest, test.depth)
+		if !ok {
+			t.Fatalf("MapDigit(%d) rejected", test.depth)
+		}
+		if got != test.want {
+			t.Fatalf("MapDigit(%d) = %#x, want %#x", test.depth, got, test.want)
+		}
+	}
+	for _, depth := range []int{-1, 22} {
+		if _, ok := geometry.MapDigit(digest, depth); ok {
+			t.Fatalf("MapDigit accepted depth %d", depth)
+		}
+	}
+}
+
+func TestKZGMapDigitsCoverDigestExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	geometry, err := ForCapacity(KZGNodeWidth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := make([]byte, 32)
+	for i := range digest {
+		digest[i] = byte(i*37 + 11)
+	}
+	var bits []byte
+	for depth := 0; depth < geometry.MapDepth(len(digest)); depth++ {
+		digit, ok := geometry.MapDigit(digest, depth)
+		if !ok {
+			t.Fatalf("MapDigit(%d) rejected", depth)
+		}
+		for bit := geometry.MapRadixBits() - 1; bit >= 0; bit-- {
+			bits = append(bits, byte((digit>>uint(bit))&1))
+		}
+	}
+	bits = bits[:len(digest)*8]
+	reconstructed := make([]byte, len(digest))
+	for i, bit := range bits {
+		if bit != 0 {
+			reconstructed[i/8] |= 1 << uint(7-i%8)
+		}
+	}
+	if !bytes.Equal(reconstructed, digest) {
+		t.Fatalf("reconstructed digest = %x, want %x", reconstructed, digest)
+	}
+
+	last, ok := geometry.MapDigit(digest, 21)
+	if !ok {
+		t.Fatal("last MapDigit rejected")
+	}
+	if want := uint64(digest[31]&0x0f) << 8; last != want {
+		t.Fatalf("last MapDigit = %#x, want %#x", last, want)
+	}
+}
+
+func TestListGeometryBoundaries(t *testing.T) {
+	t.Parallel()
+
+	for _, capacity := range []int{IPANodeWidth, KZGNodeWidth} {
+		geometry, err := ForCapacity(capacity)
+		if err != nil {
+			t.Fatal(err)
+		}
+		branching := uint64(geometry.ListBranchingFactor())
+		if got := geometry.RequiredListHeight(branching); got != 0 {
+			t.Fatalf("capacity %d height at branching = %d, want 0", capacity, got)
+		}
+		if got := geometry.RequiredListHeight(branching + 1); got != 1 {
+			t.Fatalf("capacity %d height above branching = %d, want 1", capacity, got)
+		}
+		digits, err := geometry.ListIndexDigits(branching, 1)
+		if err != nil {
+			t.Fatalf("capacity %d ListIndexDigits: %v", capacity, err)
+		}
+		if len(digits) != 2 || digits[0] != 1 || digits[1] != 0 {
+			t.Fatalf("capacity %d digits = %v, want [1 0]", capacity, digits)
+		}
+	}
+}

--- a/auth/verifier/portable_test.go
+++ b/auth/verifier/portable_test.go
@@ -2,6 +2,7 @@ package verifier_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"testing"
 
@@ -132,6 +133,35 @@ func TestPortableVerifierAcceptsRuntimeRadixAndTreeProofs(t *testing.T) {
 				}
 			})
 
+			if name == "kzg" {
+				t.Run("map_twelve_bit_second_level", func(t *testing.T) {
+					first, second := portableSharedFirstKZGDigitPaths(t)
+					firstTarget := portableTestCID(t, "twelve-bit-first")
+					secondTarget := portableTestCID(t, "twelve-bit-second")
+					scope := "portable-map-kzg-twelve-bit"
+					root, err := maps.Commit(ctx, scope, mapping.NewViewFrom(map[string]cid.Cid{
+						first:  firstTarget,
+						second: secondTarget,
+					}))
+					if err != nil {
+						t.Fatalf("Commit: %v", err)
+					}
+					binding, proof, err := maps.Prove(ctx, scope, root, arcset.CanonicalizePath(first))
+					if err != nil {
+						t.Fatalf("Prove: %v", err)
+					}
+					pl := prooflist.ProofList{Root: root, Query: first, Steps: []prooflist.Step{{
+						Kind: prooflist.KindMapStep, From: root, Path: first, Target: binding.Value,
+						EvidenceKind: "structure", EvidenceBackend: "map", Proof: proof,
+					}}}
+					assertPortableValid(t, portable, pl)
+
+					pl.Query = second
+					pl.Steps[0].Path = second
+					assertPortableRejected(t, portable, pl)
+				})
+			}
+
 			t.Run("list_index", func(t *testing.T) {
 				values := []cid.Cid{portableTestCID(t, "list-0"), portableTestCID(t, "list-1")}
 				root, err := lists.Commit(ctx, "portable-list-"+name, list.NewViewFromSlice(values))
@@ -222,4 +252,36 @@ func portableMalformedRoot(t *testing.T, root cid.Cid) cid.Cid {
 		t.Fatalf("encode malformed root: %v", err)
 	}
 	return cid.NewCidV1(root.Prefix().Codec, hash)
+}
+
+func portableSharedFirstKZGDigitPaths(t *testing.T) (string, string) {
+	t.Helper()
+	type digits struct {
+		first  uint16
+		second uint16
+	}
+	pathDigits := func(path string) digits {
+		digest := sha256.Sum256([]byte(arcset.CanonicalizePath(path).String()))
+		return digits{
+			first:  uint16(digest[0])<<4 | uint16(digest[1]>>4),
+			second: uint16(digest[1]&0x0f)<<8 | uint16(digest[2]),
+		}
+	}
+	seen := make(map[uint16]struct {
+		path   string
+		second uint16
+	})
+	for i := 0; i < 1<<16; i++ {
+		path := fmt.Sprintf("portable-shared-prefix-%d", i)
+		digits := pathDigits(path)
+		if previous, ok := seen[digits.first]; ok && previous.second != digits.second {
+			return previous.path, path
+		}
+		seen[digits.first] = struct {
+			path   string
+			second uint16
+		}{path: path, second: digits.second}
+	}
+	t.Fatal("could not find portable KZG paths with a shared first digit")
+	return "", ""
 }

--- a/auth/verifier/radix.go
+++ b/auth/verifier/radix.go
@@ -10,12 +10,12 @@ import (
 	"github.com/dewebprotocol/malt/auth/commitment"
 	structure "github.com/dewebprotocol/malt/auth/semantic"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
 
 const (
-	portableNodeWidth = 256
 	radixLeafPrefix   = "malt:map:radix:leaf:v1:"
 	radixBucketPrefix = "malt:map:radix:bucket:v1:"
 )
@@ -25,7 +25,8 @@ const (
 // locked runtime wire format, but verification requires only the primitive
 // commitment scheme.
 type radixMapVerifier struct {
-	scheme commitment.IndexVerifier
+	scheme   commitment.IndexVerifier
+	geometry nodegeometry.Geometry
 }
 
 type radixProofEnvelope struct {
@@ -42,8 +43,8 @@ type radixBucketWitness struct {
 	Proof []byte `json:"proof"`
 }
 
-func newRadixMapVerifier(scheme commitment.IndexVerifier) MapVerifier {
-	return &radixMapVerifier{scheme: scheme}
+func newRadixMapVerifier(scheme commitment.IndexVerifier, geometry nodegeometry.Geometry) MapVerifier {
+	return &radixMapVerifier{scheme: scheme, geometry: geometry}
 }
 
 func (v *radixMapVerifier) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, proof structure.Proof) (bool, error) {
@@ -72,7 +73,7 @@ func (v *radixMapVerifier) Verify(root cid.Cid, key arcset.Path, expected mappin
 	}
 
 	digest := sha256.Sum256([]byte(key.String()))
-	if len(envelope.Steps) > len(digest) {
+	if len(envelope.Steps) > v.geometry.MapDepth(len(digest)) {
 		return false, fmt.Errorf("proof has too many radix steps")
 	}
 	currentRoot := root
@@ -90,7 +91,11 @@ func (v *radixMapVerifier) Verify(root cid.Cid, key arcset.Path, expected mappin
 			}
 		}
 
-		ok, err := v.scheme.VerifyIndex(currentRoot, uint64(digest[depth]), commitment.CellFromCID(slotCID), cloneProofBytes(step.Proof))
+		slotIndex, ok := v.geometry.MapDigit(digest[:], depth)
+		if !ok {
+			return false, fmt.Errorf("invalid radix depth %d", depth)
+		}
+		ok, err = v.scheme.VerifyIndex(currentRoot, slotIndex, commitment.CellFromCID(slotCID), cloneProofBytes(step.Proof))
 		if err != nil || !ok {
 			return ok, err
 		}

--- a/auth/verifier/registry.go
+++ b/auth/verifier/registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dewebprotocol/malt/auth/commitment"
 	"github.com/dewebprotocol/malt/auth/commitment/ipa"
 	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 )
@@ -53,10 +54,17 @@ func (r *BackendRegistry) RegisterScheme(kind maltcid.BackendKind, scheme commit
 	if scheme == nil {
 		return fmt.Errorf("commitment scheme for backend %q is nil", kind)
 	}
-	if scheme.MaxValues() < portableNodeWidth {
-		return fmt.Errorf("commitment backend %q capacity %d is smaller than required width %d", kind, scheme.MaxValues(), portableNodeWidth)
+	geometry, err := nodegeometry.ForBackend(kind)
+	if err != nil {
+		return fmt.Errorf("commitment backend %q geometry: %w", kind, err)
 	}
-	return r.Register(kind, newRadixMapVerifier(scheme), newTreeListVerifier(scheme))
+	if scheme.MaxValues() != geometry.NodeWidth() {
+		return fmt.Errorf(
+			"commitment backend %q capacity %d does not match required node width %d",
+			kind, scheme.MaxValues(), geometry.NodeWidth(),
+		)
+	}
+	return r.Register(kind, newRadixMapVerifier(scheme, geometry), newTreeListVerifier(scheme, geometry))
 }
 
 func (r *BackendRegistry) mapVerifier(root cid.Cid) (MapVerifier, error) {

--- a/auth/verifier/registry_test.go
+++ b/auth/verifier/registry_test.go
@@ -1,0 +1,41 @@
+package verifier_test
+
+import (
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	authverifier "github.com/dewebprotocol/malt/auth/verifier"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+)
+
+func TestBackendRegistryRejectsMismatchedSchemeGeometry(t *testing.T) {
+	t.Parallel()
+
+	ipaScheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatalf("ipa.NewScheme: %v", err)
+	}
+	kzgScheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("kzg.NewScheme: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		kind   maltcid.BackendKind
+		scheme commitment.IndexVerifier
+	}{
+		{name: "kzg_kind_with_ipa_scheme", kind: maltcid.BackendKindKZG, scheme: ipaScheme},
+		{name: "ipa_kind_with_kzg_scheme", kind: maltcid.BackendKindIPA, scheme: kzgScheme},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := authverifier.NewBackendRegistry()
+			if err := registry.RegisterScheme(test.kind, test.scheme); err == nil {
+				t.Fatal("RegisterScheme accepted mismatched backend geometry")
+			}
+		})
+	}
+}

--- a/auth/verifier/tree.go
+++ b/auth/verifier/tree.go
@@ -4,24 +4,22 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"math"
 
 	"github.com/dewebprotocol/malt/auth/commitment"
 	structure "github.com/dewebprotocol/malt/auth/semantic"
 	"github.com/dewebprotocol/malt/auth/semantic/list"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
 	cid "github.com/ipfs/go-cid"
 )
 
-const (
-	treeBranchingFactor = portableNodeWidth - 1
-	treeNodeMetaPrefix  = "malt:list:node-meta:"
-)
+const treeNodeMetaPrefix = "malt:list:node-meta:"
 
 // treeListVerifier is the storage-free half of the runtime tree-list
 // semantic. It authenticates both index and measured-range results using only
 // proof envelopes and the primitive commitment scheme.
 type treeListVerifier struct {
-	scheme commitment.IndexVerifier
+	scheme   commitment.IndexVerifier
+	geometry nodegeometry.Geometry
 }
 
 type treeProofEnvelope struct {
@@ -53,8 +51,11 @@ type treeNodeMetadata struct {
 	ChunkSize  uint64
 }
 
-func newTreeListVerifier(scheme commitment.IndexVerifier) ListVerifier {
-	return &treeListVerifier{scheme: scheme}
+func newTreeListVerifier(scheme commitment.IndexVerifier, geometry nodegeometry.Geometry) ListVerifier {
+	return &treeListVerifier{
+		scheme:   scheme,
+		geometry: geometry,
+	}
 }
 
 func (v *treeListVerifier) Verify(root cid.Cid, index uint64, expected list.Query, proof structure.Proof) (bool, error) {
@@ -73,7 +74,7 @@ func (v *treeListVerifier) Verify(root cid.Cid, index uint64, expected list.Quer
 		return false, fmt.Errorf("missing metadata proof")
 	}
 
-	metadataTarget, err := treeMetadataTargetForVerify(expected.Length, envelope.MetadataTarget)
+	metadataTarget, err := v.treeMetadataTargetForVerify(expected.Length, envelope.MetadataTarget)
 	if err != nil {
 		return false, err
 	}
@@ -92,11 +93,11 @@ func (v *treeListVerifier) Verify(root cid.Cid, index uint64, expected list.Quer
 		return false, nil
 	}
 
-	height := treeRequiredHeight(expected.Length)
+	height := v.geometry.RequiredListHeight(expected.Length)
 	if len(envelope.Steps) != height+1 {
 		return false, nil
 	}
-	digits, err := treeIndexDigits(index, height)
+	digits, err := v.geometry.ListIndexDigits(index, height)
 	if err != nil {
 		return false, err
 	}
@@ -143,7 +144,7 @@ func (v *treeListVerifier) VerifyRange(root cid.Cid, start uint64, end *uint64, 
 		return false, fmt.Errorf("missing metadata proof")
 	}
 	meta := treeNodeMetadata{
-		Height:     uint64(treeRequiredHeight(expected.Metadata.ChildCount)),
+		Height:     uint64(v.geometry.RequiredListHeight(expected.Metadata.ChildCount)),
 		ChildCount: expected.Metadata.ChildCount,
 		TotalSize:  expected.Metadata.TotalSize,
 		ChunkSize:  expected.Metadata.ChunkSize,
@@ -194,10 +195,10 @@ func (v *treeListVerifier) VerifyRange(root cid.Cid, start uint64, end *uint64, 
 	return true, nil
 }
 
-func treeMetadataTargetForVerify(expectedLength uint64, explicit []byte) (commitment.Cell, error) {
+func (v *treeListVerifier) treeMetadataTargetForVerify(expectedLength uint64, explicit []byte) (commitment.Cell, error) {
 	if len(explicit) == 0 {
 		return treeNodeMetadataCell(treeNodeMetadata{
-			Height:     uint64(treeRequiredHeight(expectedLength)),
+			Height:     uint64(v.geometry.RequiredListHeight(expectedLength)),
 			ChildCount: expectedLength,
 		})
 	}
@@ -274,65 +275,6 @@ func validateTreeFixedMetadata(meta treeNodeMetadata) error {
 		return fmt.Errorf("child count %d does not match total size %d and chunk size %d", meta.ChildCount, meta.TotalSize, meta.ChunkSize)
 	}
 	return nil
-}
-
-func treeRequiredHeight(length uint64) int {
-	if length <= uint64(treeBranchingFactor) {
-		return 0
-	}
-	capacity := uint64(treeBranchingFactor)
-	height := 0
-	for capacity < length {
-		height++
-		if capacity > math.MaxUint64/uint64(treeBranchingFactor) {
-			return height
-		}
-		capacity *= uint64(treeBranchingFactor)
-	}
-	return height
-}
-
-func treeIndexDigits(index uint64, height int) ([]int, error) {
-	if height < 0 {
-		return nil, fmt.Errorf("height must be non-negative")
-	}
-	digits := make([]int, height+1)
-	remaining := index
-	for level := 0; level <= height; level++ {
-		exp := height - level
-		if exp == 0 {
-			if remaining >= uint64(treeBranchingFactor) {
-				return nil, fmt.Errorf("index digit %d exceeds branching factor %d", remaining, treeBranchingFactor)
-			}
-			digits[level] = int(remaining)
-			continue
-		}
-		chunk, err := treeSubtreeCapacity(exp - 1)
-		if err != nil {
-			return nil, err
-		}
-		digit := remaining / chunk
-		if digit >= uint64(treeBranchingFactor) {
-			return nil, fmt.Errorf("index digit %d exceeds branching factor %d", digit, treeBranchingFactor)
-		}
-		digits[level] = int(digit)
-		remaining %= chunk
-	}
-	return digits, nil
-}
-
-func treeSubtreeCapacity(height int) (uint64, error) {
-	if height < 0 {
-		return 0, fmt.Errorf("height must be non-negative")
-	}
-	capacity := uint64(treeBranchingFactor)
-	for i := 0; i < height; i++ {
-		if capacity > math.MaxUint64/uint64(treeBranchingFactor) {
-			return 0, fmt.Errorf("list capacity overflow at height %d", height)
-		}
-		capacity *= uint64(treeBranchingFactor)
-	}
-	return capacity, nil
 }
 
 func normalizeTreeRange(start uint64, end *uint64, totalSize uint64) (uint64, bool, error) {

--- a/conformance/resolve-read/v1/vectors.json
+++ b/conformance/resolve-read/v1/vectors.json
@@ -9,7 +9,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -23,14 +23,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -40,7 +40,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoaFBBdk52RFdVU2lCNVVlWXlqV1FHSW1Lc1JXNEQ4cXh1ZE9oYWkzOGsrSlpUdFVma0wraldPcmNYS2JZVDdQRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
               }
             ]
           }
@@ -58,7 +58,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "query": {
             "kind": "list_index",
             "index": 0
@@ -69,14 +69,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "list:0",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -86,7 +86,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0U4WS9heVdCWnFlWE5EdjFxZnc4Zlp3a0t4citTRkJpVjdmVVhyUHd3ZXZFZm5DL2JSOUp0QnJiM0FRQTFPNWpaWWcrSHJvaDQxK0lPOGJjVkYzMzZFLzJJbEdGNElEWGhaQ2F4aVlOWDU5am5EdDdiK1RSTzdQazhIdE9IMkVJRWhqcGZCRCtubGx3TEVqaU9hUmFSKytzQlNLTTl6aTBpZGdYLzlkMFdlMlhyZHZLZWxOM29mbk11Z2tjY29pWHFYOGxWeG9ScG1lNFJaQkF4bS9uWVpOeUhNQUtPL1J3MnRDU0U2M2xkUHlvMHJTTHgxWktGVkIzZEdqTmthNytFMTZEQUluWC9DYkdlNHo3V1JmbFA0eklQLzMrT0h4T3g4S0FRYnp4dmd2YWthTXhPZ0RBUjVCbjZkSmNnbUJIMGVjampQTkM4cWErNGI3aFBRSW56bzFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2xNNFlaU3dOMWxVaCtVTDhyR2p4aUN4TVFZcnR4RDM0NmFWRHZqaGlGcnRJd09UdXpabGRDaXRwNXhIa0tJVU9pVmR4RTNNM3BLUlBaS3AzYk5KL25kRWZTOGdaaXlRNWxvNDZHaWxWVll5eXJLdTRUcjB6WkRvUzhXUXkvNDdibDZ4cVRVUzVSSW5YK2VHazI1VWs4QXhXMGorQzllYWN6c3ZqL3R2NWRBa0xQWHZ2TEpuVGZPNHR1aXVwVU5JOXY3QXluY1hqNmpNOGh3blozUG5kOUVPbGhoVS9OZ1cvRmVtNFdhR1pxalNCUVlVZXBFRkw4TjNXQlZsMlA4Vm1pbUl4aElrSGQzN0VacDZ2YVBIaldsdUJRc1cybno3REd1ZWlrcDY3QjI2Sk5lQ05LQ2JvVjBKQi9TTmlpb0pMQ29xeUxrWmpxamd2czRFT2MreFV3MEFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -104,7 +104,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
+          "root": "bagbmfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -118,14 +118,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+              "/": "bagbmfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+                  "/": "bagbmfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -135,7 +135,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0U4WS9heVdCWnFlWE5EdjFxZnc4Zlp3a0t4citTRkJpVjdmVVhyUHd3ZXZFZm5DL2JSOUp0QnJiM0FRQTFPNWpaWWcrSHJvaDQxK0lPOGJjVkYzMzZFLzJJbEdGNElEWGhaQ2F4aVlOWDU5am5EdDdiK1RSTzdQazhIdE9IMkVJRWhqcGZCRCtubGx3TEVqaU9hUmFSKytzQlNLTTl6aTBpZGdYLzlkMFdlMlhyZHZLZWxOM29mbk11Z2tjY29pWHFYOGxWeG9ScG1lNFJaQkF4bS9uWVpOeUhNQUtPL1J3MnRDU0U2M2xkUHlvMHJTTHgxWktGVkIzZEdqTmthNytFMTZEQUluWC9DYkdlNHo3V1JmbFA0eklQLzMrT0h4T3g4S0FRYnp4dmd2YWthTXhPZ0RBUjVCbjZkSmNnbUJIMGVjampQTkM4cWErNGI3aFBRSW56bzFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2xNNFlaU3dOMWxVaCtVTDhyR2p4aUN4TVFZcnR4RDM0NmFWRHZqaGlGcnRJd09UdXpabGRDaXRwNXhIa0tJVU9pVmR4RTNNM3BLUlBaS3AzYk5KL25kRWZTOGdaaXlRNWxvNDZHaWxWVll5eXJLdTRUcjB6WkRvUzhXUXkvNDdibDZ4cVRVUzVSSW5YK2VHazI1VWs4QXhXMGorQzllYWN6c3ZqL3R2NWRBa0xQWHZ2TEpuVGZPNHR1aXVwVU5JOXY3QXluY1hqNmpNOGh3blozUG5kOUVPbGhoVS9OZ1cvRmVtNFdhR1pxalNCUVlVZXBFRkw4TjNXQlZsMlA4Vm1pbUl4aElrSGQzN0VacDZ2YVBIaldsdUJRc1cybno3REd1ZWlrcDY3QjI2Sk5lQ05LQ2JvVjBKQi9TTmlpb0pMQ29xeUxrWmpxamd2czRFT2MreFV3MEFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -153,7 +153,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkjqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy",
+          "root": "bagbmjqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy",
           "query": {
             "kind": "list_index",
             "index": 1
@@ -164,14 +164,14 @@
           "target": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga",
           "prooflist": {
             "root": {
-              "/": "bagbkjqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
+              "/": "bagbmjqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
             },
             "query": "list:1",
             "steps": [
               {
                 "kind": "list_index",
                 "from": {
-                  "/": "bagbkjqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
+                  "/": "bagbmjqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
                 },
                 "query": "list:1",
                 "coordinate": "1",
@@ -200,7 +200,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "root": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "query": {
             "kind": "list_range",
             "start": 2,
@@ -209,7 +209,7 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "target": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "range_segments": [
             "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
@@ -217,14 +217,14 @@
           ],
           "prooflist": {
             "root": {
-              "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+              "/": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
             },
             "query": "range:2:18",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "query": "range:2:18",
                 "coordinate": "range:2:18",
@@ -234,7 +234,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "segments": [
                   {
@@ -267,7 +267,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "root": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "query": {
             "kind": "list_range",
             "start": 8
@@ -275,21 +275,21 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "target": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "range_segments": [
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
             "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
           ],
           "prooflist": {
             "root": {
-              "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+              "/": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
             },
             "query": "range:8:",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "query": "range:8:",
                 "coordinate": "range:8:",
@@ -298,7 +298,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "segments": [
                   {
@@ -335,14 +335,14 @@
               "name"
             ]
           },
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
         },
         "result": {
           "profile": "malt.read/v0alpha1",
           "prooflist": {
             "query": "profile/name",
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "steps": [
               {
@@ -350,7 +350,7 @@
                 "evidence_backend": "map",
                 "evidence_kind": "structure",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "kind": "map_step",
                 "path": "profile/name",
@@ -377,7 +377,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -391,14 +391,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -408,7 +408,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0U4WS9heVdCWnFlWE5EdjFxZnc4Zlp3a0t4citTRkJpVjdmVVhyUHd3ZXZFZm5DL2JSOUp0QnJiM0FRQTFPNWpaWWcrSHJvaDQxK0lPOGJjVkYzMzZFLzJJbEdGNElEWGhaQ2F4aVlOWDU5am5EdDdiK1RSTzdQazhIdE9IMkVJRWhqcGZCRCtubGx3TEVqaU9hUmFSKytzQlNLTTl6aTBpZGdYLzlkMFdlMlhyZHZLZWxOM29mbk11Z2tjY29pWHFYOGxWeG9ScG1lNFJaQkF4bS9uWVpOeUhNQUtPL1J3MnRDU0U2M2xkUHlvMHJTTHgxWktGVkIzZEdqTmthNytFMTZEQUluWC9DYkdlNHo3V1JmbFA0eklQLzMrT0h4T3g4S0FRYnp4dmd2YWthTXhPZ0RBUjVCbjZkSmNnbUJIMGVjampQTkM4cWErNGI3aFBRSW56bzFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2xNNFlaU3dOMWxVaCtVTDhyR2p4aUN4TVFZcnR4RDM0NmFWRHZqaGlGcnRJd09UdXpabGRDaXRwNXhIa0tJVU9pVmR4RTNNM3BLUlBaS3AzYk5KL25kRWZTOGdaaXlRNWxvNDZHaWxWVll5eXJLdTRUcjB6WkRvUzhXUXkvNDdibDZ4cVRVUzVSSW5YK2VHazI1VWs4QXhXMGorQzllYWN6c3ZqL3R2NWRBa0xQWHZ2TEpuVGZPNHR1aXVwVU5JOXY3QXluY1hqNmpNOGh3blozUG5kOUVPbGhoVS9OZ1cvRmVtNFdhR1pxalNCUVlVZXBFRkw4TjNXQlZsMlA4Vm1pbUl4aElrSGQzN0VacDZ2YVBIaldsdUJRc1cybno3REd1ZWlrcDY3QjI2Sk5lQ05LQ2JvVjBKQi9TTmlpb0pMQ29xeUxrWmpxamd2czRFT2MreFV3MEFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -426,7 +426,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -440,14 +440,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -474,7 +474,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -487,14 +487,14 @@
           "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "@payload",
             "steps": [
               {
                 "kind": "payload_binding",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "@payload",
                 "coordinate": "@payload",
@@ -504,7 +504,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6IkFBQUFDR0M4aXVobU95ZVdHL1NlYkJUbzdzVXRRWHdTTUJDd2xnOERVaTNaV3E5T1R0clBUMGszYnlwcFJZK2NFa3lKQXJkeTlscndGeWZKNG12Y1pJTHZveXNsYXZIQWRKSWlSWnZYdERraHlJZm85eUhNY21JNDFjUVVGMC90YURPZnpRMEdwL2prZmoyR3p0dlFkU0RwZGpXRkhRZkZyVHhYNEFNdnNUMUhHclUwY3o1Y0l6M29xeTRqY0h6aWc4L002S1BrdkNFQzFUTFFCNldXNy9YRGM0bHBoN0E0eGVubWVyN3l5aUdLT3NPWmpOZ3hCdVlOSlJkMlh4VGNmcytUbUVSOUtnWlFGbzFwRXJJWUpBc1VsbWoxWHRtbUozQ2tpN0wySnlFWGdZWFlDMFJKM0FsYzdXS3JHNzNUdEdkeGFnbVhGbFlqNi93c282WnlzZG9jS2ZNU3I3V3pwdUVGWlJoR0Z5ZHdsMW9zL3ptY1VqNmhwdWNXMlBFc3RZQzJtMCtXalVoQWR4UjR5SlNtMWdIWEFPVGo5ZVMzdjcxaG4vQzFmNHh6ZGVlZmJBa2Z0Z3ZpZEFscDk1QVg0bkFVRTVnbHQza2pad29aNUFPZi9OOXBKSmN6dnFoUkVlU25aY3F6NFlDMTZZcmRJWGowWjluRU9yKzVUTUFFYWVrakUwSEdUNFZYMWZmbjFQcDA3Q0JUOVVVdGRia2NhUUx1SmNWb3JLQ0pkRjA4VXRKN1FrYXd4aFBOVy9Xa3ZxK203dVJyKzliRWVhV3plUktBVkVLazF3QWlVekpqdi9wbDZWdGJZUEowbDM4emdwSkloeU9keFY0b293TVVNWFVLaW11am4wR3VMTzVhclNiM2paZ2pEOXlyK25rRk42M3JaUkdDeEMrRVoxbGQ3ZWkvMjRlbHdZaWRrR3J0U1RCNHF1dGlhV3JxRGVETEpsall6dG8zN3dnQUFBQ1cifV19"
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6IkFBQUFDR0M4aXVobU95ZVdHL1NlYkJUbzdzVXRRWHdTTUJDd2xnOERVaTNaV3E5T0dFSWlIRFFGNUE4bFhqNmR2eDI5V1lsbzg3MVFEVDdTSnp4Rm9qdHJJT0ZaaHlwVjlrTElGWDM3ZDBja1crNjZBSXhuMDZtbEFOTWNKcG5TSmFnTWxCM0E1ZVRMd1dXU2pXWDBTNkxsbDU3MDlEcVprM25yZDlhODRZd1FSRWVwUWE3cDlKSE9tL1RrV3A1bkEyd09FaENSdVpBd3ZVdE50K1cyUUQxWDJ2TkwrN3BqR080NkI3ZDFzbC8xZWZSWmQxUjhSVVo5ZEVsSHFQcTlsN3l5OGtIUXNvaVI0T0JYY2JhV1dQTkgwdmVqaWU1K0pJVitCeFRpV09wUzJIT3VZVW80MXlsTDZGRUtsRm1LQXVITjhWRkJsV25DdDYyeTNNQ2FRQSttcS94RjJMNUhzNElZMG1BYXVFYkYxWWR3cnAvWlZRM2dLYzBrU29HNk1lYW9VVy9GUzZzSXVxd09sQ3BNUGJTYlZENFV4aGEvMWVGZzlIYnVIMDQ3T1pCTldZTmFQTkpDcXBLTS8xZXVoM05ySENmVlVudW1yMHpwSVZ5djB0ZjR1TDR6cVBuMzJYRjZYSDR0VUNtVEQ0YnFROVE4YjU5bTZNZUgyZ0RYcWVGdXgwaWFWT05wU1hHc2xKc1hidXFub2VxQVZsYllRM1BtalFOWU1rcWpscWtBR3RhcTlJTnlsckpicmF6ZEZlQTlzTjRSaXNMR2d1ZjgyNERZTUhiMGpzUWhQTzVIQzJCUkYyQmhHZzlpeXJ0Z3R0Z2wwMWNkeGRtWG5yT2dRSjhuL2dZTlB3anZsMEV4VnJac1BnTHdTT2wrWEQyTXlIeDAxamlvREpHTTJhNjZicDFTczZpaUtpYVJKWlNyZm9rWFoxQXVaSWllZ0l5U20yWDIvYi9WZ0F3QUFBQ1cifV19"
               }
             ]
           }
@@ -522,7 +522,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -536,14 +536,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -553,7 +553,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFlIiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0U4WS9heVdCWnFlWE5EdjFxZnc4Zlp3a0t4citTRkJpVjdmVVhyUHd3ZXZFZm5DL2JSOUp0QnJiM0FRQTFPNWpaWWcrSHJvaDQxK0lPOGJjVkYzMzZFLzJJbEdGNElEWGhaQ2F4aVlOWDU5am5EdDdiK1RSTzdQazhIdE9IMkVJRWhqcGZCRCtubGx3TEVqaU9hUmFSKytzQlNLTTl6aTBpZGdYLzlkMFdlMlhyZHZLZWxOM29mbk11Z2tjY29pWHFYOGxWeG9ScG1lNFJaQkF4bS9uWVpOeUhNQUtPL1J3MnRDU0U2M2xkUHlvMHJTTHgxWktGVkIzZEdqTmthNytFMTZEQUluWC9DYkdlNHo3V1JmbFA0eklQLzMrT0h4T3g4S0FRYnp4dmd2YWthTXhPZ0RBUjVCbjZkSmNnbUJIMGVjampQTkM4cWErNGI3aFBRSW56bzFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2xNNFlaU3dOMWxVaCtVTDhyR2p4aUN4TVFZcnR4RDM0NmFWRHZqaGlGcnRJd09UdXpabGRDaXRwNXhIa0tJVU9pVmR4RTNNM3BLUlBaS3AzYk5KL25kRWZTOGdaaXlRNWxvNDZHaWxWVll5eXJLdTRUcjB6WkRvUzhXUXkvNDdibDZ4cVRVUzVSSW5YK2VHazI1VWs4QXhXMGorQzllYWN6c3ZqL3R2NWRBa0xQWHZ2TEpuVGZPNHR1aXVwVU5JOXY3QXluY1hqNmpNOGh3blozUG5kOUVPbGhoVS9OZ1cvRmVtNFdhR1pxalNCUVlVZXBFRkw4TjNXQlZsMlA4Vm1pbUl4aElrSGQzN0VacDZ2YVBIaldsdUJRc1cybno3REd1ZWlrcDY3QjI2Sk5lQ05LQ2JvVjBKQi9TTmlpb0pMQ29xeUxrWmpxamd2czRFT2MreFV3MEFBQUFlIiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
               }
             ]
           }
@@ -571,7 +571,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "root": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "query": {
             "kind": "list_range",
             "start": 2,
@@ -580,7 +580,7 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "target": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
           "range_segments": [
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
             "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
@@ -588,14 +588,14 @@
           ],
           "prooflist": {
             "root": {
-              "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+              "/": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
             },
             "query": "range:2:18",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "query": "range:2:18",
                 "coordinate": "range:2:18",
@@ -605,7 +605,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "bagbkjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                  "/": "bagbmjqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
                 },
                 "segments": [
                   {
@@ -638,7 +638,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -652,14 +652,14 @@
           "target": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -669,7 +669,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0U4WS9heVdCWnFlWE5EdjFxZnc4Zlp3a0t4citTRkJpVjdmVVhyUHd3ZXZFZm5DL2JSOUp0QnJiM0FRQTFPNWpaWWcrSHJvaDQxK0lPOGJjVkYzMzZFLzJJbEdGNElEWGhaQ2F4aVlOWDU5am5EdDdiK1RSTzdQazhIdE9IMkVJRWhqcGZCRCtubGx3TEVqaU9hUmFSKytzQlNLTTl6aTBpZGdYLzlkMFdlMlhyZHZLZWxOM29mbk11Z2tjY29pWHFYOGxWeG9ScG1lNFJaQkF4bS9uWVpOeUhNQUtPL1J3MnRDU0U2M2xkUHlvMHJTTHgxWktGVkIzZEdqTmthNytFMTZEQUluWC9DYkdlNHo3V1JmbFA0eklQLzMrT0h4T3g4S0FRYnp4dmd2YWthTXhPZ0RBUjVCbjZkSmNnbUJIMGVjampQTkM4cWErNGI3aFBRSW56bzFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2xNNFlaU3dOMWxVaCtVTDhyR2p4aUN4TVFZcnR4RDM0NmFWRHZqaGlGcnRJd09UdXpabGRDaXRwNXhIa0tJVU9pVmR4RTNNM3BLUlBaS3AzYk5KL25kRWZTOGdaaXlRNWxvNDZHaWxWVll5eXJLdTRUcjB6WkRvUzhXUXkvNDdibDZ4cVRVUzVSSW5YK2VHazI1VWs4QXhXMGorQzllYWN6c3ZqL3R2NWRBa0xQWHZ2TEpuVGZPNHR1aXVwVU5JOXY3QXluY1hqNmpNOGh3blozUG5kOUVPbGhoVS9OZ1cvRmVtNFdhR1pxalNCUVlVZXBFRkw4TjNXQlZsMlA4Vm1pbUl4aElrSGQzN0VacDZ2YVBIaldsdUJRc1cybno3REd1ZWlrcDY3QjI2Sk5lQ05LQ2JvVjBKQi9TTmlpb0pMQ29xeUxrWmpxamd2czRFT2MreFV3MEFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -687,7 +687,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -701,14 +701,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -718,7 +718,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUE9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0U4WS9heVdCWnFlWE5EdjFxZnc4Zlp3a0t4citTRkJpVjdmVVhyUHd3ZXZFZm5DL2JSOUp0QnJiM0FRQTFPNWpaWWcrSHJvaDQxK0lPOGJjVkYzMzZFLzJJbEdGNElEWGhaQ2F4aVlOWDU5am5EdDdiK1RSTzdQazhIdE9IMkVJRWhqcGZCRCtubGx3TEVqaU9hUmFSKytzQlNLTTl6aTBpZGdYLzlkMFdlMlhyZHZLZWxOM29mbk11Z2tjY29pWHFYOGxWeG9ScG1lNFJaQkF4bS9uWVpOeUhNQUtPL1J3MnRDU0U2M2xkUHlvMHJTTHgxWktGVkIzZEdqTmthNytFMTZEQUluWC9DYkdlNHo3V1JmbFA0eklQLzMrT0h4T3g4S0FRYnp4dmd2YWthTXhPZ0RBUjVCbjZkSmNnbUJIMGVjampQTkM4cWErNGI3aFBRSW56bzFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2xNNFlaU3dOMWxVaCtVTDhyR2p4aUN4TVFZcnR4RDM0NmFWRHZqaGlGcnRJd09UdXpabGRDaXRwNXhIa0tJVU9pVmR4RTNNM3BLUlBaS3AzYk5KL25kRWZTOGdaaXlRNWxvNDZHaWxWVll5eXJLdTRUcjB6WkRvUzhXUXkvNDdibDZ4cVRVUzVSSW5YK2VHazI1VWs4QXhXMGorQzllYWN6c3ZqL3R2NWRBa0xQWHZ2TEpuVGZPNHR1aXVwVU5JOXY3QXluY1hqNmpNOGh3blozUG5kOUVPbGhoVS9OZ1cvRmVtNFdhR1pxalNCUVlVZXBFRkw4TjNXQlZsMlA4Vm1pbUl4aElrSGQzN0VacDZ2YVBIaldsdUJRc1cybno3REd1ZWlrcDY3QjI2Sk5lQ05LQ2JvVjBKQi9TTmlpb0pMQ29xeUxrWmpxamd2czRFT2MreFV3MEFBQUE9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
               }
             ]
           }
@@ -743,14 +743,14 @@
               "name"
             ]
           },
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
         },
         "result": {
           "profile": "malt.read/v0alpha1",
           "prooflist": {
             "query": "profile/name",
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "steps": [
               {
@@ -758,11 +758,11 @@
                 "evidence_backend": "map",
                 "evidence_kind": "structure",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "kind": "map_step",
                 "path": "profile/name",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ==",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0U4WS9heVdCWnFlWE5EdjFxZnc4Zlp3a0t4citTRkJpVjdmVVhyUHd3ZXZFZm5DL2JSOUp0QnJiM0FRQTFPNWpaWWcrSHJvaDQxK0lPOGJjVkYzMzZFLzJJbEdGNElEWGhaQ2F4aVlOWDU5am5EdDdiK1RSTzdQazhIdE9IMkVJRWhqcGZCRCtubGx3TEVqaU9hUmFSKytzQlNLTTl6aTBpZGdYLzlkMFdlMlhyZHZLZWxOM29mbk11Z2tjY29pWHFYOGxWeG9ScG1lNFJaQkF4bS9uWVpOeUhNQUtPL1J3MnRDU0U2M2xkUHlvMHJTTHgxWktGVkIzZEdqTmthNytFMTZEQUluWC9DYkdlNHo3V1JmbFA0eklQLzMrT0h4T3g4S0FRYnp4dmd2YWthTXhPZ0RBUjVCbjZkSmNnbUJIMGVjampQTkM4cWErNGI3aFBRSW56bzFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2xNNFlaU3dOMWxVaCtVTDhyR2p4aUN4TVFZcnR4RDM0NmFWRHZqaGlGcnRJd09UdXpabGRDaXRwNXhIa0tJVU9pVmR4RTNNM3BLUlBaS3AzYk5KL25kRWZTOGdaaXlRNWxvNDZHaWxWVll5eXJLdTRUcjB6WkRvUzhXUXkvNDdibDZ4cVRVUzVSSW5YK2VHazI1VWs4QXhXMGorQzllYWN6c3ZqL3R2NWRBa0xQWHZ2TEpuVGZPNHR1aXVwVU5JOXY3QXluY1hqNmpNOGh3blozUG5kOUVPbGhoVS9OZ1cvRmVtNFdhR1pxalNCUVlVZXBFRkw4TjNXQlZsMlA4Vm1pbUl4aElrSGQzN0VacDZ2YVBIaldsdUJRc1cybno3REd1ZWlrcDY3QjI2Sk5lQ05LQ2JvVjBKQi9TTmlpb0pMQ29xeUxrWmpxamd2czRFT2MreFV3MEFBQUFmIn1dfQ==",
                 "query": "profile/name",
                 "target": {
                   "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
@@ -786,7 +786,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -800,14 +800,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -817,7 +817,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0U4WS9heVdCWnFlWE5EdjFxZnc4Zlp3a0t4citTRkJpVjdmVVhyUHd3ZXZFZm5DL2JSOUp0QnJiM0FRQTFPNWpaWWcrSHJvaDQxK0lPOGJjVkYzMzZFLzJJbEdGNElEWGhaQ2F4aVlOWDU5am5EdDdiK1RSTzdQazhIdE9IMkVJRWhqcGZCRCtubGx3TEVqaU9hUmFSKytzQlNLTTl6aTBpZGdYLzlkMFdlMlhyZHZLZWxOM29mbk11Z2tjY29pWHFYOGxWeG9ScG1lNFJaQkF4bS9uWVpOeUhNQUtPL1J3MnRDU0U2M2xkUHlvMHJTTHgxWktGVkIzZEdqTmthNytFMTZEQUluWC9DYkdlNHo3V1JmbFA0eklQLzMrT0h4T3g4S0FRYnp4dmd2YWthTXhPZ0RBUjVCbjZkSmNnbUJIMGVjampQTkM4cWErNGI3aFBRSW56bzFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2xNNFlaU3dOMWxVaCtVTDhyR2p4aUN4TVFZcnR4RDM0NmFWRHZqaGlGcnRJd09UdXpabGRDaXRwNXhIa0tJVU9pVmR4RTNNM3BLUlBaS3AzYk5KL25kRWZTOGdaaXlRNWxvNDZHaWxWVll5eXJLdTRUcjB6WkRvUzhXUXkvNDdibDZ4cVRVUzVSSW5YK2VHazI1VWs4QXhXMGorQzllYWN6c3ZqL3R2NWRBa0xQWHZ2TEpuVGZPNHR1aXVwVU5JOXY3QXluY1hqNmpNOGh3blozUG5kOUVPbGhoVS9OZ1cvRmVtNFdhR1pxalNCUVlVZXBFRkw4TjNXQlZsMlA4Vm1pbUl4aElrSGQzN0VacDZ2YVBIaldsdUJRc1cybno3REd1ZWlrcDY3QjI2Sk5lQ05LQ2JvVjBKQi9TTmlpb0pMQ29xeUxrWmpxamd2czRFT2MreFV3MEFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -835,7 +835,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "query": {
             "kind": "list_index",
             "index": 0
@@ -846,14 +846,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "list:0",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -863,7 +863,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoaFBBdk52RFdVU2lCNVVlWXlqV1FHSW1Lc1JXNEQ4cXh1ZE9oYWkzOGsrSlpUdFVma0wraldPcmNYS2JZVDdQRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
               }
             ]
           }
@@ -881,7 +881,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26",
+          "root": "baga4fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -895,14 +895,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+              "/": "baga4fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+                  "/": "baga4fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -912,7 +912,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoaFBBdk52RFdVU2lCNVVlWXlqV1FHSW1Lc1JXNEQ4cXh1ZE9oYWkzOGsrSlpUdFVma0wraldPcmNYS2JZVDdQRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
               }
             ]
           }
@@ -930,7 +930,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2jqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x",
+          "root": "baga4jqabaayjae4h7mgutsgl4nlgxl2essqndkfhgylcz2ltn2lbegnycvmutvp72mr5x22o2qxlzvkkp2cq3bia",
           "query": {
             "kind": "list_index",
             "index": 1
@@ -941,14 +941,14 @@
           "target": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga",
           "prooflist": {
             "root": {
-              "/": "baga2jqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x"
+              "/": "baga4jqabaayjae4h7mgutsgl4nlgxl2essqndkfhgylcz2ltn2lbegnycvmutvp72mr5x22o2qxlzvkkp2cq3bia"
             },
             "query": "list:1",
             "steps": [
               {
                 "kind": "list_index",
                 "from": {
-                  "/": "baga2jqabaayjidmf3kr6plxhvjit4mw23iiwppfij2u2oj4k7klapqaaxam7zd6t7l4dikw4wncus4pcslwr6n5x"
+                  "/": "baga4jqabaayjae4h7mgutsgl4nlgxl2essqndkfhgylcz2ltn2lbegnycvmutvp72mr5x22o2qxlzvkkp2cq3bia"
                 },
                 "query": "list:1",
                 "coordinate": "1",
@@ -959,7 +959,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "list",
-                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6InJobFY3R1IxMGs0SCs0SVNDYmhFTm9zR2FNY1pLVHc3RVRidDh6cXhWTGNqekNiNVVCWldSc1gzT0haL3paa1ZRWHRyZVh0VTY3Qy9GMUQ0MnNjL0x0Tm8yaS9qWFZMQ29MSnlnY2libHI4QUFBQUEiLCJzdGVwcyI6W3sidGFyZ2V0IjoiQVZVU0lDZWtiLzNFZ21IazNnMzd6YjdlRHc2VTRLNDRZTUZJZnh4Z2RibTJXZ013IiwicHJvb2YiOiJwOFNwdWp4cis0WlBoQ0ZFUVNtbXlXakM0NW56TTg3blZhQmg0ZDZ4ZThROFd6MGRoY25RSk1FeVZqcGVaN1AyRHhzbXRZU3RadlRvVkxXMVFMYWZZVVpmMkJWT2ZuWFRiQlg0VmprcVRLVUFBQUFDIiwic2xvdCI6Mn1dfQ=="
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6ImdsaTlXejV4aG9CQWpkREZPT2ZQeVJBR05xajBDemZPZGdjWjI1M0M4Q2ZNRTNhTVJnSnBqZi84UVp5VkwwSGhRWHRyZVh0VTY3Qy9GMUQ0MnNjL0x0Tm8yaS9qWFZMQ29MSnlnY2libHI4QUFBQUEiLCJzdGVwcyI6W3sidGFyZ2V0IjoiQVZVU0lDZWtiLzNFZ21IazNnMzd6YjdlRHc2VTRLNDRZTUZJZnh4Z2RibTJXZ013IiwicHJvb2YiOiJ1RmxLWjlsTHlkWE9uVVdSNktqUkVXVUVEZ2dLT2F4L3lGYzB0VW9tYTdBck1XdFZCQzd1UHFsN1dEVmlZZjBwRHhzbXRZU3RadlRvVkxXMVFMYWZZVVpmMkJWT2ZuWFRiQlg0VmprcVRLVUFBQUFDIiwic2xvdCI6Mn1dfQ=="
               }
             ]
           }
@@ -977,7 +977,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "root": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
           "query": {
             "kind": "list_range",
             "start": 2,
@@ -986,7 +986,7 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "target": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
           "range_segments": [
             "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
@@ -994,14 +994,14 @@
           ],
           "prooflist": {
             "root": {
-              "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+              "/": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
             },
             "query": "range:2:18",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
                 },
                 "query": "range:2:18",
                 "coordinate": "range:2:18",
@@ -1011,7 +1011,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
                 },
                 "segments": [
                   {
@@ -1026,7 +1026,7 @@
                 ],
                 "evidence_kind": "structure",
                 "evidence_backend": "measured_list",
-                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6InFaeS9WU2VGa0pkL1V6Lzk0cVRTL2U5eXl4VmNhZGpPUytmK3dOWkFFcHFXUjBJWEZ1dXhOdEZ3L3BjdDl1NTBFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTakJrVmxRNGFuUnpSVFpzTldWeE9WY3djV3R2UVhKelJrUkxZak12Y1c1MU5uTTBibkp3YTNVNGR5SXNJbkJ5YjI5bUlqb2lhblIwYTJjd00yTnNPVzU0TVhWRFpsWklkMUZ4VG05MloweGFWV3haTTFFemRYRlRSSFV3VFVGalYxcHhlVXA0Tm5KamFuSnBibUZ5SzBGU2VFZG9WMEU0YmtORmNHdEpOa1pwVVVoSmMycG1VblJ0Y2tad1ZIcHZVbE5aTmt4d2N6Z3pSVWhPYTFabllsRkJRVUZCUWlJc0luTnNiM1FpT2pGOVhYMD0ifSx7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2laM1p5YTNaUVYwVllaVzlwT0hFNFpWbHBhR3RrZFdaWU5GcHJOR3RtV2pkNFJWUjFSRVkyT0VwTmNFTXJWVFJ1Y214VFJqWmFOSG8yZERGT1FXOUpXRlJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2ljV3N6Y3l0d1NGWXZLMmhJYWpoUlUxRXljVXBxVTNBeFVUTk1jVTFtWWt3NEwwbHJRV05NUm1abWVuQkViMWN3V0dGak9YcHpUMnRaY0ZwMVJ5dEphVlJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6ImpFRWhNMTNpRmdrRGd3WWZrVXArMk53T1lnVitJWEliVzVqcjRFSEE4MnNBZDd3VUNFVXUwNmVBT1p6N2RVNmtFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTakJrVmxRNGFuUnpSVFpzTldWeE9WY3djV3R2UVhKelJrUkxZak12Y1c1MU5uTTBibkp3YTNVNGR5SXNJbkJ5YjI5bUlqb2lhMEpqU0d4SU0wOVJObk41SzFCaFMzVjBLMnBoWmtaUVRrdzRPRmxVTDFScmIwVmljVkJwVmt0V1puZ3lTalpvT0hJMVlrUkdVMnhhUjB4NGVrOTNaMEU0YmtORmNHdEpOa1pwVVVoSmMycG1VblJ0Y2tad1ZIcHZVbE5aTmt4d2N6Z3pSVWhPYTFabllsRkJRVUZCUWlJc0luTnNiM1FpT2pGOVhYMD0ifSx7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2lkVXhEY3pCUU9VUTBOMDVJWldZNVduazFabHA1TWxZMU5FaFFRbmx4U1U0emNXbENTMVZqYmpKRFp5OTVNbW92YldVNWRUQlNhMHQxUVZFNVpTdEhLMVJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2laMjlUYkZJek9YVTJObkJ3UzFoR01YUXpibkJUSzJkdFowb3hNelZYUkV3eVYwTjJWV1ZoZFZkVWFHeHVjVWRYVmxKV1ltVm1jV013VjA1aGNVVktObFJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
               }
             ]
           }
@@ -1044,7 +1044,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "root": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
           "query": {
             "kind": "list_range",
             "start": 8
@@ -1052,21 +1052,21 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "target": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
           "range_segments": [
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
             "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
           ],
           "prooflist": {
             "root": {
-              "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+              "/": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
             },
             "query": "range:8:",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
                 },
                 "query": "range:8:",
                 "coordinate": "range:8:",
@@ -1075,7 +1075,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
                 },
                 "segments": [
                   {
@@ -1087,7 +1087,7 @@
                 ],
                 "evidence_kind": "structure",
                 "evidence_backend": "measured_list",
-                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6InFaeS9WU2VGa0pkL1V6Lzk0cVRTL2U5eXl4VmNhZGpPUytmK3dOWkFFcHFXUjBJWEZ1dXhOdEZ3L3BjdDl1NTBFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2laM1p5YTNaUVYwVllaVzlwT0hFNFpWbHBhR3RrZFdaWU5GcHJOR3RtV2pkNFJWUjFSRVkyT0VwTmNFTXJWVFJ1Y214VFJqWmFOSG8yZERGT1FXOUpXRlJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2ljV3N6Y3l0d1NGWXZLMmhJYWpoUlUxRXljVXBxVTNBeFVUTk1jVTFtWWt3NEwwbHJRV05NUm1abWVuQkViMWN3V0dGak9YcHpUMnRaY0ZwMVJ5dEphVlJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6ImpFRWhNMTNpRmdrRGd3WWZrVXArMk53T1lnVitJWEliVzVqcjRFSEE4MnNBZDd3VUNFVXUwNmVBT1p6N2RVNmtFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2lkVXhEY3pCUU9VUTBOMDVJWldZNVduazFabHA1TWxZMU5FaFFRbmx4U1U0emNXbENTMVZqYmpKRFp5OTVNbW92YldVNWRUQlNhMHQxUVZFNVpTdEhLMVJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2laMjlUYkZJek9YVTJObkJ3UzFoR01YUXpibkJUSzJkdFowb3hNelZYUkV3eVYwTjJWV1ZoZFZkVWFHeHVjVWRYVmxKV1ltVm1jV013VjA1aGNVVktObFJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
               }
             ]
           }
@@ -1112,14 +1112,14 @@
               "name"
             ]
           },
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
         },
         "result": {
           "profile": "malt.read/v0alpha1",
           "prooflist": {
             "query": "profile/name",
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "steps": [
               {
@@ -1127,7 +1127,7 @@
                 "evidence_backend": "map",
                 "evidence_kind": "structure",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "kind": "map_step",
                 "path": "profile/name",
@@ -1154,7 +1154,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1168,14 +1168,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -1185,7 +1185,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoaFBBdk52RFdVU2lCNVVlWXlqV1FHSW1Lc1JXNEQ4cXh1ZE9oYWkzOGsrSlpUdFVma0wraldPcmNYS2JZVDdQRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
               }
             ]
           }
@@ -1203,7 +1203,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1217,14 +1217,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -1251,7 +1251,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1264,14 +1264,14 @@
           "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "@payload",
             "steps": [
               {
                 "kind": "payload_binding",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "@payload",
                 "coordinate": "@payload",
@@ -1281,7 +1281,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6Imc0ckIrT0pocU1KblNVT3l0MDh1Wlc3Z1lBdDhrUW1HV0FKbkQ2L1FKbGJtTndrem9GMHRubGU2UzZkZzRnaUxQSDd6am0vMm1aOEJBa3RsQWtEQUcxWXVNU2xuYk5xQ3NoWXgyRVFWQWdRQUFBQ1cifV19"
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6InJ6ZHQxajJlbU54V1YzemNXUlNLMmJ1bWdNOXdpNlFiRit3OUZhYXdZN295SlFXSkNXMHhRZVJua1IxWDZ1NElQSDd6am0vMm1aOEJBa3RsQWtEQUcxWXVNU2xuYk5xQ3NoWXgyRVFWQWdRQUFBbGcifV19"
               }
             ]
           }
@@ -1299,7 +1299,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1313,14 +1313,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -1330,7 +1330,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFlIiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJoaFBBdk52RFdVU2lCNVVlWXlqV1FHSW1Lc1JXNEQ4cXh1ZE9oYWkzOGsrSlpUdFVma0wraldPcmNYS2JZVDdQRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh4Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
               }
             ]
           }
@@ -1348,7 +1348,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "root": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
           "query": {
             "kind": "list_range",
             "start": 2,
@@ -1357,7 +1357,7 @@
         },
         "result": {
           "profile": "malt.read/v0alpha1",
-          "target": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er",
+          "target": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
           "range_segments": [
             "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
             "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
@@ -1365,14 +1365,14 @@
           ],
           "prooflist": {
             "root": {
-              "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+              "/": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
             },
             "query": "range:2:18",
             "steps": [
               {
                 "kind": "list_range",
                 "from": {
-                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
                 },
                 "query": "range:2:18",
                 "coordinate": "range:2:18",
@@ -1382,7 +1382,7 @@
                 "total_size": 20,
                 "chunk_size": 8,
                 "target": {
-                  "/": "baga2jqabaaylgtu3aywcdczystraa7rbb7rxvx4haohu6djjzh4dxtt35bfafxsjclobwbwlg72wwdv3jhqmu4er"
+                  "/": "baga4jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
                 },
                 "segments": [
                   {
@@ -1397,7 +1397,7 @@
                 ],
                 "evidence_kind": "structure",
                 "evidence_backend": "measured_list",
-                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6InFaeS9WU2VGa0pkL1V6Lzk0cVRTL2U5eXl4VmNhZGpPUytmK3dOWkFFcHFXUjBJWEZ1dXhOdEZ3L3BjdDl1NTBFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTakJrVmxRNGFuUnpSVFpzTldWeE9WY3djV3R2UVhKelJrUkxZak12Y1c1MU5uTTBibkp3YTNVNGR5SXNJbkJ5YjI5bUlqb2lhblIwYTJjd00yTnNPVzU0TVhWRFpsWklkMUZ4VG05MloweGFWV3haTTFFemRYRlRSSFV3VFVGalYxcHhlVXA0Tm5KamFuSnBibUZ5SzBGU2VFZG9WMEU0YmtORmNHdEpOa1pwVVVoSmMycG1VblJ0Y2tad1ZIcHZVbE5aTmt4d2N6Z3pSVWhPYTFabllsRkJRVUZCUWlJc0luTnNiM1FpT2pGOVhYMD0ifSx7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2laM1p5YTNaUVYwVllaVzlwT0hFNFpWbHBhR3RrZFdaWU5GcHJOR3RtV2pkNFJWUjFSRVkyT0VwTmNFTXJWVFJ1Y214VFJqWmFOSG8yZERGT1FXOUpXRlJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkluRmFlUzlXVTJWR2EwcGtMMVY2THprMGNWUlRMMlU1ZVhsNFZtTmhaR3BQVXl0bUszZE9Xa0ZGY0hGWFVqQkpXRVoxZFhoT2RFWjNMM0JqZERsMU5UQkZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2ljV3N6Y3l0d1NGWXZLMmhJYWpoUlUxRXljVXBxVTNBeFVUTk1jVTFtWWt3NEwwbHJRV05NUm1abWVuQkViMWN3V0dGak9YcHpUMnRaY0ZwMVJ5dEphVlJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6ImpFRWhNMTNpRmdrRGd3WWZrVXArMk53T1lnVitJWEliVzVqcjRFSEE4MnNBZDd3VUNFVXUwNmVBT1p6N2RVNmtFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTakJrVmxRNGFuUnpSVFpzTldWeE9WY3djV3R2UVhKelJrUkxZak12Y1c1MU5uTTBibkp3YTNVNGR5SXNJbkJ5YjI5bUlqb2lhMEpqU0d4SU0wOVJObk41SzFCaFMzVjBLMnBoWmtaUVRrdzRPRmxVTDFScmIwVmljVkJwVmt0V1puZ3lTalpvT0hJMVlrUkdVMnhhUjB4NGVrOTNaMEU0YmtORmNHdEpOa1pwVVVoSmMycG1VblJ0Y2tad1ZIcHZVbE5aTmt4d2N6Z3pSVWhPYTFabllsRkJRVUZCUWlJc0luTnNiM1FpT2pGOVhYMD0ifSx7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2lkVXhEY3pCUU9VUTBOMDVJWldZNVduazFabHA1TWxZMU5FaFFRbmx4U1U0emNXbENTMVZqYmpKRFp5OTVNbW92YldVNWRUQlNhMHQxUVZFNVpTdEhLMVJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2laMjlUYkZJek9YVTJObkJ3UzFoR01YUXpibkJUSzJkdFowb3hNelZYUkV3eVYwTjJWV1ZoZFZkVWFHeHVjVWRYVmxKV1ltVm1jV013VjA1aGNVVktObFJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
               }
             ]
           }
@@ -1415,7 +1415,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1429,14 +1429,14 @@
           "target": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -1446,7 +1446,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoaFBBdk52RFdVU2lCNVVlWXlqV1FHSW1Lc1JXNEQ4cXh1ZE9oYWkzOGsrSlpUdFVma0wraldPcmNYS2JZVDdQRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
               }
             ]
           }
@@ -1464,7 +1464,7 @@
       "verification": {
         "request": {
           "profile": "malt.read/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "query": {
             "kind": "map_key",
             "segments": [
@@ -1478,14 +1478,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "profile/name",
                 "coordinate": "profile/name",
@@ -1495,7 +1495,7 @@
                 },
                 "evidence_kind": "structure",
                 "evidence_backend": "map",
-                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUE9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJoaFBBdk52RFdVU2lCNVVlWXlqV1FHSW1Lc1JXNEQ4cXh1ZE9oYWkzOGsrSlpUdFVma0wraldPcmNYS2JZVDdQRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUU9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
               }
             ]
           }
@@ -1520,14 +1520,14 @@
               "name"
             ]
           },
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
         },
         "result": {
           "profile": "malt.read/v0alpha1",
           "prooflist": {
             "query": "profile/name",
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "steps": [
               {
@@ -1535,11 +1535,11 @@
                 "evidence_backend": "map",
                 "evidence_kind": "structure",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "kind": "map_step",
                 "path": "profile/name",
-                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ==",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoaFBBdk52RFdVU2lCNVVlWXlqV1FHSW1Lc1JXNEQ4cXh1ZE9oYWkzOGsrSlpUdFVma0wraldPcmNYS2JZVDdQRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ==",
                 "query": "profile/name",
                 "target": {
                   "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
@@ -1589,7 +1589,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
+          "root": "bagbmfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
           "segments": [
             "docs",
             "leaf"
@@ -1600,27 +1600,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+              "/": "bagbmfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+                  "/": "bagbmfqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNDcEtnOG03dW9wbGlsbWczY25wdkdqaWJBRVR3Z1ZQV29XNUpES2ZpZittWkZGcmQvdHoxc3BVbHFZTXZWKzJiVFlCMGp6YVFuVkNPOXhCY1h3MlpzQUg3QlFxQVBQSnVBS1c4Tk1zMUVjVmVuOGdYQmJnaXBZS0pKanM1blZqamdYZkpueXJkSkZkVVJsM0pEMGJhRUxIQzdxRWU3MnkzcnhwQ1U1TlBiQUZEMmhlWkRuK1BNM21IeHlwd3lQUWpWODdvSDhHdUhJRUdtS3VwZzA3Q2ZWUmV0UHNjQ3Z2MzJrWmIvbmdEN2FrZHJmTUZnUkd3WTFwUU9YMmtTU09RbWllT2F2TVBqNlU1Z3FPNUNVS0gvNURIbDlrS3lrVlJIOHJoYkphZDlNU1J2eHJvKy9jOGRxUEsyUTZIclg4NG0reE5hVTRsc3ZhOTY1TVVjSFhyOFlyYnVQVHhacHlLR0VqaU5TUVpmN3NpNEcveHdLS1JBNnRtNG11YVhrQzBsUnVHcVhNOURTdW1QREZ0dk1UVTd6UWhCTDBYV1RIYnBUOUVXMTFuYnYyUHBrZ3pIemxiNC8wdEo4Tlc3SjhBbVgwaEpmRU1xZGVYUVhrMkhTRHZVa0tGRHFPaHlBV1RHaGpVd0w4UENvZkt6M3pKekVsSGZpREpneUs1RmlNYVcremhUbFJJZE9lc3VSL2UzWlJvV1QwWUMrcFYxa2V3WllWNDZ0Z3JLRHNRMExyRW9aTTRId2s3NUpoSlphOE1EQkZIZmYrZ2VoSWk0bC9uWnNXV1dSZXBLQjZaMHVnNWtGdEowOFJkeTNHWUs5YzRxeGVCendVT2U1SlZhZXhBbHhlZnRBbHpLUGN1TGFJTWZYMlNNemhqVlpJWnNlcDN0aVJ1N3hjcEJ1NDc2djM4SDdXWVY1ZzR6Sk1MSUlaRXlTOTlad3pKR1JJTndCSGsrblJRQU1BQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMQ3dBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNBdXFUaENEei9VdE9CQ1RxMFdyak9HMDJvNlQ1dXhWN0ZsM25QQWJLVzZEYTFNbDhJcjNwSTlGUmx3bExNT0I0VXBiSVdmRTY0L0Z2QnBneFBQTS9wVncxMDJzcEUxcFhXS3Q1M0traGR1VGpCcm1uTXN5Q3gwWWdyQXZUZWFFTENXQXIwM2QweVZKTThoblkzaEE3Y05mTXlHRTdYN05McHRIbmVuaFNReGpDNjB3RjRtdktHUVBMaWtpY09zaUwvTHUrcFdrYUFES25FbmVCOWdJYS9vM2RiMnlPRGE3WXVBUmpoeHU5OGhBdjJDNE5ZcXdkOVpnNVpsdVZsS0l0MWhQTDZEU3pMQ0hKZkdoVXlZTkI2NGpDRUl1clRxR0kvSHhsVE5PRmJqSURPL3h0ZTJqMEVCL3NqdmRIcVAxM0RKOTNjcFd5alRHNFhGcHEvRG04R1UxaUNIL05NaFdRM1pUaG9lbzZkNTNDQmpIRzVnREJ3NXVmRi9sTkpIeVNpZk04TjcvWkJjR3l2ZjVpV3Y3S3h5KzhXUzUxRUZ4VGpnRFdaT0ZSRStXSTVwUjNrSDZpRWdPdlowR3U3MGZrSVVDYmxoK3N2ME11cm5nRE42Qmc5QWgyYU9XYThTNkdyQTJ2TUlPa3JtSThBWVB6L21hcnQ2MjN4cCswUEVta1NrN3poU1FRTy94ZHc5WUlYRXEwRCtNQ0ZnVFlPbXowZlorZiswU0pnaTFZeVp5SWZkbzJOVWp3TEdZdXlSMWZZc0g3RXNLSlZUWTlZV2JFNnU0Rll4WnZtVWloM1dtWlJxVDdYakp0MVBiMGNCWTFYci8zVlo1a0pkWkpISFdpVUFRMWMwbm1iZEpGWTBkNVcxMnhSMlZkU3lYSlNUQk8zeTRzS3l0eE5GWS9wZlJTOXVLSzRDKy9pcFNGdUVGdWxHbmJaSnJQbnhhOWprWGY0aHIzd1lBQUFCRyJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -1646,7 +1646,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "segments": [
             "docs",
             "leaf"
@@ -1657,27 +1657,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0NwS2c4bTd1b3BsaWxtZzNjbnB2R2ppYkFFVHdnVlBXb1c1SkRLZmlmK21aRkZyZC90ejFzcFVscVlNdlYrMmJUWUIwanphUW5WQ085eEJjWHcyWnNBSDdCUXFBUFBKdUFLVzhOTXMxRWNWZW44Z1hCYmdpcFlLSkpqczVuVmpqZ1hmSm55cmRKRmRVUmwzSkQwYmFFTEhDN3FFZTcyeTNyeHBDVTVOUGJBRkQyaGVaRG4rUE0zbUh4eXB3eVBRalY4N29IOEd1SElFR21LdXBnMDdDZlZSZXRQc2NDdnYzMmtaYi9uZ0Q3YWtkcmZNRmdSR3dZMXBRT1gya1NTT1FtaWVPYXZNUGo2VTVncU81Q1VLSC81REhsOWtLeWtWUkg4cmhiSmFkOU1TUnZ4cm8rL2M4ZHFQSzJRNkhyWDg0bSt4TmFVNGxzdmE5NjVNVWNIWHI4WXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGxSdUdxWE05RFN1bVBERnR2TVRVN3pRaEJMMFhXVEhicFQ5RVcxMW5idjJQcGtnekh6bGI0LzB0SjhOVzdKOEFtWDBoSmZFTXFkZVhRWGsySFNEdlVrS0ZEcU9oeUFXVEdoalV3TDhQQ29mS3ozekp6RWxIZmlESmd5SzVGaU1hVyt6aFRsUklkT2VzdVIvZTNaUm9XVDBZQytwVjFrZXdaWVY0NnRncktEc1EwTHJFb1pNNEh3azc1SmhKWmE4TURCRkhmZitnZWhJaTRsL25ac1dXV1JlcEtCNlowdWc1a0Z0SjA4UmR5M0dZSzljNHF4ZUJ6d1VPZTVKVmFleEFseGVmdEFsektQY3VMYUlNZlgyU016aGpWWklac2VwM3RpUnU3eGNwQnU0NzZ2MzhIN1dZVjVnNHpKTUxJSVpFeVM5OVp3ekpHUklOd0JIaytuUlFBTUFBQUJIIiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0F1cVRoQ0R6L1V0T0JDVHEwV3JqT0cwMm82VDV1eFY3RmwzblBBYktXNkRhMU1sOElyM3BJOUZSbHdsTE1PQjRVcGJJV2ZFNjQvRnZCcGd4UFBNL3BWdzEwMnNwRTFwWFdLdDUzS2toZHVUakJybW5Nc3lDeDBZZ3JBdlRlYUVMQ1dBcjAzZDB5VkpNOGhuWTNoQTdjTmZNeUdFN1g3TkxwdEhuZW5oU1F4akM2MHdGNG12S0dRUExpa2ljT3NpTC9MdStwV2thQURLbkVuZUI5Z0lhL28zZGIyeU9EYTdZdUFSamh4dTk4aEF2MkM0Tllxd2Q5Wmc1Wmx1VmxLSXQxaFBMNkRTekxDSEpmR2hVeVlOQjY0akNFSXVyVHFHSS9IeGxUTk9GYmpJRE8veHRlMmowRUIvc2p2ZEhxUDEzREo5M2NwV3lqVEc0WEZwcS9EbThHVTFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2lmTThONy9aQmNHeXZmNWlXdjdLeHkrOFdTNTFFRnhUamdEV1pPRlJFK1dJNXBSM2tINmlFZ092WjBHdTcwZmtJVUNibGgrc3YwTXVybmdETjZCZzlBaDJhT1dhOFM2R3JBMnZNSU9rcm1JOEFZUHovbWFydDYyM3hwKzBQRW1rU2s3emhTUVFPL3hkdzlZSVhFcTBEK01DRmdUWU9tejBmWitmKzBTSmdpMVl5WnlJZmRvMk5VandMR1l1eVIxZllzSDdFc0tKVlRZOVlXYkU2dTRGWXhadm1VaWgzV21aUnFUN1hqSnQxUGIwY0JZMVhyLzNWWjVrSmRaSkhIV2lVQVExYzBubWJkSkZZMGQ1VzEyeFIyVmRTeVhKU1RCTzN5NHNLeXR4TkZZL3BmUlM5dUtLNEMrL2lwU0Z1RUZ1bEduYlpKclBueGE5amtYZjRocjN3WUFBQUJIIiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMQ3dBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -1703,7 +1703,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "segments": [
             "docs",
             "leaf"
@@ -1714,27 +1714,27 @@
           "prooflist": {
             "query": "docs/leaf",
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "steps": [
               {
                 "evidence": "not-base64%%%",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "kind": "map_step",
                 "path": "docs",
                 "query": "docs",
                 "target": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 }
               },
               {
                 "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ==",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "kind": "map_step",
                 "path": "leaf",
@@ -1760,7 +1760,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "segments": [
             "profile",
             "name"
@@ -1771,14 +1771,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "profile/name",
                 "path": "profile/name",
@@ -1786,7 +1786,7 @@
                   "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FBY0FnYnAzb0YyYlpNZWI4M0F2WHZtTitleEZaZEs5ZlNXS2llNzhLMFZjOUxMMnRjdktOTHdkSTUyZ2U0WVRoSnZLcXZXMlliWENpeE9iaGJCdWp3UHhoSnA2VzNnaFVqM0hDbXdFTUpBV3p2clJGNExsUm96eXlWeEJDUWM5bUVNUHZWZzhMRVVDcTZORzNCbmZkTCs2U216dFMrTUlQT2h6YzdYdGJKME5QZmxwcEF4Z1lhNFk0a0V6em1WZHl0aFlnbFVZWGZCL1lQckp0dHNxQ3hnNEZPMWtXRDJENzJ2ZUkxOENYMUZhblAxd21PMzZxTzZ3cTM3UERPcndYR2g2NGIxd0RWZ250YnMzNXovbXZacTRTcVJrakV0WFVOb25YMDFoSlVvTm5jazhmd1RtL2d1MTBBSk1oejEvMDBMYUg2cHZrOXVWVkdKa1pneXhNUXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGd6R2RpL1hSdWhJNXd1ZWxuUWRiUldkTFIxamVZR0hqREZxSHZpS3VSeXNFT2QwT3NMcHRDRi9zQ3ZwekZoSURUclg5T2lIWXpMVXJhckJDbFFuZVVwa1h0MDJrM25vRkNWdTZBQ2s2ZERSU0VMbEx1a1FXL3VpWE5sMzRMQ2kyUVpXbXoyOEJVWUFLZHJHZHEvUmJTeUFROFg0Unl5Q3RHM2lYa01ZbFZiMlJoaTlNNHlSMzViTENrRStYZDVBSFFTSzF3UUY2ZkdrN0o4NnZtSExjS05COHE5bUFkYWNhcHdRZU13YVJLZ0M5a0MzSnZnNEdUMnpRcUsrc1Vaak5FdHJrcTJxaUZZalZSc1kzbVlFVDNqTFhTdFpJbW5ZSmk1dGdObmdieFpNYTVpM0JxUWxiL3pkb05WaFI1WXlTSWtYZHdGNGdFd1NWRW1MYUx1YjFBSUFBQUFmIn1dfQ=="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0U4WS9heVdCWnFlWE5EdjFxZnc4Zlp3a0t4citTRkJpVjdmVVhyUHd3ZXZFZm5DL2JSOUp0QnJiM0FRQTFPNWpaWWcrSHJvaDQxK0lPOGJjVkYzMzZFLzJJbEdGNElEWGhaQ2F4aVlOWDU5am5EdDdiK1RSTzdQazhIdE9IMkVJRWhqcGZCRCtubGx3TEVqaU9hUmFSKytzQlNLTTl6aTBpZGdYLzlkMFdlMlhyZHZLZWxOM29mbk11Z2tjY29pWHFYOGxWeG9ScG1lNFJaQkF4bS9uWVpOeUhNQUtPL1J3MnRDU0U2M2xkUHlvMHJTTHgxWktGVkIzZEdqTmthNytFMTZEQUluWC9DYkdlNHo3V1JmbFA0eklQLzMrT0h4T3g4S0FRYnp4dmd2YWthTXhPZ0RBUjVCbjZkSmNnbUJIMGVjampQTkM4cWErNGI3aFBRSW56bzFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2xNNFlaU3dOMWxVaCtVTDhyR2p4aUN4TVFZcnR4RDM0NmFWRHZqaGlGcnRJd09UdXpabGRDaXRwNXhIa0tJVU9pVmR4RTNNM3BLUlBaS3AzYk5KL25kRWZTOGdaaXlRNWxvNDZHaWxWVll5eXJLdTRUcjB6WkRvUzhXUXkvNDdibDZ4cVRVUzVSSW5YK2VHazI1VWs4QXhXMGorQzllYWN6c3ZqL3R2NWRBa0xQWHZ2TEpuVGZPNHR1aXVwVU5JOXY3QXluY1hqNmpNOGh3blozUG5kOUVPbGhoVS9OZ1cvRmVtNFdhR1pxalNCUVlVZXBFRkw4TjNXQlZsMlA4Vm1pbUl4aElrSGQzN0VacDZ2YVBIaldsdUJRc1cybno3REd1ZWlrcDY3QjI2Sk5lQ05LQ2JvVjBKQi9TTmlpb0pMQ29xeUxrWmpxamd2czRFT2MreFV3MEFBQUFmIn1dfQ=="
               }
             ]
           }
@@ -1804,7 +1804,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "segments": [
             "docs",
             "leaf"
@@ -1815,26 +1815,26 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit"
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -1860,7 +1860,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "segments": [
             "docs",
             "leaf"
@@ -1871,27 +1871,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNDcEtnOG03dW9wbGlsbWczY25wdkdqaWJBRVR3Z1ZQV29XNUpES2ZpZittWkZGcmQvdHoxc3BVbHFZTXZWKzJiVFlCMGp6YVFuVkNPOXhCY1h3MlpzQUg3QlFxQVBQSnVBS1c4Tk1zMUVjVmVuOGdYQmJnaXBZS0pKanM1blZqamdYZkpueXJkSkZkVVJsM0pEMGJhRUxIQzdxRWU3MnkzcnhwQ1U1TlBiQUZEMmhlWkRuK1BNM21IeHlwd3lQUWpWODdvSDhHdUhJRUdtS3VwZzA3Q2ZWUmV0UHNjQ3Z2MzJrWmIvbmdEN2FrZHJmTUZnUkd3WTFwUU9YMmtTU09RbWllT2F2TVBqNlU1Z3FPNUNVS0gvNURIbDlrS3lrVlJIOHJoYkphZDlNU1J2eHJvKy9jOGRxUEsyUTZIclg4NG0reE5hVTRsc3ZhOTY1TVVjSFhyOFlyYnVQVHhacHlLR0VqaU5TUVpmN3NpNEcveHdLS1JBNnRtNG11YVhrQzBsUnVHcVhNOURTdW1QREZ0dk1UVTd6UWhCTDBYV1RIYnBUOUVXMTFuYnYyUHBrZ3pIemxiNC8wdEo4Tlc3SjhBbVgwaEpmRU1xZGVYUVhrMkhTRHZVa0tGRHFPaHlBV1RHaGpVd0w4UENvZkt6M3pKekVsSGZpREpneUs1RmlNYVcremhUbFJJZE9lc3VSL2UzWlJvV1QwWUMrcFYxa2V3WllWNDZ0Z3JLRHNRMExyRW9aTTRId2s3NUpoSlphOE1EQkZIZmYrZ2VoSWk0bC9uWnNXV1dSZXBLQjZaMHVnNWtGdEowOFJkeTNHWUs5YzRxeGVCendVT2U1SlZhZXhBbHhlZnRBbHpLUGN1TGFJTWZYMlNNemhqVlpJWnNlcDN0aVJ1N3hjcEJ1NDc2djM4SDdXWVY1ZzR6Sk1MSUlaRXlTOTlad3pKR1JJTndCSGsrblJRQU1BQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMQ3dBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNBdXFUaENEei9VdE9CQ1RxMFdyak9HMDJvNlQ1dXhWN0ZsM25QQWJLVzZEYTFNbDhJcjNwSTlGUmx3bExNT0I0VXBiSVdmRTY0L0Z2QnBneFBQTS9wVncxMDJzcEUxcFhXS3Q1M0traGR1VGpCcm1uTXN5Q3gwWWdyQXZUZWFFTENXQXIwM2QweVZKTThoblkzaEE3Y05mTXlHRTdYN05McHRIbmVuaFNReGpDNjB3RjRtdktHUVBMaWtpY09zaUwvTHUrcFdrYUFES25FbmVCOWdJYS9vM2RiMnlPRGE3WXVBUmpoeHU5OGhBdjJDNE5ZcXdkOVpnNVpsdVZsS0l0MWhQTDZEU3pMQ0hKZkdoVXlZTkI2NGpDRUl1clRxR0kvSHhsVE5PRmJqSURPL3h0ZTJqMEVCL3NqdmRIcVAxM0RKOTNjcFd5alRHNFhGcHEvRG04R1UxaUNIL05NaFdRM1pUaG9lbzZkNTNDQmpIRzVnREJ3NXVmRi9sTkpIeVNpZk04TjcvWkJjR3l2ZjVpV3Y3S3h5KzhXUzUxRUZ4VGpnRFdaT0ZSRStXSTVwUjNrSDZpRWdPdlowR3U3MGZrSVVDYmxoK3N2ME11cm5nRE42Qmc5QWgyYU9XYThTNkdyQTJ2TUlPa3JtSThBWVB6L21hcnQ2MjN4cCswUEVta1NrN3poU1FRTy94ZHc5WUlYRXEwRCtNQ0ZnVFlPbXowZlorZiswU0pnaTFZeVp5SWZkbzJOVWp3TEdZdXlSMWZZc0g3RXNLSlZUWTlZV2JFNnU0Rll4WnZtVWloM1dtWlJxVDdYakp0MVBiMGNCWTFYci8zVlo1a0pkWkpISFdpVUFRMWMwbm1iZEpGWTBkNVcxMnhSMlZkU3lYSlNUQk8zeTRzS3l0eE5GWS9wZlJTOXVLSzRDKy9pcFNGdUVGdWxHbmJaSnJQbnhhOWprWGY0aHIzd1lBQUFCRyJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -1917,7 +1917,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "segments": [
             "docs",
             "@payload"
@@ -1928,27 +1928,27 @@
           "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "docs/@payload",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNDcEtnOG03dW9wbGlsbWczY25wdkdqaWJBRVR3Z1ZQV29XNUpES2ZpZittWkZGcmQvdHoxc3BVbHFZTXZWKzJiVFlCMGp6YVFuVkNPOXhCY1h3MlpzQUg3QlFxQVBQSnVBS1c4Tk1zMUVjVmVuOGdYQmJnaXBZS0pKanM1blZqamdYZkpueXJkSkZkVVJsM0pEMGJhRUxIQzdxRWU3MnkzcnhwQ1U1TlBiQUZEMmhlWkRuK1BNM21IeHlwd3lQUWpWODdvSDhHdUhJRUdtS3VwZzA3Q2ZWUmV0UHNjQ3Z2MzJrWmIvbmdEN2FrZHJmTUZnUkd3WTFwUU9YMmtTU09RbWllT2F2TVBqNlU1Z3FPNUNVS0gvNURIbDlrS3lrVlJIOHJoYkphZDlNU1J2eHJvKy9jOGRxUEsyUTZIclg4NG0reE5hVTRsc3ZhOTY1TVVjSFhyOFlyYnVQVHhacHlLR0VqaU5TUVpmN3NpNEcveHdLS1JBNnRtNG11YVhrQzBsUnVHcVhNOURTdW1QREZ0dk1UVTd6UWhCTDBYV1RIYnBUOUVXMTFuYnYyUHBrZ3pIemxiNC8wdEo4Tlc3SjhBbVgwaEpmRU1xZGVYUVhrMkhTRHZVa0tGRHFPaHlBV1RHaGpVd0w4UENvZkt6M3pKekVsSGZpREpneUs1RmlNYVcremhUbFJJZE9lc3VSL2UzWlJvV1QwWUMrcFYxa2V3WllWNDZ0Z3JLRHNRMExyRW9aTTRId2s3NUpoSlphOE1EQkZIZmYrZ2VoSWk0bC9uWnNXV1dSZXBLQjZaMHVnNWtGdEowOFJkeTNHWUs5YzRxeGVCendVT2U1SlZhZXhBbHhlZnRBbHpLUGN1TGFJTWZYMlNNemhqVlpJWnNlcDN0aVJ1N3hjcEJ1NDc2djM4SDdXWVY1ZzR6Sk1MSUlaRXlTOTlad3pKR1JJTndCSGsrblJRQU1BQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMQ3dBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNBdXFUaENEei9VdE9CQ1RxMFdyak9HMDJvNlQ1dXhWN0ZsM25QQWJLVzZEYTFNbDhJcjNwSTlGUmx3bExNT0I0VXBiSVdmRTY0L0Z2QnBneFBQTS9wVncxMDJzcEUxcFhXS3Q1M0traGR1VGpCcm1uTXN5Q3gwWWdyQXZUZWFFTENXQXIwM2QweVZKTThoblkzaEE3Y05mTXlHRTdYN05McHRIbmVuaFNReGpDNjB3RjRtdktHUVBMaWtpY09zaUwvTHUrcFdrYUFES25FbmVCOWdJYS9vM2RiMnlPRGE3WXVBUmpoeHU5OGhBdjJDNE5ZcXdkOVpnNVpsdVZsS0l0MWhQTDZEU3pMQ0hKZkdoVXlZTkI2NGpDRUl1clRxR0kvSHhsVE5PRmJqSURPL3h0ZTJqMEVCL3NqdmRIcVAxM0RKOTNjcFd5alRHNFhGcHEvRG04R1UxaUNIL05NaFdRM1pUaG9lbzZkNTNDQmpIRzVnREJ3NXVmRi9sTkpIeVNpZk04TjcvWkJjR3l2ZjVpV3Y3S3h5KzhXUzUxRUZ4VGpnRFdaT0ZSRStXSTVwUjNrSDZpRWdPdlowR3U3MGZrSVVDYmxoK3N2ME11cm5nRE42Qmc5QWgyYU9XYThTNkdyQTJ2TUlPa3JtSThBWVB6L21hcnQ2MjN4cCswUEVta1NrN3poU1FRTy94ZHc5WUlYRXEwRCtNQ0ZnVFlPbXowZlorZiswU0pnaTFZeVp5SWZkbzJOVWp3TEdZdXlSMWZZc0g3RXNLSlZUWTlZV2JFNnU0Rll4WnZtVWloM1dtWlJxVDdYakp0MVBiMGNCWTFYci8zVlo1a0pkWkpISFdpVUFRMWMwbm1iZEpGWTBkNVcxMnhSMlZkU3lYSlNUQk8zeTRzS3l0eE5GWS9wZlJTOXVLSzRDKy9pcFNGdUVGdWxHbmJaSnJQbnhhOWprWGY0aHIzd1lBQUFCRyJ9XX0="
               },
               {
                 "kind": "payload_binding",
                 "from": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "@payload",
                 "path": "@payload",
@@ -1974,7 +1974,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "segments": [
             "docs",
             "leaf"
@@ -1985,27 +1985,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0NwS2c4bTd1b3BsaWxtZzNjbnB2R2ppYkFFVHdnVlBXb1c1SkRLZmlmK21aRkZyZC90ejFzcFVscVlNdlYrMmJUWUIwanphUW5WQ085eEJjWHcyWnNBSDdCUXFBUFBKdUFLVzhOTXMxRWNWZW44Z1hCYmdpcFlLSkpqczVuVmpqZ1hmSm55cmRKRmRVUmwzSkQwYmFFTEhDN3FFZTcyeTNyeHBDVTVOUGJBRkQyaGVaRG4rUE0zbUh4eXB3eVBRalY4N29IOEd1SElFR21LdXBnMDdDZlZSZXRQc2NDdnYzMmtaYi9uZ0Q3YWtkcmZNRmdSR3dZMXBRT1gya1NTT1FtaWVPYXZNUGo2VTVncU81Q1VLSC81REhsOWtLeWtWUkg4cmhiSmFkOU1TUnZ4cm8rL2M4ZHFQSzJRNkhyWDg0bSt4TmFVNGxzdmE5NjVNVWNIWHI4WXJidVBUeFpweUtHRWppTlNRWmY3c2k0Ry94d0tLUkE2dG00bXVhWGtDMGxSdUdxWE05RFN1bVBERnR2TVRVN3pRaEJMMFhXVEhicFQ5RVcxMW5idjJQcGtnekh6bGI0LzB0SjhOVzdKOEFtWDBoSmZFTXFkZVhRWGsySFNEdlVrS0ZEcU9oeUFXVEdoalV3TDhQQ29mS3ozekp6RWxIZmlESmd5SzVGaU1hVyt6aFRsUklkT2VzdVIvZTNaUm9XVDBZQytwVjFrZXdaWVY0NnRncktEc1EwTHJFb1pNNEh3azc1SmhKWmE4TURCRkhmZitnZWhJaTRsL25ac1dXV1JlcEtCNlowdWc1a0Z0SjA4UmR5M0dZSzljNHF4ZUJ6d1VPZTVKVmFleEFseGVmdEFsektQY3VMYUlNZlgyU016aGpWWklac2VwM3RpUnU3eGNwQnU0NzZ2MzhIN1dZVjVnNHpKTUxJSVpFeVM5OVp3ekpHUklOd0JIaytuUlFBTUFBQUE9Iiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0F1cVRoQ0R6L1V0T0JDVHEwV3JqT0cwMm82VDV1eFY3RmwzblBBYktXNkRhMU1sOElyM3BJOUZSbHdsTE1PQjRVcGJJV2ZFNjQvRnZCcGd4UFBNL3BWdzEwMnNwRTFwWFdLdDUzS2toZHVUakJybW5Nc3lDeDBZZ3JBdlRlYUVMQ1dBcjAzZDB5VkpNOGhuWTNoQTdjTmZNeUdFN1g3TkxwdEhuZW5oU1F4akM2MHdGNG12S0dRUExpa2ljT3NpTC9MdStwV2thQURLbkVuZUI5Z0lhL28zZGIyeU9EYTdZdUFSamh4dTk4aEF2MkM0Tllxd2Q5Wmc1Wmx1VmxLSXQxaFBMNkRTekxDSEpmR2hVeVlOQjY0akNFSXVyVHFHSS9IeGxUTk9GYmpJRE8veHRlMmowRUIvc2p2ZEhxUDEzREo5M2NwV3lqVEc0WEZwcS9EbThHVTFpQ0gvTk1oV1EzWlRob2VvNmQ1M0NCakhHNWdEQnc1dWZGL2xOSkh5U2lmTThONy9aQmNHeXZmNWlXdjdLeHkrOFdTNTFFRnhUamdEV1pPRlJFK1dJNXBSM2tINmlFZ092WjBHdTcwZmtJVUNibGgrc3YwTXVybmdETjZCZzlBaDJhT1dhOFM2R3JBMnZNSU9rcm1JOEFZUHovbWFydDYyM3hwKzBQRW1rU2s3emhTUVFPL3hkdzlZSVhFcTBEK01DRmdUWU9tejBmWitmKzBTSmdpMVl5WnlJZmRvMk5VandMR1l1eVIxZllzSDdFc0tKVlRZOVlXYkU2dTRGWXhadm1VaWgzV21aUnFUN1hqSnQxUGIwY0JZMVhyLzNWWjVrSmRaSkhIV2lVQVExYzBubWJkSkZZMGQ1VzEyeFIyVmRTeVhKU1RCTzN5NHNLeXR4TkZZL3BmUlM5dUtLNEMrL2lwU0Z1RUZ1bEduYlpKclBueGE5amtYZjRocjN3WUFBQUE9Iiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMQ3dBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2031,7 +2031,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi",
+          "root": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i",
           "segments": [
             "docs",
             "leaf"
@@ -2042,27 +2042,27 @@
           "prooflist": {
             "query": "docs/leaf",
             "root": {
-              "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+              "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
             },
             "steps": [
               {
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlLaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNDcEtnOG03dW9wbGlsbWczY25wdkdqaWJBRVR3Z1ZQV29XNUpES2ZpZittWkZGcmQvdHoxc3BVbHFZTXZWKzJiVFlCMGp6YVFuVkNPOXhCY1h3MlpzQUg3QlFxQVBQSnVBS1c4Tk1zMUVjVmVuOGdYQmJnaXBZS0pKanM1blZqamdYZkpueXJkSkZkVVJsM0pEMGJhRUxIQzdxRWU3MnkzcnhwQ1U1TlBiQUZEMmhlWkRuK1BNM21IeHlwd3lQUWpWODdvSDhHdUhJRUdtS3VwZzA3Q2ZWUmV0UHNjQ3Z2MzJrWmIvbmdEN2FrZHJmTUZnUkd3WTFwUU9YMmtTU09RbWllT2F2TVBqNlU1Z3FPNUNVS0gvNURIbDlrS3lrVlJIOHJoYkphZDlNU1J2eHJvKy9jOGRxUEsyUTZIclg4NG0reE5hVTRsc3ZhOTY1TVVjSFhyOFlyYnVQVHhacHlLR0VqaU5TUVpmN3NpNEcveHdLS1JBNnRtNG11YVhrQzBsUnVHcVhNOURTdW1QREZ0dk1UVTd6UWhCTDBYV1RIYnBUOUVXMTFuYnYyUHBrZ3pIemxiNC8wdEo4Tlc3SjhBbVgwaEpmRU1xZGVYUVhrMkhTRHZVa0tGRHFPaHlBV1RHaGpVd0w4UENvZkt6M3pKekVsSGZpREpneUs1RmlNYVcremhUbFJJZE9lc3VSL2UzWlJvV1QwWUMrcFYxa2V3WllWNDZ0Z3JLRHNRMExyRW9aTTRId2s3NUpoSlphOE1EQkZIZmYrZ2VoSWk0bC9uWnNXV1dSZXBLQjZaMHVnNWtGdEowOFJkeTNHWUs5YzRxeGVCendVT2U1SlZhZXhBbHhlZnRBbHpLUGN1TGFJTWZYMlNNemhqVlpJWnNlcDN0aVJ1N3hjcEJ1NDc2djM4SDdXWVY1ZzR6Sk1MSUlaRXlTOTlad3pKR1JJTndCSGsrblJRQU1BQUFCRyJ9XX0=",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMQ3dBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNBdXFUaENEei9VdE9CQ1RxMFdyak9HMDJvNlQ1dXhWN0ZsM25QQWJLVzZEYTFNbDhJcjNwSTlGUmx3bExNT0I0VXBiSVdmRTY0L0Z2QnBneFBQTS9wVncxMDJzcEUxcFhXS3Q1M0traGR1VGpCcm1uTXN5Q3gwWWdyQXZUZWFFTENXQXIwM2QweVZKTThoblkzaEE3Y05mTXlHRTdYN05McHRIbmVuaFNReGpDNjB3RjRtdktHUVBMaWtpY09zaUwvTHUrcFdrYUFES25FbmVCOWdJYS9vM2RiMnlPRGE3WXVBUmpoeHU5OGhBdjJDNE5ZcXdkOVpnNVpsdVZsS0l0MWhQTDZEU3pMQ0hKZkdoVXlZTkI2NGpDRUl1clRxR0kvSHhsVE5PRmJqSURPL3h0ZTJqMEVCL3NqdmRIcVAxM0RKOTNjcFd5alRHNFhGcHEvRG04R1UxaUNIL05NaFdRM1pUaG9lbzZkNTNDQmpIRzVnREJ3NXVmRi9sTkpIeVNpZk04TjcvWkJjR3l2ZjVpV3Y3S3h5KzhXUzUxRUZ4VGpnRFdaT0ZSRStXSTVwUjNrSDZpRWdPdlowR3U3MGZrSVVDYmxoK3N2ME11cm5nRE42Qmc5QWgyYU9XYThTNkdyQTJ2TUlPa3JtSThBWVB6L21hcnQ2MjN4cCswUEVta1NrN3poU1FRTy94ZHc5WUlYRXEwRCtNQ0ZnVFlPbXowZlorZiswU0pnaTFZeVp5SWZkbzJOVWp3TEdZdXlSMWZZc0g3RXNLSlZUWTlZV2JFNnU0Rll4WnZtVWloM1dtWlJxVDdYakp0MVBiMGNCWTFYci8zVlo1a0pkWkpISFdpVUFRMWMwbm1iZEpGWTBkNVcxMnhSMlZkU3lYSlNUQk8zeTRzS3l0eE5GWS9wZlJTOXVLSzRDKy9pcFNGdUVGdWxHbmJaSnJQbnhhOWprWGY0aHIzd1lBQUFCRyJ9XX0=",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagbkfqabaaqabdp4y77h6qg7jiwg5mg7w2lvkhs4egi2chsjebmojide45aktzi"
+                  "/": "bagbmfqabaaqanv7o6bq53adi5ba7grlamc5smj67slzwfmcjebrd73hzmd7qg2i"
                 },
                 "kind": "map_step",
                 "path": "docs",
                 "query": "docs",
                 "target": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 }
               },
               {
                 "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ==",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "bagbkfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                  "/": "bagbmfqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
                 },
                 "kind": "map_step",
                 "path": "leaf",
@@ -2089,7 +2089,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26",
+          "root": "baga4fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa",
           "segments": [
             "docs",
             "leaf"
@@ -2100,27 +2100,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+              "/": "baga4fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaykkrbchr4zbfzk3lmnc2uqsma6rtyoab5eiquua57zg6xv5bqxduflmkvvksqifb6cqhldjkwhkg26"
+                  "/": "baga4fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoicGRRTDdzS2lpRlJhWlJMVHhUbnRGdGZ4aWRkdjFlVkJCR0NrT0Y2cFhMWVJaenVmNVlObTlwVVdKK1J0VFdheFFqV0pmZ3c3blVHVExoYnkrai9Ec29NK3Vpd25qZllTUjJ5SnNVTVR4NjRBQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIQ3dBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSIsInByb29mIjoicDU0ODBPMERkUUo5emJmMVd1NnMycll4c0pIRys5dnVHNk1tWERhSGY0eTlkdkVZUU5LK0x3SHBSWWlBMlpNNE9melc1a0FwYlJ6MTdVZVlvY1lBNmRRdU5jRlV5Z0VhMmgzU1RWaWpPZVFBQUFSciJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2128,7 +2128,7 @@
                   "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ=="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ=="
               }
             ]
           }
@@ -2146,7 +2146,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "segments": [
             "docs",
             "leaf"
@@ -2157,27 +2157,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJwZFFMN3NLaWlGUmFaUkxUeFRudEZ0ZnhpZGR2MWVWQkJHQ2tPRjZwWExZUlp6dWY1WU5tOXBVV0orUnRUV2F4UWpXSmZndzduVUdUTGhieStqL0Rzb00rdWl3bmpmWVNSMnlKc1VNVHg2NEFBQUJIIiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJwNTQ4ME8wRGRRSjl6YmYxV3U2czJyWXhzSkhHKzl2dUc2TW1YRGFIZjR5OWR2RVlRTksrTHdIcFJZaUEyWk00T2Z6VzVrQXBiUnoxN1VlWW9jWUE2ZFF1TmNGVXlnRWEyaDNTVFZpak9lUUFBQVJxIiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIQ3dBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2185,7 +2185,7 @@
                   "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ=="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ=="
               }
             ]
           }
@@ -2203,7 +2203,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "segments": [
             "docs",
             "leaf"
@@ -2214,27 +2214,27 @@
           "prooflist": {
             "query": "docs/leaf",
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "steps": [
               {
                 "evidence": "not-base64%%%",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "kind": "map_step",
                 "path": "docs",
                 "query": "docs",
                 "target": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 }
               },
               {
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ==",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ==",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "kind": "map_step",
                 "path": "leaf",
@@ -2260,7 +2260,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "segments": [
             "profile",
             "name"
@@ -2271,14 +2271,14 @@
           "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "profile/name",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "profile/name",
                 "path": "profile/name",
@@ -2286,7 +2286,7 @@
                   "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJpQmk1ZWFNbThCVk5mV2JtV0M4eVpGV1RqSUlqYkxVd0pUcTdJVTB2V0xQSDJkRzdaci9nNmdRanhMQ05hTmJWRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUFmIn1dfQ=="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJoaFBBdk52RFdVU2lCNVVlWXlqV1FHSW1Lc1JXNEQ4cXh1ZE9oYWkzOGsrSlpUdFVma0wraldPcmNYS2JZVDdQRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
               }
             ]
           }
@@ -2304,7 +2304,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "segments": [
             "docs",
             "leaf"
@@ -2315,26 +2315,26 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "evidence_kind": "explicit"
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2342,7 +2342,7 @@
                   "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ=="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ=="
               }
             ]
           }
@@ -2360,7 +2360,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "segments": [
             "docs",
             "leaf"
@@ -2371,27 +2371,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoicGRRTDdzS2lpRlJhWlJMVHhUbnRGdGZ4aWRkdjFlVkJCR0NrT0Y2cFhMWVJaenVmNVlObTlwVVdKK1J0VFdheFFqV0pmZ3c3blVHVExoYnkrai9Ec29NK3Vpd25qZllTUjJ5SnNVTVR4NjRBQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIQ3dBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSIsInByb29mIjoicDU0ODBPMERkUUo5emJmMVd1NnMycll4c0pIRys5dnVHNk1tWERhSGY0eTlkdkVZUU5LK0x3SHBSWWlBMlpNNE9melc1a0FwYlJ6MTdVZVlvY1lBNmRRdU5jRlV5Z0VhMmgzU1RWaWpPZVFBQUFSciJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2399,7 +2399,7 @@
                   "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ=="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ=="
               }
             ]
           }
@@ -2417,7 +2417,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "segments": [
             "docs",
             "@payload"
@@ -2428,27 +2428,27 @@
           "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "docs/@payload",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoicGRRTDdzS2lpRlJhWlJMVHhUbnRGdGZ4aWRkdjFlVkJCR0NrT0Y2cFhMWVJaenVmNVlObTlwVVdKK1J0VFdheFFqV0pmZ3c3blVHVExoYnkrai9Ec29NK3Vpd25qZllTUjJ5SnNVTVR4NjRBQUFCRyJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIQ3dBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSIsInByb29mIjoicDU0ODBPMERkUUo5emJmMVd1NnMycll4c0pIRys5dnVHNk1tWERhSGY0eTlkdkVZUU5LK0x3SHBSWWlBMlpNNE9melc1a0FwYlJ6MTdVZVlvY1lBNmRRdU5jRlV5Z0VhMmgzU1RWaWpPZVFBQUFSciJ9XX0="
               },
               {
                 "kind": "payload_binding",
                 "from": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "query": "@payload",
                 "path": "@payload",
@@ -2456,7 +2456,7 @@
                   "/": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6InQyaGM1cEpkUE5VTlRJWVhJOGdrSnhGRHBnaG14NzRIWVEvdkFkSThxZGozVk1GL3I3WnV3ZWRKSWxlV0dmV3dQSDd6am0vMm1aOEJBa3RsQWtEQUcxWXVNU2xuYk5xQ3NoWXgyRVFWQWdRQUFBQ1cifV19"
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6ImdieTZHRnZnUVVzazloL1ZhcEtuWWoweHFZeFN0MzFla3VHclEwRG9zQndxYy9PV1cyckRVNFhnRXdkZWFJV0ZQSDd6am0vMm1aOEJBa3RsQWtEQUcxWXVNU2xuYk5xQ3NoWXgyRVFWQWdRQUFBbGcifV19"
               }
             ]
           }
@@ -2474,7 +2474,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "segments": [
             "docs",
             "leaf"
@@ -2485,27 +2485,27 @@
           "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
           "prooflist": {
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "query": "docs/leaf",
             "steps": [
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "query": "docs",
                 "path": "docs",
                 "target": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJwZFFMN3NLaWlGUmFaUkxUeFRudEZ0ZnhpZGR2MWVWQkJHQ2tPRjZwWExZUlp6dWY1WU5tOXBVV0orUnRUV2F4UWpXSmZndzduVUdUTGhieStqL0Rzb00rdWl3bmpmWVNSMnlKc1VNVHg2NEFBQUE9Iiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSJ9XX0="
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJwNTQ4ME8wRGRRSjl6YmYxV3U2czJyWXhzSkhHKzl2dUc2TW1YRGFIZjR5OWR2RVlRTksrTHdIcFJZaUEyWk00T2Z6VzVrQXBiUnoxN1VlWW9jWUE2ZFF1TmNGVXlnRWEyaDNTVFZpak9lUUFBQVE9Iiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIQ3dBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSJ9XX0="
               },
               {
                 "kind": "map_step",
                 "from": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "query": "leaf",
                 "path": "leaf",
@@ -2513,7 +2513,7 @@
                   "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
                 },
                 "evidence_kind": "explicit",
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ=="
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ=="
               }
             ]
           }
@@ -2531,7 +2531,7 @@
       "verification": {
         "request": {
           "profile": "malt.resolve/v0alpha1",
-          "root": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3",
+          "root": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom",
           "segments": [
             "docs",
             "leaf"
@@ -2542,27 +2542,27 @@
           "prooflist": {
             "query": "docs/leaf",
             "root": {
-              "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+              "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
             },
             "steps": [
               {
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlHaXdBRUFNSk80eExwcDdPcThQb1RlTDNsLzVTRnNPWStpVDYxUGp3bnI5Zk1NTGFzTllQRXBlNGIxWjR3RWlqZlNRNzZyRlE9PSIsInByb29mIjoicGRRTDdzS2lpRlJhWlJMVHhUbnRGdGZ4aWRkdjFlVkJCR0NrT0Y2cFhMWVJaenVmNVlObTlwVVdKK1J0VFdheFFqV0pmZ3c3blVHVExoYnkrai9Ec29NK3Vpd25qZllTUjJ5SnNVTVR4NjRBQUFCRyJ9XX0=",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIQ3dBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSIsInByb29mIjoicDU0ODBPMERkUUo5emJmMVd1NnMycll4c0pIRys5dnVHNk1tWERhSGY0eTlkdkVZUU5LK0x3SHBSWWlBMlpNNE9melc1a0FwYlJ6MTdVZVlvY1lBNmRRdU5jRlV5Z0VhMmgzU1RWaWpPZVFBQUFSciJ9XX0=",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "baga2fqabaaylk7fx2qmofuqj5qz7tdkwegmpy2le3h7z34tuqqeegrr3bj2az5wa7eutq32jecuhppkt6vepirw3"
+                  "/": "baga4fqabaaylcd3svi2pf46cn3dpbntb3pjnmzr5emmzfgkdyztsi4roryvp2aof2cqxyebz3dtzdsztdivfsiom"
                 },
                 "kind": "map_step",
                 "path": "docs",
                 "query": "docs",
                 "target": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 }
               },
               {
-                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJoNU96Tlh3aGIvVzZKVFY2dlI3VkhKYzdBUEVGM3pWZTRUbU83OVNuYkZGZVZncUZucGYzaEdvcGlxWkVya1BFU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQUNmIn1dfQ==",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ==",
                 "evidence_kind": "explicit",
                 "from": {
-                  "/": "baga2fqabaayjhogexju6z2v4h2cn4l3zp7ssc3bzr6re7lkpr4e6x5ptbqw2wdla6euxxbxvm6gajcrx2jb35kyv"
+                  "/": "baga4fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
                 },
                 "kind": "map_step",
                 "path": "leaf",

--- a/docs/spec/cid-and-wire-format.md
+++ b/docs/spec/cid-and-wire-format.md
@@ -37,7 +37,7 @@ codec = 0x300000
       | backend_id
 ```
 
-The current `MALTVersionID` is `1`. It identifies this typed-root layout;
+The current `MALTVersionID` is `2`. It identifies this typed-root layout;
 it is not the CID version, a source release, a Resolve/Read profile, or a
 conformance-corpus version. Adding a semantic kind or backend suite does not
 change it. It changes only when the interpretation of the root codec or
@@ -72,10 +72,10 @@ ID even when it belongs to the same broad cryptographic family.
 
 | Name | Value | Semantic kind | Backend |
 | --- | ---: | --- | --- |
-| `malt-map-kzg` | `0x301101` | map | KZG |
-| `malt-list-kzg` | `0x301201` | list | KZG |
-| `malt-map-ipa` | `0x301102` | map | IPA |
-| `malt-list-ipa` | `0x301202` | list | IPA |
+| `malt-map-kzg` | `0x302101` | map | KZG |
+| `malt-list-kzg` | `0x302201` | list | KZG |
+| `malt-map-ipa` | `0x302102` | map | IPA |
+| `malt-list-ipa` | `0x302202` | list | IPA |
 
 The implementation owner is `wire/maltcid`.
 
@@ -119,6 +119,13 @@ Unknown versions, semantics, backends, combinations, and codecs outside the
 typed-root subrange fail closed. Classifiers must validate the complete codec
 before returning either semantic or backend; independently masking one field
 is insufficient.
+
+Version 2 makes semantic node geometry backend-sized: KZG map and list nodes
+use all 4096 positions in the current KZG suite, while IPA nodes retain the
+current suite's 256 positions. Map radix digits and list branching therefore
+also depend on the backend suite. Version-1 experimental roots are not
+recognized by version-2 decoders and must be rebuilt together with their
+materialized node state.
 
 Verifiers must also reject roots or proof steps whose semantic kind, backend
 kind, or expected target type does not match the query and evidence.

--- a/docs/spec/commitment-proof-encoding.md
+++ b/docs/spec/commitment-proof-encoding.md
@@ -37,9 +37,17 @@ multihash digest is the raw commitment:
 The backend ID determines the commitment encoding and expected byte length.
 Verification must not infer or override the backend from the digest length.
 
-Map radix nodes and list tree nodes use 256 physical slots. Thus IPA's full
-vector and the first 256 positions of KZG's vector carry those node cells; all
-remaining primitive positions are zero.
+Semantic node geometry is locked to the selected backend suite:
+
+| Backend | Physical node slots | Map radix bits | List content slots |
+| --- | ---: | ---: | ---: |
+| KZG | 4096 | 12 | 4095 |
+| IPA | 256 | 8 | 255 |
+
+Slot zero is an ordinary radix-map slot. List nodes reserve slot zero for
+authenticated metadata, leaving the listed number of content slots. KZG
+semantic nodes supply all 4096 cells to the primitive commitment; IPA semantic
+nodes supply all 256.
 
 ## KZG
 
@@ -155,8 +163,21 @@ envelope itself is JSON-encoded:
 }
 ```
 
-`bucket` is optional. Each radix step uses the next byte of
-`SHA-256(canonical_key_utf8)` as its primitive slot index. A `slot` is either an
+`bucket` is optional. The map treats
+`SHA-256(canonical_key_utf8)` as one MSB-first bit string. KZG consumes
+successive 12-bit digits, so a digest has 22 radix digits:
+
+```text
+d0  = b0 << 4 | b1 >> 4
+d1  = (b1 & 0x0f) << 8 | b2
+...
+d20 = b30 << 4 | b31 >> 4
+d21 = (b31 & 0x0f) << 8
+```
+
+The final four digest bits occupy the high four bits of the final digit and
+the remaining eight low bits are zero-filled. IPA consumes successive 8-bit
+digits and therefore retains 32 radix levels. A `slot` is either an
 intermediate root marker, a terminal leaf marker, or a bucket-reference marker.
 The marker encodings are raw CIDv1 values with identity multihashes over:
 
@@ -175,9 +196,10 @@ In a resolve ProofList this envelope is stored in `step.evidence` with
 
 ## Tree List Semantic Proofs
 
-Every committed list node has 256 slots. Slot 0 authenticates node metadata and
-slots 1 through 255 authenticate content. Metadata is a raw CIDv1 identity
-marker over:
+Every committed KZG list node has 4096 slots: slot 0 authenticates node
+metadata and slots 1 through 4095 authenticate content. IPA list nodes retain
+256 slots with content in slots 1 through 255. Metadata is a raw CIDv1
+identity marker over:
 
 ```text
 "malt:list:node-meta:"

--- a/docs/spec/resolve-read-conformance-v1.md
+++ b/docs/spec/resolve-read-conformance-v1.md
@@ -14,7 +14,7 @@ copies.
 
 The corpus version is `malt.resolve-read.conformance/v1`. It is independent of
 the two enclosed operation profiles and of the typed-root
-`MALTVersionID=1`. Before the first release, an intentional encoding change
+`MALTVersionID=2`. Before the first release, an intentional encoding change
 may regenerate the corpus as part of the same reviewed change. Once released,
 a vector ID and its input and expected verdict are immutable; later behavioral
 or encoding changes require v2. Error strings, timing, and

--- a/wire/maltcid/codec.go
+++ b/wire/maltcid/codec.go
@@ -12,10 +12,10 @@
 //
 // Current allocations:
 //
-//	malt-map-kzg  = 0x301101
-//	malt-list-kzg = 0x301201
-//	malt-map-ipa  = 0x301102
-//	malt-list-ipa = 0x301202
+//	malt-map-kzg  = 0x302101
+//	malt-list-kzg = 0x302201
+//	malt-map-ipa  = 0x302102
+//	malt-list-ipa = 0x302202
 package maltcid
 
 import (
@@ -28,7 +28,7 @@ import (
 
 // MALTVersionID identifies the current typed-root wire layout. It is not a
 // source release or protocol-profile version.
-const MALTVersionID uint8 = 1
+const MALTVersionID uint8 = 2
 
 const (
 	codecMaltRootBase = 0x300000

--- a/wire/maltcid/codec_test.go
+++ b/wire/maltcid/codec_test.go
@@ -16,19 +16,19 @@ func TestCodecLayout(t *testing.T) {
 		semantic maltcid.SemanticKind
 		backend  maltcid.BackendKind
 	}{
-		{name: "map_kzg", codec: maltcid.CodecMaltMapKZG, version: 1, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindKZG},
-		{name: "list_kzg", codec: maltcid.CodecMaltListKZG, version: 1, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindKZG},
-		{name: "map_ipa", codec: maltcid.CodecMaltMapIPA, version: 1, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindIPA},
-		{name: "list_ipa", codec: maltcid.CodecMaltListIPA, version: 1, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindIPA},
+		{name: "map_kzg", codec: maltcid.CodecMaltMapKZG, version: 2, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindKZG},
+		{name: "list_kzg", codec: maltcid.CodecMaltListKZG, version: 2, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindKZG},
+		{name: "map_ipa", codec: maltcid.CodecMaltMapIPA, version: 2, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindIPA},
+		{name: "list_ipa", codec: maltcid.CodecMaltListIPA, version: 2, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindIPA},
 	}
 	wantCodecs := map[string]uint64{
-		"map_kzg":  0x301101,
-		"list_kzg": 0x301201,
-		"map_ipa":  0x301102,
-		"list_ipa": 0x301202,
+		"map_kzg":  0x302101,
+		"list_kzg": 0x302201,
+		"map_ipa":  0x302102,
+		"list_ipa": 0x302202,
 	}
-	if maltcid.MALTVersionID != 1 {
-		t.Fatalf("MALTVersionID = %d, want 1", maltcid.MALTVersionID)
+	if maltcid.MALTVersionID != 2 {
+		t.Fatalf("MALTVersionID = %d, want 2", maltcid.MALTVersionID)
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -63,16 +63,17 @@ func TestCodecClassificationRejectsUnsupportedFields(t *testing.T) {
 		{name: "old_flat_map_ipa", codec: 0x300003},
 		{name: "old_flat_list_ipa", codec: 0x300004},
 		{name: "version_zero", codec: 0x300101},
-		{name: "version_two", codec: 0x302101, versionHint: 2},
+		{name: "version_one", codec: 0x301101, versionHint: 1},
+		{name: "version_three", codec: 0x303101, versionHint: 3},
 		{name: "version_fifteen", codec: 0x30F101, versionHint: 15},
-		{name: "semantic_zero", codec: 0x301001, versionHint: 1},
-		{name: "semantic_unknown", codec: 0x301301, versionHint: 1},
-		{name: "semantic_fifteen", codec: 0x301F01, versionHint: 1},
-		{name: "backend_zero", codec: 0x301100, versionHint: 1},
-		{name: "backend_unknown", codec: 0x301103, versionHint: 1},
-		{name: "backend_255", codec: 0x3011FF, versionHint: 1},
+		{name: "semantic_zero", codec: 0x302001, versionHint: 2},
+		{name: "semantic_unknown", codec: 0x302301, versionHint: 2},
+		{name: "semantic_fifteen", codec: 0x302F01, versionHint: 2},
+		{name: "backend_zero", codec: 0x302100, versionHint: 2},
+		{name: "backend_unknown", codec: 0x302103, versionHint: 2},
+		{name: "backend_255", codec: 0x3021FF, versionHint: 2},
 		{name: "outside_root_subrange", codec: 0x311101},
-		{name: "high_bit_alias", codec: 0x100301101},
+		{name: "high_bit_alias", codec: 0x100302101},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- add one shared backend-sized node geometry used by semantic producers and portable verifiers
- use all 4096 KZG positions for Map and List nodes, with 12-bit Map radix digits and 4095 List content slots
- retain the fixed IPA geometry at 256 positions, 8-bit Map digits, and 255 List content slots
- remove 8-bit slot truncation from Map materialization paths and cover slots above 255
- regenerate the Resolve/Read conformance corpus and update the wire/proof specifications

## Wire and migration impact

This is an intentional pre-v1 root-format break. `MALTVersionID` advances from 1 to 2, producing codecs `0x302101`, `0x302201`, `0x302102`, and `0x302202`. Version-1 roots fail closed instead of being interpreted with the new geometry.

Existing experimental roots, Gateway heads/materialized nodes, and client accepted/candidate roots must be rebuilt when consumers upgrade. Consumer-side root classifiers and packaged verifier WASM artifacts must also be updated before they consume v2 roots.

KZG treats SHA-256 as an MSB-first bit stream. It consumes 21 full 12-bit digits plus a final digit containing the remaining four bits in the high nibble with eight zero-filled low bits. IPA continues to consume one byte per level.

## Validation

- `git diff --check`
- `gofmt -l` on changed Go packages (clean)
- `go test -count=1 ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- `sh scripts/test-verifier-wasm-vectors.sh`
  - all: 49 vectors
  - KZG-only: 25 vectors
  - IPA-only: 25 vectors

A fresh independent review of the final diff reported no actionable findings.