### PR TITLE
Add stateful dual-Worker browser writer WASM

### DIFF
--- a/auth/arcset/materializer/materializer.go
+++ b/auth/arcset/materializer/materializer.go
@@ -69,6 +69,14 @@ type NodeStore interface {
 	Updater
 }
 
+// RootedNodeUpdater optionally records which semantic node root owns an
+// unversioned node-cache ArcSet. Reference semantic implementations use it
+// when available so bounded in-memory sessions can reclaim unreachable node
+// caches without changing the portable Lookup/Updater contract.
+type RootedNodeUpdater interface {
+	UpdateNode(context.Context, string, cid.Cid, arcset.ArcSet) error
+}
+
 // MutableStore is the capability required by graph mutation/reference writer
 // algorithms. It deliberately does not require iteration.
 type MutableStore interface {

--- a/auth/arcset/materializer/memory/store.go
+++ b/auth/arcset/materializer/memory/store.go
@@ -19,8 +19,10 @@ type Store struct {
 }
 
 type scopeState struct {
-	current map[arcset.Path]cid.Cid
-	roots   map[string]map[arcset.Path]cid.Cid
+	current   map[arcset.Path]cid.Cid
+	nodes     map[arcset.Path]cid.Cid
+	nodeRoots map[string]map[arcset.Path]struct{}
+	roots     map[string]map[arcset.Path]cid.Cid
 }
 
 // New creates an in-memory materializer. branching controls whether snapshots
@@ -51,6 +53,9 @@ func (s *Store) Get(_ context.Context, scope string, root cid.Cid, path arcset.P
 		}
 	}
 	if target, ok := state.current[path]; ok {
+		return target, nil
+	}
+	if target, ok := state.nodes[path]; ok {
 		return target, nil
 	}
 	return cid.Undef, materializer.ErrNotFound
@@ -114,6 +119,39 @@ func (s *Store) Update(_ context.Context, scope string, newRoot, oldRoot cid.Cid
 	return nil
 }
 
+// UpdateNode installs unversioned node-cache entries and records their owning
+// semantic node root for reachability-based reclamation.
+func (s *Store) UpdateNode(_ context.Context, scope string, root cid.Cid, values arcset.ArcSet) error {
+	if !root.Defined() {
+		return materializer.ErrNotFound
+	}
+	delta, err := arcset.ToPathMap(values)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.ensureScope(scope)
+	paths := state.nodeRoots[root.KeyString()]
+	if paths == nil {
+		paths = make(map[arcset.Path]struct{}, len(delta))
+		state.nodeRoots[root.KeyString()] = paths
+	}
+	for path, target := range delta {
+		if target.Defined() {
+			state.nodes[path] = target
+			paths[path] = struct{}{}
+		} else {
+			delete(state.nodes, path)
+			delete(paths, path)
+		}
+	}
+	if len(paths) == 0 {
+		delete(state.nodeRoots, root.KeyString())
+	}
+	return nil
+}
+
 func (s *Store) Snapshot(_ context.Context, scope string, root cid.Cid) (arcset.ArcSet, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -144,6 +182,114 @@ func (s *Store) Iterate(ctx context.Context, scope string, root cid.Cid) arcset.
 }
 
 func (s *Store) Close() error { return nil }
+
+// RetainRoots removes versioned snapshots that are not reachable from the
+// supplied roots. Reachability follows CID targets within each scope. Scopes
+// absent from retain are removed entirely. The helper is intentionally
+// specific to this in-memory implementation; long-lived speculative SDK
+// sessions use it to release abandoned branches without adding lifecycle
+// policy to the portable materializer interfaces.
+func (s *Store) RetainRoots(retain map[string][]cid.Cid) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	removed := 0
+	for scope, state := range s.scopes {
+		roots, keepScope := retain[scope]
+		if !keepScope {
+			removed += len(state.roots)
+			delete(s.scopes, scope)
+			continue
+		}
+
+		reachable := make(map[string]struct{}, len(roots))
+		pending := make([]string, 0, len(roots))
+		for _, root := range roots {
+			if root.Defined() {
+				pending = append(pending, root.KeyString())
+			}
+		}
+		for len(pending) > 0 {
+			last := len(pending) - 1
+			key := pending[last]
+			pending = pending[:last]
+			if _, seen := reachable[key]; seen {
+				continue
+			}
+			snapshot, exists := state.roots[key]
+			nodePaths, nodeExists := state.nodeRoots[key]
+			if !exists && !nodeExists {
+				continue
+			}
+			reachable[key] = struct{}{}
+			for _, target := range snapshot {
+				if target.Defined() {
+					targetKey := target.KeyString()
+					if _, rootExists := state.roots[targetKey]; rootExists {
+						pending = append(pending, targetKey)
+					} else if _, nodeRootExists := state.nodeRoots[targetKey]; nodeRootExists {
+						pending = append(pending, targetKey)
+					}
+				}
+			}
+			for path := range nodePaths {
+				target := state.nodes[path]
+				if target.Defined() {
+					targetKey := target.KeyString()
+					if _, rootExists := state.roots[targetKey]; rootExists {
+						pending = append(pending, targetKey)
+					} else if _, nodeRootExists := state.nodeRoots[targetKey]; nodeRootExists {
+						pending = append(pending, targetKey)
+					}
+				}
+			}
+		}
+		for key := range state.roots {
+			if _, keep := reachable[key]; !keep {
+				delete(state.roots, key)
+				removed++
+			}
+		}
+		for key, paths := range state.nodeRoots {
+			if _, keep := reachable[key]; keep {
+				continue
+			}
+			for path := range paths {
+				delete(state.nodes, path)
+			}
+			delete(state.nodeRoots, key)
+			removed++
+		}
+	}
+	return removed
+}
+
+// RootCount reports the number of retained versioned snapshots. It is useful
+// for bounded-lifecycle tests and diagnostics of this in-memory store.
+func (s *Store) RootCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	count := 0
+	for _, state := range s.scopes {
+		count += len(state.roots)
+	}
+	return count
+}
+
+// EntryCount reports all retained current-cache entries plus versioned
+// snapshot entries. It is intended for bounded-lifecycle regression tests.
+func (s *Store) EntryCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	count := 0
+	for _, state := range s.scopes {
+		count += len(state.current) + len(state.nodes)
+		for _, snapshot := range state.roots {
+			count += len(snapshot)
+		}
+	}
+	return count
+}
 
 // DeleteRoot removes one materialized root. It exists for conformance and
 // failure-injection tests; production persistence belongs to the caller.
@@ -183,7 +329,12 @@ func (s *Store) SetCurrent(scope string, path arcset.Path, target cid.Cid) {
 func (s *Store) ensureScope(scope string) *scopeState {
 	state := s.scopes[scope]
 	if state == nil {
-		state = &scopeState{current: map[arcset.Path]cid.Cid{}, roots: map[string]map[arcset.Path]cid.Cid{}}
+		state = &scopeState{
+			current:   map[arcset.Path]cid.Cid{},
+			nodes:     map[arcset.Path]cid.Cid{},
+			nodeRoots: map[string]map[arcset.Path]struct{}{},
+			roots:     map[string]map[arcset.Path]cid.Cid{},
+		}
 		s.scopes[scope] = state
 	}
 	return state

--- a/auth/arcset/materializer/memory/store_test.go
+++ b/auth/arcset/materializer/memory/store_test.go
@@ -29,6 +29,55 @@ func TestStorePreservesBranchSnapshots(t *testing.T) {
 	}
 }
 
+func TestStoreRetainRootsPrunesBranchesAndPreservesReachableNodes(t *testing.T) {
+	store := New(true)
+	child := testCID(t, "child")
+	kept := testCID(t, "kept")
+	discarded := testCID(t, "discarded")
+	other := testCID(t, "other")
+	target := testCID(t, "target")
+	if err := store.UpdateNode(context.Background(), "scope", child, arcset.NewSetFrom(map[string]cid.Cid{"node/child": target})); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateNode(context.Background(), "scope", discarded, arcset.NewSetFrom(map[string]cid.Cid{"node/discarded": target})); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Update(context.Background(), "scope", child, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"leaf": target})); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Update(context.Background(), "scope", kept, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"child": child})); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Update(context.Background(), "scope", discarded, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"discarded": target})); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Update(context.Background(), "other", other, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{"other": target})); err != nil {
+		t.Fatal(err)
+	}
+
+	if removed := store.RetainRoots(map[string][]cid.Cid{"scope": {kept}}); removed != 3 {
+		t.Fatalf("removed %d roots/node roots, want 3", removed)
+	}
+	if got := store.RootCount(); got != 2 {
+		t.Fatalf("retained %d roots, want kept root and reachable child", got)
+	}
+	if _, err := store.Snapshot(context.Background(), "scope", child); err != nil {
+		t.Fatalf("reachable child was removed: %v", err)
+	}
+	if _, err := store.Snapshot(context.Background(), "scope", discarded); err == nil {
+		t.Fatal("discarded branch remains materialized")
+	}
+	if _, err := store.Snapshot(context.Background(), "other", other); err == nil {
+		t.Fatal("unretained scope remains materialized")
+	}
+	if _, err := store.Get(context.Background(), "scope", cid.Undef, "node/child"); err != nil {
+		t.Fatalf("reachable node cache was removed: %v", err)
+	}
+	if _, err := store.Get(context.Background(), "scope", cid.Undef, "node/discarded"); err == nil {
+		t.Fatal("discarded node cache remains materialized")
+	}
+}
+
 func testCID(t *testing.T, seed string) cid.Cid {
 	t.Helper()
 	hash, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)

--- a/auth/semantic/list/tree/internal/layout.go
+++ b/auth/semantic/list/tree/internal/layout.go
@@ -132,6 +132,9 @@ func StoreSlots(ctx context.Context, e materializer.Updater, namespace string, r
 	if err != nil {
 		return err
 	}
+	if rooted, ok := e.(materializer.RootedNodeUpdater); ok {
+		return rooted.UpdateNode(ctx, namespace, root, snapshot)
+	}
 	return e.Update(ctx, namespace, cid.Undef, cid.Undef, snapshot)
 }
 

--- a/auth/semantic/mapping/radix/radix.go
+++ b/auth/semantic/mapping/radix/radix.go
@@ -1191,7 +1191,16 @@ func (s *Map) storeBucketEntries(ctx context.Context, namespace string, root cid
 		return err
 	}
 	if rooted, ok := s.materializer.(materializer.RootedNodeUpdater); ok {
-		return rooted.UpdateNode(ctx, namespace, root, snapshot)
+		// Radix nodes link to the encoded bucket reference, not directly to the
+		// bucket commitment root. Record the cache under that same reference so
+		// reachability-based reclamation can follow the parent slot into the
+		// bucket entries. The raw root remains part of each entry path because
+		// it is also the commitment verified by bucket proofs.
+		refCID, err := encodeBucketRef(root)
+		if err != nil {
+			return err
+		}
+		return rooted.UpdateNode(ctx, namespace, refCID, snapshot)
 	}
 	return s.materializer.Update(ctx, namespace, cid.Undef, cid.Undef, snapshot)
 }

--- a/auth/semantic/mapping/radix/radix.go
+++ b/auth/semantic/mapping/radix/radix.go
@@ -1140,6 +1140,9 @@ func (s *Map) storeNodeSlots(ctx context.Context, namespace string, root cid.Cid
 	if err != nil {
 		return err
 	}
+	if rooted, ok := s.materializer.(materializer.RootedNodeUpdater); ok {
+		return rooted.UpdateNode(ctx, namespace, root, snapshot)
+	}
 	return s.materializer.Update(ctx, namespace, cid.Undef, cid.Undef, snapshot)
 }
 
@@ -1186,6 +1189,9 @@ func (s *Map) storeBucketEntries(ctx context.Context, namespace string, root cid
 	snapshot, err := arcset.NewArcSetFromPaths(arcs)
 	if err != nil {
 		return err
+	}
+	if rooted, ok := s.materializer.(materializer.RootedNodeUpdater); ok {
+		return rooted.UpdateNode(ctx, namespace, root, snapshot)
 	}
 	return s.materializer.Update(ctx, namespace, cid.Undef, cid.Undef, snapshot)
 }

