### PR TITLE
Add browser client-side commitment writer

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,8 +37,14 @@ jobs:
       - name: Run tests
         run: go test ./...
 
-      - name: Run WASM conformance vectors
+      - name: Run 32-bit commitment tests
+        run: GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa
+
+      - name: Run verifier WASM conformance vectors
         run: sh scripts/test-verifier-wasm-vectors.sh
+
+      - name: Run writer WASM smoke
+        run: sh scripts/test-writer-wasm.sh
 
       - name: Run vet
         run: go vet ./...

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,6 +60,7 @@ malt (module facade)
 │   └── runtime              composition over an injected materializer
 ├── sdk/verifier             trusted client facade
 ├── sdk/writer               complete-view client-root computation
+├── cmd/malt-writer-wasm     browser client-root adapter
 ├── wire/maltcid             typed CID rules
 └── artifact                 frozen compatibility profile
 ```
@@ -143,6 +144,11 @@ one exact `ClientRootBundle` locally. `sdk/writer` owns that
 application-neutral computation. It uses caller-supplied branching
 materialization only for speculative local state and defines no durable
 ArcTable or publication policy.
+
+`cmd/malt-writer-wasm` exposes the same exact computation to browsers through
+`maltComputeClientRootV1`. It accepts the existing checked client-root wire
+profiles as bounded UTF-8 JSON `Uint8Array` values and performs no network,
+publication, persistence, or trust action.
 
 A service may independently replay and materialize the exact bundle at its
 declared durability boundary, then acknowledge it with a

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ MALT core owns:
 - ProofList generation/verification semantics;
 - portable mutation and receipt values;
 - untrusted resolve/read/apply composition over caller-injected capabilities;
-- native Go and browser/WASM verification.
+- native Go and browser/WASM verification and exact client-root computation.
 
 MALT core does not own:
 
@@ -128,6 +128,7 @@ in the application client.
 | `graph` | Resolver, semantic mutation, bootstrap, and explicit reference-writer algorithms over injected capabilities |
 | `sdk/verifier` | Client-facing local verification facade |
 | `sdk/writer` | Complete-view verification and exact client-root computation |
+| `cmd/malt-writer-wasm` | Browser exact client-root computation entry point |
 | `auth/observation` | Optional request-scoped execution diagnostics; never proof evidence |
 | `artifact` | Frozen `malt.artifact/v0alpha2` compatibility decoder/verifier |
 | `cmd/malt-verifier-wasm` | Browser verifier build entry point |

--- a/auth/commitment/commitment.go
+++ b/auth/commitment/commitment.go
@@ -43,6 +43,20 @@ type IndexProver interface {
 	Replace(values []Cell, index uint64, oldValue, newValue Cell) (cid.Cid, error)
 }
 
+// IndexRootProver generates proofs against a caller-supplied root without
+// first recomputing that commitment. Implementations must fail unless the
+// generated proof verifies against root. This lets an untrusted proof service
+// open client-materialized vectors while keeping commitment computation on the
+// client.
+type IndexRootProver interface {
+	// ProveAtRoot opens one index against root. It must not call Commit.
+	ProveAtRoot(root cid.Cid, values []Cell, index uint64) (value Cell, proof []byte, err error)
+
+	// BatchProveAtRoot opens an ordered index list against root. It must not
+	// call Commit.
+	BatchProveAtRoot(root cid.Cid, values []Cell, indices []uint64) (proved []Cell, proof []byte, err error)
+}
+
 // IndexOpening is an opaque, prepared witness for one committed vector. Root
 // returns the commitment computed while the witness was prepared. Open
 // generates an index proof without recomputing that commitment.

--- a/auth/commitment/ipa/ipa.go
+++ b/auth/commitment/ipa/ipa.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	// MaxValues is the maximum number of values per commitment.
-	MaxValues = 256
+	MaxValues   = 256
+	proofRounds = 8
 	// ProofSize is the size of a primitive IPA index proof in bytes.
 	// For 256 elements: numRounds=8, size=4 + 8*32(L) + 8*32(R) + 32(A_scalar) + 4(index) = 552
 	ProofSize = 552
@@ -75,6 +76,36 @@ func (s *Scheme) Prove(values []commitment.Cell, index uint64) (cid.Cid, commitm
 	return comm, value, proof, err
 }
 
+// ProveAtRoot opens values against a caller-supplied root without recomputing
+// the IPA commitment. The generated proof is verified before it is returned so
+// inconsistent client materialization fails closed.
+func (s *Scheme) ProveAtRoot(root cid.Cid, values []commitment.Cell, index uint64) (commitment.Cell, []byte, error) {
+	if _, err := maltcid.ExtractCommitment(root); err != nil {
+		return nil, nil, fmt.Errorf("invalid proof root: %w", err)
+	}
+	if maltcid.BackendKindOf(root) != maltcid.BackendKindIPA {
+		return nil, nil, fmt.Errorf("proof root does not use the IPA backend")
+	}
+	if len(values) > MaxValues {
+		return nil, nil, fmt.Errorf("too many values: %d > %d", len(values), MaxValues)
+	}
+	if index >= uint64(len(values)) {
+		return nil, nil, fmt.Errorf("index %d out of range", index)
+	}
+	value, proof, err := s.proveValuesIndex(root, values, index)
+	if err != nil {
+		return nil, nil, err
+	}
+	ok, err := s.VerifyIndex(root, index, value, append([]byte(nil), proof...))
+	if err != nil {
+		return nil, nil, fmt.Errorf("verify root-bound IPA proof: %w", err)
+	}
+	if !ok {
+		return nil, nil, commitment.ErrInvalidCommitment
+	}
+	return value, proof, nil
+}
+
 type opening struct {
 	scheme *Scheme
 	root   cid.Cid
@@ -102,12 +133,12 @@ func (o *opening) Open(index uint64) (commitment.Cell, []byte, error) {
 
 // BatchProve proves multiple stable indices with one batch proof payload.
 func (s *Scheme) BatchProve(values []commitment.Cell, indices []uint64) (cid.Cid, []commitment.Cell, []byte, error) {
+	if err := validateBatchOpening(values, indices); err != nil {
+		return cid.Undef, nil, nil, err
+	}
 	comm, err := s.commitValues(values)
 	if err != nil {
 		return cid.Undef, nil, nil, err
-	}
-	if len(indices) == 0 {
-		return cid.Undef, nil, nil, fmt.Errorf("indices must not be empty")
 	}
 
 	commBytes, err := maltcid.ExtractCommitment(comm)
@@ -127,13 +158,6 @@ func (s *Scheme) BatchProve(values []commitment.Cell, indices []uint64) (cid.Cid
 	zs := make([]uint8, len(indices))
 	proved := make([]commitment.Cell, len(indices))
 	for i, index := range indices {
-		if index >= uint64(len(values)) {
-			return cid.Undef, nil, nil, fmt.Errorf("index %d out of range", index)
-		}
-		if index >= MaxValues {
-			return cid.Undef, nil, nil, fmt.Errorf("index %d exceeds max %d", index, MaxValues-1)
-		}
-
 		commitments[i] = c
 		cs[i] = &commitments[i]
 		fs[i] = vector
@@ -152,6 +176,61 @@ func (s *Scheme) BatchProve(values []commitment.Cell, indices []uint64) (cid.Cid
 		return cid.Undef, nil, nil, fmt.Errorf("failed to serialize IPA batch proof: %w", err)
 	}
 	return comm, proved, proofBytes, nil
+}
+
+// BatchProveAtRoot opens values against a caller-supplied root without
+// recomputing the IPA commitment.
+func (s *Scheme) BatchProveAtRoot(root cid.Cid, values []commitment.Cell, indices []uint64) ([]commitment.Cell, []byte, error) {
+	if _, err := maltcid.ExtractCommitment(root); err != nil {
+		return nil, nil, fmt.Errorf("invalid proof root: %w", err)
+	}
+	if maltcid.BackendKindOf(root) != maltcid.BackendKindIPA {
+		return nil, nil, fmt.Errorf("proof root does not use the IPA backend")
+	}
+	if err := validateBatchOpening(values, indices); err != nil {
+		return nil, nil, err
+	}
+
+	commBytes, err := maltcid.ExtractCommitment(root)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to extract commitment: %w", err)
+	}
+	var c banderwagon.Element
+	if err := c.SetBytes(commBytes); err != nil {
+		return nil, nil, fmt.Errorf("failed to reconstruct commitment: %w", err)
+	}
+
+	vector := valuesToVector(values)
+	commitments := make([]banderwagon.Element, len(indices))
+	cs := make([]*banderwagon.Element, len(indices))
+	fs := make([][]fr.Element, len(indices))
+	zs := make([]uint8, len(indices))
+	proved := make([]commitment.Cell, len(indices))
+	for i, index := range indices {
+		commitments[i] = c
+		cs[i] = &commitments[i]
+		fs[i] = vector
+		zs[i] = uint8(index)
+		proved[i] = commitment.NewCell(values[int(index)])
+	}
+
+	transcript := common.NewTranscript(batchTranscriptLabel)
+	batchProof, err := multiproof.CreateMultiProof(transcript, s.ipaConfig, cs, fs, zs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create IPA batch proof: %w", err)
+	}
+	proof, err := serializeMultiProof(batchProof)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to serialize IPA batch proof: %w", err)
+	}
+	ok, err := s.BatchVerify(root, indices, proved, append([]byte(nil), proof...))
+	if err != nil {
+		return nil, nil, fmt.Errorf("verify root-bound IPA batch proof: %w", err)
+	}
+	if !ok {
+		return nil, nil, commitment.ErrInvalidCommitment
+	}
+	return proved, proof, nil
 }
 
 func (s *Scheme) proveValuesIndex(comm cid.Cid, values []commitment.Cell, index uint64) (commitment.Cell, []byte, error) {
@@ -190,6 +269,9 @@ func (s *Scheme) proveValuesIndex(comm cid.Cid, values []commitment.Cell, index 
 
 // VerifyIndex verifies a proof for a stable index without requiring cache state.
 func (s *Scheme) VerifyIndex(comm cid.Cid, index uint64, value commitment.Cell, proof []byte) (bool, error) {
+	if index >= MaxValues {
+		return false, fmt.Errorf("index %d exceeds max %d", index, MaxValues-1)
+	}
 	commBytes, err := maltcid.ExtractCommitment(comm)
 	if err != nil {
 		return false, fmt.Errorf("failed to extract commitment: %w", err)
@@ -223,11 +305,8 @@ func (s *Scheme) VerifyIndex(comm cid.Cid, index uint64, value commitment.Cell, 
 
 // BatchVerify verifies a batch proof for an ordered index list.
 func (s *Scheme) BatchVerify(comm cid.Cid, indices []uint64, values []commitment.Cell, proof []byte) (bool, error) {
-	if len(indices) == 0 {
-		return false, fmt.Errorf("indices must not be empty")
-	}
-	if len(indices) != len(values) {
-		return false, fmt.Errorf("indices/value length mismatch: %d != %d", len(indices), len(values))
+	if err := validateBatchVerification(indices, values); err != nil {
+		return false, err
 	}
 
 	commBytes, err := maltcid.ExtractCommitment(comm)
@@ -251,10 +330,6 @@ func (s *Scheme) BatchVerify(comm cid.Cid, indices []uint64, values []commitment
 	ys := make([]*fr.Element, len(indices))
 	zs := make([]uint8, len(indices))
 	for i, index := range indices {
-		if index >= MaxValues {
-			return false, fmt.Errorf("index %d exceeds max %d", index, MaxValues-1)
-		}
-
 		commitments[i] = c
 		cs[i] = &commitments[i]
 		outputs[i] = cellToFieldElement(values[i])
@@ -270,6 +345,42 @@ func (s *Scheme) BatchVerify(comm cid.Cid, indices []uint64, values []commitment
 	return ok, nil
 }
 
+func validateBatchOpening(values []commitment.Cell, indices []uint64) error {
+	if len(values) > MaxValues {
+		return fmt.Errorf("too many values: %d > %d", len(values), MaxValues)
+	}
+	if len(indices) == 0 {
+		return fmt.Errorf("indices must not be empty")
+	}
+	if len(indices) > MaxValues {
+		return fmt.Errorf("too many indices: %d > %d", len(indices), MaxValues)
+	}
+	for _, index := range indices {
+		if index >= uint64(len(values)) {
+			return fmt.Errorf("index %d out of range", index)
+		}
+	}
+	return nil
+}
+
+func validateBatchVerification(indices []uint64, values []commitment.Cell) error {
+	if len(indices) == 0 {
+		return fmt.Errorf("indices must not be empty")
+	}
+	if len(indices) > MaxValues {
+		return fmt.Errorf("too many indices: %d > %d", len(indices), MaxValues)
+	}
+	if len(indices) != len(values) {
+		return fmt.Errorf("indices/value length mismatch: %d != %d", len(indices), len(values))
+	}
+	for _, index := range indices {
+		if index >= MaxValues {
+			return fmt.Errorf("index %d exceeds max %d", index, MaxValues-1)
+		}
+	}
+	return nil
+}
+
 // VerifyProof verifies a proof carrying its own index metadata.
 func (s *Scheme) VerifyProof(comm cid.Cid, value commitment.Cell, proof []byte) (bool, error) {
 	commBytes, err := maltcid.ExtractCommitment(comm)
@@ -280,6 +391,9 @@ func (s *Scheme) VerifyProof(comm cid.Cid, value commitment.Cell, proof []byte) 
 	ipaProof, index, err := s.deserializeProof(proof)
 	if err != nil {
 		return false, fmt.Errorf("failed to deserialize proof: %w", err)
+	}
+	if index >= MaxValues {
+		return false, fmt.Errorf("proof index %d exceeds max %d", index, MaxValues-1)
 	}
 
 	transcript := common.NewTranscript(singleTranscriptLabel)
@@ -316,10 +430,12 @@ func (s *Scheme) Replace(values []commitment.Cell, index uint64, oldValue, newVa
 
 // serializeProof serializes an IPA proof with index information.
 func (s *Scheme) serializeProof(proof *ipa.IPAProof, index int) ([]byte, error) {
-	numRounds := len(proof.L)
-	totalSize := 4 + (numRounds*2+1)*32 + 4
+	if len(proof.L) != proofRounds || len(proof.R) != proofRounds {
+		return nil, fmt.Errorf("IPA proof has %d L and %d R rounds, want %d each", len(proof.L), len(proof.R), proofRounds)
+	}
+	numRounds := proofRounds
 
-	result := make([]byte, totalSize)
+	result := make([]byte, ProofSize)
 	binary.BigEndian.PutUint32(result[0:4], uint32(numRounds))
 
 	offset := 4
@@ -344,15 +460,15 @@ func (s *Scheme) serializeProof(proof *ipa.IPAProof, index int) ([]byte, error) 
 
 // deserializeProof deserializes an IPA proof and returns the proof and index.
 func (s *Scheme) deserializeProof(data []byte) (*ipa.IPAProof, uint64, error) {
-	if len(data) < 40 {
-		return nil, 0, fmt.Errorf("proof data too short")
+	if len(data) != ProofSize {
+		return nil, 0, fmt.Errorf("proof data has wrong size: expected %d, got %d", ProofSize, len(data))
 	}
 
-	numRounds := int(binary.BigEndian.Uint32(data[0:4]))
-	expectedSize := 4 + (numRounds*2+1)*32 + 4
-	if len(data) != expectedSize {
-		return nil, 0, fmt.Errorf("proof data has wrong size: expected %d, got %d", expectedSize, len(data))
+	rawRounds := binary.BigEndian.Uint32(data[0:4])
+	if rawRounds != uint32(proofRounds) {
+		return nil, 0, fmt.Errorf("proof has %d rounds, want %d", rawRounds, proofRounds)
 	}
+	numRounds := proofRounds
 
 	proof := &ipa.IPAProof{
 		L: make([]banderwagon.Element, numRounds),
@@ -433,3 +549,4 @@ func valuesToVector(values []commitment.Cell) []fr.Element {
 var _ commitment.IndexCommitment = (*Scheme)(nil)
 var _ commitment.IndexVerifier = (*Scheme)(nil)
 var _ commitment.IndexProver = (*Scheme)(nil)
+var _ commitment.IndexRootProver = (*Scheme)(nil)

--- a/auth/commitment/ipa/ipa_test.go
+++ b/auth/commitment/ipa/ipa_test.go
@@ -1,6 +1,7 @@
 package ipa_test
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/commitment"
@@ -89,6 +90,40 @@ func TestIPAProveIsStateless(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("expected VerifyProof to verify")
+	}
+}
+
+func TestIPAProveAtRootRejectsInconsistentMaterialization(t *testing.T) {
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme failed: %v", err)
+	}
+	values := []commitment.Cell{
+		commitment.NewCell([]byte("slot0")),
+		commitment.NewCell([]byte("slot1")),
+	}
+	root, err := scheme.Commit(values)
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	value, proof, err := scheme.ProveAtRoot(root, values, 1)
+	if err != nil {
+		t.Fatalf("ProveAtRoot failed: %v", err)
+	}
+	if !value.Equal(values[1]) {
+		t.Fatalf("unexpected value %x", value)
+	}
+	if ok, err := scheme.VerifyIndex(root, 1, value, proof); err != nil || !ok {
+		t.Fatalf("VerifyIndex = %v, %v; want true, nil", ok, err)
+	}
+
+	inconsistent := commitment.CloneCells(values)
+	inconsistent[0] = commitment.NewCell([]byte("different slot0"))
+	if _, _, err := scheme.ProveAtRoot(root, inconsistent, 1); err == nil {
+		t.Fatal("ProveAtRoot accepted materialization inconsistent with root")
+	}
+	if _, _, err := scheme.ProveAtRoot(root, make([]commitment.Cell, ipa.MaxValues+1), 0); err == nil {
+		t.Fatal("ProveAtRoot accepted an oversized materialization")
 	}
 }
 
@@ -232,5 +267,87 @@ func TestIPABatchProveIsStateless(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("expected wrong batch value verification to fail")
+	}
+
+	rootBoundValues, rootBoundProof, err := scheme.BatchProveAtRoot(root, values, indices)
+	if err != nil {
+		t.Fatalf("BatchProveAtRoot failed: %v", err)
+	}
+	if ok, err := scheme.BatchVerify(root, indices, rootBoundValues, rootBoundProof); err != nil || !ok {
+		t.Fatalf("root-bound BatchVerify = %v, %v; want true, nil", ok, err)
+	}
+	inconsistent := commitment.CloneCells(values)
+	inconsistent[1] = commitment.NewCell([]byte("different slot1"))
+	if _, _, err := scheme.BatchProveAtRoot(root, inconsistent, indices); err == nil {
+		t.Fatal("BatchProveAtRoot accepted materialization inconsistent with root")
+	}
+}
+
+func TestIPABatchOperationsRejectOversizedRequests(t *testing.T) {
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme failed: %v", err)
+	}
+	values := []commitment.Cell{commitment.NewCell([]byte("slot0"))}
+	root, err := scheme.Commit(values)
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	indices := make([]uint64, ipa.MaxValues+1)
+	proved := make([]commitment.Cell, len(indices))
+	for i := range proved {
+		proved[i] = values[0]
+	}
+
+	if _, _, _, err := scheme.BatchProve(values, indices); err == nil {
+		t.Fatal("BatchProve accepted too many indices")
+	}
+	if _, _, err := scheme.BatchProveAtRoot(root, values, indices); err == nil {
+		t.Fatal("BatchProveAtRoot accepted too many indices")
+	}
+	if ok, err := scheme.BatchVerify(root, indices, proved, nil); err == nil || ok {
+		t.Fatalf("BatchVerify(too many indices) = %v, %v; want false, error", ok, err)
+	}
+}
+
+func TestIPAVerifyRejectsOverflowingRoundCount(t *testing.T) {
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme failed: %v", err)
+	}
+	values := []commitment.Cell{commitment.NewCell([]byte("slot0"))}
+	root, err := scheme.Commit(values)
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	proof := make([]byte, ipa.ProofSize)
+	binary.BigEndian.PutUint32(proof[:4], uint32(1)<<31)
+	if ok, err := scheme.VerifyIndex(root, 0, values[0], proof); err == nil || ok {
+		t.Fatalf("VerifyIndex(overflowing round count) = %v, %v; want false, error", ok, err)
+	}
+	if ok, err := scheme.VerifyProof(root, values[0], proof); err == nil || ok {
+		t.Fatalf("VerifyProof(overflowing round count) = %v, %v; want false, error", ok, err)
+	}
+}
+
+func TestIPAVerifyRejectsOutOfRangeStableIndex(t *testing.T) {
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme failed: %v", err)
+	}
+	values := []commitment.Cell{commitment.NewCell([]byte("slot0"))}
+	root, value, proof, err := scheme.Prove(values, 0)
+	if err != nil {
+		t.Fatalf("Prove failed: %v", err)
+	}
+	const hostileIndex = uint64(1) << 31
+	if ok, err := scheme.VerifyIndex(root, hostileIndex, value, proof); err == nil || ok {
+		t.Fatalf("VerifyIndex(out-of-range index) = %v, %v; want false, error", ok, err)
+	}
+
+	hostileProof := append([]byte(nil), proof...)
+	binary.BigEndian.PutUint32(hostileProof[len(hostileProof)-4:], uint32(hostileIndex))
+	if ok, err := scheme.VerifyProof(root, value, hostileProof); err == nil || ok {
+		t.Fatalf("VerifyProof(out-of-range index) = %v, %v; want false, error", ok, err)
 	}
 }

--- a/auth/commitment/kzg/kzg.go
+++ b/auth/commitment/kzg/kzg.go
@@ -76,6 +76,36 @@ func (s *Scheme) Prove(values []commitment.Cell, index uint64) (cid.Cid, commitm
 	return comm, value, proof, err
 }
 
+// ProveAtRoot opens values against a caller-supplied root without recomputing
+// the KZG commitment. The generated proof is verified before it is returned so
+// inconsistent client materialization fails closed.
+func (s *Scheme) ProveAtRoot(root cid.Cid, values []commitment.Cell, index uint64) (commitment.Cell, []byte, error) {
+	if _, err := maltcid.ExtractCommitment(root); err != nil {
+		return nil, nil, fmt.Errorf("invalid proof root: %w", err)
+	}
+	if maltcid.BackendKindOf(root) != maltcid.BackendKindKZG {
+		return nil, nil, fmt.Errorf("proof root does not use the KZG backend")
+	}
+	if len(values) > MaxValues {
+		return nil, nil, fmt.Errorf("too many values: %d > %d", len(values), MaxValues)
+	}
+	if index >= uint64(len(values)) {
+		return nil, nil, fmt.Errorf("index %d out of range", index)
+	}
+	value, proof, err := s.proveValuesIndex(values, index)
+	if err != nil {
+		return nil, nil, err
+	}
+	ok, err := s.VerifyIndex(root, index, value, append([]byte(nil), proof...))
+	if err != nil {
+		return nil, nil, fmt.Errorf("verify root-bound KZG proof: %w", err)
+	}
+	if !ok {
+		return nil, nil, commitment.ErrInvalidCommitment
+	}
+	return value, proof, nil
+}
+
 type opening struct {
 	scheme *Scheme
 	root   cid.Cid
@@ -116,21 +146,17 @@ func (s *Scheme) proveValuesIndex(values []commitment.Cell, index uint64) (commi
 // TODO: replace this looped encoding with a real KZG multiproof when the
 // backend supports batch opening generation for our index-commitment setting.
 func (s *Scheme) BatchProve(values []commitment.Cell, indices []uint64) (cid.Cid, []commitment.Cell, []byte, error) {
+	if err := validateBatchOpening(values, indices); err != nil {
+		return cid.Undef, nil, nil, err
+	}
 	comm, err := s.commitValues(values)
 	if err != nil {
 		return cid.Undef, nil, nil, err
-	}
-	if len(indices) == 0 {
-		return cid.Undef, nil, nil, fmt.Errorf("indices must not be empty")
 	}
 
 	proved := make([]commitment.Cell, len(indices))
 	proofs := make([][]byte, len(indices))
 	for i, index := range indices {
-		if index >= uint64(len(values)) {
-			return cid.Undef, nil, nil, fmt.Errorf("index %d out of range", index)
-		}
-
 		value, proof, err := s.proveValuesIndex(values, index)
 		if err != nil {
 			return cid.Undef, nil, nil, err
@@ -139,6 +165,40 @@ func (s *Scheme) BatchProve(values []commitment.Cell, indices []uint64) (cid.Cid
 		proofs[i] = proof
 	}
 	return comm, proved, serializeBatchProof(proofs), nil
+}
+
+// BatchProveAtRoot opens values against a caller-supplied root without
+// recomputing the KZG commitment.
+func (s *Scheme) BatchProveAtRoot(root cid.Cid, values []commitment.Cell, indices []uint64) ([]commitment.Cell, []byte, error) {
+	if _, err := maltcid.ExtractCommitment(root); err != nil {
+		return nil, nil, fmt.Errorf("invalid proof root: %w", err)
+	}
+	if maltcid.BackendKindOf(root) != maltcid.BackendKindKZG {
+		return nil, nil, fmt.Errorf("proof root does not use the KZG backend")
+	}
+	if err := validateBatchOpening(values, indices); err != nil {
+		return nil, nil, err
+	}
+
+	proved := make([]commitment.Cell, len(indices))
+	proofs := make([][]byte, len(indices))
+	for i, index := range indices {
+		value, proof, err := s.proveValuesIndex(values, index)
+		if err != nil {
+			return nil, nil, err
+		}
+		proved[i] = value
+		proofs[i] = proof
+	}
+	proof := serializeBatchProof(proofs)
+	ok, err := s.BatchVerify(root, indices, proved, append([]byte(nil), proof...))
+	if err != nil {
+		return nil, nil, fmt.Errorf("verify root-bound KZG batch proof: %w", err)
+	}
+	if !ok {
+		return nil, nil, commitment.ErrInvalidCommitment
+	}
+	return proved, proof, nil
 }
 
 // VerifyIndex verifies a proof for a stable index without cache state.
@@ -180,11 +240,8 @@ func (s *Scheme) VerifyIndex(comm cid.Cid, index uint64, value commitment.Cell, 
 // TODO: replace this looped verification path once BatchProve emits a real
 // KZG multiproof for our index-commitment setting.
 func (s *Scheme) BatchVerify(comm cid.Cid, indices []uint64, values []commitment.Cell, proof []byte) (bool, error) {
-	if len(indices) == 0 {
-		return false, fmt.Errorf("indices must not be empty")
-	}
-	if len(indices) != len(values) {
-		return false, fmt.Errorf("indices/value length mismatch: %d != %d", len(indices), len(values))
+	if err := validateBatchVerification(indices, values); err != nil {
+		return false, err
 	}
 
 	proofs, err := deserializeBatchProof(proof)
@@ -205,6 +262,42 @@ func (s *Scheme) BatchVerify(comm cid.Cid, indices []uint64, values []commitment
 		}
 	}
 	return true, nil
+}
+
+func validateBatchOpening(values []commitment.Cell, indices []uint64) error {
+	if len(values) > MaxValues {
+		return fmt.Errorf("too many values: %d > %d", len(values), MaxValues)
+	}
+	if len(indices) == 0 {
+		return fmt.Errorf("indices must not be empty")
+	}
+	if len(indices) > MaxValues {
+		return fmt.Errorf("too many indices: %d > %d", len(indices), MaxValues)
+	}
+	for _, index := range indices {
+		if index >= uint64(len(values)) {
+			return fmt.Errorf("index %d out of range", index)
+		}
+	}
+	return nil
+}
+
+func validateBatchVerification(indices []uint64, values []commitment.Cell) error {
+	if len(indices) == 0 {
+		return fmt.Errorf("indices must not be empty")
+	}
+	if len(indices) > MaxValues {
+		return fmt.Errorf("too many indices: %d > %d", len(indices), MaxValues)
+	}
+	if len(indices) != len(values) {
+		return fmt.Errorf("indices/value length mismatch: %d != %d", len(indices), len(values))
+	}
+	for _, index := range indices {
+		if index >= MaxValues {
+			return fmt.Errorf("index %d exceeds max %d", index, MaxValues-1)
+		}
+	}
+	return nil
 }
 
 // VerifyProof verifies a proof carrying its own index metadata.
@@ -308,7 +401,11 @@ func deserializeBatchProof(data []byte) ([][]byte, error) {
 		return nil, fmt.Errorf("batch proof too short: %d", len(data))
 	}
 
-	count := int(binary.BigEndian.Uint32(data[:4]))
+	rawCount := binary.BigEndian.Uint32(data[:4])
+	if rawCount > uint32(MaxValues) {
+		return nil, fmt.Errorf("batch proof count exceeds max: %d > %d", rawCount, MaxValues)
+	}
+	count := int(rawCount)
 	expectedSize := 4 + count*ProofSize
 	if len(data) != expectedSize {
 		return nil, fmt.Errorf("batch proof has wrong size: expected %d, got %d", expectedSize, len(data))
@@ -373,3 +470,4 @@ func bitReverseRoots(roots []blsfr.Element) {
 var _ commitment.IndexCommitment = (*Scheme)(nil)
 var _ commitment.IndexVerifier = (*Scheme)(nil)
 var _ commitment.IndexProver = (*Scheme)(nil)
+var _ commitment.IndexRootProver = (*Scheme)(nil)

--- a/auth/commitment/kzg/kzg_test.go
+++ b/auth/commitment/kzg/kzg_test.go
@@ -52,6 +52,40 @@ func TestKZGProveIsStateless(t *testing.T) {
 	}
 }
 
+func TestKZGProveAtRootRejectsInconsistentMaterialization(t *testing.T) {
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme failed: %v", err)
+	}
+	values := []commitment.Cell{
+		commitment.NewCell([]byte("slot0")),
+		commitment.NewCell([]byte("slot1")),
+	}
+	root, err := scheme.Commit(values)
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	value, proof, err := scheme.ProveAtRoot(root, values, 1)
+	if err != nil {
+		t.Fatalf("ProveAtRoot failed: %v", err)
+	}
+	if !value.Equal(values[1]) {
+		t.Fatalf("unexpected value %x", value)
+	}
+	if ok, err := scheme.VerifyIndex(root, 1, value, proof); err != nil || !ok {
+		t.Fatalf("VerifyIndex = %v, %v; want true, nil", ok, err)
+	}
+
+	inconsistent := commitment.CloneCells(values)
+	inconsistent[0] = commitment.NewCell([]byte("different slot0"))
+	if _, _, err := scheme.ProveAtRoot(root, inconsistent, 1); err == nil {
+		t.Fatal("ProveAtRoot accepted materialization inconsistent with root")
+	}
+	if _, _, err := scheme.ProveAtRoot(root, make([]commitment.Cell, kzg.MaxValues+1), 0); err == nil {
+		t.Fatal("ProveAtRoot accepted an oversized materialization")
+	}
+}
+
 func TestKZGPreparedOpeningBindsRootAndClonesWitness(t *testing.T) {
 	scheme, err := kzg.NewScheme()
 	if err != nil {
@@ -140,6 +174,56 @@ func TestKZGBatchProveIsStateless(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("expected wrong batch value verification to fail")
+	}
+
+	rootBoundValues, rootBoundProof, err := scheme.BatchProveAtRoot(root, values, indices)
+	if err != nil {
+		t.Fatalf("BatchProveAtRoot failed: %v", err)
+	}
+	if ok, err := scheme.BatchVerify(root, indices, rootBoundValues, rootBoundProof); err != nil || !ok {
+		t.Fatalf("root-bound BatchVerify = %v, %v; want true, nil", ok, err)
+	}
+	inconsistent := commitment.CloneCells(values)
+	inconsistent[0] = commitment.NewCell([]byte("different slot0"))
+	if _, _, err := scheme.BatchProveAtRoot(root, inconsistent, indices); err == nil {
+		t.Fatal("BatchProveAtRoot accepted materialization inconsistent with root")
+	}
+}
+
+func TestKZGBatchOperationsRejectOversizedRequests(t *testing.T) {
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme failed: %v", err)
+	}
+	values := []commitment.Cell{commitment.NewCell([]byte("slot0"))}
+	root, err := scheme.Commit(values)
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	indices := make([]uint64, kzg.MaxValues+1)
+	proved := make([]commitment.Cell, len(indices))
+	for i := range proved {
+		proved[i] = values[0]
+	}
+
+	if _, _, _, err := scheme.BatchProve(values, indices); err == nil {
+		t.Fatal("BatchProve accepted too many indices")
+	}
+	if _, _, err := scheme.BatchProveAtRoot(root, values, indices); err == nil {
+		t.Fatal("BatchProveAtRoot accepted too many indices")
+	}
+	if ok, err := scheme.BatchVerify(root, indices, proved, nil); err == nil || ok {
+		t.Fatalf("BatchVerify(too many indices) = %v, %v; want false, error", ok, err)
+	}
+
+	oversizedProof := make([]byte, 4)
+	binary.BigEndian.PutUint32(oversizedProof, uint32(kzg.MaxValues+1))
+	if ok, err := scheme.BatchVerify(root, []uint64{0}, values, oversizedProof); err == nil || ok {
+		t.Fatalf("BatchVerify(oversized proof count) = %v, %v; want false, error", ok, err)
+	}
+	binary.BigEndian.PutUint32(oversizedProof, uint32(1)<<31)
+	if ok, err := scheme.BatchVerify(root, []uint64{0}, values, oversizedProof); err == nil || ok {
+		t.Fatalf("BatchVerify(32-bit-overflow proof count) = %v, %v; want false, error", ok, err)
 	}
 }
 

--- a/auth/semantic/list/commitment_test.go
+++ b/auth/semantic/list/commitment_test.go
@@ -45,6 +45,26 @@ func TestCommitmentCommitRejectsUndefinedValues(t *testing.T) {
 	}
 }
 
+func TestCommitmentProveSlotUsesCallerSuppliedRoot(t *testing.T) {
+	scheme := &rootBoundScheme{}
+	handler, err := NewCommitment(scheme)
+	if err != nil {
+		t.Fatalf("NewCommitment failed: %v", err)
+	}
+	root := testCID(t, "caller-root")
+	slot := testCID(t, "slot")
+	value, proof, err := handler.ProveSlot(root, []cid.Cid{slot}, 0)
+	if err != nil {
+		t.Fatalf("ProveSlot failed: %v", err)
+	}
+	if !scheme.rootBoundCalled || scheme.fallbackCalled {
+		t.Fatalf("root-bound=%v fallback=%v; want true, false", scheme.rootBoundCalled, scheme.fallbackCalled)
+	}
+	if !value.Equal(commitment.CellFromCID(slot)) || len(proof) != 8 {
+		t.Fatal("ProveSlot returned an unexpected root-bound opening")
+	}
+}
+
 type testScheme struct{}
 
 func (testScheme) MaxValues() int { return 1024 }
@@ -83,6 +103,31 @@ func (testScheme) VerifyProof(cid.Cid, commitment.Cell, []byte) (bool, error) {
 
 func (testScheme) Replace([]commitment.Cell, uint64, commitment.Cell, commitment.Cell) (cid.Cid, error) {
 	return cid.Undef, fmt.Errorf("not implemented")
+}
+
+type rootBoundScheme struct {
+	testScheme
+	rootBoundCalled bool
+	fallbackCalled  bool
+}
+
+func (s *rootBoundScheme) Prove([]commitment.Cell, uint64) (cid.Cid, commitment.Cell, []byte, error) {
+	s.fallbackCalled = true
+	return cid.Undef, nil, nil, fmt.Errorf("fallback Prove must not be called")
+}
+
+func (s *rootBoundScheme) ProveAtRoot(_ cid.Cid, values []commitment.Cell, index uint64) (commitment.Cell, []byte, error) {
+	s.rootBoundCalled = true
+	if index >= uint64(len(values)) {
+		return nil, nil, fmt.Errorf("index %d out of range", index)
+	}
+	proof := make([]byte, 8)
+	binary.BigEndian.PutUint64(proof, index)
+	return commitment.NewCell(values[index]), proof, nil
+}
+
+func (*rootBoundScheme) BatchProveAtRoot(cid.Cid, []commitment.Cell, []uint64) ([]commitment.Cell, []byte, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 
 func testCID(t *testing.T, payload string) cid.Cid {

--- a/auth/semantic/list/list.go
+++ b/auth/semantic/list/list.go
@@ -115,6 +115,9 @@ func (c *Commitment) ProveSlot(root cid.Cid, slots []cid.Cid, slot uint64) (comm
 	}
 
 	cells := cellsFromCIDs(slots)
+	if rootProver, ok := c.scheme.(commitment.IndexRootProver); ok {
+		return rootProver.ProveAtRoot(root, cells, slot)
+	}
 	provedRoot, value, proof, err := c.scheme.Prove(cells, slot)
 	if err != nil {
 		return nil, nil, err

--- a/auth/semantic/mapping/commitment_test.go
+++ b/auth/semantic/mapping/commitment_test.go
@@ -83,6 +83,26 @@ func TestCommitmentCommitProveSlotRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCommitmentProveSlotUsesCallerSuppliedRoot(t *testing.T) {
+	scheme := &rootBoundScheme{}
+	handler, err := NewCommitment(scheme)
+	if err != nil {
+		t.Fatalf("NewCommitment failed: %v", err)
+	}
+	root := testCID(t, "caller-root")
+	slot := testCID(t, "slot")
+	value, proof, err := handler.ProveSlot(root, []cid.Cid{slot}, 0)
+	if err != nil {
+		t.Fatalf("ProveSlot failed: %v", err)
+	}
+	if !scheme.rootBoundCalled || scheme.fallbackCalled {
+		t.Fatalf("root-bound=%v fallback=%v; want true, false", scheme.rootBoundCalled, scheme.fallbackCalled)
+	}
+	if !value.Equal(commitment.CellFromCID(slot)) || len(proof) != 8 {
+		t.Fatal("ProveSlot returned an unexpected root-bound opening")
+	}
+}
+
 func TestCommitmentCommitRejectsInvalidBindings(t *testing.T) {
 	handler, err := NewCommitment(testScheme{})
 	if err != nil {
@@ -207,6 +227,31 @@ func (testScheme) VerifyProof(cid.Cid, commitment.Cell, []byte) (bool, error) {
 
 func (testScheme) Replace([]commitment.Cell, uint64, commitment.Cell, commitment.Cell) (cid.Cid, error) {
 	return cid.Undef, fmt.Errorf("not implemented")
+}
+
+type rootBoundScheme struct {
+	testScheme
+	rootBoundCalled bool
+	fallbackCalled  bool
+}
+
+func (s *rootBoundScheme) Prove([]commitment.Cell, uint64) (cid.Cid, commitment.Cell, []byte, error) {
+	s.fallbackCalled = true
+	return cid.Undef, nil, nil, fmt.Errorf("fallback Prove must not be called")
+}
+
+func (s *rootBoundScheme) ProveAtRoot(_ cid.Cid, values []commitment.Cell, index uint64) (commitment.Cell, []byte, error) {
+	s.rootBoundCalled = true
+	if index >= uint64(len(values)) {
+		return nil, nil, fmt.Errorf("index %d out of range", index)
+	}
+	proof := make([]byte, 8)
+	binary.BigEndian.PutUint64(proof, index)
+	return commitment.NewCell(values[index]), proof, nil
+}
+
+func (*rootBoundScheme) BatchProveAtRoot(cid.Cid, []commitment.Cell, []uint64) ([]commitment.Cell, []byte, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 
 func testCID(t *testing.T, payload string) cid.Cid {

--- a/auth/semantic/mapping/mapping.go
+++ b/auth/semantic/mapping/mapping.go
@@ -130,6 +130,9 @@ func (c *Commitment) ProveSlot(root cid.Cid, slots []cid.Cid, slot uint64) (comm
 	}
 
 	cells := cellsFromCIDs(slots)
+	if rootProver, ok := c.scheme.(commitment.IndexRootProver); ok {
+		return rootProver.ProveAtRoot(root, cells, slot)
+	}
 	provedRoot, value, proof, err := c.scheme.Prove(cells, slot)
 	if err != nil {
 		return nil, nil, err

--- a/cmd/malt-writer-wasm/README.md
+++ b/cmd/malt-writer-wasm/README.md
@@ -1,0 +1,42 @@
+# Browser Client-Root Writer
+
+Build the browser writer bundle from the repository root:
+
+```bash
+scripts/build-writer-wasm.sh dist/writer
+```
+
+Before starting the Go runtime, a browser may select `kzg`, `ipa`, or `all`
+through `globalThis.maltWriterBackend`. The default is `all`. After the runtime
+starts, the module registers:
+
+```text
+globalThis.maltComputeClientRootV1(
+  operationIDUTF8,
+  updateViewJSONUTF8,
+  semanticIntentJSONUTF8
+) -> Promise<resultJSON>
+```
+
+All three arguments are `Uint8Array` values. The operation ID contains up to
+128 ASCII bytes; the update view and semantic intent use the checked-in
+`malt.update-view/v1` and `malt.semantic-intent/v1` schemas. The writer strictly
+decodes them from `Uint8Array` values containing UTF-8 JSON. Inputs are rejected
+before copying if the operation ID exceeds 128 bytes or either JSON byte array
+exceeds the protocol's 64 MiB document limit. The writer independently
+recomputes every old root, computes all changed commitments locally, and
+returns:
+
+```json
+{
+  "profile": "malt.writer-compute-result/v1",
+  "bundle": {},
+  "next_view": {},
+  "metrics": {}
+}
+```
+
+`bundle` is a canonical `malt.client-root-bundle/v1` value. `next_view` is the
+complete candidate view that a long-lived client may retain only after the
+service returns an exact durable receipt. The operation does not publish or
+trust the candidate and does not contact a Gateway.

--- a/cmd/malt-writer-wasm/compute.go
+++ b/cmd/malt-writer-wasm/compute.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	materializermemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/protocol"
+	clientwriter "github.com/dewebprotocol/malt/sdk/writer"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+)
+
+type computer struct {
+	schemes map[maltcid.BackendKind]commitment.IndexCommitment
+}
+
+func newComputer(backend string) (*computer, error) {
+	schemes := make(map[maltcid.BackendKind]commitment.IndexCommitment)
+	if backend == "all" || backend == string(maltcid.BackendKindKZG) {
+		scheme, err := kzg.NewScheme()
+		if err != nil {
+			return nil, fmt.Errorf("initialize KZG writer: %w", err)
+		}
+		schemes[maltcid.BackendKindKZG] = scheme
+	}
+	if backend == "all" || backend == string(maltcid.BackendKindIPA) {
+		scheme, err := ipa.NewScheme()
+		if err != nil {
+			return nil, fmt.Errorf("initialize IPA writer: %w", err)
+		}
+		schemes[maltcid.BackendKindIPA] = scheme
+	}
+	if len(schemes) == 0 {
+		return nil, fmt.Errorf("unsupported writer backend %q", backend)
+	}
+	return &computer{schemes: schemes}, nil
+}
+
+func (c *computer) compute(ctx context.Context, operationID string, updateViewJSON, semanticIntentJSON []byte) ([]byte, error) {
+	if c == nil || len(c.schemes) == 0 {
+		return nil, fmt.Errorf("client writer is not initialized")
+	}
+	wireView, err := protocol.DecodeUpdateView(updateViewJSON)
+	if err != nil {
+		return nil, err
+	}
+	view, err := wireView.Core()
+	if err != nil {
+		return nil, err
+	}
+	wireIntent, err := protocol.DecodeSemanticIntent(semanticIntentJSON, view)
+	if err != nil {
+		return nil, err
+	}
+	intent, err := wireIntent.Core(view)
+	if err != nil {
+		return nil, err
+	}
+	runtime, err := clientwriter.NewRuntime(materializermemory.New(true), c.schemes)
+	if err != nil {
+		return nil, err
+	}
+	verified, err := runtime.VerifyUpdateView(ctx, view)
+	if err != nil {
+		return nil, fmt.Errorf("verify update view: %w", err)
+	}
+	result, err := runtime.ComputeBundle(ctx, operationID, verified, intent)
+	if err != nil {
+		return nil, fmt.Errorf("compute client root: %w", err)
+	}
+	response, err := protocol.NewWriterComputeResult(result.Bundle, result.NextView, protocol.WriterComputeMetrics{
+		ViewNormalizationNS:    result.Metrics.ViewNormalizationNS,
+		IntentNormalizationNS:  result.Metrics.IntentNormalizationNS,
+		DigestNS:               result.Metrics.DigestNS,
+		CommitmentUpdateNS:     result.Metrics.CommitmentUpdateNS,
+		RootComputationNS:      result.Metrics.RootComputationNS,
+		ExpectedRootEncodingNS: result.Metrics.ExpectedRootEncodingNS,
+		BundleValidationNS:     result.Metrics.BundleValidationNS,
+		NextViewNS:             result.Metrics.NextViewNS,
+		TotalNS:                result.Metrics.TotalNS,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode writer compute result: %w", err)
+	}
+	return json.Marshal(response)
+}

--- a/cmd/malt-writer-wasm/compute_test.go
+++ b/cmd/malt-writer-wasm/compute_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materializermemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	mappingradix "github.com/dewebprotocol/malt/auth/semantic/mapping/radix"
+	"github.com/dewebprotocol/malt/mutation"
+	"github.com/dewebprotocol/malt/protocol"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestComputerComputesCanonicalClientRootBundle(t *testing.T) {
+	view, intent := computeFixture(t, maltcid.BackendKindKZG)
+	wireView, err := protocol.NewUpdateView(view)
+	if err != nil {
+		t.Fatalf("NewUpdateView failed: %v", err)
+	}
+	wireIntent, err := protocol.NewSemanticIntent(view, intent)
+	if err != nil {
+		t.Fatalf("NewSemanticIntent failed: %v", err)
+	}
+	viewJSON, err := json.Marshal(wireView)
+	if err != nil {
+		t.Fatalf("marshal update view: %v", err)
+	}
+	intentJSON, err := json.Marshal(wireIntent)
+	if err != nil {
+		t.Fatalf("marshal semantic intent: %v", err)
+	}
+
+	writer, err := newComputer("kzg")
+	if err != nil {
+		t.Fatalf("newComputer failed: %v", err)
+	}
+	raw, err := writer.compute(t.Context(), "browser-operation-1", viewJSON, intentJSON)
+	if err != nil {
+		t.Fatalf("compute failed: %v", err)
+	}
+	response, err := protocol.DecodeWriterComputeResult(raw)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Profile != protocol.WriterComputeResultProfile {
+		t.Fatalf("profile = %q, want %q", response.Profile, protocol.WriterComputeResultProfile)
+	}
+	bundle, err := response.Bundle.Core()
+	if err != nil {
+		t.Fatalf("bundle Core failed: %v", err)
+	}
+	if bundle.Candidate.Equals(view.BaseRoot) {
+		t.Fatal("client writer did not change the candidate root")
+	}
+	if maltcid.BackendKindOf(bundle.Candidate) != maltcid.BackendKindKZG {
+		t.Fatalf("candidate backend = %q, want KZG", maltcid.BackendKindOf(bundle.Candidate))
+	}
+	if bundle.OperationID != "browser-operation-1" || len(bundle.Outputs) != 1 || len(bundle.PayloadCIDs) != 1 {
+		t.Fatalf("unexpected bundle summary: operation=%q outputs=%d payloads=%d", bundle.OperationID, len(bundle.Outputs), len(bundle.PayloadCIDs))
+	}
+	next, err := response.NextView.Core()
+	if err != nil {
+		t.Fatalf("next view Core failed: %v", err)
+	}
+	if !next.BaseRoot.Equals(bundle.Candidate) {
+		t.Fatalf("next base %s does not match candidate %s", next.BaseRoot, bundle.Candidate)
+	}
+	if response.Metrics.CommitmentUpdateNS == 0 || response.Metrics.TotalNS == 0 {
+		t.Fatalf("writer metrics did not record local commitment work: %+v", response.Metrics)
+	}
+}
+
+func TestComputerRejectsUnavailableBackendAndInvalidJSON(t *testing.T) {
+	view, intent := computeFixture(t, maltcid.BackendKindKZG)
+	wireView, err := protocol.NewUpdateView(view)
+	if err != nil {
+		t.Fatalf("NewUpdateView failed: %v", err)
+	}
+	wireIntent, err := protocol.NewSemanticIntent(view, intent)
+	if err != nil {
+		t.Fatalf("NewSemanticIntent failed: %v", err)
+	}
+	viewJSON, _ := json.Marshal(wireView)
+	intentJSON, _ := json.Marshal(wireIntent)
+
+	writer, err := newComputer("ipa")
+	if err != nil {
+		t.Fatalf("newComputer failed: %v", err)
+	}
+	if _, err := writer.compute(t.Context(), "browser-operation-2", viewJSON, intentJSON); err == nil {
+		t.Fatal("IPA-only writer accepted a KZG update view")
+	}
+	if _, err := writer.compute(t.Context(), "browser-operation-3", []byte(`{}`), []byte(`{}`)); err == nil {
+		t.Fatal("writer accepted invalid client-root JSON")
+	}
+}
+
+type wasmComputeFixture struct {
+	Backend          maltcid.BackendKind       `json:"backend"`
+	OperationID      string                    `json:"operation_id"`
+	UpdateView       protocol.UpdateView       `json:"update_view"`
+	SemanticIntent   protocol.SemanticIntent   `json:"semantic_intent"`
+	ExpectedBundle   protocol.ClientRootBundle `json:"expected_bundle"`
+	ExpectedNextView protocol.UpdateView       `json:"expected_next_view"`
+}
+
+func TestGenerateWASMFixtures(t *testing.T) {
+	outputPath := os.Getenv("MALT_WRITER_WASM_FIXTURE_OUT")
+	if outputPath == "" {
+		t.Skip("MALT_WRITER_WASM_FIXTURE_OUT is not set")
+	}
+
+	fixtures := make([]wasmComputeFixture, 0, 2)
+	for _, backend := range []maltcid.BackendKind{maltcid.BackendKindKZG, maltcid.BackendKindIPA} {
+		view, intent := computeFixture(t, backend)
+		wireView, err := protocol.NewUpdateView(view)
+		if err != nil {
+			t.Fatalf("NewUpdateView(%s) failed: %v", backend, err)
+		}
+		wireIntent, err := protocol.NewSemanticIntent(view, intent)
+		if err != nil {
+			t.Fatalf("NewSemanticIntent(%s) failed: %v", backend, err)
+		}
+		viewJSON, err := json.Marshal(wireView)
+		if err != nil {
+			t.Fatalf("marshal update view (%s): %v", backend, err)
+		}
+		intentJSON, err := json.Marshal(wireIntent)
+		if err != nil {
+			t.Fatalf("marshal semantic intent (%s): %v", backend, err)
+		}
+		operationID := "wasm-" + string(backend) + "-fixture"
+		writer, err := newComputer(string(backend))
+		if err != nil {
+			t.Fatalf("newComputer(%s) failed: %v", backend, err)
+		}
+		raw, err := writer.compute(t.Context(), operationID, viewJSON, intentJSON)
+		if err != nil {
+			t.Fatalf("compute fixture (%s) failed: %v", backend, err)
+		}
+		response, err := protocol.DecodeWriterComputeResult(raw)
+		if err != nil {
+			t.Fatalf("decode fixture response (%s): %v", backend, err)
+		}
+		fixtures = append(fixtures, wasmComputeFixture{
+			Backend: backend, OperationID: operationID,
+			UpdateView: wireView, SemanticIntent: wireIntent,
+			ExpectedBundle: response.Bundle, ExpectedNextView: response.NextView,
+		})
+	}
+
+	data, err := json.Marshal(fixtures)
+	if err != nil {
+		t.Fatalf("marshal WASM fixtures: %v", err)
+	}
+	if err := os.WriteFile(outputPath, data, 0o600); err != nil {
+		t.Fatalf("write WASM fixtures: %v", err)
+	}
+}
+
+func computeFixture(t *testing.T, backend maltcid.BackendKind) (mutation.UpdateView, mutation.SemanticIntent) {
+	t.Helper()
+	ctx := context.Background()
+	var (
+		scheme commitment.IndexCommitment
+		err    error
+	)
+	switch backend {
+	case maltcid.BackendKindKZG:
+		scheme, err = kzg.NewScheme()
+	case maltcid.BackendKindIPA:
+		scheme, err = ipa.NewScheme()
+	default:
+		t.Fatalf("unsupported fixture backend %q", backend)
+	}
+	if err != nil {
+		t.Fatalf("NewScheme(%s) failed: %v", backend, err)
+	}
+	semantic, err := mappingradix.NewMap(scheme, materializermemory.New(true))
+	if err != nil {
+		t.Fatalf("NewMap failed: %v", err)
+	}
+	before := payloadCID(t, "before")
+	after := payloadCID(t, "after")
+	root, err := semantic.Commit(ctx, "fixture", mapping.NewViewFrom(map[string]cid.Cid{"file": before}))
+	if err != nil {
+		t.Fatalf("Commit fixture failed: %v", err)
+	}
+	coordinate, err := arcset.NewMapCoordinate("file")
+	if err != nil {
+		t.Fatalf("NewMapCoordinate failed: %v", err)
+	}
+	entries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
+		Coordinate: coordinate,
+		Target:     arcset.NewCASTarget(before),
+	}})
+	if err != nil {
+		t.Fatalf("NewCanonicalArcSet failed: %v", err)
+	}
+	view, err := mutation.NormalizeUpdateView(mutation.UpdateView{
+		Profile: mutation.UpdateViewProfile, StateProfile: mutation.StatefulCompleteVectorsProfile,
+		BaseRoot: root,
+		Bounds:   mutation.UpdateViewBounds{MaxObjects: 8, MaxTotalEntries: 64, MaxDepth: 8},
+		Objects: []mutation.UpdateObject{{
+			ObjectID: "root", Root: root, Kind: arcset.KindMap, Entries: entries,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeUpdateView failed: %v", err)
+	}
+	beforeTarget := arcset.NewCASTarget(before)
+	afterTarget := arcset.NewCASTarget(after)
+	intent, err := mutation.NormalizeSemanticIntent(view, mutation.SemanticIntent{
+		Profile: mutation.SemanticIntentProfile, BaseRoot: root, TopOutputID: "root-output",
+		Transitions: []mutation.IntentTransition{{
+			ID: "root-output", ObjectID: "root", OldRoot: root, Kind: arcset.KindMap,
+			Backend: backend,
+			Changes: []mutation.IntentChange{{
+				Coordinate: coordinate, Before: &beforeTarget, After: &afterTarget,
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeSemanticIntent failed: %v", err)
+	}
+	return view, intent
+}
+
+func payloadCID(t *testing.T, value string) cid.Cid {
+	t.Helper()
+	digest, err := mh.Sum([]byte(value), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("multihash: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, digest)
+}

--- a/cmd/malt-writer-wasm/main.go
+++ b/cmd/malt-writer-wasm/main.go
@@ -1,0 +1,114 @@
+//go:build js && wasm
+
+// malt-writer-wasm exposes exact client-root computation to browser clients.
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"syscall/js"
+
+	"github.com/dewebprotocol/malt/protocol"
+)
+
+const maxOperationIDBytes = 128
+
+func main() {
+	backend := requestedBackend()
+	writer, initErr := newComputer(backend)
+	if initErr != nil {
+		js.Global().Set("maltWriterInitError", initErr.Error())
+	}
+	js.Global().Set("maltWriterLoadedBackend", backend)
+	computeFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		promise := js.Global().Get("Promise")
+		if initErr != nil {
+			return promise.Call("reject", fmt.Sprintf("initialize MALT writer: %v", initErr))
+		}
+		if len(args) != 3 {
+			return promise.Call("reject", "maltComputeClientRootV1 expects operation ID, update-view JSON, and semantic-intent JSON Uint8Arrays")
+		}
+		operationIDBytes, err := copyBoundedBytes(args[0], "operation ID", maxOperationIDBytes)
+		if err != nil {
+			return promise.Call("reject", err.Error())
+		}
+		operationID := string(operationIDBytes)
+		updateViewJSON, err := copyBoundedBytes(args[1], "update-view JSON", protocol.MaxClientRootJSONBytes)
+		if err != nil {
+			return promise.Call("reject", err.Error())
+		}
+		semanticIntentJSON, err := copyBoundedBytes(args[2], "semantic-intent JSON", protocol.MaxClientRootJSONBytes)
+		if err != nil {
+			return promise.Call("reject", err.Error())
+		}
+		var executor js.Func
+		executor = js.FuncOf(func(_ js.Value, callbacks []js.Value) any {
+			resolve, reject := callbacks[0], callbacks[1]
+			go func() {
+				result, err := writer.compute(context.Background(), operationID, updateViewJSON, semanticIntentJSON)
+				if err != nil {
+					reject.Invoke(err.Error())
+					return
+				}
+				resolve.Invoke(string(result))
+			}()
+			return nil
+		})
+		value := promise.New(executor)
+		executor.Release()
+		return value
+	})
+	js.Global().Set("maltComputeClientRootV1", computeFunction)
+	js.Global().Set("maltWriterReady", true)
+	select {}
+}
+
+func copyBoundedBytes(value js.Value, label string, maxBytes int) ([]byte, error) {
+	uint8Array := js.Global().Get("Uint8Array")
+	arrayBuffer := js.Global().Get("ArrayBuffer")
+	if uint8Array.Type() != js.TypeFunction ||
+		arrayBuffer.Type() != js.TypeFunction ||
+		value.Type() != js.TypeObject ||
+		!arrayBuffer.Call("isView", value).Bool() ||
+		!value.InstanceOf(uint8Array) {
+		return nil, fmt.Errorf("%s must be a Uint8Array", label)
+	}
+
+	object := js.Global().Get("Object")
+	typedArrayPrototype := object.Call("getPrototypeOf", uint8Array.Get("prototype"))
+	byteLengthGetter := object.Call("getOwnPropertyDescriptor", typedArrayPrototype, "byteLength").Get("get")
+	byteOffsetGetter := object.Call("getOwnPropertyDescriptor", typedArrayPrototype, "byteOffset").Get("get")
+	bufferGetter := object.Call("getOwnPropertyDescriptor", typedArrayPrototype, "buffer").Get("get")
+	sizeNumber := byteLengthGetter.Call("call", value).Float()
+	if math.IsNaN(sizeNumber) || math.IsInf(sizeNumber, 0) || math.Trunc(sizeNumber) != sizeNumber {
+		return nil, fmt.Errorf("%s has an invalid byte length", label)
+	}
+	if sizeNumber < 1 {
+		return nil, fmt.Errorf("%s is empty", label)
+	}
+	if sizeNumber > float64(maxBytes) {
+		return nil, fmt.Errorf("%s exceeds %d bytes", label, maxBytes)
+	}
+	offsetNumber := byteOffsetGetter.Call("call", value).Float()
+	if math.IsNaN(offsetNumber) || math.IsInf(offsetNumber, 0) ||
+		math.Trunc(offsetNumber) != offsetNumber || offsetNumber < 0 {
+		return nil, fmt.Errorf("%s has an invalid byte offset", label)
+	}
+	size := int(sizeNumber)
+	buffer := bufferGetter.Call("call", value)
+	canonicalView := uint8Array.New(buffer, offsetNumber, sizeNumber)
+	data := make([]byte, size)
+	if copied := js.CopyBytesToGo(data, canonicalView); copied != size {
+		return nil, fmt.Errorf("copy %s: copied %d of %d bytes", label, copied, size)
+	}
+	return data, nil
+}
+
+func requestedBackend() string {
+	value := js.Global().Get("maltWriterBackend")
+	if value.Type() != js.TypeString || value.String() == "" {
+		return "all"
+	}
+	return value.String()
+}

--- a/cmd/malt-writer-wasm/main_stub.go
+++ b/cmd/malt-writer-wasm/main_stub.go
@@ -1,0 +1,9 @@
+//go:build !js || !wasm
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("malt-writer-wasm must be built with GOOS=js GOARCH=wasm")
+}

--- a/docs/policy/compatibility.md
+++ b/docs/policy/compatibility.md
@@ -14,6 +14,7 @@ profiles rejected.
 | `stateful-complete-vectors-v1` | Experimental state profile required by the current update-view contract |
 | `malt.semantic-intent/v1` | Experimental post-v0.0.6 output-free update intent |
 | `malt.client-root-bundle/v1` | Experimental post-v0.0.6 exact-root submission; not a transition proof |
+| `malt.writer-compute-result/v1` | Experimental post-v0.0.6 browser-local bundle and next-view result |
 | `malt.materialization-receipt/v1` | Experimental post-v0.0.6 exact-bundle durability acknowledgement |
 | ProofList JSON and proof semantics | Experimental, verifier-facing |
 | Typed MALT root CIDs/codecs | Experimental, verifier-facing |

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -13,9 +13,9 @@ behavior, wire formats, and proof semantics in this folder.
 The current transport-neutral proof-bearing contracts are
 `malt.resolve/v0alpha1` and `malt.read/v0alpha1`. The post-release client-root
 contracts are `malt.update-view/v1`, `malt.semantic-intent/v1`,
-`malt.client-root-bundle/v1`, and `malt.materialization-receipt/v1`. The
-v0.0.4 `malt.artifact/v0alpha2` profile remains frozen for compatibility. See
-[MIP-1012](../mips/mip-1012-segment-path-resolution.md) and
+`malt.client-root-bundle/v1`, `malt.writer-compute-result/v1`, and
+`malt.materialization-receipt/v1`. The v0.0.4 `malt.artifact/v0alpha2` profile
+remains frozen for compatibility. See [MIP-1012](../mips/mip-1012-segment-path-resolution.md) and
 [MIP-1013](../mips/mip-1013-client-gateway-core-boundary.md).
 
 ## Documents
@@ -49,6 +49,7 @@ Every filename returned by `protocol.SchemaNames()` is indexed here:
 - [`semantic-intent.schema.json`](../../protocol/schemas/semantic-intent.schema.json)
 - [`update-view.schema.json`](../../protocol/schemas/update-view.schema.json)
 - [`verification-result.schema.json`](../../protocol/schemas/verification-result.schema.json)
+- [`writer-compute-result.schema.json`](../../protocol/schemas/writer-compute-result.schema.json)
 <!-- schema-catalog:protocol:end -->
 
 ## Notes

--- a/docs/spec/client-root-contract.md
+++ b/docs/spec/client-root-contract.md
@@ -19,6 +19,7 @@ Go source APIs stable at v1.
 | complete old-state closure | `malt.update-view/v1` | `update-view.schema.json` |
 | output-free requested change | `malt.semantic-intent/v1` | `semantic-intent.schema.json` |
 | exact locally computed submission | `malt.client-root-bundle/v1` | `client-root-bundle.schema.json` |
+| browser-local computation result | `malt.writer-compute-result/v1` | `writer-compute-result.schema.json` |
 | durable exact-bundle acknowledgement | `malt.materialization-receipt/v1` | `materialization-receipt.schema.json` |
 
 Canonical in-process values live in `mutation`. Their JSON projections and
@@ -170,6 +171,14 @@ with a different root while claiming to accept that bundle.
 Payload CIDs in the bundle support service-side availability checks. Their
 presence does not prove that payload bytes are durable, published, fresh, or
 authorized for another reader.
+
+Browser clients may invoke the same computation through
+`cmd/malt-writer-wasm`. Its `maltComputeClientRootV1` entry point strictly
+decodes bounded UTF-8 JSON `Uint8Array` values for an `UpdateView` and
+`SemanticIntent`, runs `sdk/writer`, and returns a strictly validated
+`malt.writer-compute-result/v1` carrying the canonical bundle, complete next
+view, and diagnostic local timings. The WASM adapter does not contact a service
+or change publication or trusted-root state.
 
 ## Strict JSON Decoding And Limits
 

--- a/docs/spec/commitment.md
+++ b/docs/spec/commitment.md
@@ -69,6 +69,21 @@ root without a base root. A resolver that crosses multiple structure roots
 repeats backend selection for each step rather than pinning the first root's
 backend for the complete traversal.
 
+## Root-Bound Proof Generation
+
+The built-in KZG and IPA backends implement the optional
+`commitment.IndexRootProver` capability. It opens a caller-supplied materialized
+vector against an already selected typed root without first calling `Commit`.
+Each generated proof is verified against that root before it is returned, so a
+vector inconsistent with the selected root fails closed.
+
+Semantic map and list proving prefer this capability and retain the older
+commit-and-compare path only for compatible external backends that do not
+implement it. Root-bound proving does not itself define a materialization
+upload, persistence, authorization, publication, or receipt protocol. It is
+the primitive needed by an untrusted proof service that receives commitment
+roots from a client instead of creating them.
+
 ## Related Proposals
 
 - [MIP-1005](../mips/mip-1005-kzg-map-label-domain.md) records the accepted

--- a/protocol/client_root_decode.go
+++ b/protocol/client_root_decode.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"reflect"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/dewebprotocol/malt/mutation"
 )
@@ -85,6 +86,9 @@ func decodeClientRootJSON(data []byte, target any) error {
 	}
 	if len(data) > MaxClientRootJSONBytes {
 		return fmt.Errorf("client-root JSON exceeds %d bytes", MaxClientRootJSONBytes)
+	}
+	if !utf8.Valid(data) {
+		return fmt.Errorf("client-root JSON is not valid UTF-8")
 	}
 	targetType := reflect.TypeOf(target)
 	if targetType.Kind() != reflect.Pointer || targetType.Elem().Kind() != reflect.Struct {

--- a/protocol/client_root_decode.go
+++ b/protocol/client_root_decode.go
@@ -66,6 +66,19 @@ func DecodeMaterializationReceipt(data []byte, bundle mutation.ClientRootBundle)
 	return value, nil
 }
 
+// DecodeWriterComputeResult strictly decodes and validates one browser writer
+// result.
+func DecodeWriterComputeResult(data []byte) (WriterComputeResult, error) {
+	var value WriterComputeResult
+	if err := decodeClientRootJSON(data, &value); err != nil {
+		return WriterComputeResult{}, fmt.Errorf("decode writer compute result: %w", err)
+	}
+	if err := value.Validate(); err != nil {
+		return WriterComputeResult{}, err
+	}
+	return value, nil
+}
+
 func decodeClientRootJSON(data []byte, target any) error {
 	if len(data) == 0 {
 		return fmt.Errorf("client-root JSON is empty")

--- a/protocol/client_root_test.go
+++ b/protocol/client_root_test.go
@@ -1,6 +1,7 @@
 package protocol_test
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"math"
@@ -168,6 +169,32 @@ func TestClientRootDecodeRejectsUnknownDuplicateMissingNullTrailingAndOversized(
 	oversized := make([]byte, protocol.MaxClientRootJSONBytes+1)
 	if _, err := protocol.DecodeUpdateView(oversized); err == nil {
 		t.Fatal("DecodeUpdateView accepted oversized JSON")
+	}
+}
+
+func TestClientRootDecodeRejectsInvalidUTF8WithoutRejectingReplacementRune(t *testing.T) {
+	bundle, _ := protocolClientRootFixture(t)
+	wire, err := protocol.NewClientRootBundle(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	childIndex := wireObjectIndex(t, &wire, "child")
+	wire.View.Objects[childIndex].Entries[0].Coordinate.MapPath = "\uFFFD"
+	validRaw, err := json.Marshal(wire.View)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementRune := []byte("\uFFFD")
+	if count := bytes.Count(validRaw, replacementRune); count != 1 {
+		t.Fatalf("valid JSON contains %d replacement rune encodings, want 1: %q", count, validRaw)
+	}
+	if _, err := protocol.DecodeUpdateView(validRaw); err != nil {
+		t.Fatalf("DecodeUpdateView rejected valid U+FFFD: %v", err)
+	}
+
+	invalidRaw := bytes.Replace(validRaw, replacementRune, []byte{0xff}, 1)
+	if _, err := protocol.DecodeUpdateView(invalidRaw); err == nil || !strings.Contains(err.Error(), "not valid UTF-8") {
+		t.Fatalf("invalid UTF-8 error = %v", err)
 	}
 }
 

--- a/protocol/client_root_test.go
+++ b/protocol/client_root_test.go
@@ -280,12 +280,51 @@ func TestMaterializationReceiptWireRejectsWrongDigest(t *testing.T) {
 	}
 }
 
+func TestWriterComputeResultRoundTripsAndBindsNextView(t *testing.T) {
+	bundle, _ := protocolClientRootFixture(t)
+	nextView, err := mutation.NormalizeUpdateView(bundle.View)
+	if err != nil {
+		t.Fatalf("NormalizeUpdateView failed: %v", err)
+	}
+	nextView.BaseRoot = bundle.Candidate
+	for index := range nextView.Objects {
+		if nextView.Objects[index].Root.Equals(bundle.View.BaseRoot) {
+			nextView.Objects[index].Root = bundle.Candidate
+		}
+	}
+	metrics := protocol.WriterComputeMetrics{CommitmentUpdateNS: 7, TotalNS: 11}
+	wire, err := protocol.NewWriterComputeResult(bundle, nextView, metrics)
+	if err != nil {
+		t.Fatalf("NewWriterComputeResult failed: %v", err)
+	}
+	data, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatalf("marshal writer compute result: %v", err)
+	}
+	decoded, err := protocol.DecodeWriterComputeResult(data)
+	if err != nil {
+		t.Fatalf("DecodeWriterComputeResult failed: %v", err)
+	}
+	if decoded.Profile != protocol.WriterComputeResultProfile ||
+		decoded.Bundle.Candidate != bundle.Candidate.String() ||
+		decoded.NextView.BaseRoot != bundle.Candidate.String() ||
+		decoded.Metrics != metrics {
+		t.Fatalf("unexpected writer compute result: %+v", decoded)
+	}
+
+	wire.NextView.BaseRoot = bundle.View.BaseRoot.String()
+	if err := wire.Validate(); err == nil {
+		t.Fatal("writer compute result accepted a next view at the wrong root")
+	}
+}
+
 func TestClientRootSchemasAreEmbedded(t *testing.T) {
 	want := map[string]bool{
 		"update-view.schema.json":             false,
 		"semantic-intent.schema.json":         false,
 		"client-root-bundle.schema.json":      false,
 		"materialization-receipt.schema.json": false,
+		"writer-compute-result.schema.json":   false,
 	}
 	for _, name := range protocol.SchemaNames() {
 		if _, ok := want[name]; ok {

--- a/protocol/schemas/writer-compute-result.schema.json
+++ b/protocol/schemas/writer-compute-result.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/writer-compute-result/v1/writer-compute-result.schema.json",
+  "title": "MALT Browser Writer Compute Result v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "bundle", "next_view", "metrics"],
+  "properties": {
+    "profile": {"const": "malt.writer-compute-result/v1"},
+    "bundle": {"$ref": "https://deweb.world/schemas/malt/client-root-bundle/v1/client-root-bundle.schema.json"},
+    "next_view": {"$ref": "https://deweb.world/schemas/malt/update-view/v1/update-view.schema.json"},
+    "metrics": {"$ref": "#/$defs/metrics"}
+  },
+  "$defs": {
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "view_normalization_ns",
+        "intent_normalization_ns",
+        "digest_ns",
+        "commitment_update_ns",
+        "root_computation_ns",
+        "expected_root_encoding_ns",
+        "bundle_validation_ns",
+        "next_view_ns",
+        "total_ns"
+      ],
+      "properties": {
+        "view_normalization_ns": {"type": "integer", "minimum": 0},
+        "intent_normalization_ns": {"type": "integer", "minimum": 0},
+        "digest_ns": {"type": "integer", "minimum": 0},
+        "commitment_update_ns": {"type": "integer", "minimum": 0},
+        "root_computation_ns": {"type": "integer", "minimum": 0},
+        "expected_root_encoding_ns": {"type": "integer", "minimum": 0},
+        "bundle_validation_ns": {"type": "integer", "minimum": 0},
+        "next_view_ns": {"type": "integer", "minimum": 0},
+        "total_ns": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/protocol/writer_compute.go
+++ b/protocol/writer_compute.go
@@ -1,0 +1,73 @@
+package protocol
+
+import (
+	"fmt"
+
+	"github.com/dewebprotocol/malt/mutation"
+)
+
+const WriterComputeResultProfile = "malt.writer-compute-result/v1"
+
+// WriterComputeMetrics reports browser-local writer phases. These values are
+// diagnostic timing data, not authenticated protocol evidence.
+type WriterComputeMetrics struct {
+	ViewNormalizationNS    uint64 `json:"view_normalization_ns"`
+	IntentNormalizationNS  uint64 `json:"intent_normalization_ns"`
+	DigestNS               uint64 `json:"digest_ns"`
+	CommitmentUpdateNS     uint64 `json:"commitment_update_ns"`
+	RootComputationNS      uint64 `json:"root_computation_ns"`
+	ExpectedRootEncodingNS uint64 `json:"expected_root_encoding_ns"`
+	BundleValidationNS     uint64 `json:"bundle_validation_ns"`
+	NextViewNS             uint64 `json:"next_view_ns"`
+	TotalNS                uint64 `json:"total_ns"`
+}
+
+// WriterComputeResult is the versioned browser wire result for one exact
+// client-root computation.
+type WriterComputeResult struct {
+	Profile  string               `json:"profile"`
+	Bundle   ClientRootBundle     `json:"bundle"`
+	NextView UpdateView           `json:"next_view"`
+	Metrics  WriterComputeMetrics `json:"metrics"`
+}
+
+// NewWriterComputeResult projects canonical core values into the browser wire
+// result and checks the candidate-to-next-view binding.
+func NewWriterComputeResult(bundle mutation.ClientRootBundle, nextView mutation.UpdateView, metrics WriterComputeMetrics) (WriterComputeResult, error) {
+	wireBundle, err := NewClientRootBundle(bundle)
+	if err != nil {
+		return WriterComputeResult{}, fmt.Errorf("encode writer bundle: %w", err)
+	}
+	wireNextView, err := NewUpdateView(nextView)
+	if err != nil {
+		return WriterComputeResult{}, fmt.Errorf("encode writer next view: %w", err)
+	}
+	result := WriterComputeResult{
+		Profile: WriterComputeResultProfile,
+		Bundle:  wireBundle, NextView: wireNextView, Metrics: metrics,
+	}
+	if err := result.Validate(); err != nil {
+		return WriterComputeResult{}, err
+	}
+	return result, nil
+}
+
+// Validate checks the complete nested wire values and requires the retained
+// next view to start at the exact bundle candidate.
+func (r WriterComputeResult) Validate() error {
+	if r.Profile != WriterComputeResultProfile {
+		return fmt.Errorf("writer compute result profile must be %q", WriterComputeResultProfile)
+	}
+	bundle, err := r.Bundle.Core()
+	if err != nil {
+		return fmt.Errorf("writer compute result bundle: %w", err)
+	}
+	nextView, err := r.NextView.Core()
+	if err != nil {
+		return fmt.Errorf("writer compute result next view: %w", err)
+	}
+	if !nextView.BaseRoot.Equals(bundle.Candidate) {
+		return fmt.Errorf("writer next-view base %s does not match candidate %s", nextView.BaseRoot, bundle.Candidate)
+	}
+	return nil
+}

--- a/scripts/build-writer-wasm.sh
+++ b/scripts/build-writer-wasm.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -eu
+
+output_dir=${1:-dist/writer}
+mkdir -p "$output_dir"
+GOOS=js GOARCH=wasm go build -buildvcs=false -trimpath -o "$output_dir/malt-writer.wasm" ./cmd/malt-writer-wasm
+cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" "$output_dir/wasm_exec.js"
+printf '%s\n' "built $output_dir/malt-writer.wasm"

--- a/scripts/run-writer-wasm-smoke.mjs
+++ b/scripts/run-writer-wasm-smoke.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { webcrypto } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const [wasmPath, wasmExecPath, fixturePath, selectedBackend = "all"] =
+  process.argv.slice(2);
+if (!wasmPath || !wasmExecPath || !fixturePath) {
+  console.error(
+    "usage: node run-writer-wasm-smoke.mjs <writer.wasm> <wasm_exec.js> <fixtures.json> [all|kzg|ipa]",
+  );
+  process.exit(2);
+}
+if (!["all", "kzg", "ipa"].includes(selectedBackend)) {
+  throw new Error(`unsupported writer backend ${JSON.stringify(selectedBackend)}`);
+}
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto;
+}
+const fixtures = JSON.parse(await readFile(fixturePath, "utf8"));
+
+await import(pathToFileURL(wasmExecPath).href);
+if (typeof globalThis.Go !== "function") {
+  throw new Error(`${wasmExecPath} did not install the Go WASM runtime`);
+}
+
+globalThis.maltWriterBackend = selectedBackend;
+const go = new globalThis.Go();
+const wasm = await readFile(wasmPath);
+const { instance } = await WebAssembly.instantiate(wasm, go.importObject);
+let runtimeFailure;
+void go.run(instance).catch((error) => {
+  runtimeFailure = error;
+});
+
+const deadline = Date.now() + 120_000;
+while (Date.now() < deadline) {
+  if (runtimeFailure) {
+    throw new Error(`Go WASM runtime failed: ${runtimeFailure}`);
+  }
+  if (globalThis.maltWriterReady && typeof globalThis.maltComputeClientRootV1 === "function") {
+    break;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!globalThis.maltWriterReady || typeof globalThis.maltComputeClientRootV1 !== "function") {
+  throw new Error("timed out waiting for MALT writer globals");
+}
+if (globalThis.maltWriterInitError) {
+  throw new Error(`MALT writer initialization failed: ${globalThis.maltWriterInitError}`);
+}
+if (globalThis.maltWriterLoadedBackend !== selectedBackend) {
+  throw new Error(
+    `MALT writer loaded backend ${JSON.stringify(globalThis.maltWriterLoadedBackend)}, expected ${JSON.stringify(selectedBackend)}`,
+  );
+}
+
+let rejectedStrings = false;
+try {
+  await globalThis.maltComputeClientRootV1("smoke", "{}", "{}");
+} catch {
+  rejectedStrings = true;
+}
+if (!rejectedStrings) {
+  throw new Error("writer accepted JSON strings instead of bounded Uint8Arrays");
+}
+
+const encoder = new TextEncoder();
+const hostileLength = new Proxy(encoder.encode("smoke"), {
+  get(target, property) {
+    if (property === "byteLength") {
+      return -1;
+    }
+    return Reflect.get(target, property, target);
+  },
+});
+let rejectedHostileLength = false;
+try {
+  await globalThis.maltComputeClientRootV1(
+    hostileLength,
+    encoder.encode("{}"),
+    encoder.encode("{}"),
+  );
+} catch {
+  rejectedHostileLength = true;
+}
+if (!rejectedHostileLength) {
+  throw new Error("writer accepted a proxied Uint8Array with hostile length metadata");
+}
+
+if (selectedBackend === "all") {
+  const oversizedJSON = new Uint8Array(64 * 1024 * 1024 + 1);
+  let rejectedOversized = false;
+  try {
+    await globalThis.maltComputeClientRootV1(
+      encoder.encode("smoke"),
+      oversizedJSON,
+      encoder.encode("{}"),
+    );
+  } catch {
+    rejectedOversized = true;
+  }
+  if (!rejectedOversized) {
+    throw new Error("writer accepted JSON above the 64 MiB wire limit");
+  }
+}
+
+let rejectedInvalidJSON = false;
+try {
+  await globalThis.maltComputeClientRootV1(
+    encoder.encode("smoke"),
+    encoder.encode("{}"),
+    encoder.encode("{}"),
+  );
+} catch {
+  rejectedInvalidJSON = true;
+}
+if (!rejectedInvalidJSON) {
+  throw new Error("writer accepted invalid update-view and semantic-intent JSON");
+}
+
+const selectedFixtures = fixtures.filter(
+  ({ backend }) => selectedBackend === "all" || backend === selectedBackend,
+);
+const expectedFixtureCount = selectedBackend === "all" ? 2 : 1;
+if (selectedFixtures.length !== expectedFixtureCount) {
+  throw new Error(
+    `selected ${selectedFixtures.length} fixtures for ${selectedBackend}, expected ${expectedFixtureCount}`,
+  );
+}
+for (const fixture of selectedFixtures) {
+  const operationID = encoder.encode(fixture.operation_id);
+  Object.defineProperty(operationID, "byteLength", { value: -1 });
+  const updateView = encoder.encode(JSON.stringify(fixture.update_view));
+  const semanticIntent = encoder.encode(JSON.stringify(fixture.semantic_intent));
+  for (const input of [operationID, updateView, semanticIntent]) {
+    Object.defineProperty(input, "subarray", {
+      value() {
+        throw new Error("caller-controlled subarray must not be invoked");
+      },
+    });
+  }
+  const resultJSON = await globalThis.maltComputeClientRootV1(
+    operationID,
+    updateView,
+    semanticIntent,
+  );
+  const result = JSON.parse(resultJSON);
+  if (result.profile !== "malt.writer-compute-result/v1") {
+    throw new Error(`unexpected writer result profile ${JSON.stringify(result.profile)}`);
+  }
+  if (result.bundle.operation_id !== fixture.operation_id) {
+    throw new Error(`unexpected operation ID for ${fixture.backend}`);
+  }
+  assert.deepStrictEqual(
+    result.bundle,
+    fixture.expected_bundle,
+    `${fixture.backend} WASM bundle differs from the native canonical bundle`,
+  );
+  assert.deepStrictEqual(
+    result.next_view,
+    fixture.expected_next_view,
+    `${fixture.backend} WASM next view differs from the native canonical next view`,
+  );
+  assert.deepStrictEqual(
+    Object.keys(result.metrics).sort(),
+    [
+      "bundle_validation_ns",
+      "commitment_update_ns",
+      "digest_ns",
+      "expected_root_encoding_ns",
+      "intent_normalization_ns",
+      "next_view_ns",
+      "root_computation_ns",
+      "total_ns",
+      "view_normalization_ns",
+    ],
+    `${fixture.backend} result has an unexpected metrics shape`,
+  );
+  for (const [name, value] of Object.entries(result.metrics)) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`${fixture.backend} metric ${name} is not a non-negative safe integer`);
+    }
+  }
+}
+
+console.log(
+  `WASM ${selectedBackend} writer smoke passed (${selectedFixtures.length} valid fixture(s))`,
+);
+process.exit(0);

--- a/scripts/test-writer-wasm.sh
+++ b/scripts/test-writer-wasm.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/malt-writer-wasm.XXXXXX")
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+sh "$repo_root/scripts/build-writer-wasm.sh" "$work_dir/writer"
+(
+  cd "$repo_root"
+  MALT_WRITER_WASM_FIXTURE_OUT="$work_dir/fixtures.json" \
+    go test ./cmd/malt-writer-wasm \
+    -run '^TestGenerateWASMFixtures$' \
+    -count=1
+)
+node "$repo_root/scripts/run-writer-wasm-smoke.mjs" \
+  "$work_dir/writer/malt-writer.wasm" \
+  "$work_dir/writer/wasm_exec.js" \
+  "$work_dir/fixtures.json" \
+  all
+node "$repo_root/scripts/run-writer-wasm-smoke.mjs" \
+  "$work_dir/writer/malt-writer.wasm" \
+  "$work_dir/writer/wasm_exec.js" \
+  "$work_dir/fixtures.json" \
+  kzg
+node "$repo_root/scripts/run-writer-wasm-smoke.mjs" \
+  "$work_dir/writer/malt-writer.wasm" \
+  "$work_dir/writer/wasm_exec.js" \
+  "$work_dir/fixtures.json" \
+  ipa


### PR DESCRIPTION
## Summary

- add a browser-targeted `malt-writer-wasm` entry point that verifies complete update views and computes exact KZG/IPA client-root bundles locally through `sdk/writer`
- add optional root-bound KZG/IPA proof generation so a future proof service can open caller-supplied materialization against an existing root without recomputing the commitment
- add the versioned `malt.writer-compute-result/v1` protocol DTO, strict decoder, schema, compatibility documentation, and candidate-to-next-view binding
- harden batch proof counts, IPA stable-index bounds, 32-bit integer conversions, and JS-to-WASM byte copying before allocation
- add native/WASM parity tests that deep-compare complete canonical bundles and next views for both backends

## Why

This is the first compatible stage of moving commitment computation into the trusted client/browser. It provides the Core/WASM computation boundary and the root-bound proving primitive needed by a later Gateway proof-serving path.

This PR does **not** switch the current Gateway to prove-only behavior and does not redefine `malt.client-root-bundle/v1`. Client materialization upload, durable storage, authorization, receipts, publication, cancellation, and Gateway scheduling remain follow-up contracts and product work.

## Validation

- `go test -p=6 -parallel=6 ./...`
- `go vet -p=7 ./...`
- `go build -p=7 -buildvcs=false ./...`
- `GOARCH=386 go test ./auth/commitment/kzg`
- `GOARCH=386 go test ./auth/commitment/ipa`
- `scripts/test-writer-wasm.sh` (`all`, `kzg`, `ipa`, valid fixtures plus hostile input cases)
- `scripts/test-verifier-wasm-vectors.sh` (`all`: 49, `kzg`: 25, `ipa`: 25)
- six independent review passes; the final pass reported no actionable findings