--- a/auth/semantic/mapping/radix/radix_retention_test.go
+++ b/auth/semantic/mapping/radix/radix_retention_test.go
@@ -1,0 +1,61 @@
+package radix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func TestBucketEntriesRemainReachableThroughEncodedReference(t *testing.T) {
+	ctx := context.Background()
+	const namespace = "radix-bucket-retention"
+
+	store := memory.New(true)
+	semantic := &Map{materializer: store}
+	parentRoot := retentionTestCID(t, "parent")
+	bucketRoot := retentionTestCID(t, "bucket")
+	markers := []cid.Cid{
+		retentionTestCID(t, "first-marker"),
+		retentionTestCID(t, "second-marker"),
+	}
+	bucketRef, err := encodeBucketRef(bucketRoot)
+	if err != nil {
+		t.Fatalf("encodeBucketRef failed: %v", err)
+	}
+
+	if err := semantic.storeBucketEntries(ctx, namespace, bucketRoot, markers); err != nil {
+		t.Fatalf("storeBucketEntries failed: %v", err)
+	}
+	if err := semantic.storeNodeSlots(ctx, namespace, parentRoot, []cid.Cid{bucketRef}); err != nil {
+		t.Fatalf("storeNodeSlots failed: %v", err)
+	}
+
+	if removed := store.RetainRoots(map[string][]cid.Cid{namespace: {parentRoot}}); removed != 0 {
+		t.Fatalf("RetainRoots removed %d reachable node roots, want 0", removed)
+	}
+
+	got, err := semantic.loadBucketEntries(ctx, namespace, bucketRoot)
+	if err != nil {
+		t.Fatalf("loadBucketEntries after RetainRoots failed: %v", err)
+	}
+	if len(got) != len(markers) {
+		t.Fatalf("loaded %d bucket entries, want %d", len(got), len(markers))
+	}
+	for i := range markers {
+		if !got[i].Equals(markers[i]) {
+			t.Fatalf("bucket entry %d = %s, want %s", i, got[i], markers[i])
+		}
+	}
+}
+
+func retentionTestCID(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	hash, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("hashing test CID: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, hash)
+}

--- a/cmd/malt-writer-wasm/README.md
+++ b/cmd/malt-writer-wasm/README.md
@@ -35,6 +35,11 @@ globalThis.maltWriterPrepareSessionV1(
   semanticIntentJSONUTF8
 ) -> Promise<resultJSON>
 
+globalThis.maltWriterPrepareSessionCompactV1(
+  operationIDUTF8,
+  semanticIntentJSONUTF8
+) -> Promise<summaryJSON>
+
 globalThis.maltWriterAcceptSessionReceiptV1(
   operationIDUTF8,
   materializationReceiptJSONUTF8
@@ -59,7 +64,8 @@ be retained at once. Only one prepare is admitted across the JS/WASM boundary
 at a time. Discard and accept prune every materialized snapshot that is no
 longer reachable from the accepted view or a remaining prepared candidate.
 
-Both compute paths return `malt.writer-compute-result/v1`:
+The stateless and full session compute paths return
+`malt.writer-compute-result/v1`:
 
 ```json
 {
@@ -67,6 +73,20 @@ Both compute paths return `malt.writer-compute-result/v1`:
   "bundle": {},
   "next_view": {},
   "metrics": {}
+}
+```
+
+The compact session path performs and retains the same full computation, but
+only crosses the JS/WASM boundary with the complete root summary used by the
+comparison runner:
+
+```json
+{
+  "profile": "malt.writer-prepare-summary/v1",
+  "operation_id": "write-1",
+  "candidate": "bag...",
+  "outputs": [{"transition_id": "root", "root": "bag..."}],
+  "payload_cids": ["baf..."]
 }
 ```
 

--- a/cmd/malt-writer-wasm/README.md
+++ b/cmd/malt-writer-wasm/README.md
@@ -6,63 +6,95 @@ Build the browser writer artifacts from the repository root:
 scripts/build-writer-wasm.sh dist/writer
 ```
 
-The build emits separate `malt-writer-kzg.wasm` and
-`malt-writer-ipa.wasm` artifacts plus one `wasm_exec.js`. Each artifact links
-exactly one commitment backend; the backend cannot be selected through a
-mutable JavaScript global.
+The build emits one `malt-writer.wasm`, one `wasm_exec.js`, and the
+`malt-writer-workers.mjs` controller plus its `malt-writer-worker.mjs` Worker.
+The unified WASM file contains both commitment backends. The controller
+downloads and compiles it once, then transfers the compiled
+`WebAssembly.Module` to two independent Workers. One instance initializes only
+KZG and the other initializes only IPA.
 
-After the Go runtime starts, the module registers the backward-compatible
-stateless entry point:
+```js
+import { createMaltWriterWorkers } from "./malt-writer-workers.mjs";
+
+const writers = await createMaltWriterWorkers();
+
+// KZG normally becomes usable while IPA is still initializing.
+await writers.kzgReady;
+console.log(writers.status("ipa")); // { backend: "ipa", state: "initializing" }
+
+const baseRoot = await writers.load("kzg", updateViewJSONUTF8);
+const summaryJSON = await writers.prepareCompact(
+  "kzg",
+  operationIDUTF8,
+  semanticIntentJSONUTF8,
+);
+
+// Await IPA only when an IPA view needs it.
+await writers.ipaReady;
+```
+
+`kzgReady`, `ipaReady`, `whenReady(backend)`, and `status(backend)` are
+independent. IPA initialization cannot block the KZG Worker event loop, RPC
+queue, session, or WASM memory. Call `terminate()` when both instances are no
+longer needed.
+
+The controller exposes the following backend-routed methods:
 
 ```text
-globalThis.maltComputeClientRootV1(
+compute(
+  backend,
   operationIDUTF8,
   updateViewJSONUTF8,
   semanticIntentJSONUTF8
 ) -> Promise<resultJSON>
-```
 
-Long-lived clients should load one verified session and retain its semantic
-materialization between writes:
+load(backend, updateViewJSONUTF8) -> Promise<baseRoot>
 
-```text
-globalThis.maltWriterLoadSessionV1(
-  updateViewJSONUTF8
-) -> Promise<baseRoot>
-
-globalThis.maltWriterPrepareSessionV1(
+prepare(
+  backend,
   operationIDUTF8,
   semanticIntentJSONUTF8
 ) -> Promise<resultJSON>
 
-globalThis.maltWriterPrepareSessionCompactV1(
+prepareCompact(
+  backend,
   operationIDUTF8,
   semanticIntentJSONUTF8
 ) -> Promise<summaryJSON>
 
-globalThis.maltWriterAcceptSessionReceiptV1(
+acceptReceipt(
+  backend,
   operationIDUTF8,
   materializationReceiptJSONUTF8
 ) -> Promise<newBaseRoot>
 
-globalThis.maltWriterDiscardSessionCandidateV1(
-  operationIDUTF8
-) -> Promise<operationID>
+discard(backend, operationIDUTF8) -> Promise<operationID>
 ```
 
-All arguments are strict `Uint8Array` values. The operation ID contains up to
-128 ASCII bytes; JSON arguments use the checked-in client-root wire profiles
+All byte arguments are strict `Uint8Array` values. The operation ID contains up
+to 128 ASCII bytes; JSON arguments use the checked-in client-root wire profiles
 and are bounded by the protocol's 64 MiB document limit.
+
+Each Worker supplies exactly one immutable startup argument to its Go instance:
+`--backend=kzg` or `--backend=ipa`. The runtime rejects missing, invalid, or
+multiple backend arguments. There is no mutable JavaScript backend selector,
+and a single instance never initializes both schemes.
+
+## Session behavior
 
 Loading recomputes and verifies the complete update view once. Preparing a
 mutation uses the retained logical vectors and semantic materialization, but
 does not advance the session. Only an exact
-`malt.materialization-receipt/v1` for the prepared bundle advances the
-retained base. Accepting one candidate invalidates every other speculative
-candidate; at most 64 candidates and 64 MiB of encoded prepared responses may
-be retained at once. Only one prepare is admitted across the JS/WASM boundary
-at a time. Discard and accept prune every materialized snapshot that is no
-longer reachable from the accepted view or a remaining prepared candidate.
+`malt.materialization-receipt/v1` for the prepared bundle advances the retained
+base.
+
+Accepting one candidate invalidates every other speculative candidate; at most
+64 candidates and 64 MiB of encoded prepared responses may be retained at once.
+Only one prepare is admitted in each backend instance across the JS/WASM
+boundary at a time. Discard and accept prune every materialized snapshot that
+is no longer reachable from the accepted view or a remaining prepared
+candidate. KZG and IPA sessions are unrelated because they live in different
+Workers.
 
 The stateless and full session compute paths return
 `malt.writer-compute-result/v1`:
@@ -77,7 +109,7 @@ The stateless and full session compute paths return
 ```
 
 The compact session path performs and retains the same full computation, but
-only crosses the JS/WASM boundary with the complete root summary used by the
+only crosses the Worker boundary with the complete root summary used by the
 comparison runner:
 
 ```json
@@ -93,8 +125,26 @@ comparison runner:
 The writer computes locally and does not contact a Gateway, publish a root, or
 promote a candidate to trusted state.
 
-Run the native tests, dependency-isolation checks, and both real WASM smoke
-suites with:
+## Direct runtime API
+
+The Worker wraps these globals registered inside one backend-specific WASM
+instance:
+
+```text
+globalThis.maltComputeClientRootV1(...)
+globalThis.maltWriterLoadSessionV1(...)
+globalThis.maltWriterPrepareSessionV1(...)
+globalThis.maltWriterPrepareSessionCompactV1(...)
+globalThis.maltWriterAcceptSessionReceiptV1(...)
+globalThis.maltWriterDiscardSessionCandidateV1(...)
+```
+
+Code that starts the Go runtime directly must set
+`go.argv = ["malt-writer.wasm", "--backend=kzg"]` (or `ipa`) before
+`go.run(instance)`. Browser applications should normally use the controller.
+
+Run the native tests, compile-time dependency-isolation checks, direct real-WASM
+smokes for both backends, and the dual-Worker independence smoke with:
 
 ```bash
 scripts/test-writer-wasm.sh

--- a/cmd/malt-writer-wasm/README.md
+++ b/cmd/malt-writer-wasm/README.md
@@ -1,14 +1,18 @@
 # Browser Client-Root Writer
 
-Build the browser writer bundle from the repository root:
+Build the browser writer artifacts from the repository root:
 
 ```bash
 scripts/build-writer-wasm.sh dist/writer
 ```
 
-Before starting the Go runtime, a browser may select `kzg`, `ipa`, or `all`
-through `globalThis.maltWriterBackend`. The default is `all`. After the runtime
-starts, the module registers:
+The build emits separate `malt-writer-kzg.wasm` and
+`malt-writer-ipa.wasm` artifacts plus one `wasm_exec.js`. Each artifact links
+exactly one commitment backend; the backend cannot be selected through a
+mutable JavaScript global.
+
+After the Go runtime starts, the module registers the backward-compatible
+stateless entry point:
 
 ```text
 globalThis.maltComputeClientRootV1(
@@ -18,14 +22,44 @@ globalThis.maltComputeClientRootV1(
 ) -> Promise<resultJSON>
 ```
 
-All three arguments are `Uint8Array` values. The operation ID contains up to
-128 ASCII bytes; the update view and semantic intent use the checked-in
-`malt.update-view/v1` and `malt.semantic-intent/v1` schemas. The writer strictly
-decodes them from `Uint8Array` values containing UTF-8 JSON. Inputs are rejected
-before copying if the operation ID exceeds 128 bytes or either JSON byte array
-exceeds the protocol's 64 MiB document limit. The writer independently
-recomputes every old root, computes all changed commitments locally, and
-returns:
+Long-lived clients should load one verified session and retain its semantic
+materialization between writes:
+
+```text
+globalThis.maltWriterLoadSessionV1(
+  updateViewJSONUTF8
+) -> Promise<baseRoot>
+
+globalThis.maltWriterPrepareSessionV1(
+  operationIDUTF8,
+  semanticIntentJSONUTF8
+) -> Promise<resultJSON>
+
+globalThis.maltWriterAcceptSessionReceiptV1(
+  operationIDUTF8,
+  materializationReceiptJSONUTF8
+) -> Promise<newBaseRoot>
+
+globalThis.maltWriterDiscardSessionCandidateV1(
+  operationIDUTF8
+) -> Promise<operationID>
+```
+
+All arguments are strict `Uint8Array` values. The operation ID contains up to
+128 ASCII bytes; JSON arguments use the checked-in client-root wire profiles
+and are bounded by the protocol's 64 MiB document limit.
+
+Loading recomputes and verifies the complete update view once. Preparing a
+mutation uses the retained logical vectors and semantic materialization, but
+does not advance the session. Only an exact
+`malt.materialization-receipt/v1` for the prepared bundle advances the
+retained base. Accepting one candidate invalidates every other speculative
+candidate; at most 64 candidates and 64 MiB of encoded prepared responses may
+be retained at once. Only one prepare is admitted across the JS/WASM boundary
+at a time. Discard and accept prune every materialized snapshot that is no
+longer reachable from the accepted view or a remaining prepared candidate.
+
+Both compute paths return `malt.writer-compute-result/v1`:
 
 ```json
 {
@@ -36,7 +70,12 @@ returns:
 }
 ```
 
-`bundle` is a canonical `malt.client-root-bundle/v1` value. `next_view` is the
-complete candidate view that a long-lived client may retain only after the
-service returns an exact durable receipt. The operation does not publish or
-trust the candidate and does not contact a Gateway.
+The writer computes locally and does not contact a Gateway, publish a root, or
+promote a candidate to trusted state.
+
+Run the native tests, dependency-isolation checks, and both real WASM smoke
+suites with:
+
+```bash
+scripts/test-writer-wasm.sh
+```

--- a/cmd/malt-writer-wasm/README.md
+++ b/cmd/malt-writer-wasm/README.md
@@ -23,11 +23,13 @@ await writers.kzgReady;
 console.log(writers.status("ipa")); // { backend: "ipa", state: "initializing" }
 
 const baseRoot = await writers.load("kzg", updateViewJSONUTF8);
-const summaryJSON = await writers.prepareCompact(
+const candidateRoot = await writers.prepare(
   "kzg",
   operationIDUTF8,
   semanticIntentJSONUTF8,
 );
+const resultJSON = await writers.getPreparedResult("kzg", operationIDUTF8);
+await writers.closeSession("kzg");
 
 // Await IPA only when an IPA view needs it.
 await writers.ipaReady;
@@ -35,8 +37,11 @@ await writers.ipaReady;
 
 `kzgReady`, `ipaReady`, `whenReady(backend)`, and `status(backend)` are
 independent. IPA initialization cannot block the KZG Worker event loop, RPC
-queue, session, or WASM memory. Call `terminate()` when both instances are no
-longer needed.
+queue, session, or WASM memory. Closing a session releases its accepted view,
+prepared candidates, and materialized snapshots while keeping that Worker ready
+for another `load`. Call `terminateBackend(backend)` to release one Worker, or
+`terminateAll()` when neither instance is needed. `terminate()` remains an alias
+for `terminateAll()`.
 
 The controller exposes the following backend-routed methods:
 
@@ -54,13 +59,12 @@ prepare(
   backend,
   operationIDUTF8,
   semanticIntentJSONUTF8
-) -> Promise<resultJSON>
+) -> Promise<candidateRoot>
 
-prepareCompact(
+getPreparedResult(
   backend,
-  operationIDUTF8,
-  semanticIntentJSONUTF8
-) -> Promise<summaryJSON>
+  operationIDUTF8
+) -> Promise<resultJSON>
 
 acceptReceipt(
   backend,
@@ -69,6 +73,11 @@ acceptReceipt(
 ) -> Promise<newBaseRoot>
 
 discard(backend, operationIDUTF8) -> Promise<operationID>
+
+closeSession(backend) -> Promise<void>
+
+terminateBackend(backend) -> void
+terminateAll() -> void
 ```
 
 All byte arguments are strict `Uint8Array` values. The operation ID contains up
@@ -84,7 +93,10 @@ and a single instance never initializes both schemes.
 
 Loading recomputes and verifies the complete update view once. Preparing a
 mutation uses the retained logical vectors and semantic materialization, but
-does not advance the session. Only an exact
+does not advance the session. `prepare` returns only the candidate root. The
+caller requests the full result for a retained operation through
+`getPreparedResult` only when it needs the bundle, next view, or metrics. Only
+an exact
 `malt.materialization-receipt/v1` for the prepared bundle advances the retained
 base.
 
@@ -96,7 +108,7 @@ is no longer reachable from the accepted view or a remaining prepared
 candidate. KZG and IPA sessions are unrelated because they live in different
 Workers.
 
-The stateless and full session compute paths return
+The stateless compute path and `getPreparedResult` return the protocol-owned
 `malt.writer-compute-result/v1`:
 
 ```json
@@ -105,20 +117,6 @@ The stateless and full session compute paths return
   "bundle": {},
   "next_view": {},
   "metrics": {}
-}
-```
-
-The compact session path performs and retains the same full computation, but
-only crosses the Worker boundary with the complete root summary used by the
-comparison runner:
-
-```json
-{
-  "profile": "malt.writer-prepare-summary/v1",
-  "operation_id": "write-1",
-  "candidate": "bag...",
-  "outputs": [{"transition_id": "root", "root": "bag..."}],
-  "payload_cids": ["baf..."]
 }
 ```
 
@@ -134,9 +132,10 @@ instance:
 globalThis.maltComputeClientRootV1(...)
 globalThis.maltWriterLoadSessionV1(...)
 globalThis.maltWriterPrepareSessionV1(...)
-globalThis.maltWriterPrepareSessionCompactV1(...)
+globalThis.maltWriterGetPreparedResultV1(...)
 globalThis.maltWriterAcceptSessionReceiptV1(...)
 globalThis.maltWriterDiscardSessionCandidateV1(...)
+globalThis.maltWriterCloseSessionV1()
 ```
 
 Code that starts the Go runtime directly must set

--- a/cmd/malt-writer-wasm/backend.go
+++ b/cmd/malt-writer-wasm/backend.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const backendArgumentPrefix = "--backend="
+
+func parseStartupBackend(args []string) (string, error) {
+	if len(args) != 1 || !strings.HasPrefix(args[0], backendArgumentPrefix) {
+		return "", fmt.Errorf("writer requires exactly one %s{kzg|ipa} argument", backendArgumentPrefix)
+	}
+	backend := strings.TrimPrefix(args[0], backendArgumentPrefix)
+	switch backend {
+	case "kzg", "ipa":
+		return backend, nil
+	default:
+		return "", fmt.Errorf("unsupported writer backend %q", backend)
+	}
+}

--- a/cmd/malt-writer-wasm/browser/malt-writer-worker.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-worker.mjs
@@ -3,14 +3,24 @@ const RPC_FUNCTIONS = Object.freeze({
   compute: "maltComputeClientRootV1",
   load: "maltWriterLoadSessionV1",
   prepare: "maltWriterPrepareSessionV1",
-  prepareCompact: "maltWriterPrepareSessionCompactV1",
+  getPreparedResult: "maltWriterGetPreparedResultV1",
   acceptReceipt: "maltWriterAcceptSessionReceiptV1",
   discard: "maltWriterDiscardSessionCandidateV1",
+  closeSession: "maltWriterCloseSessionV1",
 });
+const STATEFUL_RPC_METHODS = new Set([
+  "load",
+  "prepare",
+  "getPreparedResult",
+  "acceptReceipt",
+  "discard",
+  "closeSession",
+]);
 
 let initialized = false;
 let ready = false;
 let loadedBackend;
+let sessionRequestQueue = Promise.resolve();
 
 function errorMessage(error) {
   return error instanceof Error ? error.message : String(error);
@@ -108,6 +118,21 @@ async function handleRequest(message) {
   return globalThis[functionName](...args);
 }
 
+function postResponse(message, task) {
+  void task.then(
+    (result) => {
+      self.postMessage({ type: "response", id: message.id, result });
+    },
+    (error) => {
+      self.postMessage({
+        type: "response",
+        id: message.id,
+        error: errorMessage(error),
+      });
+    },
+  );
+}
+
 self.addEventListener("message", (event) => {
   const message = event.data;
   if (!message || typeof message !== "object") {
@@ -126,16 +151,14 @@ self.addEventListener("message", (event) => {
     return;
   }
 
-  void handleRequest(message).then(
-    (result) => {
-      self.postMessage({ type: "response", id: message.id, result });
-    },
-    (error) => {
-      self.postMessage({
-        type: "response",
-        id: message.id,
-        error: errorMessage(error),
-      });
-    },
-  );
+  if (STATEFUL_RPC_METHODS.has(message.method)) {
+    const task = sessionRequestQueue.then(() => handleRequest(message));
+    sessionRequestQueue = task.then(
+      () => undefined,
+      () => undefined,
+    );
+    postResponse(message, task);
+    return;
+  }
+  postResponse(message, handleRequest(message));
 });

--- a/cmd/malt-writer-wasm/browser/malt-writer-worker.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-worker.mjs
@@ -1,0 +1,141 @@
+const SUPPORTED_BACKENDS = new Set(["kzg", "ipa"]);
+const RPC_FUNCTIONS = Object.freeze({
+  compute: "maltComputeClientRootV1",
+  load: "maltWriterLoadSessionV1",
+  prepare: "maltWriterPrepareSessionV1",
+  prepareCompact: "maltWriterPrepareSessionCompactV1",
+  acceptReceipt: "maltWriterAcceptSessionReceiptV1",
+  discard: "maltWriterDiscardSessionCandidateV1",
+});
+
+let initialized = false;
+let ready = false;
+let loadedBackend;
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function postFailure(backend, error) {
+  self.postMessage({
+    type: "failed",
+    backend,
+    error: errorMessage(error),
+  });
+}
+
+async function initialize(message) {
+  if (initialized) {
+    throw new Error("MALT writer Worker is already initialized");
+  }
+  initialized = true;
+
+  const { backend, module, wasmExecURL } = message;
+  if (!SUPPORTED_BACKENDS.has(backend)) {
+    throw new Error(`unsupported writer backend ${JSON.stringify(backend)}`);
+  }
+  if (typeof wasmExecURL !== "string" || wasmExecURL.length === 0) {
+    throw new Error("wasmExecURL must be a non-empty string");
+  }
+  try {
+    WebAssembly.Module.exports(module);
+  } catch {
+    throw new Error("module must be a compiled WebAssembly.Module");
+  }
+
+  loadedBackend = backend;
+  await import(wasmExecURL);
+  if (typeof globalThis.Go !== "function") {
+    throw new Error(`${wasmExecURL} did not install the Go WASM runtime`);
+  }
+
+  const go = new globalThis.Go();
+  go.argv = ["malt-writer.wasm", `--backend=${backend}`];
+  const instance = await WebAssembly.instantiate(module, go.importObject);
+  let runtimeFailure;
+  void go.run(instance).catch((error) => {
+    runtimeFailure = error;
+    ready = false;
+    postFailure(backend, new Error(`Go WASM runtime failed: ${errorMessage(error)}`));
+  });
+
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (runtimeFailure) {
+      throw runtimeFailure;
+    }
+    if (globalThis.maltWriterReady) {
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  if (!globalThis.maltWriterReady) {
+    throw new Error("timed out waiting for the MALT writer runtime");
+  }
+  if (globalThis.maltWriterInitError) {
+    throw new Error(`MALT writer initialization failed: ${globalThis.maltWriterInitError}`);
+  }
+  if (globalThis.maltWriterLoadedBackend !== backend) {
+    throw new Error(
+      `MALT writer loaded backend ${JSON.stringify(globalThis.maltWriterLoadedBackend)}, expected ${JSON.stringify(backend)}`,
+    );
+  }
+  for (const functionName of Object.values(RPC_FUNCTIONS)) {
+    if (typeof globalThis[functionName] !== "function") {
+      throw new Error(`MALT writer did not register ${functionName}`);
+    }
+  }
+
+  ready = true;
+  self.postMessage({ type: "ready", backend });
+}
+
+async function handleRequest(message) {
+  const { id, method, args } = message;
+  if (!ready) {
+    throw new Error(`${loadedBackend ?? "uninitialized"} writer is not ready`);
+  }
+  if (!Number.isSafeInteger(id) || id < 1) {
+    throw new Error("request id must be a positive safe integer");
+  }
+  const functionName = RPC_FUNCTIONS[method];
+  if (!functionName) {
+    throw new Error(`unsupported writer method ${JSON.stringify(method)}`);
+  }
+  if (!Array.isArray(args)) {
+    throw new Error("request args must be an array");
+  }
+  return globalThis[functionName](...args);
+}
+
+self.addEventListener("message", (event) => {
+  const message = event.data;
+  if (!message || typeof message !== "object") {
+    postFailure(loadedBackend, new Error("Worker message must be an object"));
+    return;
+  }
+  if (message.type === "initialize") {
+    void initialize(message).catch((error) => {
+      ready = false;
+      postFailure(message.backend, error);
+    });
+    return;
+  }
+  if (message.type !== "request") {
+    postFailure(loadedBackend, new Error(`unsupported Worker message ${JSON.stringify(message.type)}`));
+    return;
+  }
+
+  void handleRequest(message).then(
+    (result) => {
+      self.postMessage({ type: "response", id: message.id, result });
+    },
+    (error) => {
+      self.postMessage({
+        type: "response",
+        id: message.id,
+        error: errorMessage(error),
+      });
+    },
+  );
+});

--- a/cmd/malt-writer-wasm/browser/malt-writer-workers.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-workers.mjs
@@ -1,0 +1,297 @@
+const BACKENDS = Object.freeze(["kzg", "ipa"]);
+const BACKEND_SET = new Set(BACKENDS);
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function requireBackend(backend) {
+  if (!BACKEND_SET.has(backend)) {
+    throw new Error(`unsupported writer backend ${JSON.stringify(backend)}`);
+  }
+  return backend;
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  // A caller may intentionally use only one backend. Keep failure of the other
+  // readiness Promise observable without producing an unhandled rejection.
+  void promise.catch(() => {});
+  return { promise, resolve, reject };
+}
+
+async function compileModule(wasmURL, fetchFunction) {
+  const response = await fetchFunction(wasmURL);
+  if (!response.ok) {
+    throw new Error(`fetch ${wasmURL}: HTTP ${response.status}`);
+  }
+  if (typeof WebAssembly.compileStreaming === "function") {
+    const fallback = response.clone();
+    try {
+      return await WebAssembly.compileStreaming(response);
+    } catch {
+      return WebAssembly.compile(await fallback.arrayBuffer());
+    }
+  }
+  return WebAssembly.compile(await response.arrayBuffer());
+}
+
+function defaultWorkerFactory({ backend, workerURL }) {
+  return new Worker(workerURL, {
+    type: "module",
+    name: `malt-writer-${backend}`,
+  });
+}
+
+function validateWorker(worker) {
+  if (
+    !worker ||
+    typeof worker.postMessage !== "function" ||
+    typeof worker.addEventListener !== "function" ||
+    typeof worker.terminate !== "function"
+  ) {
+    throw new Error("workerFactory must return a Worker-compatible object");
+  }
+  return worker;
+}
+
+export class MaltWriterWorkers {
+  #module;
+  #wasmExecURL;
+  #workerURL;
+  #workerFactory;
+  #states = new Map();
+  #nextRequestID = 1;
+  #terminated = false;
+
+  constructor({ module, wasmExecURL, workerURL, workerFactory = defaultWorkerFactory }) {
+    try {
+      WebAssembly.Module.exports(module);
+    } catch {
+      throw new Error("module must be a compiled WebAssembly.Module");
+    }
+    if (typeof wasmExecURL !== "string" || wasmExecURL.length === 0) {
+      throw new Error("wasmExecURL must be a non-empty string");
+    }
+    if (typeof workerFactory !== "function") {
+      throw new Error("workerFactory must be a function");
+    }
+
+    this.#module = module;
+    this.#wasmExecURL = wasmExecURL;
+    this.#workerURL = workerURL;
+    this.#workerFactory = workerFactory;
+    for (const backend of BACKENDS) {
+      this.#start(backend);
+    }
+    this.kzgReady = this.#states.get("kzg").ready.promise;
+    this.ipaReady = this.#states.get("ipa").ready.promise;
+  }
+
+  #start(backend) {
+    const state = {
+      backend,
+      phase: "initializing",
+      error: undefined,
+      ready: deferred(),
+      pending: new Map(),
+      worker: undefined,
+    };
+    this.#states.set(backend, state);
+    try {
+      state.worker = validateWorker(
+        this.#workerFactory({ backend, workerURL: this.#workerURL }),
+      );
+      state.worker.addEventListener("message", (event) => {
+        this.#handleMessage(state, event.data);
+      });
+      state.worker.addEventListener("error", (event) => {
+        this.#fail(state, event?.error ?? event?.message ?? "Worker error");
+      });
+      state.worker.addEventListener("messageerror", () => {
+        this.#fail(state, "Worker message could not be deserialized");
+      });
+      state.worker.postMessage({
+        type: "initialize",
+        backend,
+        module: this.#module,
+        wasmExecURL: this.#wasmExecURL,
+      });
+    } catch (error) {
+      this.#fail(state, error);
+    }
+  }
+
+  #handleMessage(state, message) {
+    if (!message || typeof message !== "object") {
+      this.#fail(state, "Worker returned a non-object message");
+      return;
+    }
+    if (message.backend !== undefined && message.backend !== state.backend) {
+      this.#fail(
+        state,
+        `Worker identified itself as ${JSON.stringify(message.backend)}, expected ${JSON.stringify(state.backend)}`,
+      );
+      return;
+    }
+    if (message.type === "ready") {
+      if (state.phase !== "initializing") {
+        this.#fail(state, `Worker became ready from state ${state.phase}`);
+        return;
+      }
+      state.phase = "ready";
+      state.ready.resolve(Object.freeze({ backend: state.backend }));
+      return;
+    }
+    if (message.type === "failed") {
+      this.#fail(state, message.error ?? "Worker failed");
+      return;
+    }
+    if (message.type !== "response") {
+      this.#fail(state, `Worker returned unsupported message ${JSON.stringify(message.type)}`);
+      return;
+    }
+
+    const pending = state.pending.get(message.id);
+    if (!pending) {
+      this.#fail(state, `Worker returned unknown request id ${JSON.stringify(message.id)}`);
+      return;
+    }
+    state.pending.delete(message.id);
+    if (message.error !== undefined) {
+      pending.reject(new Error(String(message.error)));
+    } else {
+      pending.resolve(message.result);
+    }
+  }
+
+  #fail(state, error) {
+    if (state.phase === "failed" || state.phase === "terminated") {
+      return;
+    }
+    const failure = error instanceof Error ? error : new Error(errorMessage(error));
+    state.phase = "failed";
+    state.error = failure;
+    state.ready.reject(failure);
+    for (const pending of state.pending.values()) {
+      pending.reject(failure);
+    }
+    state.pending.clear();
+  }
+
+  status(backend) {
+    const state = this.#states.get(requireBackend(backend));
+    return Object.freeze({
+      backend,
+      state: state.phase,
+      ...(state.error ? { error: state.error.message } : {}),
+    });
+  }
+
+  whenReady(backend) {
+    return this.#states.get(requireBackend(backend)).ready.promise;
+  }
+
+  async #request(backend, method, args) {
+    const state = this.#states.get(requireBackend(backend));
+    if (this.#terminated) {
+      throw new Error("MALT writer Workers are terminated");
+    }
+    await state.ready.promise;
+    if (state.phase !== "ready") {
+      throw state.error ?? new Error(`${backend} writer is not ready`);
+    }
+    const id = this.#nextRequestID++;
+    if (!Number.isSafeInteger(id)) {
+      throw new Error("MALT writer request id space is exhausted");
+    }
+    return new Promise((resolve, reject) => {
+      state.pending.set(id, { resolve, reject });
+      try {
+        state.worker.postMessage({ type: "request", id, method, args });
+      } catch (error) {
+        state.pending.delete(id);
+        reject(error);
+      }
+    });
+  }
+
+  compute(backend, operationID, updateViewJSON, semanticIntentJSON) {
+    return this.#request(backend, "compute", [
+      operationID,
+      updateViewJSON,
+      semanticIntentJSON,
+    ]);
+  }
+
+  load(backend, updateViewJSON) {
+    return this.#request(backend, "load", [updateViewJSON]);
+  }
+
+  prepare(backend, operationID, semanticIntentJSON) {
+    return this.#request(backend, "prepare", [operationID, semanticIntentJSON]);
+  }
+
+  prepareCompact(backend, operationID, semanticIntentJSON) {
+    return this.#request(backend, "prepareCompact", [operationID, semanticIntentJSON]);
+  }
+
+  acceptReceipt(backend, operationID, materializationReceiptJSON) {
+    return this.#request(backend, "acceptReceipt", [
+      operationID,
+      materializationReceiptJSON,
+    ]);
+  }
+
+  discard(backend, operationID) {
+    return this.#request(backend, "discard", [operationID]);
+  }
+
+  terminate() {
+    if (this.#terminated) {
+      return;
+    }
+    this.#terminated = true;
+    for (const state of this.#states.values()) {
+      state.worker?.terminate();
+      if (state.phase !== "failed") {
+        const failure = new Error(`${state.backend} writer was terminated`);
+        state.error = failure;
+        state.ready.reject(failure);
+        for (const pending of state.pending.values()) {
+          pending.reject(failure);
+        }
+        state.pending.clear();
+        state.phase = "terminated";
+      }
+    }
+  }
+}
+
+export async function createMaltWriterWorkers({
+  wasmURL = new URL("./malt-writer.wasm", import.meta.url),
+  wasmExecURL = new URL("./wasm_exec.js", import.meta.url),
+  workerURL = new URL("./malt-writer-worker.mjs", import.meta.url),
+  module,
+  fetch: fetchFunction = globalThis.fetch,
+  workerFactory,
+} = {}) {
+  let compiledModule = module;
+  if (compiledModule === undefined) {
+    if (typeof fetchFunction !== "function") {
+      throw new Error("fetch is unavailable and no compiled module was provided");
+    }
+    compiledModule = await compileModule(wasmURL, fetchFunction);
+  }
+  return new MaltWriterWorkers({
+    module: compiledModule,
+    wasmExecURL: String(wasmExecURL),
+    workerURL,
+    ...(workerFactory ? { workerFactory } : {}),
+  });
+}

--- a/cmd/malt-writer-wasm/browser/malt-writer-workers.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-workers.mjs
@@ -175,8 +175,23 @@ export class MaltWriterWorkers {
       return;
     }
     const failure = error instanceof Error ? error : new Error(errorMessage(error));
-    state.phase = "failed";
+    this.#stop(state, "failed", failure);
+  }
+
+  #stop(state, phase, failure) {
+    if (state.phase === "failed" || state.phase === "terminated") {
+      return;
+    }
+    state.phase = phase;
     state.error = failure;
+    const worker = state.worker;
+    state.worker = undefined;
+    try {
+      worker?.terminate();
+    } catch {
+      // Reject readiness and requests even if a custom Worker adapter fails
+      // while releasing its underlying Worker.
+    }
     state.ready.reject(failure);
     for (const pending of state.pending.values()) {
       pending.reject(failure);
@@ -237,8 +252,8 @@ export class MaltWriterWorkers {
     return this.#request(backend, "prepare", [operationID, semanticIntentJSON]);
   }
 
-  prepareCompact(backend, operationID, semanticIntentJSON) {
-    return this.#request(backend, "prepareCompact", [operationID, semanticIntentJSON]);
+  getPreparedResult(backend, operationID) {
+    return this.#request(backend, "getPreparedResult", [operationID]);
   }
 
   acceptReceipt(backend, operationID, materializationReceiptJSON) {
@@ -252,24 +267,35 @@ export class MaltWriterWorkers {
     return this.#request(backend, "discard", [operationID]);
   }
 
-  terminate() {
+  closeSession(backend) {
+    return this.#request(backend, "closeSession", []).then(() => undefined);
+  }
+
+  terminateBackend(backend) {
+    const state = this.#states.get(requireBackend(backend));
+    this.#stop(
+      state,
+      "terminated",
+      new Error(`${state.backend} writer was terminated`),
+    );
+  }
+
+  terminateAll() {
     if (this.#terminated) {
       return;
     }
     this.#terminated = true;
     for (const state of this.#states.values()) {
-      state.worker?.terminate();
-      if (state.phase !== "failed") {
-        const failure = new Error(`${state.backend} writer was terminated`);
-        state.error = failure;
-        state.ready.reject(failure);
-        for (const pending of state.pending.values()) {
-          pending.reject(failure);
-        }
-        state.pending.clear();
-        state.phase = "terminated";
-      }
+      this.#stop(
+        state,
+        "terminated",
+        new Error(`${state.backend} writer was terminated`),
+      );
     }
+  }
+
+  terminate() {
+    this.terminateAll();
   }
 }
 

--- a/cmd/malt-writer-wasm/browser/malt-writer-workers.test.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-workers.test.mjs
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MaltWriterWorkers } from "./malt-writer-workers.mjs";
+
+const EMPTY_WASM_MODULE = new WebAssembly.Module(
+  new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]),
+);
+
+class FakeWorker {
+  constructor(backend, throwOnInitialize = false) {
+    this.backend = backend;
+    this.throwOnInitialize = throwOnInitialize;
+    this.listeners = new Map();
+    this.requests = [];
+    this.requestWaiters = [];
+    this.terminationCount = 0;
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message) {
+    if (message.type === "initialize") {
+      if (this.throwOnInitialize) {
+        throw new Error(`${this.backend} initialize postMessage failed`);
+      }
+      this.initialization = message;
+      return;
+    }
+    const waiter = this.requestWaiters.shift();
+    if (waiter) {
+      waiter(message);
+    } else {
+      this.requests.push(message);
+    }
+  }
+
+  terminate() {
+    this.terminationCount += 1;
+  }
+
+  emit(type, event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  ready() {
+    this.emit("message", {
+      data: { type: "ready", backend: this.backend },
+    });
+  }
+
+  fail(error) {
+    this.emit("error", { error, message: error.message });
+  }
+
+  nextRequest() {
+    const request = this.requests.shift();
+    if (request) {
+      return Promise.resolve(request);
+    }
+    return new Promise((resolve) => {
+      this.requestWaiters.push(resolve);
+    });
+  }
+
+  respond(request, { result, error } = {}) {
+    this.emit("message", {
+      data: {
+        type: "response",
+        backend: this.backend,
+        id: request.id,
+        ...(error === undefined ? { result } : { error }),
+      },
+    });
+  }
+}
+
+function newHarness({ throwOnInitializeBackend } = {}) {
+  const workers = new Map();
+  const writers = new MaltWriterWorkers({
+    module: EMPTY_WASM_MODULE,
+    wasmExecURL: "https://example.test/wasm_exec.js",
+    workerURL: new URL("https://example.test/malt-writer-worker.mjs"),
+    workerFactory: ({ backend }) => {
+      const worker = new FakeWorker(backend, throwOnInitializeBackend === backend);
+      workers.set(backend, worker);
+      return worker;
+    },
+  });
+  return { writers, workers };
+}
+
+function makeReady(writers, workers) {
+  workers.get("kzg").ready();
+  workers.get("ipa").ready();
+  return Promise.all([writers.kzgReady, writers.ipaReady]);
+}
+
+test("initialize postMessage failure terminates only the failed backend", async () => {
+  const { writers, workers } = newHarness({ throwOnInitializeBackend: "kzg" });
+  const kzg = workers.get("kzg");
+  const ipa = workers.get("ipa");
+
+  await assert.rejects(writers.kzgReady, /kzg initialize postMessage failed/);
+  assert.deepEqual(writers.status("kzg"), {
+    backend: "kzg",
+    state: "failed",
+    error: "kzg initialize postMessage failed",
+  });
+  assert.equal(kzg.terminationCount, 1);
+  assert.equal(ipa.terminationCount, 0);
+
+  ipa.ready();
+  await writers.ipaReady;
+  assert.equal(writers.status("ipa").state, "ready");
+  assert.equal(ipa.terminationCount, 0);
+
+  writers.terminateAll();
+  assert.equal(kzg.terminationCount, 1);
+  assert.equal(ipa.terminationCount, 1);
+});
+
+test("request errors and session close keep the backend Worker alive", async () => {
+  const { writers, workers } = newHarness();
+  await makeReady(writers, workers);
+  const kzg = workers.get("kzg");
+  const ipa = workers.get("ipa");
+
+  const invalidLoad = writers.load("kzg", new Uint8Array([1]));
+  const invalidRequest = await kzg.nextRequest();
+  kzg.respond(invalidRequest, { error: "invalid update view" });
+  await assert.rejects(invalidLoad, /invalid update view/);
+  assert.equal(writers.status("kzg").state, "ready");
+  assert.equal(kzg.terminationCount, 0);
+
+  const close = writers.closeSession("kzg");
+  const closeRequest = await kzg.nextRequest();
+  assert.equal(closeRequest.method, "closeSession");
+  assert.deepEqual(closeRequest.args, []);
+  kzg.respond(closeRequest, { result: "closed" });
+  assert.equal(await close, undefined);
+  assert.equal(writers.status("kzg").state, "ready");
+  assert.equal(kzg.terminationCount, 0);
+  assert.equal(ipa.terminationCount, 0);
+
+  writers.terminateAll();
+  assert.equal(kzg.terminationCount, 1);
+  assert.equal(ipa.terminationCount, 1);
+});
+
+test("a fatal backend failure terminates only that Worker", async () => {
+  const { writers, workers } = newHarness();
+  await makeReady(writers, workers);
+  const kzg = workers.get("kzg");
+  const ipa = workers.get("ipa");
+
+  const pending = writers.load("kzg", new Uint8Array([1]));
+  await kzg.nextRequest();
+  kzg.fail(new Error("KZG runtime crashed"));
+  await assert.rejects(pending, /KZG runtime crashed/);
+  assert.deepEqual(writers.status("kzg"), {
+    backend: "kzg",
+    state: "failed",
+    error: "KZG runtime crashed",
+  });
+  assert.equal(kzg.terminationCount, 1);
+  assert.equal(ipa.terminationCount, 0);
+
+  kzg.fail(new Error("duplicate failure"));
+  assert.equal(kzg.terminationCount, 1);
+
+  const healthyRequest = writers.load("ipa", new Uint8Array([2]));
+  const request = await ipa.nextRequest();
+  ipa.respond(request, { result: "ipa-root" });
+  assert.equal(await healthyRequest, "ipa-root");
+  assert.equal(writers.status("ipa").state, "ready");
+
+  writers.terminateAll();
+  writers.terminate();
+  assert.equal(kzg.terminationCount, 1);
+  assert.equal(ipa.terminationCount, 1);
+  assert.equal(writers.status("kzg").state, "failed");
+  assert.equal(writers.status("ipa").state, "terminated");
+});
+
+test("terminateBackend rejects its pending work and preserves the peer", async () => {
+  const { writers, workers } = newHarness();
+  await makeReady(writers, workers);
+  const kzg = workers.get("kzg");
+  const ipa = workers.get("ipa");
+
+  const pending = writers.prepare("kzg", new Uint8Array([1]), new Uint8Array([2]));
+  await kzg.nextRequest();
+  writers.terminateBackend("kzg");
+  await assert.rejects(pending, /kzg writer was terminated/);
+  assert.equal(writers.status("kzg").state, "terminated");
+  assert.equal(kzg.terminationCount, 1);
+  await assert.rejects(
+    writers.load("kzg", new Uint8Array([3])),
+    /kzg writer was terminated/,
+  );
+
+  const peerClose = writers.closeSession("ipa");
+  const closeRequest = await ipa.nextRequest();
+  ipa.respond(closeRequest, { result: undefined });
+  await peerClose;
+  assert.equal(writers.status("ipa").state, "ready");
+  assert.equal(ipa.terminationCount, 0);
+
+  writers.terminateBackend("kzg");
+  assert.equal(kzg.terminationCount, 1);
+  writers.terminate();
+  assert.equal(kzg.terminationCount, 1);
+  assert.equal(ipa.terminationCount, 1);
+});

--- a/cmd/malt-writer-wasm/compute.go
+++ b/cmd/malt-writer-wasm/compute.go
@@ -31,27 +31,13 @@ type sessionComputer struct {
 
 type preparedCandidate struct {
 	result        clientwriter.ComputeResult
-	responseBytes int
+	encodedResult []byte
 }
 
 const (
 	maxPreparedCandidates    = 64
 	maxPreparedResponseBytes = 64 << 20
-	writerPrepareSummaryV1   = "malt.writer-prepare-summary/v1"
 )
-
-type writerPrepareSummary struct {
-	Profile     string                       `json:"profile"`
-	OperationID string                       `json:"operation_id"`
-	Candidate   string                       `json:"candidate"`
-	Outputs     []writerPrepareSummaryOutput `json:"outputs"`
-	PayloadCIDs []string                     `json:"payload_cids"`
-}
-
-type writerPrepareSummaryOutput struct {
-	TransitionID string `json:"transition_id"`
-	Root         string `json:"root"`
-}
 
 func newSessionComputer(computer *computer) (*sessionComputer, error) {
 	if computer == nil || len(computer.schemes) == 0 {
@@ -140,6 +126,9 @@ func (s *sessionComputer) load(ctx context.Context, updateViewJSON []byte) (stri
 	if err := session.Load(ctx, view); err != nil {
 		return "", fmt.Errorf("load client writer session: %w", err)
 	}
+	if s.store != nil {
+		s.store.RetainRoots(nil)
+	}
 
 	s.session = session
 	s.store = store
@@ -149,20 +138,52 @@ func (s *sessionComputer) load(ctx context.Context, updateViewJSON []byte) (stri
 	return view.BaseRoot.String(), nil
 }
 
-func (s *sessionComputer) prepare(ctx context.Context, operationID string, semanticIntentJSON []byte) ([]byte, error) {
-	return s.prepareResponse(ctx, operationID, semanticIntentJSON, false)
+func (s *sessionComputer) prepare(ctx context.Context, operationID string, semanticIntentJSON []byte) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("client writer session is not initialized")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.session == nil {
+		return "", fmt.Errorf("client writer session has no update view")
+	}
+	if _, exists := s.prepared[operationID]; exists {
+		return "", fmt.Errorf("operation %q is already prepared", operationID)
+	}
+	if len(s.prepared) >= maxPreparedCandidates {
+		return "", fmt.Errorf("client writer session already retains %d prepared candidates", maxPreparedCandidates)
+	}
+	wireIntent, err := protocol.DecodeSemanticIntent(semanticIntentJSON, s.view)
+	if err != nil {
+		return "", err
+	}
+	intent, err := wireIntent.Core(s.view)
+	if err != nil {
+		return "", err
+	}
+	result, err := s.session.Prepare(ctx, operationID, intent)
+	if err != nil {
+		s.retainMaterializedRoots()
+		return "", fmt.Errorf("prepare client writer session: %w", err)
+	}
+	fullResponse, err := encodeComputeResult(result)
+	if err != nil {
+		s.retainMaterializedRoots()
+		return "", err
+	}
+	if len(fullResponse) > maxPreparedResponseBytes-s.preparedResponseBytes {
+		s.retainMaterializedRoots()
+		return "", fmt.Errorf(
+			"prepared client writer responses exceed %d retained bytes",
+			maxPreparedResponseBytes,
+		)
+	}
+	s.prepared[operationID] = preparedCandidate{result: result, encodedResult: fullResponse}
+	s.preparedResponseBytes += len(fullResponse)
+	return result.Bundle.Candidate.String(), nil
 }
 
-func (s *sessionComputer) prepareCompact(ctx context.Context, operationID string, semanticIntentJSON []byte) ([]byte, error) {
-	return s.prepareResponse(ctx, operationID, semanticIntentJSON, true)
-}
-
-func (s *sessionComputer) prepareResponse(
-	ctx context.Context,
-	operationID string,
-	semanticIntentJSON []byte,
-	compact bool,
-) ([]byte, error) {
+func (s *sessionComputer) getPreparedResult(operationID string) ([]byte, error) {
 	if s == nil {
 		return nil, fmt.Errorf("client writer session is not initialized")
 	}
@@ -171,48 +192,27 @@ func (s *sessionComputer) prepareResponse(
 	if s.session == nil {
 		return nil, fmt.Errorf("client writer session has no update view")
 	}
-	if _, exists := s.prepared[operationID]; exists {
-		return nil, fmt.Errorf("operation %q is already prepared", operationID)
+	candidate, ok := s.prepared[operationID]
+	if !ok {
+		return nil, fmt.Errorf("operation %q is not prepared", operationID)
 	}
-	if len(s.prepared) >= maxPreparedCandidates {
-		return nil, fmt.Errorf("client writer session already retains %d prepared candidates", maxPreparedCandidates)
+	return append([]byte(nil), candidate.encodedResult...), nil
+}
+
+func (s *sessionComputer) closeSession() {
+	if s == nil {
+		return
 	}
-	wireIntent, err := protocol.DecodeSemanticIntent(semanticIntentJSON, s.view)
-	if err != nil {
-		return nil, err
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.store != nil {
+		s.store.RetainRoots(nil)
 	}
-	intent, err := wireIntent.Core(s.view)
-	if err != nil {
-		return nil, err
-	}
-	result, err := s.session.Prepare(ctx, operationID, intent)
-	if err != nil {
-		s.retainMaterializedRoots()
-		return nil, fmt.Errorf("prepare client writer session: %w", err)
-	}
-	fullResponse, err := encodeComputeResult(result)
-	if err != nil {
-		s.retainMaterializedRoots()
-		return nil, err
-	}
-	response := fullResponse
-	if compact {
-		response, err = encodePrepareSummary(result)
-		if err != nil {
-			s.retainMaterializedRoots()
-			return nil, err
-		}
-	}
-	if len(fullResponse) > maxPreparedResponseBytes-s.preparedResponseBytes {
-		s.retainMaterializedRoots()
-		return nil, fmt.Errorf(
-			"prepared client writer responses exceed %d retained bytes",
-			maxPreparedResponseBytes,
-		)
-	}
-	s.prepared[operationID] = preparedCandidate{result: result, responseBytes: len(fullResponse)}
-	s.preparedResponseBytes += len(fullResponse)
-	return response, nil
+	s.session = nil
+	s.store = nil
+	s.view = mutation.UpdateView{}
+	s.prepared = nil
+	s.preparedResponseBytes = 0
 }
 
 func (s *sessionComputer) acceptReceipt(operationID string, receiptJSON []byte) (string, error) {
@@ -265,7 +265,7 @@ func (s *sessionComputer) discard(operationID string) error {
 	}
 	candidate := s.prepared[operationID]
 	delete(s.prepared, operationID)
-	s.preparedResponseBytes -= candidate.responseBytes
+	s.preparedResponseBytes -= len(candidate.encodedResult)
 	s.retainMaterializedRoots()
 	return nil
 }
@@ -305,25 +305,4 @@ func encodeComputeResult(result clientwriter.ComputeResult) ([]byte, error) {
 		return nil, fmt.Errorf("encode writer compute result: %w", err)
 	}
 	return json.Marshal(response)
-}
-
-func encodePrepareSummary(result clientwriter.ComputeResult) ([]byte, error) {
-	outputs := make([]writerPrepareSummaryOutput, len(result.Bundle.Outputs))
-	for index, output := range result.Bundle.Outputs {
-		outputs[index] = writerPrepareSummaryOutput{
-			TransitionID: output.TransitionID,
-			Root:         output.Root.String(),
-		}
-	}
-	payloadCIDs := make([]string, len(result.Bundle.PayloadCIDs))
-	for index, payload := range result.Bundle.PayloadCIDs {
-		payloadCIDs[index] = payload.String()
-	}
-	return json.Marshal(writerPrepareSummary{
-		Profile:     writerPrepareSummaryV1,
-		OperationID: result.Bundle.OperationID,
-		Candidate:   result.Bundle.Candidate.String(),
-		Outputs:     outputs,
-		PayloadCIDs: payloadCIDs,
-	})
 }

--- a/cmd/malt-writer-wasm/compute.go
+++ b/cmd/malt-writer-wasm/compute.go
@@ -4,40 +4,65 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	materializermemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
 	"github.com/dewebprotocol/malt/auth/commitment"
-	"github.com/dewebprotocol/malt/auth/commitment/ipa"
-	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/mutation"
 	"github.com/dewebprotocol/malt/protocol"
 	clientwriter "github.com/dewebprotocol/malt/sdk/writer"
 	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
 )
 
 type computer struct {
 	schemes map[maltcid.BackendKind]commitment.IndexCommitment
 }
 
-func newComputer(backend string) (*computer, error) {
-	schemes := make(map[maltcid.BackendKind]commitment.IndexCommitment)
-	if backend == "all" || backend == string(maltcid.BackendKindKZG) {
-		scheme, err := kzg.NewScheme()
-		if err != nil {
-			return nil, fmt.Errorf("initialize KZG writer: %w", err)
-		}
-		schemes[maltcid.BackendKindKZG] = scheme
+type sessionComputer struct {
+	mu                    sync.Mutex
+	computer              *computer
+	session               *clientwriter.Session
+	store                 *materializermemory.Store
+	view                  mutation.UpdateView
+	prepared              map[string]preparedCandidate
+	preparedResponseBytes int
+}
+
+type preparedCandidate struct {
+	result        clientwriter.ComputeResult
+	responseBytes int
+}
+
+const (
+	maxPreparedCandidates    = 64
+	maxPreparedResponseBytes = 64 << 20
+)
+
+func newSessionComputer(computer *computer) (*sessionComputer, error) {
+	if computer == nil || len(computer.schemes) == 0 {
+		return nil, fmt.Errorf("client writer is not initialized")
 	}
-	if backend == "all" || backend == string(maltcid.BackendKindIPA) {
-		scheme, err := ipa.NewScheme()
-		if err != nil {
-			return nil, fmt.Errorf("initialize IPA writer: %w", err)
-		}
-		schemes[maltcid.BackendKindIPA] = scheme
+	return &sessionComputer{computer: computer}, nil
+}
+
+func (c *computer) newRuntime() (*clientwriter.Runtime, error) {
+	if c == nil || len(c.schemes) == 0 {
+		return nil, fmt.Errorf("client writer is not initialized")
 	}
-	if len(schemes) == 0 {
-		return nil, fmt.Errorf("unsupported writer backend %q", backend)
+	return clientwriter.NewRuntime(materializermemory.New(true), c.schemes)
+}
+
+func (c *computer) newSessionRuntime() (*clientwriter.Runtime, *materializermemory.Store, error) {
+	if c == nil || len(c.schemes) == 0 {
+		return nil, nil, fmt.Errorf("client writer is not initialized")
 	}
-	return &computer{schemes: schemes}, nil
+	store := materializermemory.New(true)
+	runtime, err := clientwriter.NewRuntime(store, c.schemes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return runtime, store, nil
 }
 
 func (c *computer) compute(ctx context.Context, operationID string, updateViewJSON, semanticIntentJSON []byte) ([]byte, error) {
@@ -60,7 +85,7 @@ func (c *computer) compute(ctx context.Context, operationID string, updateViewJS
 	if err != nil {
 		return nil, err
 	}
-	runtime, err := clientwriter.NewRuntime(materializermemory.New(true), c.schemes)
+	runtime, err := c.newRuntime()
 	if err != nil {
 		return nil, err
 	}
@@ -72,6 +97,164 @@ func (c *computer) compute(ctx context.Context, operationID string, updateViewJS
 	if err != nil {
 		return nil, fmt.Errorf("compute client root: %w", err)
 	}
+	return encodeComputeResult(result)
+}
+
+func (s *sessionComputer) load(ctx context.Context, updateViewJSON []byte) (string, error) {
+	if s == nil || s.computer == nil {
+		return "", fmt.Errorf("client writer session is not initialized")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	wireView, err := protocol.DecodeUpdateView(updateViewJSON)
+	if err != nil {
+		return "", err
+	}
+	view, err := wireView.Core()
+	if err != nil {
+		return "", err
+	}
+	runtime, store, err := s.computer.newSessionRuntime()
+	if err != nil {
+		return "", err
+	}
+	session, err := clientwriter.NewSession(runtime)
+	if err != nil {
+		return "", err
+	}
+	if err := session.Load(ctx, view); err != nil {
+		return "", fmt.Errorf("load client writer session: %w", err)
+	}
+
+	s.session = session
+	s.store = store
+	s.view = view
+	s.prepared = make(map[string]preparedCandidate)
+	s.preparedResponseBytes = 0
+	return view.BaseRoot.String(), nil
+}
+
+func (s *sessionComputer) prepare(ctx context.Context, operationID string, semanticIntentJSON []byte) ([]byte, error) {
+	if s == nil {
+		return nil, fmt.Errorf("client writer session is not initialized")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.session == nil {
+		return nil, fmt.Errorf("client writer session has no update view")
+	}
+	if _, exists := s.prepared[operationID]; exists {
+		return nil, fmt.Errorf("operation %q is already prepared", operationID)
+	}
+	if len(s.prepared) >= maxPreparedCandidates {
+		return nil, fmt.Errorf("client writer session already retains %d prepared candidates", maxPreparedCandidates)
+	}
+	wireIntent, err := protocol.DecodeSemanticIntent(semanticIntentJSON, s.view)
+	if err != nil {
+		return nil, err
+	}
+	intent, err := wireIntent.Core(s.view)
+	if err != nil {
+		return nil, err
+	}
+	result, err := s.session.Prepare(ctx, operationID, intent)
+	if err != nil {
+		s.retainMaterializedRoots()
+		return nil, fmt.Errorf("prepare client writer session: %w", err)
+	}
+	encoded, err := encodeComputeResult(result)
+	if err != nil {
+		s.retainMaterializedRoots()
+		return nil, err
+	}
+	if len(encoded) > maxPreparedResponseBytes-s.preparedResponseBytes {
+		s.retainMaterializedRoots()
+		return nil, fmt.Errorf(
+			"prepared client writer responses exceed %d retained bytes",
+			maxPreparedResponseBytes,
+		)
+	}
+	s.prepared[operationID] = preparedCandidate{result: result, responseBytes: len(encoded)}
+	s.preparedResponseBytes += len(encoded)
+	return encoded, nil
+}
+
+func (s *sessionComputer) acceptReceipt(operationID string, receiptJSON []byte) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("client writer session is not initialized")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.session == nil {
+		return "", fmt.Errorf("client writer session has no update view")
+	}
+	candidate, ok := s.prepared[operationID]
+	if !ok {
+		return "", fmt.Errorf("operation %q is not prepared", operationID)
+	}
+	prepared := candidate.result
+	wireReceipt, err := protocol.DecodeMaterializationReceipt(receiptJSON, prepared.Bundle)
+	if err != nil {
+		return "", err
+	}
+	receipt, err := wireReceipt.Core(prepared.Bundle)
+	if err != nil {
+		return "", err
+	}
+	if err := s.session.AcceptReceipt(receipt, prepared); err != nil {
+		return "", fmt.Errorf("accept client writer receipt: %w", err)
+	}
+	next, err := mutation.NormalizeUpdateView(prepared.NextView)
+	if err != nil {
+		return "", fmt.Errorf("retain client writer next view: %w", err)
+	}
+	s.view = next
+	s.prepared = make(map[string]preparedCandidate)
+	s.preparedResponseBytes = 0
+	s.retainMaterializedRoots()
+	return next.BaseRoot.String(), nil
+}
+
+func (s *sessionComputer) discard(operationID string) error {
+	if s == nil {
+		return fmt.Errorf("client writer session is not initialized")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.session == nil {
+		return fmt.Errorf("client writer session has no update view")
+	}
+	if _, ok := s.prepared[operationID]; !ok {
+		return fmt.Errorf("operation %q is not prepared", operationID)
+	}
+	candidate := s.prepared[operationID]
+	delete(s.prepared, operationID)
+	s.preparedResponseBytes -= candidate.responseBytes
+	s.retainMaterializedRoots()
+	return nil
+}
+
+func (s *sessionComputer) retainMaterializedRoots() {
+	if s.store == nil {
+		return
+	}
+	retain := make(map[string][]cid.Cid)
+	addViewRoots(retain, s.view)
+	for _, candidate := range s.prepared {
+		addViewRoots(retain, candidate.result.NextView)
+	}
+	s.store.RetainRoots(retain)
+}
+
+func addViewRoots(retain map[string][]cid.Cid, view mutation.UpdateView) {
+	for _, object := range view.Objects {
+		scope := "client-root/v1/" + object.ObjectID
+		retain[scope] = append(retain[scope], object.Root)
+	}
+}
+
+func encodeComputeResult(result clientwriter.ComputeResult) ([]byte, error) {
 	response, err := protocol.NewWriterComputeResult(result.Bundle, result.NextView, protocol.WriterComputeMetrics{
 		ViewNormalizationNS:    result.Metrics.ViewNormalizationNS,
 		IntentNormalizationNS:  result.Metrics.IntentNormalizationNS,

--- a/cmd/malt-writer-wasm/compute.go
+++ b/cmd/malt-writer-wasm/compute.go
@@ -37,7 +37,21 @@ type preparedCandidate struct {
 const (
 	maxPreparedCandidates    = 64
 	maxPreparedResponseBytes = 64 << 20
+	writerPrepareSummaryV1   = "malt.writer-prepare-summary/v1"
 )
+
+type writerPrepareSummary struct {
+	Profile     string                       `json:"profile"`
+	OperationID string                       `json:"operation_id"`
+	Candidate   string                       `json:"candidate"`
+	Outputs     []writerPrepareSummaryOutput `json:"outputs"`
+	PayloadCIDs []string                     `json:"payload_cids"`
+}
+
+type writerPrepareSummaryOutput struct {
+	TransitionID string `json:"transition_id"`
+	Root         string `json:"root"`
+}
 
 func newSessionComputer(computer *computer) (*sessionComputer, error) {
 	if computer == nil || len(computer.schemes) == 0 {
@@ -136,6 +150,19 @@ func (s *sessionComputer) load(ctx context.Context, updateViewJSON []byte) (stri
 }
 
 func (s *sessionComputer) prepare(ctx context.Context, operationID string, semanticIntentJSON []byte) ([]byte, error) {
+	return s.prepareResponse(ctx, operationID, semanticIntentJSON, false)
+}
+
+func (s *sessionComputer) prepareCompact(ctx context.Context, operationID string, semanticIntentJSON []byte) ([]byte, error) {
+	return s.prepareResponse(ctx, operationID, semanticIntentJSON, true)
+}
+
+func (s *sessionComputer) prepareResponse(
+	ctx context.Context,
+	operationID string,
+	semanticIntentJSON []byte,
+	compact bool,
+) ([]byte, error) {
 	if s == nil {
 		return nil, fmt.Errorf("client writer session is not initialized")
 	}
@@ -163,21 +190,29 @@ func (s *sessionComputer) prepare(ctx context.Context, operationID string, seman
 		s.retainMaterializedRoots()
 		return nil, fmt.Errorf("prepare client writer session: %w", err)
 	}
-	encoded, err := encodeComputeResult(result)
+	fullResponse, err := encodeComputeResult(result)
 	if err != nil {
 		s.retainMaterializedRoots()
 		return nil, err
 	}
-	if len(encoded) > maxPreparedResponseBytes-s.preparedResponseBytes {
+	response := fullResponse
+	if compact {
+		response, err = encodePrepareSummary(result)
+		if err != nil {
+			s.retainMaterializedRoots()
+			return nil, err
+		}
+	}
+	if len(fullResponse) > maxPreparedResponseBytes-s.preparedResponseBytes {
 		s.retainMaterializedRoots()
 		return nil, fmt.Errorf(
 			"prepared client writer responses exceed %d retained bytes",
 			maxPreparedResponseBytes,
 		)
 	}
-	s.prepared[operationID] = preparedCandidate{result: result, responseBytes: len(encoded)}
-	s.preparedResponseBytes += len(encoded)
-	return encoded, nil
+	s.prepared[operationID] = preparedCandidate{result: result, responseBytes: len(fullResponse)}
+	s.preparedResponseBytes += len(fullResponse)
+	return response, nil
 }
 
 func (s *sessionComputer) acceptReceipt(operationID string, receiptJSON []byte) (string, error) {
@@ -270,4 +305,25 @@ func encodeComputeResult(result clientwriter.ComputeResult) ([]byte, error) {
 		return nil, fmt.Errorf("encode writer compute result: %w", err)
 	}
 	return json.Marshal(response)
+}
+
+func encodePrepareSummary(result clientwriter.ComputeResult) ([]byte, error) {
+	outputs := make([]writerPrepareSummaryOutput, len(result.Bundle.Outputs))
+	for index, output := range result.Bundle.Outputs {
+		outputs[index] = writerPrepareSummaryOutput{
+			TransitionID: output.TransitionID,
+			Root:         output.Root.String(),
+		}
+	}
+	payloadCIDs := make([]string, len(result.Bundle.PayloadCIDs))
+	for index, payload := range result.Bundle.PayloadCIDs {
+		payloadCIDs[index] = payload.String()
+	}
+	return json.Marshal(writerPrepareSummary{
+		Profile:     writerPrepareSummaryV1,
+		OperationID: result.Bundle.OperationID,
+		Candidate:   result.Bundle.Candidate.String(),
+		Outputs:     outputs,
+		PayloadCIDs: payloadCIDs,
+	})
 }

--- a/cmd/malt-writer-wasm/compute_test.go
+++ b/cmd/malt-writer-wasm/compute_test.go
@@ -238,6 +238,73 @@ func TestSessionComputerDiscardReclaimsCandidateSnapshots(t *testing.T) {
 	}
 }
 
+func TestSessionComputerPrepareCompactReturnsCompleteRootSummary(t *testing.T) {
+	view, intent := computeFixture(t, maltcid.BackendKindKZG)
+	wireView, err := protocol.NewUpdateView(view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wireIntent, err := protocol.NewSemanticIntent(view, intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	viewJSON, _ := json.Marshal(wireView)
+	intentJSON, _ := json.Marshal(wireIntent)
+	computer, err := newComputer("kzg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := newSessionComputer(computer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.load(t.Context(), viewJSON); err != nil {
+		t.Fatal(err)
+	}
+
+	const operationID = "compact-operation"
+	raw, err := session.prepareCompact(t.Context(), operationID, intentJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var summary writerPrepareSummary
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatal(err)
+	}
+	if summary.Profile != writerPrepareSummaryV1 {
+		t.Fatalf("profile = %q, want %q", summary.Profile, writerPrepareSummaryV1)
+	}
+	if summary.OperationID != operationID {
+		t.Fatalf("operation ID = %q, want %q", summary.OperationID, operationID)
+	}
+	candidate := session.prepared[operationID]
+	if summary.Candidate != candidate.result.Bundle.Candidate.String() {
+		t.Fatalf("candidate = %q, want %q", summary.Candidate, candidate.result.Bundle.Candidate)
+	}
+	if got, want := len(summary.Outputs), len(candidate.result.Bundle.Outputs); got != want {
+		t.Fatalf("outputs = %d, want %d", got, want)
+	}
+	for index, output := range candidate.result.Bundle.Outputs {
+		if got := summary.Outputs[index]; got.TransitionID != output.TransitionID || got.Root != output.Root.String() {
+			t.Fatalf("output %d = %+v, want %s/%s", index, got, output.TransitionID, output.Root)
+		}
+	}
+	if got, want := len(summary.PayloadCIDs), len(candidate.result.Bundle.PayloadCIDs); got != want {
+		t.Fatalf("payload CIDs = %d, want %d", got, want)
+	}
+	for index, payload := range candidate.result.Bundle.PayloadCIDs {
+		if summary.PayloadCIDs[index] != payload.String() {
+			t.Fatalf("payload CID %d = %q, want %q", index, summary.PayloadCIDs[index], payload)
+		}
+	}
+	if candidate.responseBytes <= len(raw) {
+		t.Fatalf("retained full response = %d bytes, compact response = %d bytes", candidate.responseBytes, len(raw))
+	}
+	if err := session.discard(operationID); err != nil {
+		t.Fatal(err)
+	}
+}
+
 type wasmComputeFixture struct {
 	Backend          maltcid.BackendKind             `json:"backend"`
 	OperationID      string                          `json:"operation_id"`

--- a/cmd/malt-writer-wasm/compute_test.go
+++ b/cmd/malt-writer-wasm/compute_test.go
@@ -104,13 +104,148 @@ func TestComputerRejectsUnavailableBackendAndInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestSessionComputerAdvancesOnlyAfterExactReceipt(t *testing.T) {
+	view, intent := computeFixture(t, maltcid.BackendKindKZG)
+	wireView, err := protocol.NewUpdateView(view)
+	if err != nil {
+		t.Fatalf("NewUpdateView failed: %v", err)
+	}
+	wireIntent, err := protocol.NewSemanticIntent(view, intent)
+	if err != nil {
+		t.Fatalf("NewSemanticIntent failed: %v", err)
+	}
+	viewJSON, _ := json.Marshal(wireView)
+	intentJSON, _ := json.Marshal(wireIntent)
+	computer, err := newComputer("kzg")
+	if err != nil {
+		t.Fatalf("newComputer failed: %v", err)
+	}
+	session, err := newSessionComputer(computer)
+	if err != nil {
+		t.Fatalf("newSessionComputer failed: %v", err)
+	}
+	loadedRoot, err := session.load(t.Context(), viewJSON)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if loadedRoot != view.BaseRoot.String() {
+		t.Fatalf("loaded root = %s, want %s", loadedRoot, view.BaseRoot)
+	}
+
+	const operationID = "session-operation-1"
+	raw, err := session.prepare(t.Context(), operationID, intentJSON)
+	if err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+	if _, err := session.prepare(t.Context(), operationID, intentJSON); err == nil {
+		t.Fatal("session accepted a duplicate prepared operation")
+	}
+	response, err := protocol.DecodeWriterComputeResult(raw)
+	if err != nil {
+		t.Fatalf("DecodeWriterComputeResult failed: %v", err)
+	}
+	bundle, err := response.Bundle.Core()
+	if err != nil {
+		t.Fatalf("bundle Core failed: %v", err)
+	}
+	bundleDigest, err := bundle.Digest()
+	if err != nil {
+		t.Fatalf("bundle Digest failed: %v", err)
+	}
+	receipt, err := protocol.NewMaterializationReceipt(mutation.MaterializationReceipt{
+		Profile: mutation.MaterializationReceiptProfile, OperationID: operationID,
+		BaseRoot: bundle.View.BaseRoot, Candidate: bundle.Candidate,
+		BundleDigest: bundleDigest, DurableBoundary: "unit-memory-v1",
+	}, bundle)
+	if err != nil {
+		t.Fatalf("NewMaterializationReceipt failed: %v", err)
+	}
+	badReceipt := receipt
+	badReceipt.Candidate = view.BaseRoot.String()
+	badReceiptJSON, _ := json.Marshal(badReceipt)
+	if _, err := session.acceptReceipt(operationID, badReceiptJSON); err == nil {
+		t.Fatal("session accepted a mismatched receipt")
+	}
+	if got := session.session.BaseRoot(); !got.Equals(view.BaseRoot) {
+		t.Fatalf("base advanced after bad receipt: %s", got)
+	}
+
+	receiptJSON, _ := json.Marshal(receipt)
+	acceptedRoot, err := session.acceptReceipt(operationID, receiptJSON)
+	if err != nil {
+		t.Fatalf("acceptReceipt failed: %v", err)
+	}
+	if acceptedRoot != bundle.Candidate.String() {
+		t.Fatalf("accepted root = %s, want %s", acceptedRoot, bundle.Candidate)
+	}
+	if got := session.session.BaseRoot(); !got.Equals(bundle.Candidate) {
+		t.Fatalf("retained base = %s, want %s", got, bundle.Candidate)
+	}
+	fresh, err := newSessionComputer(computer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nextViewJSON, err := json.Marshal(response.NextView)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fresh.load(t.Context(), nextViewJSON); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := session.store.EntryCount(), fresh.store.EntryCount(); got != want {
+		t.Fatalf("accepted session retained %d entries, fresh accepted view retains %d", got, want)
+	}
+	if _, err := session.prepare(t.Context(), "stale-operation", intentJSON); err == nil {
+		t.Fatal("session accepted an intent at the stale base")
+	}
+}
+
+func TestSessionComputerDiscardReclaimsCandidateSnapshots(t *testing.T) {
+	view, intent := computeFixture(t, maltcid.BackendKindIPA)
+	wireView, err := protocol.NewUpdateView(view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wireIntent, err := protocol.NewSemanticIntent(view, intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	viewJSON, _ := json.Marshal(wireView)
+	intentJSON, _ := json.Marshal(wireIntent)
+	computer, err := newComputer("ipa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := newSessionComputer(computer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.load(t.Context(), viewJSON); err != nil {
+		t.Fatal(err)
+	}
+	baseline := session.store.EntryCount()
+	if _, err := session.prepare(t.Context(), "discard-operation", intentJSON); err != nil {
+		t.Fatal(err)
+	}
+	if got := session.store.EntryCount(); got <= baseline {
+		t.Fatalf("prepare retained %d entries, want more than loaded baseline %d", got, baseline)
+	}
+	if err := session.discard("discard-operation"); err != nil {
+		t.Fatal(err)
+	}
+	if got := session.store.EntryCount(); got != baseline {
+		t.Fatalf("discard retained %d entries, want loaded baseline %d", got, baseline)
+	}
+}
+
 type wasmComputeFixture struct {
-	Backend          maltcid.BackendKind       `json:"backend"`
-	OperationID      string                    `json:"operation_id"`
-	UpdateView       protocol.UpdateView       `json:"update_view"`
-	SemanticIntent   protocol.SemanticIntent   `json:"semantic_intent"`
-	ExpectedBundle   protocol.ClientRootBundle `json:"expected_bundle"`
-	ExpectedNextView protocol.UpdateView       `json:"expected_next_view"`
+	Backend          maltcid.BackendKind             `json:"backend"`
+	OperationID      string                          `json:"operation_id"`
+	UpdateView       protocol.UpdateView             `json:"update_view"`
+	SemanticIntent   protocol.SemanticIntent         `json:"semantic_intent"`
+	ExpectedBundle   protocol.ClientRootBundle       `json:"expected_bundle"`
+	ExpectedNextView protocol.UpdateView             `json:"expected_next_view"`
+	ExpectedReceipt  protocol.MaterializationReceipt `json:"expected_receipt"`
 }
 
 func TestGenerateWASMFixtures(t *testing.T) {
@@ -151,10 +286,27 @@ func TestGenerateWASMFixtures(t *testing.T) {
 		if err != nil {
 			t.Fatalf("decode fixture response (%s): %v", backend, err)
 		}
+		bundle, err := response.Bundle.Core()
+		if err != nil {
+			t.Fatalf("decode fixture bundle (%s): %v", backend, err)
+		}
+		bundleDigest, err := bundle.Digest()
+		if err != nil {
+			t.Fatalf("digest fixture bundle (%s): %v", backend, err)
+		}
+		receipt, err := protocol.NewMaterializationReceipt(mutation.MaterializationReceipt{
+			Profile: mutation.MaterializationReceiptProfile, OperationID: operationID,
+			BaseRoot: bundle.View.BaseRoot, Candidate: bundle.Candidate,
+			BundleDigest: bundleDigest, DurableBoundary: "wasm-smoke-memory-v1",
+		}, bundle)
+		if err != nil {
+			t.Fatalf("encode fixture receipt (%s): %v", backend, err)
+		}
 		fixtures = append(fixtures, wasmComputeFixture{
 			Backend: backend, OperationID: operationID,
 			UpdateView: wireView, SemanticIntent: wireIntent,
 			ExpectedBundle: response.Bundle, ExpectedNextView: response.NextView,
+			ExpectedReceipt: receipt,
 		})
 	}
 
@@ -170,21 +322,7 @@ func TestGenerateWASMFixtures(t *testing.T) {
 func computeFixture(t *testing.T, backend maltcid.BackendKind) (mutation.UpdateView, mutation.SemanticIntent) {
 	t.Helper()
 	ctx := context.Background()
-	var (
-		scheme commitment.IndexCommitment
-		err    error
-	)
-	switch backend {
-	case maltcid.BackendKindKZG:
-		scheme, err = kzg.NewScheme()
-	case maltcid.BackendKindIPA:
-		scheme, err = ipa.NewScheme()
-	default:
-		t.Fatalf("unsupported fixture backend %q", backend)
-	}
-	if err != nil {
-		t.Fatalf("NewScheme(%s) failed: %v", backend, err)
-	}
+	scheme := fixtureScheme(t, backend)
 	semantic, err := mappingradix.NewMap(scheme, materializermemory.New(true))
 	if err != nil {
 		t.Fatalf("NewMap failed: %v", err)
@@ -233,6 +371,26 @@ func computeFixture(t *testing.T, backend maltcid.BackendKind) (mutation.UpdateV
 		t.Fatalf("NormalizeSemanticIntent failed: %v", err)
 	}
 	return view, intent
+}
+
+func fixtureScheme(t *testing.T, backend maltcid.BackendKind) commitment.IndexCommitment {
+	t.Helper()
+	var (
+		scheme commitment.IndexCommitment
+		err    error
+	)
+	switch backend {
+	case maltcid.BackendKindKZG:
+		scheme, err = kzg.NewScheme()
+	case maltcid.BackendKindIPA:
+		scheme, err = ipa.NewScheme()
+	default:
+		t.Fatalf("unsupported fixture backend %q", backend)
+	}
+	if err != nil {
+		t.Fatalf("NewScheme(%s) failed: %v", backend, err)
+	}
+	return scheme
 }
 
 func payloadCID(t *testing.T, value string) cid.Cid {

--- a/cmd/malt-writer-wasm/compute_test.go
+++ b/cmd/malt-writer-wasm/compute_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -161,16 +162,23 @@ func TestSessionComputerAdvancesOnlyAfterExactReceipt(t *testing.T) {
 	}
 
 	const operationID = "session-operation-1"
-	raw, err := session.prepare(t.Context(), operationID, intentJSON)
+	preparedRoot, err := session.prepare(t.Context(), operationID, intentJSON)
 	if err != nil {
 		t.Fatalf("prepare failed: %v", err)
 	}
 	if _, err := session.prepare(t.Context(), operationID, intentJSON); err == nil {
 		t.Fatal("session accepted a duplicate prepared operation")
 	}
+	raw, err := session.getPreparedResult(operationID)
+	if err != nil {
+		t.Fatalf("getPreparedResult failed: %v", err)
+	}
 	response, err := protocol.DecodeWriterComputeResult(raw)
 	if err != nil {
 		t.Fatalf("DecodeWriterComputeResult failed: %v", err)
+	}
+	if preparedRoot != response.Bundle.Candidate {
+		t.Fatalf("prepared root = %s, result candidate = %s", preparedRoot, response.Bundle.Candidate)
 	}
 	bundle, err := response.Bundle.Core()
 	if err != nil {
@@ -197,6 +205,21 @@ func TestSessionComputerAdvancesOnlyAfterExactReceipt(t *testing.T) {
 	if got := session.session.BaseRoot(); !got.Equals(view.BaseRoot) {
 		t.Fatalf("base advanced after bad receipt: %s", got)
 	}
+	stillPrepared, err := session.getPreparedResult(operationID)
+	if err != nil {
+		t.Fatalf("getPreparedResult after rejected receipt failed: %v", err)
+	}
+	if !bytes.Equal(stillPrepared, raw) {
+		t.Fatal("rejected receipt changed the prepared result")
+	}
+	stillPrepared[0] ^= 0xff
+	unmodified, err := session.getPreparedResult(operationID)
+	if err != nil {
+		t.Fatalf("getPreparedResult after caller mutation failed: %v", err)
+	}
+	if !bytes.Equal(unmodified, raw) {
+		t.Fatal("caller mutation changed the retained prepared result")
+	}
 
 	receiptJSON, _ := json.Marshal(receipt)
 	acceptedRoot, err := session.acceptReceipt(operationID, receiptJSON)
@@ -208,6 +231,9 @@ func TestSessionComputerAdvancesOnlyAfterExactReceipt(t *testing.T) {
 	}
 	if got := session.session.BaseRoot(); !got.Equals(bundle.Candidate) {
 		t.Fatalf("retained base = %s, want %s", got, bundle.Candidate)
+	}
+	if _, err := session.getPreparedResult(operationID); err == nil {
+		t.Fatal("accepted operation remained available as a prepared result")
 	}
 	fresh, err := newSessionComputer(computer)
 	if err != nil {
@@ -264,9 +290,12 @@ func TestSessionComputerDiscardReclaimsCandidateSnapshots(t *testing.T) {
 	if got := session.store.EntryCount(); got != baseline {
 		t.Fatalf("discard retained %d entries, want loaded baseline %d", got, baseline)
 	}
+	if _, err := session.getPreparedResult("discard-operation"); err == nil {
+		t.Fatal("discarded operation remained available as a prepared result")
+	}
 }
 
-func TestSessionComputerPrepareCompactReturnsCompleteRootSummary(t *testing.T) {
+func TestSessionComputerCloseReleasesStateAndAllowsReload(t *testing.T) {
 	view, intent := computeFixture(t, maltcid.BackendKindKZG)
 	wireView, err := protocol.NewUpdateView(view)
 	if err != nil {
@@ -286,50 +315,76 @@ func TestSessionComputerPrepareCompactReturnsCompleteRootSummary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	session.closeSession()
+	session.closeSession()
+	if _, err := session.prepare(t.Context(), "before-load", intentJSON); err == nil {
+		t.Fatal("closed session prepared without a loaded update view")
+	}
 	if _, err := session.load(t.Context(), viewJSON); err != nil {
 		t.Fatal(err)
 	}
+	const operationID = "close-operation"
+	if _, err := session.prepare(t.Context(), operationID, intentJSON); err != nil {
+		t.Fatal(err)
+	}
+	firstStore := session.store
+	firstSession := session.session
+	if firstStore.EntryCount() == 0 {
+		t.Fatal("loaded and prepared session retained no materialized state")
+	}
+	if _, err := session.load(t.Context(), []byte(`{}`)); err == nil {
+		t.Fatal("session accepted an invalid replacement update view")
+	}
+	if session.store != firstStore || session.session != firstSession {
+		t.Fatal("failed load replaced the current session")
+	}
+	if _, err := session.getPreparedResult(operationID); err != nil {
+		t.Fatalf("failed load discarded the prepared result: %v", err)
+	}
 
-	const operationID = "compact-operation"
-	raw, err := session.prepareCompact(t.Context(), operationID, intentJSON)
-	if err != nil {
+	if _, err := session.load(t.Context(), viewJSON); err != nil {
 		t.Fatal(err)
 	}
-	var summary writerPrepareSummary
-	if err := json.Unmarshal(raw, &summary); err != nil {
-		t.Fatal(err)
+	if got := firstStore.EntryCount(); got != 0 {
+		t.Fatalf("successful replacement retained %d entries in the old store", got)
 	}
-	if summary.Profile != writerPrepareSummaryV1 {
-		t.Fatalf("profile = %q, want %q", summary.Profile, writerPrepareSummaryV1)
+	if session.store == firstStore {
+		t.Fatal("successful replacement reused the old store")
 	}
-	if summary.OperationID != operationID {
-		t.Fatalf("operation ID = %q, want %q", summary.OperationID, operationID)
+	if _, err := session.getPreparedResult(operationID); err == nil {
+		t.Fatal("successful replacement retained an old prepared result")
 	}
-	candidate := session.prepared[operationID]
-	if summary.Candidate != candidate.result.Bundle.Candidate.String() {
-		t.Fatalf("candidate = %q, want %q", summary.Candidate, candidate.result.Bundle.Candidate)
+	if _, err := session.prepare(t.Context(), operationID, intentJSON); err != nil {
+		t.Fatalf("prepare after successful replacement failed: %v", err)
 	}
-	if got, want := len(summary.Outputs), len(candidate.result.Bundle.Outputs); got != want {
-		t.Fatalf("outputs = %d, want %d", got, want)
+	secondStore := session.store
+	session.closeSession()
+	session.closeSession()
+	if got := secondStore.EntryCount(); got != 0 {
+		t.Fatalf("closed session retained %d materialized entries", got)
 	}
-	for index, output := range candidate.result.Bundle.Outputs {
-		if got := summary.Outputs[index]; got.TransitionID != output.TransitionID || got.Root != output.Root.String() {
-			t.Fatalf("output %d = %+v, want %s/%s", index, got, output.TransitionID, output.Root)
-		}
+	if session.session != nil || session.store != nil || session.view.BaseRoot.Defined() || session.prepared != nil || session.preparedResponseBytes != 0 {
+		t.Fatal("close did not clear all retained session state")
 	}
-	if got, want := len(summary.PayloadCIDs), len(candidate.result.Bundle.PayloadCIDs); got != want {
-		t.Fatalf("payload CIDs = %d, want %d", got, want)
+	if _, err := session.getPreparedResult(operationID); err == nil {
+		t.Fatal("closed session returned a prepared result")
 	}
-	for index, payload := range candidate.result.Bundle.PayloadCIDs {
-		if summary.PayloadCIDs[index] != payload.String() {
-			t.Fatalf("payload CID %d = %q, want %q", index, summary.PayloadCIDs[index], payload)
-		}
+	if _, err := session.prepare(t.Context(), operationID, intentJSON); err == nil {
+		t.Fatal("closed session prepared without reload")
 	}
-	if candidate.responseBytes <= len(raw) {
-		t.Fatalf("retained full response = %d bytes, compact response = %d bytes", candidate.responseBytes, len(raw))
+	if _, err := session.acceptReceipt(operationID, []byte(`{}`)); err == nil {
+		t.Fatal("closed session accepted a receipt")
 	}
-	if err := session.discard(operationID); err != nil {
-		t.Fatal(err)
+	if err := session.discard(operationID); err == nil {
+		t.Fatal("closed session discarded a candidate")
+	}
+
+	if _, err := session.load(t.Context(), viewJSON); err != nil {
+		t.Fatalf("reload after close failed: %v", err)
+	}
+	if _, err := session.prepare(t.Context(), "after-close", intentJSON); err != nil {
+		t.Fatalf("prepare after reload failed: %v", err)
 	}
 }
 

--- a/cmd/malt-writer-wasm/compute_test.go
+++ b/cmd/malt-writer-wasm/compute_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -19,6 +20,33 @@ import (
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
+
+func TestParseStartupBackend(t *testing.T) {
+	for _, backend := range []string{"kzg", "ipa"} {
+		t.Run(backend, func(t *testing.T) {
+			got, err := parseStartupBackend([]string{backendArgumentPrefix + backend})
+			if err != nil {
+				t.Fatalf("parseStartupBackend failed: %v", err)
+			}
+			if got != backend {
+				t.Fatalf("backend = %q, want %q", got, backend)
+			}
+		})
+	}
+	for _, args := range [][]string{
+		nil,
+		{"kzg"},
+		{backendArgumentPrefix},
+		{backendArgumentPrefix + "all"},
+		{backendArgumentPrefix + "kzg", backendArgumentPrefix + "ipa"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			if backend, err := parseStartupBackend(args); err == nil {
+				t.Fatalf("parseStartupBackend(%q) = %q, want error", args, backend)
+			}
+		})
+	}
+}
 
 func TestComputerComputesCanonicalClientRootBundle(t *testing.T) {
 	view, intent := computeFixture(t, maltcid.BackendKindKZG)

--- a/cmd/malt-writer-wasm/main.go
+++ b/cmd/malt-writer-wasm/main.go
@@ -15,8 +15,11 @@ import (
 const maxOperationIDBytes = 128
 
 func main() {
-	backend := compiledBackend()
-	writer, initErr := newComputer(backend)
+	backend, initErr := startupBackend()
+	var writer *computer
+	if initErr == nil {
+		writer, initErr = newComputer(backend)
+	}
 	sessionWriter, sessionInitErr := newSessionComputer(writer)
 	if initErr == nil && sessionInitErr != nil {
 		initErr = sessionInitErr

--- a/cmd/malt-writer-wasm/main.go
+++ b/cmd/malt-writer-wasm/main.go
@@ -81,37 +81,47 @@ func registerSessionFunctions(writer *sessionComputer, initErr error) {
 	})
 	js.Global().Set("maltWriterLoadSessionV1", loadFunction)
 
-	prepareFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
-		promise := js.Global().Get("Promise")
-		if initErr != nil {
-			return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
-		}
-		if len(args) != 2 {
-			return promise.Call("reject", "maltWriterPrepareSessionV1 expects operation ID and semantic-intent JSON Uint8Arrays")
-		}
-		select {
-		case prepareGate <- struct{}{}:
-		default:
-			return promise.Call("reject", "a client writer session prepare is already in flight")
-		}
-		releasePrepare := func() { <-prepareGate }
-		operationIDBytes, err := copyBoundedBytes(args[0], "operation ID", maxOperationIDBytes)
-		if err != nil {
-			releasePrepare()
-			return promise.Call("reject", err.Error())
-		}
-		intentJSON, err := copyBoundedBytes(args[1], "semantic-intent JSON", protocol.MaxClientRootJSONBytes)
-		if err != nil {
-			releasePrepare()
-			return promise.Call("reject", err.Error())
-		}
-		operationID := string(operationIDBytes)
-		return promiseStringFinally(func() (string, error) {
-			result, err := writer.prepare(context.Background(), operationID, intentJSON)
-			return string(result), err
-		}, releasePrepare)
-	})
+	newPrepareFunction := func(name string, compact bool) js.Func {
+		return js.FuncOf(func(_ js.Value, args []js.Value) any {
+			promise := js.Global().Get("Promise")
+			if initErr != nil {
+				return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
+			}
+			if len(args) != 2 {
+				return promise.Call("reject", fmt.Sprintf("%s expects operation ID and semantic-intent JSON Uint8Arrays", name))
+			}
+			select {
+			case prepareGate <- struct{}{}:
+			default:
+				return promise.Call("reject", "a client writer session prepare is already in flight")
+			}
+			releasePrepare := func() { <-prepareGate }
+			operationIDBytes, err := copyBoundedBytes(args[0], "operation ID", maxOperationIDBytes)
+			if err != nil {
+				releasePrepare()
+				return promise.Call("reject", err.Error())
+			}
+			intentJSON, err := copyBoundedBytes(args[1], "semantic-intent JSON", protocol.MaxClientRootJSONBytes)
+			if err != nil {
+				releasePrepare()
+				return promise.Call("reject", err.Error())
+			}
+			operationID := string(operationIDBytes)
+			return promiseStringFinally(func() (string, error) {
+				var result []byte
+				if compact {
+					result, err = writer.prepareCompact(context.Background(), operationID, intentJSON)
+				} else {
+					result, err = writer.prepare(context.Background(), operationID, intentJSON)
+				}
+				return string(result), err
+			}, releasePrepare)
+		})
+	}
+	prepareFunction := newPrepareFunction("maltWriterPrepareSessionV1", false)
 	js.Global().Set("maltWriterPrepareSessionV1", prepareFunction)
+	prepareCompactFunction := newPrepareFunction("maltWriterPrepareSessionCompactV1", true)
+	js.Global().Set("maltWriterPrepareSessionCompactV1", prepareCompactFunction)
 
 	acceptFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
 		promise := js.Global().Get("Promise")

--- a/cmd/malt-writer-wasm/main.go
+++ b/cmd/malt-writer-wasm/main.go
@@ -15,12 +15,23 @@ import (
 const maxOperationIDBytes = 128
 
 func main() {
-	backend := requestedBackend()
+	backend := compiledBackend()
 	writer, initErr := newComputer(backend)
+	sessionWriter, sessionInitErr := newSessionComputer(writer)
+	if initErr == nil && sessionInitErr != nil {
+		initErr = sessionInitErr
+	}
 	if initErr != nil {
 		js.Global().Set("maltWriterInitError", initErr.Error())
 	}
 	js.Global().Set("maltWriterLoadedBackend", backend)
+	registerStatelessCompute(writer, initErr)
+	registerSessionFunctions(sessionWriter, initErr)
+	js.Global().Set("maltWriterReady", true)
+	select {}
+}
+
+func registerStatelessCompute(writer *computer, initErr error) {
 	computeFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
 		promise := js.Global().Get("Promise")
 		if initErr != nil {
@@ -42,26 +53,135 @@ func main() {
 		if err != nil {
 			return promise.Call("reject", err.Error())
 		}
-		var executor js.Func
-		executor = js.FuncOf(func(_ js.Value, callbacks []js.Value) any {
-			resolve, reject := callbacks[0], callbacks[1]
-			go func() {
-				result, err := writer.compute(context.Background(), operationID, updateViewJSON, semanticIntentJSON)
-				if err != nil {
-					reject.Invoke(err.Error())
-					return
-				}
-				resolve.Invoke(string(result))
-			}()
-			return nil
+		return promiseString(func() (string, error) {
+			result, err := writer.compute(context.Background(), operationID, updateViewJSON, semanticIntentJSON)
+			return string(result), err
 		})
-		value := promise.New(executor)
-		executor.Release()
-		return value
 	})
 	js.Global().Set("maltComputeClientRootV1", computeFunction)
-	js.Global().Set("maltWriterReady", true)
-	select {}
+}
+
+func registerSessionFunctions(writer *sessionComputer, initErr error) {
+	prepareGate := make(chan struct{}, 1)
+	loadFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		promise := js.Global().Get("Promise")
+		if initErr != nil {
+			return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
+		}
+		if len(args) != 1 {
+			return promise.Call("reject", "maltWriterLoadSessionV1 expects update-view JSON Uint8Array")
+		}
+		updateViewJSON, err := copyBoundedBytes(args[0], "update-view JSON", protocol.MaxClientRootJSONBytes)
+		if err != nil {
+			return promise.Call("reject", err.Error())
+		}
+		return promiseString(func() (string, error) {
+			return writer.load(context.Background(), updateViewJSON)
+		})
+	})
+	js.Global().Set("maltWriterLoadSessionV1", loadFunction)
+
+	prepareFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		promise := js.Global().Get("Promise")
+		if initErr != nil {
+			return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
+		}
+		if len(args) != 2 {
+			return promise.Call("reject", "maltWriterPrepareSessionV1 expects operation ID and semantic-intent JSON Uint8Arrays")
+		}
+		select {
+		case prepareGate <- struct{}{}:
+		default:
+			return promise.Call("reject", "a client writer session prepare is already in flight")
+		}
+		releasePrepare := func() { <-prepareGate }
+		operationIDBytes, err := copyBoundedBytes(args[0], "operation ID", maxOperationIDBytes)
+		if err != nil {
+			releasePrepare()
+			return promise.Call("reject", err.Error())
+		}
+		intentJSON, err := copyBoundedBytes(args[1], "semantic-intent JSON", protocol.MaxClientRootJSONBytes)
+		if err != nil {
+			releasePrepare()
+			return promise.Call("reject", err.Error())
+		}
+		operationID := string(operationIDBytes)
+		return promiseStringFinally(func() (string, error) {
+			result, err := writer.prepare(context.Background(), operationID, intentJSON)
+			return string(result), err
+		}, releasePrepare)
+	})
+	js.Global().Set("maltWriterPrepareSessionV1", prepareFunction)
+
+	acceptFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		promise := js.Global().Get("Promise")
+		if initErr != nil {
+			return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
+		}
+		if len(args) != 2 {
+			return promise.Call("reject", "maltWriterAcceptSessionReceiptV1 expects operation ID and materialization-receipt JSON Uint8Arrays")
+		}
+		operationIDBytes, err := copyBoundedBytes(args[0], "operation ID", maxOperationIDBytes)
+		if err != nil {
+			return promise.Call("reject", err.Error())
+		}
+		receiptJSON, err := copyBoundedBytes(args[1], "materialization-receipt JSON", protocol.MaxClientRootJSONBytes)
+		if err != nil {
+			return promise.Call("reject", err.Error())
+		}
+		operationID := string(operationIDBytes)
+		return promiseString(func() (string, error) {
+			return writer.acceptReceipt(operationID, receiptJSON)
+		})
+	})
+	js.Global().Set("maltWriterAcceptSessionReceiptV1", acceptFunction)
+
+	discardFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		promise := js.Global().Get("Promise")
+		if initErr != nil {
+			return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
+		}
+		if len(args) != 1 {
+			return promise.Call("reject", "maltWriterDiscardSessionCandidateV1 expects an operation ID Uint8Array")
+		}
+		operationIDBytes, err := copyBoundedBytes(args[0], "operation ID", maxOperationIDBytes)
+		if err != nil {
+			return promise.Call("reject", err.Error())
+		}
+		operationID := string(operationIDBytes)
+		return promiseString(func() (string, error) {
+			if err := writer.discard(operationID); err != nil {
+				return "", err
+			}
+			return operationID, nil
+		})
+	})
+	js.Global().Set("maltWriterDiscardSessionCandidateV1", discardFunction)
+}
+
+func promiseString(task func() (string, error)) any {
+	return promiseStringFinally(task, func() {})
+}
+
+func promiseStringFinally(task func() (string, error), finally func()) any {
+	promise := js.Global().Get("Promise")
+	var executor js.Func
+	executor = js.FuncOf(func(_ js.Value, callbacks []js.Value) any {
+		resolve, reject := callbacks[0], callbacks[1]
+		go func() {
+			defer finally()
+			result, err := task()
+			if err != nil {
+				reject.Invoke(err.Error())
+				return
+			}
+			resolve.Invoke(result)
+		}()
+		return nil
+	})
+	value := promise.New(executor)
+	executor.Release()
+	return value
 }
 
 func copyBoundedBytes(value js.Value, label string, maxBytes int) ([]byte, error) {
@@ -103,12 +223,4 @@ func copyBoundedBytes(value js.Value, label string, maxBytes int) ([]byte, error
 		return nil, fmt.Errorf("copy %s: copied %d of %d bytes", label, copied, size)
 	}
 	return data, nil
-}
-
-func requestedBackend() string {
-	value := js.Global().Get("maltWriterBackend")
-	if value.Type() != js.TypeString || value.String() == "" {
-		return "all"
-	}
-	return value.String()
 }

--- a/cmd/malt-writer-wasm/main.go
+++ b/cmd/malt-writer-wasm/main.go
@@ -84,47 +84,56 @@ func registerSessionFunctions(writer *sessionComputer, initErr error) {
 	})
 	js.Global().Set("maltWriterLoadSessionV1", loadFunction)
 
-	newPrepareFunction := func(name string, compact bool) js.Func {
-		return js.FuncOf(func(_ js.Value, args []js.Value) any {
-			promise := js.Global().Get("Promise")
-			if initErr != nil {
-				return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
-			}
-			if len(args) != 2 {
-				return promise.Call("reject", fmt.Sprintf("%s expects operation ID and semantic-intent JSON Uint8Arrays", name))
-			}
-			select {
-			case prepareGate <- struct{}{}:
-			default:
-				return promise.Call("reject", "a client writer session prepare is already in flight")
-			}
-			releasePrepare := func() { <-prepareGate }
-			operationIDBytes, err := copyBoundedBytes(args[0], "operation ID", maxOperationIDBytes)
-			if err != nil {
-				releasePrepare()
-				return promise.Call("reject", err.Error())
-			}
-			intentJSON, err := copyBoundedBytes(args[1], "semantic-intent JSON", protocol.MaxClientRootJSONBytes)
-			if err != nil {
-				releasePrepare()
-				return promise.Call("reject", err.Error())
-			}
-			operationID := string(operationIDBytes)
-			return promiseStringFinally(func() (string, error) {
-				var result []byte
-				if compact {
-					result, err = writer.prepareCompact(context.Background(), operationID, intentJSON)
-				} else {
-					result, err = writer.prepare(context.Background(), operationID, intentJSON)
-				}
-				return string(result), err
-			}, releasePrepare)
-		})
-	}
-	prepareFunction := newPrepareFunction("maltWriterPrepareSessionV1", false)
+	prepareFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		promise := js.Global().Get("Promise")
+		if initErr != nil {
+			return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
+		}
+		if len(args) != 2 {
+			return promise.Call("reject", "maltWriterPrepareSessionV1 expects operation ID and semantic-intent JSON Uint8Arrays")
+		}
+		select {
+		case prepareGate <- struct{}{}:
+		default:
+			return promise.Call("reject", "a client writer session prepare is already in flight")
+		}
+		releasePrepare := func() { <-prepareGate }
+		operationIDBytes, err := copyBoundedBytes(args[0], "operation ID", maxOperationIDBytes)
+		if err != nil {
+			releasePrepare()
+			return promise.Call("reject", err.Error())
+		}
+		intentJSON, err := copyBoundedBytes(args[1], "semantic-intent JSON", protocol.MaxClientRootJSONBytes)
+		if err != nil {
+			releasePrepare()
+			return promise.Call("reject", err.Error())
+		}
+		operationID := string(operationIDBytes)
+		return promiseStringFinally(func() (string, error) {
+			return writer.prepare(context.Background(), operationID, intentJSON)
+		}, releasePrepare)
+	})
 	js.Global().Set("maltWriterPrepareSessionV1", prepareFunction)
-	prepareCompactFunction := newPrepareFunction("maltWriterPrepareSessionCompactV1", true)
-	js.Global().Set("maltWriterPrepareSessionCompactV1", prepareCompactFunction)
+
+	getPreparedResultFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		promise := js.Global().Get("Promise")
+		if initErr != nil {
+			return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
+		}
+		if len(args) != 1 {
+			return promise.Call("reject", "maltWriterGetPreparedResultV1 expects an operation ID Uint8Array")
+		}
+		operationIDBytes, err := copyBoundedBytes(args[0], "operation ID", maxOperationIDBytes)
+		if err != nil {
+			return promise.Call("reject", err.Error())
+		}
+		operationID := string(operationIDBytes)
+		return promiseString(func() (string, error) {
+			result, err := writer.getPreparedResult(operationID)
+			return string(result), err
+		})
+	})
+	js.Global().Set("maltWriterGetPreparedResultV1", getPreparedResultFunction)
 
 	acceptFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
 		promise := js.Global().Get("Promise")
@@ -170,6 +179,21 @@ func registerSessionFunctions(writer *sessionComputer, initErr error) {
 		})
 	})
 	js.Global().Set("maltWriterDiscardSessionCandidateV1", discardFunction)
+
+	closeFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		promise := js.Global().Get("Promise")
+		if initErr != nil {
+			return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
+		}
+		if len(args) != 0 {
+			return promise.Call("reject", "maltWriterCloseSessionV1 expects no arguments")
+		}
+		return promiseString(func() (string, error) {
+			writer.closeSession()
+			return "", nil
+		})
+	})
+	js.Global().Set("maltWriterCloseSessionV1", closeFunction)
 }
 
 func promiseString(task func() (string, error)) any {

--- a/cmd/malt-writer-wasm/schemes_all.go
+++ b/cmd/malt-writer-wasm/schemes_all.go
@@ -1,0 +1,36 @@
+//go:build !writer_kzg && !writer_ipa
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+)
+
+func compiledBackend() string { return "all" }
+
+func newComputer(backend string) (*computer, error) {
+	schemes := make(map[maltcid.BackendKind]commitment.IndexCommitment)
+	if backend == "all" || backend == string(maltcid.BackendKindKZG) {
+		scheme, err := kzg.NewScheme()
+		if err != nil {
+			return nil, fmt.Errorf("initialize KZG writer: %w", err)
+		}
+		schemes[maltcid.BackendKindKZG] = scheme
+	}
+	if backend == "all" || backend == string(maltcid.BackendKindIPA) {
+		scheme, err := ipa.NewScheme()
+		if err != nil {
+			return nil, fmt.Errorf("initialize IPA writer: %w", err)
+		}
+		schemes[maltcid.BackendKindIPA] = scheme
+	}
+	if len(schemes) == 0 {
+		return nil, fmt.Errorf("unsupported writer backend %q", backend)
+	}
+	return &computer{schemes: schemes}, nil
+}

--- a/cmd/malt-writer-wasm/schemes_all.go
+++ b/cmd/malt-writer-wasm/schemes_all.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/dewebprotocol/malt/auth/commitment"
 	"github.com/dewebprotocol/malt/auth/commitment/ipa"
@@ -11,26 +12,33 @@ import (
 	"github.com/dewebprotocol/malt/wire/maltcid"
 )
 
-func compiledBackend() string { return "all" }
+func startupBackend() (string, error) {
+	return parseStartupBackend(os.Args[1:])
+}
 
 func newComputer(backend string) (*computer, error) {
-	schemes := make(map[maltcid.BackendKind]commitment.IndexCommitment)
-	if backend == "all" || backend == string(maltcid.BackendKindKZG) {
-		scheme, err := kzg.NewScheme()
+	var (
+		kind   maltcid.BackendKind
+		scheme commitment.IndexCommitment
+		err    error
+	)
+	switch backend {
+	case string(maltcid.BackendKindKZG):
+		kind = maltcid.BackendKindKZG
+		scheme, err = kzg.NewScheme()
 		if err != nil {
 			return nil, fmt.Errorf("initialize KZG writer: %w", err)
 		}
-		schemes[maltcid.BackendKindKZG] = scheme
-	}
-	if backend == "all" || backend == string(maltcid.BackendKindIPA) {
-		scheme, err := ipa.NewScheme()
+	case string(maltcid.BackendKindIPA):
+		kind = maltcid.BackendKindIPA
+		scheme, err = ipa.NewScheme()
 		if err != nil {
 			return nil, fmt.Errorf("initialize IPA writer: %w", err)
 		}
-		schemes[maltcid.BackendKindIPA] = scheme
-	}
-	if len(schemes) == 0 {
+	default:
 		return nil, fmt.Errorf("unsupported writer backend %q", backend)
 	}
-	return &computer{schemes: schemes}, nil
+	return &computer{schemes: map[maltcid.BackendKind]commitment.IndexCommitment{
+		kind: scheme,
+	}}, nil
 }

--- a/cmd/malt-writer-wasm/schemes_ipa.go
+++ b/cmd/malt-writer-wasm/schemes_ipa.go
@@ -1,0 +1,26 @@
+//go:build writer_ipa && !writer_kzg
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+)
+
+func compiledBackend() string { return string(maltcid.BackendKindIPA) }
+
+func newComputer(backend string) (*computer, error) {
+	if backend != string(maltcid.BackendKindIPA) {
+		return nil, fmt.Errorf("IPA writer does not support backend %q", backend)
+	}
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		return nil, fmt.Errorf("initialize IPA writer: %w", err)
+	}
+	return &computer{schemes: map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindIPA: scheme,
+	}}, nil
+}

--- a/cmd/malt-writer-wasm/schemes_ipa.go
+++ b/cmd/malt-writer-wasm/schemes_ipa.go
@@ -10,7 +10,9 @@ import (
 	"github.com/dewebprotocol/malt/wire/maltcid"
 )
 
-func compiledBackend() string { return string(maltcid.BackendKindIPA) }
+func startupBackend() (string, error) {
+	return string(maltcid.BackendKindIPA), nil
+}
 
 func newComputer(backend string) (*computer, error) {
 	if backend != string(maltcid.BackendKindIPA) {

--- a/cmd/malt-writer-wasm/schemes_kzg.go
+++ b/cmd/malt-writer-wasm/schemes_kzg.go
@@ -10,7 +10,9 @@ import (
 	"github.com/dewebprotocol/malt/wire/maltcid"
 )
 
-func compiledBackend() string { return string(maltcid.BackendKindKZG) }
+func startupBackend() (string, error) {
+	return string(maltcid.BackendKindKZG), nil
+}
 
 func newComputer(backend string) (*computer, error) {
 	if backend != string(maltcid.BackendKindKZG) {

--- a/cmd/malt-writer-wasm/schemes_kzg.go
+++ b/cmd/malt-writer-wasm/schemes_kzg.go
@@ -1,0 +1,26 @@
+//go:build writer_kzg && !writer_ipa
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+)
+
+func compiledBackend() string { return string(maltcid.BackendKindKZG) }
+
+func newComputer(backend string) (*computer, error) {
+	if backend != string(maltcid.BackendKindKZG) {
+		return nil, fmt.Errorf("KZG writer does not support backend %q", backend)
+	}
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		return nil, fmt.Errorf("initialize KZG writer: %w", err)
+	}
+	return &computer{schemes: map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	}}, nil
+}

--- a/graph/runtime/default_scheme.go
+++ b/graph/runtime/default_scheme.go
@@ -1,0 +1,12 @@
+//go:build !malt_no_default_kzg
+
+package runtimegraph
+
+import (
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+)
+
+func newDefaultCommitmentScheme() (commitment.IndexCommitment, error) {
+	return kzg.NewScheme()
+}

--- a/graph/runtime/default_scheme_disabled.go
+++ b/graph/runtime/default_scheme_disabled.go
@@ -1,0 +1,13 @@
+//go:build malt_no_default_kzg
+
+package runtimegraph
+
+import (
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/commitment"
+)
+
+func newDefaultCommitmentScheme() (commitment.IndexCommitment, error) {
+	return nil, fmt.Errorf("default KZG scheme is excluded; inject an explicit commitment backend")
+}

--- a/graph/runtime/graph.go
+++ b/graph/runtime/graph.go
@@ -9,7 +9,6 @@ import (
 
 	malt "github.com/dewebprotocol/malt"
 	materializer "github.com/dewebprotocol/malt/auth/arcset/materializer"
-	"github.com/dewebprotocol/malt/auth/commitment/kzg"
 	"github.com/dewebprotocol/malt/auth/proof/prooflist"
 	"github.com/dewebprotocol/malt/auth/semantic/list"
 	listtree "github.com/dewebprotocol/malt/auth/semantic/list/tree"
@@ -80,7 +79,7 @@ func NewGraph(id string, materializer materializer.MutableStore, opts ...Option)
 		// Default commitment scheme: KZG.
 		scheme := o.Scheme
 		if scheme == nil {
-			s, err := kzg.NewScheme()
+			s, err := newDefaultCommitmentScheme()
 			if err != nil {
 				return nil, fmt.Errorf("failed to create default KZG scheme: %w", err)
 			}

--- a/scripts/build-writer-wasm.sh
+++ b/scripts/build-writer-wasm.sh
@@ -3,9 +3,11 @@ set -eu
 
 output_dir=${1:-dist/writer}
 mkdir -p "$output_dir"
-GOOS=js GOARCH=wasm go build -tags=writer_kzg -buildvcs=false -trimpath -o "$output_dir/malt-writer-kzg.wasm" ./cmd/malt-writer-wasm
-GOOS=js GOARCH=wasm go build -tags=writer_ipa,malt_no_default_kzg -buildvcs=false -trimpath -o "$output_dir/malt-writer-ipa.wasm" ./cmd/malt-writer-wasm
+GOOS=js GOARCH=wasm go build -buildvcs=false -trimpath -o "$output_dir/malt-writer.wasm" ./cmd/malt-writer-wasm
 cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" "$output_dir/wasm_exec.js"
+cp cmd/malt-writer-wasm/browser/malt-writer-worker.mjs "$output_dir/malt-writer-worker.mjs"
+cp cmd/malt-writer-wasm/browser/malt-writer-workers.mjs "$output_dir/malt-writer-workers.mjs"
 printf '%s\n' \
-  "built $output_dir/malt-writer-kzg.wasm" \
-  "built $output_dir/malt-writer-ipa.wasm"
+  "built $output_dir/malt-writer.wasm" \
+  "built $output_dir/malt-writer-worker.mjs" \
+  "built $output_dir/malt-writer-workers.mjs"

--- a/scripts/build-writer-wasm.sh
+++ b/scripts/build-writer-wasm.sh
@@ -3,6 +3,9 @@ set -eu
 
 output_dir=${1:-dist/writer}
 mkdir -p "$output_dir"
-GOOS=js GOARCH=wasm go build -buildvcs=false -trimpath -o "$output_dir/malt-writer.wasm" ./cmd/malt-writer-wasm
+GOOS=js GOARCH=wasm go build -tags=writer_kzg -buildvcs=false -trimpath -o "$output_dir/malt-writer-kzg.wasm" ./cmd/malt-writer-wasm
+GOOS=js GOARCH=wasm go build -tags=writer_ipa,malt_no_default_kzg -buildvcs=false -trimpath -o "$output_dir/malt-writer-ipa.wasm" ./cmd/malt-writer-wasm
 cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" "$output_dir/wasm_exec.js"
-printf '%s\n' "built $output_dir/malt-writer.wasm"
+printf '%s\n' \
+  "built $output_dir/malt-writer-kzg.wasm" \
+  "built $output_dir/malt-writer-ipa.wasm"

--- a/scripts/run-writer-dual-worker-smoke.mjs
+++ b/scripts/run-writer-dual-worker-smoke.mjs
@@ -83,18 +83,20 @@ try {
     encoder.encode(JSON.stringify(kzgFixture.update_view)),
   );
   assert.equal(loadedRoot, kzgFixture.update_view.base_root);
-  const compactJSON = await writers.prepareCompact(
+  const kzgCandidate = await writers.prepare(
     "kzg",
     encoder.encode(kzgFixture.operation_id),
     encoder.encode(JSON.stringify(kzgFixture.semantic_intent)),
   );
-  assert.deepStrictEqual(JSON.parse(compactJSON), {
-    profile: "malt.writer-prepare-summary/v1",
-    operation_id: kzgFixture.expected_bundle.operation_id,
-    candidate: kzgFixture.expected_bundle.candidate,
-    outputs: kzgFixture.expected_bundle.outputs,
-    payload_cids: kzgFixture.expected_bundle.payload_cids,
-  });
+  assert.equal(kzgCandidate, kzgFixture.expected_bundle.candidate);
+  const kzgPreparedJSON = await writers.getPreparedResult(
+    "kzg",
+    encoder.encode(kzgFixture.operation_id),
+  );
+  const kzgPrepared = JSON.parse(kzgPreparedJSON);
+  assert.equal(kzgPrepared.profile, "malt.writer-compute-result/v1");
+  assert.deepStrictEqual(kzgPrepared.bundle, kzgFixture.expected_bundle);
+  assert.deepStrictEqual(kzgPrepared.next_view, kzgFixture.expected_next_view);
   const kzgWorkFinishedAt = performance.now();
   assert.equal(
     writers.status("ipa").state,
@@ -111,18 +113,44 @@ try {
     encoder.encode(JSON.stringify(ipaFixture.update_view)),
   );
   assert.equal(ipaLoadedRoot, ipaFixture.update_view.base_root);
-  const ipaCompactJSON = await writers.prepareCompact(
+  const ipaCandidate = await writers.prepare(
     "ipa",
     encoder.encode(ipaFixture.operation_id),
     encoder.encode(JSON.stringify(ipaFixture.semantic_intent)),
   );
-  assert.deepStrictEqual(JSON.parse(ipaCompactJSON), {
-    profile: "malt.writer-prepare-summary/v1",
-    operation_id: ipaFixture.expected_bundle.operation_id,
-    candidate: ipaFixture.expected_bundle.candidate,
-    outputs: ipaFixture.expected_bundle.outputs,
-    payload_cids: ipaFixture.expected_bundle.payload_cids,
-  });
+  assert.equal(ipaCandidate, ipaFixture.expected_bundle.candidate);
+  const ipaPreparedJSON = await writers.getPreparedResult(
+    "ipa",
+    encoder.encode(ipaFixture.operation_id),
+  );
+  const ipaPrepared = JSON.parse(ipaPreparedJSON);
+  assert.equal(ipaPrepared.profile, "malt.writer-compute-result/v1");
+  assert.deepStrictEqual(ipaPrepared.bundle, ipaFixture.expected_bundle);
+  assert.deepStrictEqual(ipaPrepared.next_view, ipaFixture.expected_next_view);
+
+  const orderedReload = writers.load(
+    "kzg",
+    encoder.encode(JSON.stringify(kzgFixture.update_view)),
+  );
+  const orderedClose = writers.closeSession("kzg");
+  assert.equal(await orderedReload, kzgFixture.update_view.base_root);
+  assert.equal(await orderedClose, undefined);
+  await assert.rejects(
+    writers.prepare(
+      "kzg",
+      encoder.encode(`${kzgFixture.operation_id}-after-close`),
+      encoder.encode(JSON.stringify(kzgFixture.semantic_intent)),
+    ),
+    /has no update view/,
+    "stateful Worker RPCs did not preserve load-then-close arrival order",
+  );
+  assert.equal(writers.status("kzg").state, "ready");
+  assert.equal(writers.status("ipa").state, "ready");
+  assert.equal(
+    await writers.getPreparedResult("ipa", encoder.encode(ipaFixture.operation_id)),
+    ipaPreparedJSON,
+    "closing the KZG session affected the IPA prepared candidate",
+  );
 
   console.log(
     [
@@ -134,5 +162,5 @@ try {
     ].join("; "),
   );
 } finally {
-  writers.terminate();
+  writers.terminateAll();
 }

--- a/scripts/run-writer-dual-worker-smoke.mjs
+++ b/scripts/run-writer-dual-worker-smoke.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { Worker as NodeWorker } from "node:worker_threads";
+import { pathToFileURL } from "node:url";
+
+const [wasmPath, wasmExecPath, controllerPath, workerPath, fixturePath] =
+  process.argv.slice(2);
+if (!wasmPath || !wasmExecPath || !controllerPath || !workerPath || !fixturePath) {
+  console.error(
+    "usage: node run-writer-dual-worker-smoke.mjs <writer.wasm> <wasm_exec.js> <controller.mjs> <worker.mjs> <fixtures.json>",
+  );
+  process.exit(2);
+}
+
+const [{ createMaltWriterWorkers }, wasm, fixtureJSON] = await Promise.all([
+  import(pathToFileURL(controllerPath).href),
+  readFile(wasmPath),
+  readFile(fixturePath, "utf8"),
+]);
+const module = await WebAssembly.compile(wasm);
+const fixtures = JSON.parse(fixtureJSON);
+const nodeWorkerWrapper = new URL("./run-writer-worker-node.mjs", import.meta.url);
+const workerThreads = [];
+
+class NodeWorkerAdapter {
+  constructor(workerURL) {
+    this.worker = new NodeWorker(nodeWorkerWrapper, {
+      workerData: { workerURL: String(workerURL) },
+    });
+    workerThreads.push(this.worker);
+  }
+
+  addEventListener(type, listener) {
+    if (type === "message") {
+      this.worker.on("message", (data) => listener({ data }));
+      return;
+    }
+    if (type === "error") {
+      this.worker.on("error", (error) => listener({ error, message: error.message }));
+      return;
+    }
+    if (type === "messageerror") {
+      this.worker.on("messageerror", (error) => listener({ error }));
+    }
+  }
+
+  postMessage(message) {
+    this.worker.postMessage(message);
+  }
+
+  terminate() {
+    return this.worker.terminate();
+  }
+}
+
+const startedAt = performance.now();
+const writers = await createMaltWriterWorkers({
+  module,
+  wasmExecURL: pathToFileURL(wasmExecPath),
+  workerURL: pathToFileURL(workerPath),
+  workerFactory: ({ workerURL }) => new NodeWorkerAdapter(workerURL),
+});
+
+try {
+  assert.equal(writers.status("kzg").state, "initializing");
+  assert.equal(writers.status("ipa").state, "initializing");
+  assert.equal(workerThreads.length, 2);
+  assert.notEqual(workerThreads[0].threadId, workerThreads[1].threadId);
+
+  await writers.kzgReady;
+  const kzgReadyAt = performance.now();
+  assert.equal(
+    writers.status("ipa").state,
+    "initializing",
+    "IPA became ready before KZG, so the smoke test did not exercise independent readiness",
+  );
+
+  const encoder = new TextEncoder();
+  const kzgFixture = fixtures.find(({ backend }) => backend === "kzg");
+  assert.ok(kzgFixture, "missing KZG fixture");
+  const loadedRoot = await writers.load(
+    "kzg",
+    encoder.encode(JSON.stringify(kzgFixture.update_view)),
+  );
+  assert.equal(loadedRoot, kzgFixture.update_view.base_root);
+  const compactJSON = await writers.prepareCompact(
+    "kzg",
+    encoder.encode(kzgFixture.operation_id),
+    encoder.encode(JSON.stringify(kzgFixture.semantic_intent)),
+  );
+  assert.deepStrictEqual(JSON.parse(compactJSON), {
+    profile: "malt.writer-prepare-summary/v1",
+    operation_id: kzgFixture.expected_bundle.operation_id,
+    candidate: kzgFixture.expected_bundle.candidate,
+    outputs: kzgFixture.expected_bundle.outputs,
+    payload_cids: kzgFixture.expected_bundle.payload_cids,
+  });
+  const kzgWorkFinishedAt = performance.now();
+  assert.equal(
+    writers.status("ipa").state,
+    "initializing",
+    "KZG work did not finish while IPA initialization was still in progress",
+  );
+
+  await writers.ipaReady;
+  const ipaReadyAt = performance.now();
+  const ipaFixture = fixtures.find(({ backend }) => backend === "ipa");
+  assert.ok(ipaFixture, "missing IPA fixture");
+  const ipaLoadedRoot = await writers.load(
+    "ipa",
+    encoder.encode(JSON.stringify(ipaFixture.update_view)),
+  );
+  assert.equal(ipaLoadedRoot, ipaFixture.update_view.base_root);
+  const ipaCompactJSON = await writers.prepareCompact(
+    "ipa",
+    encoder.encode(ipaFixture.operation_id),
+    encoder.encode(JSON.stringify(ipaFixture.semantic_intent)),
+  );
+  assert.deepStrictEqual(JSON.parse(ipaCompactJSON), {
+    profile: "malt.writer-prepare-summary/v1",
+    operation_id: ipaFixture.expected_bundle.operation_id,
+    candidate: ipaFixture.expected_bundle.candidate,
+    outputs: ipaFixture.expected_bundle.outputs,
+    payload_cids: ipaFixture.expected_bundle.payload_cids,
+  });
+
+  console.log(
+    [
+      "dual Worker smoke passed",
+      `KZG ready ${(kzgReadyAt - startedAt).toFixed(1)} ms`,
+      `KZG work finished ${(kzgWorkFinishedAt - startedAt).toFixed(1)} ms`,
+      `IPA ready ${(ipaReadyAt - startedAt).toFixed(1)} ms`,
+      `threads ${workerThreads.map(({ threadId }) => threadId).join(",")}`,
+    ].join("; "),
+  );
+} finally {
+  writers.terminate();
+}

--- a/scripts/run-writer-wasm-smoke.mjs
+++ b/scripts/run-writer-wasm-smoke.mjs
@@ -25,6 +25,7 @@ if (typeof globalThis.Go !== "function") {
 }
 
 const go = new globalThis.Go();
+go.argv = ["malt-writer.wasm", `--backend=${selectedBackend}`];
 const wasm = await readFile(wasmPath);
 const { instance } = await WebAssembly.instantiate(wasm, go.importObject);
 let runtimeFailure;

--- a/scripts/run-writer-wasm-smoke.mjs
+++ b/scripts/run-writer-wasm-smoke.mjs
@@ -42,6 +42,7 @@ while (Date.now() < deadline) {
     typeof globalThis.maltComputeClientRootV1 === "function" &&
     typeof globalThis.maltWriterLoadSessionV1 === "function" &&
     typeof globalThis.maltWriterPrepareSessionV1 === "function" &&
+    typeof globalThis.maltWriterPrepareSessionCompactV1 === "function" &&
     typeof globalThis.maltWriterAcceptSessionReceiptV1 === "function" &&
     typeof globalThis.maltWriterDiscardSessionCandidateV1 === "function"
   ) {
@@ -54,6 +55,7 @@ if (
   typeof globalThis.maltComputeClientRootV1 !== "function" ||
   typeof globalThis.maltWriterLoadSessionV1 !== "function" ||
   typeof globalThis.maltWriterPrepareSessionV1 !== "function" ||
+  typeof globalThis.maltWriterPrepareSessionCompactV1 !== "function" ||
   typeof globalThis.maltWriterAcceptSessionReceiptV1 !== "function" ||
   typeof globalThis.maltWriterDiscardSessionCandidateV1 !== "function"
 ) {
@@ -227,14 +229,21 @@ for (const fixture of selectedFixtures) {
   if (discarded !== fixture.operation_id) {
     throw new Error(`${fixture.backend} session discarded the wrong operation`);
   }
-  const preparedAfterDiscardJSON = await globalThis.maltWriterPrepareSessionV1(
+  const preparedAfterDiscardJSON = await globalThis.maltWriterPrepareSessionCompactV1(
     sessionOperationID,
     sessionIntent,
   );
+  const preparedAfterDiscard = JSON.parse(preparedAfterDiscardJSON);
   assert.deepStrictEqual(
-    JSON.parse(preparedAfterDiscardJSON).bundle,
-    fixture.expected_bundle,
-    `${fixture.backend} session changed after discard and re-prepare`,
+    preparedAfterDiscard,
+    {
+      profile: "malt.writer-prepare-summary/v1",
+      operation_id: fixture.expected_bundle.operation_id,
+      candidate: fixture.expected_bundle.candidate,
+      outputs: fixture.expected_bundle.outputs,
+      payload_cids: fixture.expected_bundle.payload_cids,
+    },
+    `${fixture.backend} compact session result differs from the full result`,
   );
   const acceptedRoot = await globalThis.maltWriterAcceptSessionReceiptV1(
     sessionOperationID,

--- a/scripts/run-writer-wasm-smoke.mjs
+++ b/scripts/run-writer-wasm-smoke.mjs
@@ -3,15 +3,15 @@ import { webcrypto } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
-const [wasmPath, wasmExecPath, fixturePath, selectedBackend = "all"] =
+const [wasmPath, wasmExecPath, fixturePath, selectedBackend = "kzg"] =
   process.argv.slice(2);
 if (!wasmPath || !wasmExecPath || !fixturePath) {
   console.error(
-    "usage: node run-writer-wasm-smoke.mjs <writer.wasm> <wasm_exec.js> <fixtures.json> [all|kzg|ipa]",
+    "usage: node run-writer-wasm-smoke.mjs <writer.wasm> <wasm_exec.js> <fixtures.json> [kzg|ipa]",
   );
   process.exit(2);
 }
-if (!["all", "kzg", "ipa"].includes(selectedBackend)) {
+if (!["kzg", "ipa"].includes(selectedBackend)) {
   throw new Error(`unsupported writer backend ${JSON.stringify(selectedBackend)}`);
 }
 if (!globalThis.crypto) {
@@ -24,7 +24,6 @@ if (typeof globalThis.Go !== "function") {
   throw new Error(`${wasmExecPath} did not install the Go WASM runtime`);
 }
 
-globalThis.maltWriterBackend = selectedBackend;
 const go = new globalThis.Go();
 const wasm = await readFile(wasmPath);
 const { instance } = await WebAssembly.instantiate(wasm, go.importObject);
@@ -38,12 +37,26 @@ while (Date.now() < deadline) {
   if (runtimeFailure) {
     throw new Error(`Go WASM runtime failed: ${runtimeFailure}`);
   }
-  if (globalThis.maltWriterReady && typeof globalThis.maltComputeClientRootV1 === "function") {
+  if (
+    globalThis.maltWriterReady &&
+    typeof globalThis.maltComputeClientRootV1 === "function" &&
+    typeof globalThis.maltWriterLoadSessionV1 === "function" &&
+    typeof globalThis.maltWriterPrepareSessionV1 === "function" &&
+    typeof globalThis.maltWriterAcceptSessionReceiptV1 === "function" &&
+    typeof globalThis.maltWriterDiscardSessionCandidateV1 === "function"
+  ) {
     break;
   }
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
-if (!globalThis.maltWriterReady || typeof globalThis.maltComputeClientRootV1 !== "function") {
+if (
+  !globalThis.maltWriterReady ||
+  typeof globalThis.maltComputeClientRootV1 !== "function" ||
+  typeof globalThis.maltWriterLoadSessionV1 !== "function" ||
+  typeof globalThis.maltWriterPrepareSessionV1 !== "function" ||
+  typeof globalThis.maltWriterAcceptSessionReceiptV1 !== "function" ||
+  typeof globalThis.maltWriterDiscardSessionCandidateV1 !== "function"
+) {
   throw new Error("timed out waiting for MALT writer globals");
 }
 if (globalThis.maltWriterInitError) {
@@ -88,7 +101,7 @@ if (!rejectedHostileLength) {
   throw new Error("writer accepted a proxied Uint8Array with hostile length metadata");
 }
 
-if (selectedBackend === "all") {
+if (selectedBackend === "kzg") {
   const oversizedJSON = new Uint8Array(64 * 1024 * 1024 + 1);
   let rejectedOversized = false;
   try {
@@ -120,9 +133,9 @@ if (!rejectedInvalidJSON) {
 }
 
 const selectedFixtures = fixtures.filter(
-  ({ backend }) => selectedBackend === "all" || backend === selectedBackend,
+  ({ backend }) => backend === selectedBackend,
 );
-const expectedFixtureCount = selectedBackend === "all" ? 2 : 1;
+const expectedFixtureCount = 1;
 if (selectedFixtures.length !== expectedFixtureCount) {
   throw new Error(
     `selected ${selectedFixtures.length} fixtures for ${selectedBackend}, expected ${expectedFixtureCount}`,
@@ -182,9 +195,72 @@ for (const fixture of selectedFixtures) {
       throw new Error(`${fixture.backend} metric ${name} is not a non-negative safe integer`);
     }
   }
+
+  const sessionView = encoder.encode(JSON.stringify(fixture.update_view));
+  const loadedRoot = await globalThis.maltWriterLoadSessionV1(sessionView);
+  if (loadedRoot !== fixture.update_view.base_root) {
+    throw new Error(
+      `${fixture.backend} session loaded ${loadedRoot}, expected ${fixture.update_view.base_root}`,
+    );
+  }
+  const sessionOperationID = encoder.encode(fixture.operation_id);
+  const sessionIntent = encoder.encode(JSON.stringify(fixture.semantic_intent));
+  const preparedJSON = await globalThis.maltWriterPrepareSessionV1(
+    sessionOperationID,
+    sessionIntent,
+  );
+  const prepared = JSON.parse(preparedJSON);
+  assert.deepStrictEqual(
+    prepared.bundle,
+    fixture.expected_bundle,
+    `${fixture.backend} session bundle differs from the stateless reference`,
+  );
+  assert.deepStrictEqual(
+    prepared.next_view,
+    fixture.expected_next_view,
+    `${fixture.backend} session next view differs from the stateless reference`,
+  );
+
+  const discarded = await globalThis.maltWriterDiscardSessionCandidateV1(
+    sessionOperationID,
+  );
+  if (discarded !== fixture.operation_id) {
+    throw new Error(`${fixture.backend} session discarded the wrong operation`);
+  }
+  const preparedAfterDiscardJSON = await globalThis.maltWriterPrepareSessionV1(
+    sessionOperationID,
+    sessionIntent,
+  );
+  assert.deepStrictEqual(
+    JSON.parse(preparedAfterDiscardJSON).bundle,
+    fixture.expected_bundle,
+    `${fixture.backend} session changed after discard and re-prepare`,
+  );
+  const acceptedRoot = await globalThis.maltWriterAcceptSessionReceiptV1(
+    sessionOperationID,
+    encoder.encode(JSON.stringify(fixture.expected_receipt)),
+  );
+  if (acceptedRoot !== fixture.expected_bundle.candidate) {
+    throw new Error(
+      `${fixture.backend} session accepted ${acceptedRoot}, expected ${fixture.expected_bundle.candidate}`,
+    );
+  }
+
+  let rejectedStaleIntent = false;
+  try {
+    await globalThis.maltWriterPrepareSessionV1(
+      encoder.encode(`${fixture.operation_id}-stale`),
+      sessionIntent,
+    );
+  } catch {
+    rejectedStaleIntent = true;
+  }
+  if (!rejectedStaleIntent) {
+    throw new Error(`${fixture.backend} session accepted an intent at the stale base`);
+  }
 }
 
 console.log(
-  `WASM ${selectedBackend} writer smoke passed (${selectedFixtures.length} valid fixture(s))`,
+  `WASM ${selectedBackend} stateless/session smoke passed (${selectedFixtures.length} valid fixture(s))`,
 );
 process.exit(0);

--- a/scripts/run-writer-wasm-smoke.mjs
+++ b/scripts/run-writer-wasm-smoke.mjs
@@ -43,9 +43,10 @@ while (Date.now() < deadline) {
     typeof globalThis.maltComputeClientRootV1 === "function" &&
     typeof globalThis.maltWriterLoadSessionV1 === "function" &&
     typeof globalThis.maltWriterPrepareSessionV1 === "function" &&
-    typeof globalThis.maltWriterPrepareSessionCompactV1 === "function" &&
+    typeof globalThis.maltWriterGetPreparedResultV1 === "function" &&
     typeof globalThis.maltWriterAcceptSessionReceiptV1 === "function" &&
-    typeof globalThis.maltWriterDiscardSessionCandidateV1 === "function"
+    typeof globalThis.maltWriterDiscardSessionCandidateV1 === "function" &&
+    typeof globalThis.maltWriterCloseSessionV1 === "function"
   ) {
     break;
   }
@@ -56,9 +57,10 @@ if (
   typeof globalThis.maltComputeClientRootV1 !== "function" ||
   typeof globalThis.maltWriterLoadSessionV1 !== "function" ||
   typeof globalThis.maltWriterPrepareSessionV1 !== "function" ||
-  typeof globalThis.maltWriterPrepareSessionCompactV1 !== "function" ||
+  typeof globalThis.maltWriterGetPreparedResultV1 !== "function" ||
   typeof globalThis.maltWriterAcceptSessionReceiptV1 !== "function" ||
-  typeof globalThis.maltWriterDiscardSessionCandidateV1 !== "function"
+  typeof globalThis.maltWriterDiscardSessionCandidateV1 !== "function" ||
+  typeof globalThis.maltWriterCloseSessionV1 !== "function"
 ) {
   throw new Error("timed out waiting for MALT writer globals");
 }
@@ -208,9 +210,22 @@ for (const fixture of selectedFixtures) {
   }
   const sessionOperationID = encoder.encode(fixture.operation_id);
   const sessionIntent = encoder.encode(JSON.stringify(fixture.semantic_intent));
-  const preparedJSON = await globalThis.maltWriterPrepareSessionV1(
+  const candidate = await globalThis.maltWriterPrepareSessionV1(
     sessionOperationID,
     sessionIntent,
+  );
+  if (candidate !== fixture.expected_bundle.candidate) {
+    throw new Error(
+      `${fixture.backend} session prepared ${candidate}, expected ${fixture.expected_bundle.candidate}`,
+    );
+  }
+  const preparedJSON = await globalThis.maltWriterGetPreparedResultV1(
+    sessionOperationID,
+  );
+  assert.equal(
+    await globalThis.maltWriterGetPreparedResultV1(sessionOperationID),
+    preparedJSON,
+    `${fixture.backend} repeated prepared-result lookup changed bytes`,
   );
   const prepared = JSON.parse(preparedJSON);
   assert.deepStrictEqual(
@@ -230,21 +245,37 @@ for (const fixture of selectedFixtures) {
   if (discarded !== fixture.operation_id) {
     throw new Error(`${fixture.backend} session discarded the wrong operation`);
   }
-  const preparedAfterDiscardJSON = await globalThis.maltWriterPrepareSessionCompactV1(
+  let rejectedDiscardedResult = false;
+  try {
+    await globalThis.maltWriterGetPreparedResultV1(sessionOperationID);
+  } catch {
+    rejectedDiscardedResult = true;
+  }
+  if (!rejectedDiscardedResult) {
+    throw new Error(`${fixture.backend} session returned a discarded prepared result`);
+  }
+  const candidateAfterDiscard = await globalThis.maltWriterPrepareSessionV1(
     sessionOperationID,
     sessionIntent,
   );
+  assert.equal(
+    candidateAfterDiscard,
+    fixture.expected_bundle.candidate,
+    `${fixture.backend} re-prepared a different candidate after discard`,
+  );
+  const preparedAfterDiscardJSON = await globalThis.maltWriterGetPreparedResultV1(
+    sessionOperationID,
+  );
   const preparedAfterDiscard = JSON.parse(preparedAfterDiscardJSON);
   assert.deepStrictEqual(
-    preparedAfterDiscard,
-    {
-      profile: "malt.writer-prepare-summary/v1",
-      operation_id: fixture.expected_bundle.operation_id,
-      candidate: fixture.expected_bundle.candidate,
-      outputs: fixture.expected_bundle.outputs,
-      payload_cids: fixture.expected_bundle.payload_cids,
-    },
-    `${fixture.backend} compact session result differs from the full result`,
+    preparedAfterDiscard.bundle,
+    fixture.expected_bundle,
+    `${fixture.backend} re-prepared bundle differs from the reference`,
+  );
+  assert.deepStrictEqual(
+    preparedAfterDiscard.next_view,
+    fixture.expected_next_view,
+    `${fixture.backend} re-prepared next view differs from the reference`,
   );
   const acceptedRoot = await globalThis.maltWriterAcceptSessionReceiptV1(
     sessionOperationID,
@@ -268,8 +299,30 @@ for (const fixture of selectedFixtures) {
   if (!rejectedStaleIntent) {
     throw new Error(`${fixture.backend} session accepted an intent at the stale base`);
   }
+  await globalThis.maltWriterCloseSessionV1();
+  let rejectedClosedPrepare = false;
+  try {
+    await globalThis.maltWriterPrepareSessionV1(
+      encoder.encode(`${fixture.operation_id}-closed`),
+      sessionIntent,
+    );
+  } catch {
+    rejectedClosedPrepare = true;
+  }
+  if (!rejectedClosedPrepare) {
+    throw new Error(`${fixture.backend} session prepared after close`);
+  }
+  const reloadedRoot = await globalThis.maltWriterLoadSessionV1(
+    encoder.encode(JSON.stringify(fixture.update_view)),
+  );
+  assert.equal(
+    reloadedRoot,
+    fixture.update_view.base_root,
+    `${fixture.backend} Worker could not load a new session after close`,
+  );
+  await globalThis.maltWriterCloseSessionV1();
+  await globalThis.maltWriterCloseSessionV1();
 }
-
 console.log(
   `WASM ${selectedBackend} stateless/session smoke passed (${selectedFixtures.length} valid fixture(s))`,
 );

--- a/scripts/run-writer-worker-node.mjs
+++ b/scripts/run-writer-worker-node.mjs
@@ -1,0 +1,43 @@
+import { webcrypto } from "node:crypto";
+import { parentPort, workerData } from "node:worker_threads";
+
+if (!parentPort) {
+  throw new Error("run-writer-worker-node.mjs must run in a Node worker thread");
+}
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto;
+}
+
+const listeners = new Map();
+const queuedMessages = [];
+
+globalThis.self = globalThis;
+globalThis.postMessage = (message, transfer) => {
+  parentPort.postMessage(message, transfer);
+};
+globalThis.addEventListener = (type, listener) => {
+  if (typeof listener !== "function") {
+    throw new TypeError("event listener must be a function");
+  }
+  const typedListeners = listeners.get(type) ?? [];
+  typedListeners.push(listener);
+  listeners.set(type, typedListeners);
+  if (type === "message" && queuedMessages.length > 0) {
+    for (const data of queuedMessages.splice(0)) {
+      listener({ data });
+    }
+  }
+};
+
+parentPort.on("message", (data) => {
+  const messageListeners = listeners.get("message");
+  if (!messageListeners || messageListeners.length === 0) {
+    queuedMessages.push(data);
+    return;
+  }
+  for (const listener of messageListeners) {
+    listener({ data });
+  }
+});
+
+await import(workerData.workerURL);

--- a/scripts/test-writer-wasm.sh
+++ b/scripts/test-writer-wasm.sh
@@ -5,6 +5,15 @@ repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 work_dir=$(mktemp -d "${TMPDIR:-/tmp}/malt-writer-wasm.XXXXXX")
 trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
 
+if go list -buildvcs=false -deps -tags=writer_kzg ./cmd/malt-writer-wasm | rg -q '/auth/commitment/ipa$'; then
+  printf '%s\n' "KZG writer unexpectedly links the IPA backend" >&2
+  exit 1
+fi
+if go list -buildvcs=false -deps -tags=writer_ipa,malt_no_default_kzg ./cmd/malt-writer-wasm | rg -q '/auth/commitment/kzg$'; then
+  printf '%s\n' "IPA writer unexpectedly links the KZG backend" >&2
+  exit 1
+fi
+
 sh "$repo_root/scripts/build-writer-wasm.sh" "$work_dir/writer"
 (
   cd "$repo_root"
@@ -14,17 +23,12 @@ sh "$repo_root/scripts/build-writer-wasm.sh" "$work_dir/writer"
     -count=1
 )
 node "$repo_root/scripts/run-writer-wasm-smoke.mjs" \
-  "$work_dir/writer/malt-writer.wasm" \
-  "$work_dir/writer/wasm_exec.js" \
-  "$work_dir/fixtures.json" \
-  all
-node "$repo_root/scripts/run-writer-wasm-smoke.mjs" \
-  "$work_dir/writer/malt-writer.wasm" \
+  "$work_dir/writer/malt-writer-kzg.wasm" \
   "$work_dir/writer/wasm_exec.js" \
   "$work_dir/fixtures.json" \
   kzg
 node "$repo_root/scripts/run-writer-wasm-smoke.mjs" \
-  "$work_dir/writer/malt-writer.wasm" \
+  "$work_dir/writer/malt-writer-ipa.wasm" \
   "$work_dir/writer/wasm_exec.js" \
   "$work_dir/fixtures.json" \
   ipa

--- a/scripts/test-writer-wasm.sh
+++ b/scripts/test-writer-wasm.sh
@@ -23,12 +23,18 @@ sh "$repo_root/scripts/build-writer-wasm.sh" "$work_dir/writer"
     -count=1
 )
 node "$repo_root/scripts/run-writer-wasm-smoke.mjs" \
-  "$work_dir/writer/malt-writer-kzg.wasm" \
+  "$work_dir/writer/malt-writer.wasm" \
   "$work_dir/writer/wasm_exec.js" \
   "$work_dir/fixtures.json" \
   kzg
 node "$repo_root/scripts/run-writer-wasm-smoke.mjs" \
-  "$work_dir/writer/malt-writer-ipa.wasm" \
+  "$work_dir/writer/malt-writer.wasm" \
   "$work_dir/writer/wasm_exec.js" \
   "$work_dir/fixtures.json" \
   ipa
+node "$repo_root/scripts/run-writer-dual-worker-smoke.mjs" \
+  "$work_dir/writer/malt-writer.wasm" \
+  "$work_dir/writer/wasm_exec.js" \
+  "$work_dir/writer/malt-writer-workers.mjs" \
+  "$work_dir/writer/malt-writer-worker.mjs" \
+  "$work_dir/fixtures.json"

--- a/scripts/test-writer-wasm.sh
+++ b/scripts/test-writer-wasm.sh
@@ -5,6 +5,9 @@ repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 work_dir=$(mktemp -d "${TMPDIR:-/tmp}/malt-writer-wasm.XXXXXX")
 trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
 
+node --test \
+  "$repo_root/cmd/malt-writer-wasm/browser/malt-writer-workers.test.mjs"
+
 if go list -buildvcs=false -deps -tags=writer_kzg ./cmd/malt-writer-wasm | rg -q '/auth/commitment/ipa$'; then
   printf '%s\n' "KZG writer unexpectedly links the IPA backend" >&2
   exit 1


### PR DESCRIPTION
## Summary

- emit one unified `malt-writer.wasm` containing both KZG and IPA code, plus a browser Worker and controller
- download and compile the WASM module once, then structured-clone the same compiled `WebAssembly.Module` into two independent Workers
- bind each Go/WASM instance immutably at startup with exactly one `--backend=kzg|ipa` argument; a single instance never initializes both schemes
- expose independent readiness, status, and backend-routed compute/session RPCs so IPA initialization cannot block KZG work
- keep `prepare` as the candidate-producing phase but return only the candidate root; retrieve the existing protocol-owned `malt.writer-compute-result/v1` through `getPreparedResult(operationID)` when bundle, next-view, or metrics detail is needed
- separate session and process lifecycle: `closeSession(backend)` releases accepted/prepared/materialized session state while keeping that Worker ready for another load; `terminateBackend` and `terminateAll` release Worker/WASM resources
- terminate only the failed backend Worker on fatal initialization/runtime/transport failure, while ordinary RPC errors leave it ready and the peer backend remains independent
- preserve radix collision-bucket entries during reachability reclamation by owning their node cache under the encoded bucket reference stored by the parent slot

## Browser behavior

`createMaltWriterWorkers()` fetches and compiles the unified artifact once and starts both Workers immediately. KZG and IPA have separate event loops, WASM instances, linear memories, session state, request queues, failure states, and readiness promises. Applications can await `kzgReady` and begin KZG work without awaiting `ipaReady`.

Stateful RPCs are serialized in message-arrival order within each Worker. Preparing does not advance the accepted base. An exact `malt.materialization-receipt/v1` is still required to advance it; discard, successful replacement load, receipt acceptance, and close reclaim obsolete prepared/materialized state.

The backend selector is not a mutable JavaScript global. Each Worker sets the Go runtime arguments before instantiation, and the unified runtime rejects missing, invalid, or multiple backend arguments.

## Validation

- `scripts/test-writer-wasm.sh`
  - fake-Worker lifecycle tests for initialization failure, ordinary RPC errors, single-backend fatal failure, close, and terminate isolation/idempotency
  - compile-time KZG/IPA dependency isolation
  - one unified real WASM artifact exercised directly with both backends
  - minimal prepare return, on-demand full-result parity, exact receipt gate, discard/close/reload, stale intent rejection, and hostile TypedArray checks
  - same compiled module instantiated in two Node worker threads
  - real dual-Worker load-then-close ordering and peer-session isolation
- `go test -p=6 -parallel=6 ./...`
- `go vet -p=7 ./...`
- `go build -buildvcs=false -p=7 ./...`
- `GOOS=linux GOARCH=386 go test -p=6 -run "^$" ./cmd/malt-writer-wasm ./auth/semantic/mapping/radix`
- `git diff --check` and `gofmt -l` on changed Go files

Latest local dual-Worker smoke: KZG ready in 769.6 ms, KZG load + prepare + result lookup finished in 2114.5 ms, and IPA ready in 9943.4 ms on distinct Node worker thread IDs 1 and 2. These timings are smoke evidence, not a stable performance benchmark; reusable comparison runners and result schemas remain owned by `malt-evaluation`.

## Notes

This is the stateful Go/WASM implementation. The independent TypeScript semantics plus commitment-only WASM comparison branch remains in #181; it is not combined with this branch.