### PR TITLE
Add client-root materialization and verifiable map absence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   consume SHA-256 keys in 12-bit radix digits and KZG lists branch over 4095
   content slots; the fixed 256-position IPA suite retains 8-bit map digits and
   255 list content slots.
-- Advance typed MALT roots to `MALTVersionID=2`. Experimental version-1 roots
-  and their materialized node state must be rebuilt; current decoders reject
-  them rather than interpreting them with the new geometry.
+- Advance newly constructed typed MALT roots to `MALTVersionID=3` for
+  fixed-domain collision buckets and sound map non-membership proofs. Version-2
+  roots remain explicitly readable and verifiable. Incremental mutation APIs
+  reject a root/semantics version mismatch; the client writer verifies an exact
+  v2 complete view, fully rebuilds it as v3, and only then applies changes so it
+  cannot emit mixed-version trees. Experimental version-1 roots remain rejected.
 
 ### Removed
 

--- a/auth/proof/prooflist/prooflist.go
+++ b/auth/proof/prooflist/prooflist.go
@@ -12,6 +12,7 @@ type StepKind string
 
 const (
 	KindMapStep        StepKind = "map_step"
+	KindMapAbsence     StepKind = "map_absence"
 	KindPayloadBinding StepKind = "payload_binding"
 	KindListIndex      StepKind = "list_index"
 	KindListRange      StepKind = "list_range"
@@ -92,8 +93,15 @@ func (p ProofList) ValidateShape(opts ...ValidateOption) error {
 		if !step.From.Defined() {
 			return fmt.Errorf("prooflist step %d from CID is undefined", i)
 		}
-		if !step.Target.Defined() {
+		terminalAbsence := step.Kind == KindMapAbsence && i == len(p.Steps)-1
+		if step.Kind == KindMapAbsence && !terminalAbsence {
+			return fmt.Errorf("prooflist step %d map_absence must be terminal", i)
+		}
+		if !step.Target.Defined() && !terminalAbsence {
 			return fmt.Errorf("prooflist step %d target CID is undefined", i)
+		}
+		if terminalAbsence && step.Target.Defined() {
+			return fmt.Errorf("prooflist step %d map_absence target CID must be undefined", i)
 		}
 		if !step.From.Equals(current) {
 			return fmt.Errorf("prooflist step %d from CID %s does not continue from current target %s", i, step.From.String(), current.String())
@@ -116,6 +124,12 @@ func (p ProofList) ValidateShape(opts ...ValidateOption) error {
 			listIndexPhase = true
 			continue
 		}
+		if terminalAbsence {
+			if step.EvidenceKind != "structure" || step.EvidenceBackend != "map" {
+				return fmt.Errorf("prooflist step %d map_absence kind does not match structure/map evidence", i)
+			}
+			continue
+		}
 		if listIndexPhase {
 			return fmt.Errorf("prooflist step %d traversal step appears after list index evidence", i)
 		}
@@ -135,7 +149,7 @@ func (p ProofList) LastStepTarget() (cid.Cid, error) {
 // Known reports whether k is part of the current ProofList schema.
 func (k StepKind) Known() bool {
 	switch k {
-	case KindMapStep, KindPayloadBinding, KindListIndex, KindListRange, KindBlobBinding, KindImplicitBlock, KindLegacyUnknown:
+	case KindMapStep, KindMapAbsence, KindPayloadBinding, KindListIndex, KindListRange, KindBlobBinding, KindImplicitBlock, KindLegacyUnknown:
 		return true
 	default:
 		return false

--- a/auth/proof/prooflist/prooflist_test.go
+++ b/auth/proof/prooflist/prooflist_test.go
@@ -325,3 +325,28 @@ func TestValidateShapeRejectsTraversalAfterListEvidence(t *testing.T) {
 		t.Fatal("expected traversal after structure/measured_list evidence to be rejected")
 	}
 }
+
+func TestValidateShapeAcceptsOnlyTerminalStructureMapAbsence(t *testing.T) {
+	root := testCID(t, "absence-root")
+	absence := Step{
+		Kind: KindMapAbsence, From: root, Path: "missing", Target: cid.Undef,
+		EvidenceKind: "structure", EvidenceBackend: "map", Proof: []byte("absence"),
+	}
+	if err := (ProofList{Root: root, Query: "missing", Steps: []Step{absence}}).ValidateShape(RequireSteps()); err != nil {
+		t.Fatalf("terminal map absence rejected: %v", err)
+	}
+
+	wrongEvidence := absence
+	wrongEvidence.EvidenceBackend = "list"
+	if err := (ProofList{Root: root, Steps: []Step{wrongEvidence}}).ValidateShape(RequireSteps()); err == nil {
+		t.Fatal("map absence with non-map evidence was accepted")
+	}
+
+	nonTerminal := absence
+	nonTerminal.Target = testCID(t, "forged-target")
+	if err := (ProofList{Root: root, Steps: []Step{nonTerminal, {
+		Kind: KindMapStep, From: nonTerminal.Target, Path: "next", Target: testCID(t, "next"),
+	}}}).ValidateShape(RequireSteps()); err == nil {
+		t.Fatal("non-terminal map absence was accepted")
+	}
+}

--- a/auth/semantic/list/list.go
+++ b/auth/semantic/list/list.go
@@ -11,6 +11,7 @@ package list
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/dewebprotocol/malt/auth/commitment"
@@ -18,6 +19,10 @@ import (
 	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 )
+
+// ErrNotMeasured reports that a plain list does not carry fixed-width byte
+// range metadata. Callers may fall back to index semantics for this case.
+var ErrNotMeasured = errors.New("list is not measured")
 
 // Iterator iterates over a list view in index order.
 type Iterator interface {

--- a/auth/semantic/list/tree/tree.go
+++ b/auth/semantic/list/tree/tree.go
@@ -26,6 +26,7 @@ type TreeList struct {
 	commitment   *list.Commitment
 	materializer materializer.NodeStore
 	geometry     nodegeometry.Geometry
+	version      uint8
 }
 
 type proofEnvelope struct {
@@ -51,6 +52,12 @@ type rangeIndexProof struct {
 }
 
 func NewList(scheme commitment.IndexCommitment, materializer materializer.NodeStore) (*TreeList, error) {
+	return NewListForVersion(scheme, materializer, maltcid.MALTVersionID)
+}
+
+// NewListForVersion creates list semantics that emit an exact supported typed
+// root version. Legacy mode is reserved for replaying complete old views.
+func NewListForVersion(scheme commitment.IndexCommitment, materializer materializer.NodeStore, version uint8) (*TreeList, error) {
 	geometry, err := layout.ValidateCommitment(scheme)
 	if err != nil {
 		return nil, err
@@ -64,16 +71,27 @@ func NewList(scheme commitment.IndexCommitment, materializer materializer.NodeSt
 		return nil, fmt.Errorf("failed to create list commitment: %w", err)
 	}
 
+	if version != maltcid.MALTVersionID && version != maltcid.LegacyMALTVersionID {
+		return nil, fmt.Errorf("unsupported MALT version %d", version)
+	}
 	return &TreeList{
 		commitment:   commitmentHandler,
 		materializer: materializer,
 		geometry:     geometry,
+		version:      version,
 	}, nil
 }
 
 // Commitment returns the underlying commitment primitives.
 func (s *TreeList) Commitment() *list.Commitment {
 	return s.commitment
+}
+
+func (s *TreeList) validateMutationRootVersion(root cid.Cid) error {
+	if version := maltcid.VersionIDOf(root); version != s.version {
+		return fmt.Errorf("list root version %d cannot be mutated by version %d semantics; replay the complete view first", version, s.version)
+	}
+	return nil
 }
 
 func (s *TreeList) Commit(ctx context.Context, namespace string, view list.View) (cid.Cid, error) {
@@ -344,6 +362,9 @@ func (s *TreeList) VerifyRange(root cid.Cid, start uint64, end *uint64, expected
 }
 
 func (s *TreeList) Replace(ctx context.Context, namespace string, root cid.Cid, index uint64, oldKey, newKey cid.Cid) (cid.Cid, error) {
+	if err := s.validateMutationRootVersion(root); err != nil {
+		return cid.Undef, err
+	}
 	if !oldKey.Defined() {
 		return cid.Undef, fmt.Errorf("old key is undefined")
 	}
@@ -361,6 +382,9 @@ func (s *TreeList) Replace(ctx context.Context, namespace string, root cid.Cid, 
 }
 
 func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, key cid.Cid) (cid.Cid, uint64, error) {
+	if err := s.validateMutationRootVersion(root); err != nil {
+		return cid.Undef, 0, err
+	}
 	if !key.Defined() {
 		return cid.Undef, 0, fmt.Errorf("key is undefined")
 	}
@@ -449,6 +473,9 @@ func (s *TreeList) Append(ctx context.Context, namespace string, root cid.Cid, k
 // updated measured root. The existing measured list must end on a chunk
 // boundary; extending a partial final chunk requires replacing that chunk first.
 func (s *TreeList) AppendFixed(ctx context.Context, namespace string, root cid.Cid, key cid.Cid, totalSize uint64) (cid.Cid, uint64, error) {
+	if err := s.validateMutationRootVersion(root); err != nil {
+		return cid.Undef, 0, err
+	}
 	if !key.Defined() {
 		return cid.Undef, 0, fmt.Errorf("key is undefined")
 	}
@@ -543,6 +570,9 @@ func (s *TreeList) AppendFixed(ctx context.Context, namespace string, root cid.C
 }
 
 func (s *TreeList) Truncate(ctx context.Context, namespace string, root cid.Cid, newLen uint64) (cid.Cid, error) {
+	if err := s.validateMutationRootVersion(root); err != nil {
+		return cid.Undef, err
+	}
 	rootSlots, oldLen, err := s.loadRoot(ctx, namespace, root)
 	if err != nil {
 		return cid.Undef, err
@@ -985,9 +1015,18 @@ func (s *TreeList) loadNode(ctx context.Context, namespace string, root cid.Cid,
 	return nil, validateErr
 }
 
-// validateSlots checks that the materialized slot vector recomputes to root.
+// validateSlots proves one materialized cell against root when the backend
+// supports root-bound openings. The compatibility fallback recomputes only for
+// older third-party backends that do not expose IndexRootProver.
 func (s *TreeList) validateSlots(root cid.Cid, slots []cid.Cid) error {
-	recomputed, err := s.commitment.Scheme().Commit(cellsFromCIDs(slots))
+	cells := cellsFromCIDs(slots)
+	if rootProver, ok := s.commitment.Scheme().(commitment.IndexRootProver); ok {
+		if _, _, err := rootProver.ProveAtRoot(root, cells, 0); err != nil {
+			return fmt.Errorf("%w: node state does not match root %s: %v", materializer.ErrIncomplete, root.String(), err)
+		}
+		return nil
+	}
+	recomputed, err := s.commitment.Scheme().Commit(cells)
 	if err != nil {
 		return err
 	}
@@ -1012,7 +1051,7 @@ func (s *TreeList) commitSlots(ctx context.Context, namespace string, slots []ci
 	if err != nil {
 		return cid.Undef, err
 	}
-	listRoot, err := maltcid.NewTypedCID(maltcid.SemanticKindList, maltcid.BackendKindOf(root), commBytes)
+	listRoot, err := maltcid.NewTypedCIDForVersion(s.version, maltcid.SemanticKindList, maltcid.BackendKindOf(root), commBytes)
 	if err != nil {
 		return cid.Undef, err
 	}

--- a/auth/semantic/list/tree/tree.go
+++ b/auth/semantic/list/tree/tree.go
@@ -1200,7 +1200,7 @@ func fixedRangeMetadata(marker cid.Cid) (layout.NodeMetadata, error) {
 		return layout.NodeMetadata{}, fmt.Errorf("root does not carry node metadata: %w", err)
 	}
 	if meta.ChunkSize == 0 {
-		return layout.NodeMetadata{}, fmt.Errorf("root does not carry fixed range metadata")
+		return layout.NodeMetadata{}, list.ErrNotMeasured
 	}
 	return meta, nil
 }

--- a/auth/semantic/list/tree/tree_test.go
+++ b/auth/semantic/list/tree/tree_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -844,4 +845,49 @@ func TestTreeListRejectsCorruptedMaterialization(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMutationRejectsLegacyRootBeforePartialVersionUpgrade(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := materialmemory.New(true)
+	legacy, err := tree.NewListForVersion(scheme, store, maltcid.LegacyMALTVersionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := tree.NewList(scheme, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	geometry := geometryForScheme(t, scheme)
+	values := makeValues(geometry.ListBranchingFactor() + 1)
+	root, err := legacy.Commit(ctx, "legacy-deep-list", list.NewViewFromSlice(values))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if maltcid.VersionIDOf(root) != maltcid.LegacyMALTVersionID {
+		t.Fatal("fixture did not produce a v2 list root")
+	}
+	assertRejected := func(operation string, err error) {
+		t.Helper()
+		if err == nil || !strings.Contains(err.Error(), "cannot be mutated") {
+			t.Fatalf("%s legacy root error = %v", operation, err)
+		}
+	}
+	_, err = current.Replace(ctx, "legacy-deep-list", root, uint64(len(values)-1), values[len(values)-1], newPayloadCID([]byte("replacement")))
+	assertRejected("Replace", err)
+	_, _, err = current.Append(ctx, "legacy-deep-list", root, newPayloadCID([]byte("append")))
+	assertRejected("Append", err)
+	_, err = current.Truncate(ctx, "legacy-deep-list", root, uint64(len(values)-1))
+	assertRejected("Truncate", err)
+
+	fixedRoot, err := legacy.CommitFixed(ctx, "legacy-fixed-list", values[:2], 4, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = current.AppendFixed(ctx, "legacy-fixed-list", fixedRoot, newPayloadCID([]byte("fixed-append")), 12)
+	assertRejected("AppendFixed", err)
 }

--- a/auth/semantic/list/tree/tree_test.go
+++ b/auth/semantic/list/tree/tree_test.go
@@ -571,6 +571,23 @@ func TestTreeListMeasuredChildNodesCarryRangeMetadata(t *testing.T) {
 	}
 }
 
+func TestTreeListPlainRangeReportsNotMeasured(t *testing.T) {
+	ctx := context.Background()
+	for name, factory := range listSchemes() {
+		t.Run(name, func(t *testing.T) {
+			semantic := newList(t, factory, materialmemory.New(true))
+			root, err := semantic.Commit(ctx, "tree-plain-range-"+name, list.NewViewFromSlice(makeValues(1)))
+			if err != nil {
+				t.Fatalf("Commit failed: %v", err)
+			}
+			end := uint64(0)
+			if _, _, err := semantic.ProveRange(ctx, "tree-plain-range-"+name, root, 0, &end); !errors.Is(err, list.ErrNotMeasured) {
+				t.Fatalf("ProveRange error = %v, want ErrNotMeasured", err)
+			}
+		})
+	}
+}
+
 func TestTreeListFixedRangeProofsUseOptionalEnd(t *testing.T) {
 	ctx := context.Background()
 	chunks := makeValues(5)

--- a/auth/semantic/mapping/mapping.go
+++ b/auth/semantic/mapping/mapping.go
@@ -26,9 +26,9 @@ import (
 const bindingPrefix = "malt:map:binding:v1:"
 
 // ErrPathNotFound indicates that a requested map path is absent from the
-// committed semantic state. Implementations should wrap this sentinel
-// when Prove cannot find the requested binding so layout adapters do not need
-// to depend on implementation-specific runtime packages.
+// committed semantic state. It is retained for read APIs that translate an
+// absent verified binding into a not-found error; Prove returns a verifiable
+// Binding{Present:false} instead.
 var ErrPathNotFound = errors.New("map path not found")
 
 // Iterator iterates over a map view in canonical key order.
@@ -46,10 +46,8 @@ type View interface {
 
 // Binding is the verifiable result for one keyed binding.
 //
-// Current map semantics emit membership proofs only. Callers should obtain
-// absence through current structure state (for example a caller materializer or a
-// supplied materialized view) rather than expecting a dedicated semantic
-// non-membership proof.
+// Present=false denotes a cryptographically verifiable non-membership result;
+// Value must then be undefined.
 type Binding struct {
 	Value   cid.Cid
 	Present bool
@@ -149,6 +147,31 @@ func (c *Commitment) ProveSlot(root cid.Cid, slots []cid.Cid, slot uint64) (comm
 	return value, proof, nil
 }
 
+// ProveSlots proves an ordered index set in one committed node. The caller
+// supplies the complete stable vector, including explicit undefined padding
+// when the proof needs to establish canonical tail emptiness.
+func (c *Commitment) ProveSlots(root cid.Cid, slots []cid.Cid, indices []uint64) ([]commitment.Cell, []byte, error) {
+	if !root.Defined() {
+		return nil, nil, fmt.Errorf("root is undefined")
+	}
+	cells := cellsFromCIDs(slots)
+	if rootProver, ok := c.scheme.(commitment.IndexRootProver); ok {
+		return rootProver.BatchProveAtRoot(root, cells, indices)
+	}
+	provedRoot, values, proof, err := c.scheme.BatchProve(cells, indices)
+	if err != nil {
+		return nil, nil, err
+	}
+	ok, err := maltcid.EqualCommitment(provedRoot, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !ok {
+		return nil, nil, fmt.Errorf("proved root does not match requested root")
+	}
+	return values, proof, nil
+}
+
 // VerifySlot verifies a single slot proof against a committed root.
 //
 // This function does not require access to the actual slot values - it only
@@ -220,8 +243,9 @@ type Semantics interface {
 	// Commit commits the supplied map view and returns a structure root.
 	Commit(ctx context.Context, namespace string, view View) (cid.Cid, error)
 
-	// Prove proves the existing binding for key under root.
-	// It returns an error if key is absent from the committed runtime state.
+	// Prove proves membership or non-membership for key under root. An absent
+	// key returns Binding{Present:false} with a root-bound proof; errors denote
+	// malformed inputs or unavailable/inconsistent materialization.
 	Prove(ctx context.Context, namespace string, root cid.Cid, key arcset.Path) (Binding, structure.Proof, error)
 
 	// Verify verifies the proof for a keyed binding under root.
@@ -237,4 +261,12 @@ type Semantics interface {
 	// Updates are applied in an order determined by the implementation to
 	// maintain structural consistency.
 	BatchUpdate(ctx context.Context, namespace string, root cid.Cid, updates []BatchUpdate) (cid.Cid, error)
+}
+
+// MaterializationExporter returns the complete backend-specific proof-serving
+// state for a caller-supplied logical map view. The returned ArcSet is
+// untrusted transport data until a root-bound validator accepts it against
+// the declared root and logical view.
+type MaterializationExporter interface {
+	ExportMaterialization(context.Context, string, cid.Cid, View) (*arcset.CanonicalArcSet, error)
 }

--- a/auth/semantic/mapping/radix/absence_internal_test.go
+++ b/auth/semantic/mapping/radix/absence_internal_test.go
@@ -1,0 +1,466 @@
+package radix
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materialmemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func bucketAbsenceValue(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	hash, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cid.NewCidV1(cid.Raw, hash)
+}
+
+func TestLoadBucketEntriesRejectsOversizedCountBeforeAllocation(t *testing.T) {
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := materialmemory.New(true)
+	maps, err := NewMap(scheme, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := bucketAbsenceValue(t, "hostile-bucket-root")
+	count, err := encodeBucketCountMarker(math.MaxUint64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := arcset.NewArcSetFromPaths(map[arcset.Path]cid.Cid{
+		bucketCountPath(root): count,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Update(context.Background(), "hostile-bucket-count", cid.Undef, cid.Undef, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := maps.loadBucketEntries(context.Background(), "hostile-bucket-count", root); err == nil {
+		t.Fatal("oversized bucket count was accepted")
+	}
+}
+
+func TestBucketAbsenceWitnessOpensCompleteCanonicalVector(t *testing.T) {
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	maps, err := NewMap(scheme, materialmemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths := []arcset.Path{arcset.CanonicalizePath("a"), arcset.CanonicalizePath("z")}
+	markers := make([]cid.Cid, len(paths))
+	for index, path := range paths {
+		markers[index], err = encodeLeafMarker(path, bucketAbsenceValue(t, path.String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	root, err := scheme.Commit(cellsFromCIDs(bucketVector(markers, scheme.MaxValues())))
+	if err != nil {
+		t.Fatal(err)
+	}
+	absent := arcset.CanonicalizePath("m")
+	witness, err := maps.proveBucketAbsence(root, markers, absent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := maps.verifyBucketAbsence(root, absent, witness); err != nil || !ok {
+		t.Fatalf("verify complete bucket absence = %v, %v", ok, err)
+	}
+	if ok, err := maps.verifyBucketAbsence(root, paths[0], witness); err != nil || ok {
+		t.Fatalf("bucket witness proved present path absent = %v, %v", ok, err)
+	}
+
+	batchCopy := make([][]byte, len(witness.Batches))
+	for index := range witness.Batches {
+		batchCopy[index] = append([]byte(nil), witness.Batches[index]...)
+	}
+	reordered := &bucketWitness{
+		Entries: append([][]byte(nil), witness.Entries...), Batches: batchCopy,
+	}
+	reordered.Entries[0], reordered.Entries[1] = reordered.Entries[1], reordered.Entries[0]
+	if ok, err := maps.verifyBucketAbsence(root, absent, reordered); err != nil || ok {
+		t.Fatalf("reordered bucket witness = %v, %v", ok, err)
+	}
+
+	truncated := &bucketWitness{
+		Entries: append([][]byte(nil), witness.Entries[:1]...), Batches: batchCopy,
+	}
+	if ok, err := maps.verifyBucketAbsence(root, absent, truncated); err != nil || ok {
+		t.Fatalf("truncated bucket witness = %v, %v", ok, err)
+	}
+}
+
+func TestLegacyV1BucketMembershipAndNoOpUpdateRemainReadable(t *testing.T) {
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := materialmemory.New(true)
+	maps, err := NewMapForVersion(scheme, store, maltcid.LegacyMALTVersionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	namespace := "legacy-v1-bucket"
+	paths := []arcset.Path{arcset.CanonicalizePath("a"), arcset.CanonicalizePath("z")}
+	markers := make([]cid.Cid, len(paths))
+	for index, path := range paths {
+		markers[index], err = encodeLeafMarker(path, bucketAbsenceValue(t, "legacy-"+path.String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	bucketRoot, err := maps.commitSlots(markers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bucketRef, err := encodeBucketRefVersion(bucketRoot, bucketRefV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := hashPath(paths[0])
+	slotIndex, ok := maps.geometry.MapDigit(digest[:], 0)
+	if !ok {
+		t.Fatal("missing radix digit")
+	}
+	slots := make([]cid.Cid, maps.geometry.NodeWidth())
+	slots[slotIndex] = bucketRef
+	root, err := maps.commitSlots(slots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := maps.storeBucketEntries(ctx, namespace, bucketRoot, markers); err != nil {
+		t.Fatal(err)
+	}
+	if err := maps.storeNodeSlots(ctx, namespace, root, slots); err != nil {
+		t.Fatal(err)
+	}
+	binding, proof, err := maps.Prove(ctx, namespace, root, paths[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !binding.Present {
+		t.Fatal("legacy v1 bucket membership was reported absent")
+	}
+	if ok, err := maps.Verify(root, paths[0], binding, proof); err != nil || !ok {
+		t.Fatalf("verify legacy v1 bucket membership = %v, %v", ok, err)
+	}
+
+	sameRef, nodes, buckets, err := maps.updateBucketWithoutPersist(ctx, namespace, bucketRoot, bucketRefV1, arcset.CanonicalizePath("missing"), cid.Undef, cid.Undef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameRef.Equals(bucketRef) || len(nodes) != 0 || len(buckets) != 0 {
+		t.Fatal("legacy v1 no-op update changed the bucket reference")
+	}
+
+	nextValue := bucketAbsenceValue(t, "legacy-replacement")
+	updatedRef, _, pending, err := maps.updateBucketWithoutPersist(ctx, namespace, bucketRoot, bucketRefV1, paths[0], binding.Value, nextValue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, version, ok, err := decodeBucketRef(updatedRef)
+	if err != nil || !ok || version != bucketRefV1 || len(pending) != 1 {
+		t.Fatalf("legacy bucket replay = version %d, decoded %v, buckets %d, err %v", version, ok, len(pending), err)
+	}
+}
+
+func TestLegacyShortBucketRootDiffersFromFixedWidthRoot(t *testing.T) {
+	schemes := map[string]commitment.IndexCommitment{}
+	ipaScheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	schemes["ipa"] = ipaScheme
+	kzgScheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	schemes["kzg"] = kzgScheme
+	for name, scheme := range schemes {
+		t.Run(name, func(t *testing.T) {
+			markers := make([]cid.Cid, 2)
+			for index, path := range []arcset.Path{arcset.CanonicalizePath("a"), arcset.CanonicalizePath("z")} {
+				marker, err := encodeLeafMarker(path, bucketAbsenceValue(t, name+path.String()))
+				if err != nil {
+					t.Fatal(err)
+				}
+				markers[index] = marker
+			}
+			shortRoot, err := scheme.Commit(cellsFromCIDs(markers))
+			if err != nil {
+				t.Fatal(err)
+			}
+			paddedRoot, err := scheme.Commit(cellsFromCIDs(bucketVector(markers, scheme.MaxValues())))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if shortRoot.Equals(paddedRoot) {
+				t.Fatal("legacy short bucket root unexpectedly equals the v3 fixed-domain root")
+			}
+		})
+	}
+}
+
+type commitCountingRootScheme struct {
+	commitment.IndexCommitment
+	rootProver commitment.IndexRootProver
+	commits    int
+}
+
+func (s *commitCountingRootScheme) Commit(values []commitment.Cell) (cid.Cid, error) {
+	s.commits++
+	return s.IndexCommitment.Commit(values)
+}
+
+func (s *commitCountingRootScheme) ProveAtRoot(root cid.Cid, values []commitment.Cell, index uint64) (commitment.Cell, []byte, error) {
+	return s.rootProver.ProveAtRoot(root, values, index)
+}
+
+func (s *commitCountingRootScheme) BatchProveAtRoot(root cid.Cid, values []commitment.Cell, indices []uint64) ([]commitment.Cell, []byte, error) {
+	return s.rootProver.BatchProveAtRoot(root, values, indices)
+}
+
+func absenceSchemes(t *testing.T) map[string]commitment.IndexCommitment {
+	t.Helper()
+	ipaScheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kzgScheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return map[string]commitment.IndexCommitment{"ipa": ipaScheme, "kzg": kzgScheme}
+}
+
+func TestV2BucketMembershipOpensFixedDomainAcrossBackends(t *testing.T) {
+	for name, scheme := range absenceSchemes(t) {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			store := materialmemory.New(true)
+			maps, err := NewMap(scheme, store)
+			if err != nil {
+				t.Fatal(err)
+			}
+			paths := []arcset.Path{arcset.CanonicalizePath("a"), arcset.CanonicalizePath("z")}
+			markers := make([]cid.Cid, len(paths))
+			for index, path := range paths {
+				markers[index], err = encodeLeafMarker(path, bucketAbsenceValue(t, name+"-v2-"+path.String()))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			bucketRoot, err := maps.commitSlots(bucketVector(markers, scheme.MaxValues()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			bucketRef, err := encodeBucketRefVersion(bucketRoot, bucketRefV2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			digest := hashPath(paths[0])
+			slotIndex, ok := maps.geometry.MapDigit(digest[:], 0)
+			if !ok {
+				t.Fatal("missing radix digit")
+			}
+			slots := make([]cid.Cid, maps.geometry.NodeWidth())
+			slots[slotIndex] = bucketRef
+			root, err := maps.commitSlots(slots)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := maps.storeBucketEntries(ctx, name+"-v2-bucket", bucketRoot, markers); err != nil {
+				t.Fatal(err)
+			}
+			if err := maps.storeNodeSlots(ctx, name+"-v2-bucket", root, slots); err != nil {
+				t.Fatal(err)
+			}
+			binding, proof, err := maps.Prove(ctx, name+"-v2-bucket", root, paths[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !binding.Present {
+				t.Fatal("v2 bucket membership was reported absent")
+			}
+			if ok, err := maps.Verify(root, paths[0], binding, proof); err != nil || !ok {
+				t.Fatalf("verify v2 bucket membership = %v, %v", ok, err)
+			}
+		})
+	}
+}
+
+func TestLegacyV2TypedRootProvesWithoutCommitAcrossBackends(t *testing.T) {
+	for name, backend := range absenceSchemes(t) {
+		t.Run(name, func(t *testing.T) {
+			rootProver, ok := backend.(commitment.IndexRootProver)
+			if !ok {
+				t.Fatal("backend does not implement IndexRootProver")
+			}
+			scheme := &commitCountingRootScheme{IndexCommitment: backend, rootProver: rootProver}
+			store := materialmemory.New(true)
+			maps, err := NewMapForVersion(scheme, store, 2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := context.Background()
+			path := arcset.CanonicalizePath("legacy")
+			root, err := maps.Commit(ctx, name+"-legacy-v2", mapping.NewViewFromPaths(map[arcset.Path]cid.Cid{
+				path: bucketAbsenceValue(t, name+"-legacy-value"),
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := maltcid.VersionIDOf(root); got != maltcid.LegacyMALTVersionID {
+				t.Fatalf("root version = %d, want %d", got, maltcid.LegacyMALTVersionID)
+			}
+			scheme.commits = 0
+			binding, proof, err := maps.Prove(ctx, name+"-legacy-v2", root, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !binding.Present || scheme.commits != 0 {
+				t.Fatalf("binding present = %v, prove commits = %d", binding.Present, scheme.commits)
+			}
+			if ok, err := maps.Verify(root, path, binding, proof); err != nil || !ok {
+				t.Fatalf("verify legacy v2 root = %v, %v", ok, err)
+			}
+		})
+	}
+}
+
+func TestMutationRejectsLegacyRootBeforePartialVersionUpgradeAcrossBackends(t *testing.T) {
+	for name, scheme := range absenceSchemes(t) {
+		t.Run(name, func(t *testing.T) {
+			store := materialmemory.New(true)
+			legacy, err := NewMapForVersion(scheme, store, maltcid.LegacyMALTVersionID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			current, err := NewMap(scheme, store)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var first arcset.Path
+			var firstDigit uint64
+			var secondDigit uint64
+			found := false
+			for index := 0; index < 100000 && !found; index++ {
+				candidate := arcset.CanonicalizePath(fmt.Sprintf("nested-%d", index))
+				digest := hashPath(candidate)
+				digit0, ok0 := legacy.geometry.MapDigit(digest[:], 0)
+				digit1, ok1 := legacy.geometry.MapDigit(digest[:], 1)
+				if !ok0 || !ok1 {
+					t.Fatal("missing radix digit")
+				}
+				if first.IsEmpty() {
+					first, firstDigit, secondDigit = candidate, digit0, digit1
+					continue
+				}
+				if digit0 == firstDigit && digit1 != secondDigit {
+					values := map[arcset.Path]cid.Cid{
+						first:     bucketAbsenceValue(t, name+"-legacy-first"),
+						candidate: bucketAbsenceValue(t, name+"-legacy-second"),
+					}
+					root, err := legacy.Commit(context.Background(), name+"-legacy-nested", mapping.NewViewFromPaths(values))
+					if err != nil {
+						t.Fatal(err)
+					}
+					slots, err := legacy.loadNodeSlots(context.Background(), name+"-legacy-nested", root)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if maltcid.VersionIDOf(root) != maltcid.LegacyMALTVersionID || maltcid.VersionIDOf(slots[firstDigit]) != maltcid.LegacyMALTVersionID {
+						t.Fatal("fixture did not contain a nested v2 map node")
+					}
+					replacement := bucketAbsenceValue(t, name+"-replacement")
+					if _, err := current.Update(context.Background(), name+"-legacy-nested", root, first, values[first], replacement); err == nil || !strings.Contains(err.Error(), "cannot be mutated") {
+						t.Fatalf("Update legacy root error = %v", err)
+					}
+					if _, err := current.BatchUpdate(context.Background(), name+"-legacy-nested", root, []mapping.BatchUpdate{{
+						Key: first, OldValue: values[first], NewValue: replacement,
+					}}); err == nil || !strings.Contains(err.Error(), "cannot be mutated") {
+						t.Fatalf("BatchUpdate legacy root error = %v", err)
+					}
+					found = true
+				}
+			}
+			if !found {
+				t.Fatal("failed to construct nested radix paths")
+			}
+		})
+	}
+}
+
+func TestRuntimeVerifyRejectsV1BucketAbsenceUnderV3Root(t *testing.T) {
+	scheme := absenceSchemes(t)["ipa"]
+	maps, err := NewMap(scheme, materialmemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths := []arcset.Path{arcset.CanonicalizePath("a"), arcset.CanonicalizePath("z")}
+	markers := make([]cid.Cid, len(paths))
+	for index, path := range paths {
+		markers[index], err = encodeLeafMarker(path, bucketAbsenceValue(t, "runtime-v1-"+path.String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	bucketRoot, err := maps.commitSlots(bucketVector(markers, scheme.MaxValues()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bucketRef, err := encodeBucketRefVersion(bucketRoot, bucketRefV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absent := arcset.CanonicalizePath("missing")
+	digest := hashPath(absent)
+	slotIndex, ok := maps.geometry.MapDigit(digest[:], 0)
+	if !ok {
+		t.Fatal("missing radix digit")
+	}
+	slots := make([]cid.Cid, maps.geometry.NodeWidth())
+	slots[slotIndex] = bucketRef
+	root, err := maps.commitSlots(slots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, rootProof, err := maps.commitment.ProveSlot(root, slots, slotIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bucketWitness, err := maps.proveBucketAbsence(bucketRoot, markers, absent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(proofEnvelope{
+		Steps: []proofStep{{Slot: cidBytes(bucketRef), Proof: rootProof}}, Bucket: bucketWitness,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := maps.Verify(root, absent, mapping.Binding{Present: false}, encoded); err != nil || ok {
+		t.Fatalf("v1 bucket absence under v3 root = %v, %v", ok, err)
+	}
+}

--- a/auth/semantic/mapping/radix/materialization.go
+++ b/auth/semantic/mapping/radix/materialization.go
@@ -1,0 +1,295 @@
+package radix
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/auth/arcset/materializer"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+)
+
+// RootBoundVerifier is the primitive capability required to validate a radix
+// materialization against caller-supplied roots without recomputing them.
+type RootBoundVerifier interface {
+	commitment.IndexVerifier
+	commitment.IndexRootProver
+}
+
+type materializationSource func(arcset.Path) (cid.Cid, bool, error)
+
+type materializationWalker struct {
+	ctx                   context.Context
+	scheme                RootBoundVerifier
+	geometry              nodegeometry.Geometry
+	source                materializationSource
+	consumed              map[arcset.Path]cid.Cid
+	visiting              map[string]struct{}
+	version               uint8
+	backend               maltcid.BackendKind
+	expectedBucketVersion bucketRefVersion
+}
+
+// ExportMaterialization returns the exact internal radix node and collision
+// bucket entries needed to prove the supplied logical view at root. The
+// exported state remains untrusted until ValidateMaterialization accepts it.
+func (s *Map) ExportMaterialization(ctx context.Context, namespace string, root cid.Cid, view mapping.View) (*arcset.CanonicalArcSet, error) {
+	if s == nil || s.materializer == nil || s.commitment == nil {
+		return nil, fmt.Errorf("radix map is nil")
+	}
+	scheme, ok := s.commitment.Scheme().(RootBoundVerifier)
+	if !ok {
+		return nil, fmt.Errorf("commitment backend does not support root-bound materialization validation")
+	}
+	walker := &materializationWalker{
+		ctx: ctx, scheme: scheme, geometry: s.geometry,
+		consumed: make(map[arcset.Path]cid.Cid), visiting: make(map[string]struct{}),
+	}
+	walker.source = func(path arcset.Path) (cid.Cid, bool, error) {
+		value, err := s.materializer.Get(ctx, namespace, cid.Undef, path)
+		if err == nil {
+			return value, true, nil
+		}
+		if materializer.IsNotFound(err) {
+			return cid.Undef, false, nil
+		}
+		return cid.Undef, false, err
+	}
+	if err := walker.validate(root, view); err != nil {
+		return nil, err
+	}
+	return canonicalMaterialization(walker.consumed)
+}
+
+// ValidateMaterialization validates an untrusted internal radix witness
+// against root and the complete logical view. It invokes only ProveAtRoot;
+// callers can therefore import client-computed roots without calling Commit.
+func ValidateMaterialization(ctx context.Context, scheme RootBoundVerifier, root cid.Cid, view mapping.View, witness *arcset.CanonicalArcSet) error {
+	if scheme == nil {
+		return fmt.Errorf("root-bound commitment verifier is nil")
+	}
+	if witness == nil || witness.Kind() != arcset.KindMap {
+		return fmt.Errorf("radix materialization witness must be a canonical map")
+	}
+	values := make(map[arcset.Path]cid.Cid, witness.Len())
+	for _, entry := range witness.Entries() {
+		path, err := arcset.NewPath(entry.Coordinate.String())
+		if err != nil {
+			return fmt.Errorf("invalid radix materialization coordinate: %w", err)
+		}
+		values[path] = entry.Target.CID()
+	}
+	geometry, err := nodegeometry.ForCapacity(scheme.MaxValues())
+	if err != nil {
+		return err
+	}
+	walker := &materializationWalker{
+		ctx: ctx, scheme: scheme, geometry: geometry,
+		consumed: make(map[arcset.Path]cid.Cid), visiting: make(map[string]struct{}),
+		source: func(path arcset.Path) (cid.Cid, bool, error) {
+			value, ok := values[path]
+			return value, ok, nil
+		},
+	}
+	if err := walker.validate(root, view); err != nil {
+		return err
+	}
+	if len(walker.consumed) != len(values) {
+		return fmt.Errorf("radix materialization witness contains unreachable entries")
+	}
+	return nil
+}
+
+func (w *materializationWalker) validate(root cid.Cid, view mapping.View) error {
+	if err := w.ctx.Err(); err != nil {
+		return err
+	}
+	if !root.Defined() {
+		return fmt.Errorf("radix materialization root is undefined")
+	}
+	w.version = maltcid.VersionIDOf(root)
+	w.backend = maltcid.BackendKindOf(root)
+	var ok bool
+	w.expectedBucketVersion, ok = bucketVersionForMALTVersion(w.version)
+	if !ok || !matchesRadixRootProfile(root, w.version, w.backend) {
+		return fmt.Errorf("radix materialization root has an unsupported map profile")
+	}
+	bindings, err := extractBindings(view)
+	if err != nil {
+		return err
+	}
+	return w.validateNode(root, bindings, 0)
+}
+
+func (w *materializationWalker) validateNode(root cid.Cid, bindings []leafBinding, depth int) error {
+	if err := w.ctx.Err(); err != nil {
+		return err
+	}
+	if !matchesRadixRootProfile(root, w.version, w.backend) {
+		return fmt.Errorf("radix materialization contains a mixed-version or mixed-backend node")
+	}
+	if depth >= w.geometry.MapDepth(sha256Size) {
+		return fmt.Errorf("radix materialization exceeds map depth")
+	}
+	key := root.KeyString()
+	if _, exists := w.visiting[key]; exists {
+		return fmt.Errorf("radix materialization contains a node cycle")
+	}
+	w.visiting[key] = struct{}{}
+	defer delete(w.visiting, key)
+
+	slots := make([]cid.Cid, w.geometry.NodeWidth())
+	for index := range slots {
+		path := nodeSlotPath(root, uint64(index))
+		value, found, err := w.read(path)
+		if err != nil {
+			return err
+		}
+		if found {
+			slots[index] = value
+		}
+	}
+	if err := proveVectorAtRoot(w.scheme, root, slots); err != nil {
+		return fmt.Errorf("radix node %s does not match its root: %w", root, err)
+	}
+	grouped, err := groupBindings(w.geometry, bindings, depth)
+	if err != nil {
+		return err
+	}
+	for index, slot := range slots {
+		group := grouped[uint64(index)]
+		if len(group) == 0 {
+			if slot.Defined() {
+				return fmt.Errorf("radix node has an unexpected slot %d", index)
+			}
+			continue
+		}
+		if !slot.Defined() {
+			return fmt.Errorf("radix node is missing slot %d", index)
+		}
+		nextDepth := depth + 1
+		switch {
+		case len(group) == 1:
+			expected, err := encodeLeafMarker(group[0].path, group[0].value)
+			if err != nil {
+				return err
+			}
+			if !slot.Equals(expected) {
+				return fmt.Errorf("radix leaf marker mismatch at depth %d slot %d", depth, index)
+			}
+		case nextDepth >= w.geometry.MapDepth(sha256Size) || allSameDigest(group):
+			bucketRoot, version, ok, err := decodeBucketRef(slot)
+			if err != nil || !ok {
+				return fmt.Errorf("radix collision bucket reference is invalid at depth %d slot %d", depth, index)
+			}
+			if err := w.validateBucket(bucketRoot, version, group); err != nil {
+				return err
+			}
+		default:
+			if err := w.validateNode(slot, group, nextDepth); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (w *materializationWalker) validateBucket(root cid.Cid, version bucketRefVersion, bindings []leafBinding) error {
+	if version != w.expectedBucketVersion || !matchesRadixRootProfile(root, w.version, w.backend) {
+		return fmt.Errorf("radix materialization collision bucket does not match the root profile")
+	}
+	if len(bindings) < 2 || len(bindings) > w.scheme.MaxValues() {
+		return fmt.Errorf("radix collision bucket size is invalid")
+	}
+	countPath := bucketCountPath(root)
+	countMarker, found, err := w.read(countPath)
+	if err != nil {
+		return err
+	}
+	expectedCount, err := encodeBucketCountMarker(uint64(len(bindings)))
+	if err != nil {
+		return err
+	}
+	if !found || !countMarker.Equals(expectedCount) {
+		return fmt.Errorf("radix collision bucket count is invalid")
+	}
+	markers := make([]cid.Cid, len(bindings))
+	for index, binding := range bindings {
+		path := bucketEntryPath(root, uint64(index))
+		marker, found, err := w.read(path)
+		if err != nil {
+			return err
+		}
+		expected, err := encodeLeafMarker(binding.path, binding.value)
+		if err != nil {
+			return err
+		}
+		if !found || !marker.Equals(expected) {
+			return fmt.Errorf("radix collision bucket entry %d is invalid", index)
+		}
+		markers[index] = marker
+	}
+	vector := markers
+	if version == bucketRefV2 {
+		vector = bucketVector(markers, w.scheme.MaxValues())
+	}
+	if err := proveVectorAtRoot(w.scheme, root, vector); err != nil {
+		return fmt.Errorf("radix collision bucket does not match its root: %w", err)
+	}
+	return nil
+}
+
+func (w *materializationWalker) read(path arcset.Path) (cid.Cid, bool, error) {
+	value, found, err := w.source(path)
+	if err != nil {
+		return cid.Undef, false, err
+	}
+	if !found {
+		return cid.Undef, false, nil
+	}
+	if !value.Defined() {
+		return cid.Undef, false, fmt.Errorf("radix materialization contains an undefined target")
+	}
+	w.consumed[path] = value
+	return value, true, nil
+}
+
+func proveVectorAtRoot(scheme RootBoundVerifier, root cid.Cid, values []cid.Cid) error {
+	if len(values) == 0 {
+		return fmt.Errorf("radix commitment vector is empty")
+	}
+	_, _, err := scheme.ProveAtRoot(root, cellsFromCIDs(values), 0)
+	return err
+}
+
+func groupBindings(geometry nodegeometry.Geometry, bindings []leafBinding, depth int) (map[uint64][]leafBinding, error) {
+	grouped := make(map[uint64][]leafBinding)
+	for _, binding := range bindings {
+		digit, ok := geometry.MapDigit(binding.digest[:], depth)
+		if !ok {
+			return nil, fmt.Errorf("invalid radix depth %d", depth)
+		}
+		grouped[digit] = append(grouped[digit], binding)
+	}
+	return grouped, nil
+}
+
+func canonicalMaterialization(values map[arcset.Path]cid.Cid) (*arcset.CanonicalArcSet, error) {
+	entries := make([]arcset.ArcEntry, 0, len(values))
+	for path, value := range values {
+		coordinate, err := arcset.NewMapCoordinate(path.String())
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, arcset.ArcEntry{Coordinate: coordinate, Target: arcset.NewUnknownTarget(value)})
+	}
+	return arcset.NewCanonicalArcSet(arcset.KindMap, entries)
+}
+
+const sha256Size = 32
+
+var _ mapping.MaterializationExporter = (*Map)(nil)

--- a/auth/semantic/mapping/radix/materialization_profile_internal_test.go
+++ b/auth/semantic/mapping/radix/materialization_profile_internal_test.go
@@ -1,0 +1,130 @@
+package radix
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materialmemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+)
+
+func TestValidateMaterializationRejectsMixedVersionInternalNodeAcrossBackends(t *testing.T) {
+	for name, scheme := range absenceSchemes(t) {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			store := materialmemory.New(true)
+			legacy, err := NewMapForVersion(scheme, store, maltcid.LegacyMALTVersionID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			current, err := NewMap(scheme, store)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var first arcset.Path
+			var firstDigit, secondDigit uint64
+			var second arcset.Path
+			for index := 0; index < 100000 && second.IsEmpty(); index++ {
+				candidate := arcset.CanonicalizePath(fmt.Sprintf("mixed-%d", index))
+				digest := hashPath(candidate)
+				digit0, ok0 := legacy.geometry.MapDigit(digest[:], 0)
+				digit1, ok1 := legacy.geometry.MapDigit(digest[:], 1)
+				if !ok0 || !ok1 {
+					t.Fatal("missing radix digit")
+				}
+				if first.IsEmpty() {
+					first, firstDigit, secondDigit = candidate, digit0, digit1
+				} else if digit0 == firstDigit && digit1 != secondDigit {
+					second = candidate
+				}
+			}
+			if second.IsEmpty() {
+				t.Fatal("failed to construct nested radix paths")
+			}
+			view := mapping.NewViewFromPaths(map[arcset.Path]cid.Cid{
+				first:  bucketAbsenceValue(t, name+"-mixed-first"),
+				second: bucketAbsenceValue(t, name+"-mixed-second"),
+			})
+			legacyRoot, err := legacy.Commit(ctx, name+"-mixed", view)
+			if err != nil {
+				t.Fatal(err)
+			}
+			legacyWitness, err := legacy.ExportMaterialization(ctx, name+"-mixed", legacyRoot, view)
+			if err != nil {
+				t.Fatal(err)
+			}
+			slots, err := legacy.loadNodeSlots(ctx, name+"-mixed", legacyRoot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if maltcid.VersionIDOf(slots[firstDigit]) != maltcid.LegacyMALTVersionID {
+				t.Fatal("fixture has no nested v2 child")
+			}
+			mixedRoot, err := current.commitSlots(slots)
+			if err != nil {
+				t.Fatal(err)
+			}
+			entries := legacyWitness.Entries()
+			for entryIndex := range entries {
+				for slotIndex := range slots {
+					if entries[entryIndex].Coordinate.String() != nodeSlotPath(legacyRoot, uint64(slotIndex)).String() {
+						continue
+					}
+					coordinate, err := arcset.NewMapCoordinate(nodeSlotPath(mixedRoot, uint64(slotIndex)).String())
+					if err != nil {
+						t.Fatal(err)
+					}
+					entries[entryIndex].Coordinate = coordinate
+				}
+			}
+			mixedWitness, err := arcset.NewCanonicalArcSet(arcset.KindMap, entries)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rootBound, ok := scheme.(RootBoundVerifier)
+			if !ok {
+				t.Fatal("backend does not implement root-bound validation")
+			}
+			if err := ValidateMaterialization(ctx, rootBound, mixedRoot, view, mixedWitness); err == nil {
+				t.Fatal("materialization validator accepted a v3 root with a v2 internal child")
+			}
+		})
+	}
+}
+
+func TestMaterializationWalkerRejectsV1BucketUnderV3Root(t *testing.T) {
+	scheme := absenceSchemes(t)["ipa"]
+	rootBound, ok := scheme.(RootBoundVerifier)
+	if !ok {
+		t.Fatal("IPA backend does not implement root-bound validation")
+	}
+	maps, err := NewMap(scheme, materialmemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths := []arcset.Path{arcset.CanonicalizePath("a"), arcset.CanonicalizePath("z")}
+	bindings := make([]leafBinding, len(paths))
+	markers := make([]cid.Cid, len(paths))
+	for index, path := range paths {
+		bindings[index] = newLeafBinding(path, bucketAbsenceValue(t, "profile-"+path.String()))
+		markers[index], err = encodeLeafMarker(path, bindings[index].value)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	bucketRoot, err := maps.commitSlots(bucketVector(markers, scheme.MaxValues()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	walker := &materializationWalker{
+		ctx: context.Background(), scheme: rootBound, geometry: maps.geometry,
+		version: maltcid.MALTVersionID, backend: maltcid.BackendKindIPA, expectedBucketVersion: bucketRefV2,
+	}
+	if err := walker.validateBucket(bucketRoot, bucketRefV1, bindings); err == nil {
+		t.Fatal("materialization walker accepted a v1 bucket reference under a v3 root")
+	}
+}

--- a/auth/semantic/mapping/radix/materialization_test.go
+++ b/auth/semantic/mapping/radix/materialization_test.go
@@ -1,0 +1,99 @@
+package radix_test
+
+import (
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materialmemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	mappingradix "github.com/dewebprotocol/malt/auth/semantic/mapping/radix"
+	cid "github.com/ipfs/go-cid"
+)
+
+func TestRadixMaterializationRoundTripUsesOnlyRootBoundProving(t *testing.T) {
+	for name, factory := range mappingSchemes() {
+		t.Run(name, func(t *testing.T) {
+			scheme := factory(t)
+			store := materialmemory.New(true)
+			semantic, err := mappingradix.NewMap(scheme, store)
+			if err != nil {
+				t.Fatal(err)
+			}
+			view := mapping.NewViewFrom(map[string]cid.Cid{
+				"@payload": fakeCID("materialization-payload"),
+				"docs/a":   fakeCID("materialization-a"),
+				"docs/b":   fakeCID("materialization-b"),
+			})
+			root, err := semantic.Commit(t.Context(), testNamespace, view)
+			if err != nil {
+				t.Fatal(err)
+			}
+			witness, err := semantic.ExportMaterialization(t.Context(), testNamespace, root, view)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if witness.Len() == 0 {
+				t.Fatal("exported radix materialization is empty")
+			}
+			prover, ok := scheme.(commitment.IndexRootProver)
+			if !ok {
+				t.Fatal("test commitment backend has no root-bound prover")
+			}
+			rootBound := &countingRootBoundVerifier{IndexVerifier: scheme, prover: prover}
+			if err := mappingradix.ValidateMaterialization(t.Context(), rootBound, root, view, witness); err != nil {
+				t.Fatalf("ValidateMaterialization failed: %v", err)
+			}
+			if rootBound.proves == 0 {
+				t.Fatal("materialization validation did not call ProveAtRoot")
+			}
+
+			entries := witness.Entries()
+			missing, err := arcset.NewCanonicalArcSet(arcset.KindMap, entries[1:])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := mappingradix.ValidateMaterialization(t.Context(), rootBound, root, view, missing); err == nil {
+				t.Fatal("materialization validation accepted a missing internal entry")
+			}
+
+			extraCoordinate, err := arcset.NewMapCoordinate("runtime/map/radix/unreachable")
+			if err != nil {
+				t.Fatal(err)
+			}
+			extra, err := arcset.NewCanonicalArcSet(arcset.KindMap, append(entries, arcset.ArcEntry{
+				Coordinate: extraCoordinate, Target: arcset.NewUnknownTarget(fakeCID("unreachable")),
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := mappingradix.ValidateMaterialization(t.Context(), rootBound, root, view, extra); err == nil {
+				t.Fatal("materialization validation accepted an unreachable internal entry")
+			}
+
+			wrongView := mapping.NewViewFrom(map[string]cid.Cid{
+				"@payload": fakeCID("materialization-payload"),
+				"docs/a":   fakeCID("tampered-a"),
+				"docs/b":   fakeCID("materialization-b"),
+			})
+			if err := mappingradix.ValidateMaterialization(t.Context(), rootBound, root, wrongView, witness); err == nil {
+				t.Fatal("materialization validation accepted the wrong logical view")
+			}
+		})
+	}
+}
+
+type countingRootBoundVerifier struct {
+	commitment.IndexVerifier
+	prover commitment.IndexRootProver
+	proves int
+}
+
+func (v *countingRootBoundVerifier) ProveAtRoot(root cid.Cid, values []commitment.Cell, index uint64) (commitment.Cell, []byte, error) {
+	v.proves++
+	return v.prover.ProveAtRoot(root, values, index)
+}
+
+func (v *countingRootBoundVerifier) BatchProveAtRoot(root cid.Cid, values []commitment.Cell, indices []uint64) ([]commitment.Cell, []byte, error) {
+	return v.prover.BatchProveAtRoot(root, values, indices)
+}

--- a/auth/semantic/mapping/radix/radix.go
+++ b/auth/semantic/mapping/radix/radix.go
@@ -21,20 +21,48 @@ import (
 	"github.com/dewebprotocol/malt/auth/semantic"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
 	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
 
 const (
 	leafPrefix        = "malt:map:radix:leaf:v1:"
-	bucketRefPrefix   = "malt:map:radix:bucket:v1:"
+	bucketRefPrefixV1 = "malt:map:radix:bucket:v1:"
+	bucketRefPrefixV2 = "malt:map:radix:bucket:v2:"
 	bucketCountPrefix = "malt:map:radix:bucket-count:v1:"
+	bucketProofBatch  = 16
 )
+
+type bucketRefVersion uint8
+
+const (
+	bucketRefV1 bucketRefVersion = 1
+	bucketRefV2 bucketRefVersion = 2
+)
+
+func bucketVersionForMALTVersion(version uint8) (bucketRefVersion, bool) {
+	switch version {
+	case maltcid.LegacyMALTVersionID:
+		return bucketRefV1, true
+	case maltcid.MALTVersionID:
+		return bucketRefV2, true
+	default:
+		return 0, false
+	}
+}
+
+func matchesRadixRootProfile(root cid.Cid, version uint8, backend maltcid.BackendKind) bool {
+	return maltcid.VersionIDOf(root) == version &&
+		maltcid.SemanticKindOf(root) == maltcid.SemanticKindMap &&
+		maltcid.BackendKindOf(root) == backend
+}
 
 type Map struct {
 	commitment   *mapping.Commitment
 	materializer materializer.NodeStore
 	geometry     nodegeometry.Geometry
+	version      uint8
 }
 
 // ErrPathNotFound is retained as a compatibility alias for the semantic-level
@@ -70,10 +98,19 @@ type proofStep struct {
 }
 
 type bucketWitness struct {
-	Proof []byte `json:"proof"`
+	Entries [][]byte `json:"entries,omitempty"`
+	Proof   []byte   `json:"proof"`
+	Batches [][]byte `json:"batches,omitempty"`
 }
 
 func NewMap(scheme commitment.IndexCommitment, e materializer.NodeStore) (*Map, error) {
+	return NewMapForVersion(scheme, e, maltcid.MALTVersionID)
+}
+
+// NewMapForVersion creates radix-map semantics that emit an exact supported
+// typed-root version. Legacy mode exists only to replay and verify old complete
+// views; new state should use [NewMap].
+func NewMapForVersion(scheme commitment.IndexCommitment, e materializer.NodeStore, version uint8) (*Map, error) {
 	if scheme == nil {
 		return nil, fmt.Errorf("scheme is nil")
 	}
@@ -90,12 +127,56 @@ func NewMap(scheme commitment.IndexCommitment, e materializer.NodeStore) (*Map, 
 		return nil, fmt.Errorf("failed to create map commitment: %w", err)
 	}
 
-	return &Map{commitment: commitmentHandler, materializer: e, geometry: geometry}, nil
+	if version != maltcid.MALTVersionID && version != maltcid.LegacyMALTVersionID {
+		return nil, fmt.Errorf("unsupported MALT version %d", version)
+	}
+	return &Map{commitment: commitmentHandler, materializer: e, geometry: geometry, version: version}, nil
 }
 
 // Commitment returns the underlying commitment primitives.
 func (s *Map) Commitment() *mapping.Commitment {
 	return s.commitment
+}
+
+func (s *Map) typedRoot(root cid.Cid) (cid.Cid, error) {
+	commitmentBytes, err := maltcid.ExtractCommitment(root)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return maltcid.NewTypedCIDForVersion(s.version, maltcid.SemanticKindMap, maltcid.BackendKindOf(root), commitmentBytes)
+}
+
+func (s *Map) commitSlots(slots []cid.Cid) (cid.Cid, error) {
+	root, err := s.commitment.Scheme().Commit(cellsFromCIDs(slots))
+	if err != nil {
+		return cid.Undef, err
+	}
+	return s.typedRoot(root)
+}
+
+func (s *Map) bucketVersion() bucketRefVersion {
+	if s.version == maltcid.LegacyMALTVersionID {
+		return bucketRefV1
+	}
+	return bucketRefV2
+}
+
+func (s *Map) encodeBucketRef(root cid.Cid) (cid.Cid, error) {
+	return encodeBucketRefVersion(root, s.bucketVersion())
+}
+
+func (s *Map) bucketCommitVector(markers []cid.Cid) []cid.Cid {
+	if s.bucketVersion() == bucketRefV1 {
+		return markers
+	}
+	return bucketVector(markers, s.commitment.Scheme().MaxValues())
+}
+
+func (s *Map) validateMutationRootVersion(root cid.Cid) error {
+	if version := maltcid.VersionIDOf(root); version != s.version {
+		return fmt.Errorf("map root version %d cannot be mutated by version %d semantics; replay the complete view first", version, s.version)
+	}
+	return nil
 }
 
 func (s *Map) Commit(ctx context.Context, namespace string, view mapping.View) (cid.Cid, error) {
@@ -112,6 +193,12 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 	}
 	if key.IsEmpty() {
 		return mapping.Binding{}, nil, fmt.Errorf("key is empty")
+	}
+	rootVersion := maltcid.VersionIDOf(root)
+	expectedBucketVersion, ok := bucketVersionForMALTVersion(rootVersion)
+	rootBackend := maltcid.BackendKindOf(root)
+	if !ok || !matchesRadixRootProfile(root, rootVersion, rootBackend) {
+		return mapping.Binding{}, nil, fmt.Errorf("root does not encode a supported radix map profile")
 	}
 
 	digest := hashPath(key)
@@ -151,14 +238,26 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 		})
 
 		if !slotCID.Defined() {
-			return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+			finishSerialization := observation.Start(ctx, observation.PhaseSerialization)
+			proofBytes, err := json.Marshal(envelope)
+			finishSerialization(1, uint64(len(envelope.Steps)), uint64(len(proofBytes)))
+			if err != nil {
+				return mapping.Binding{}, nil, err
+			}
+			return mapping.Binding{Present: false}, structure.Proof(proofBytes), nil
 		}
 
 		if leafPath, leafValue, ok, err := tryDecodeLeafMarker(slotCID); err != nil {
 			return mapping.Binding{}, nil, err
 		} else if ok {
 			if leafPath != key {
-				return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+				finishSerialization := observation.Start(ctx, observation.PhaseSerialization)
+				proofBytes, err := json.Marshal(envelope)
+				finishSerialization(1, uint64(len(envelope.Steps)), uint64(len(proofBytes)))
+				if err != nil {
+					return mapping.Binding{}, nil, err
+				}
+				return mapping.Binding{Present: false}, structure.Proof(proofBytes), nil
 			}
 			finishSerialization := observation.Start(ctx, observation.PhaseSerialization)
 			proofBytes, err := json.Marshal(envelope)
@@ -169,9 +268,12 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), nil
 		}
 
-		if bucketRoot, ok, err := tryDecodeBucketRef(slotCID); err != nil {
+		if bucketRoot, version, ok, err := decodeBucketRef(slotCID); err != nil {
 			return mapping.Binding{}, nil, err
 		} else if ok {
+			if version != expectedBucketVersion || !matchesRadixRootProfile(bucketRoot, rootVersion, rootBackend) {
+				return mapping.Binding{}, nil, fmt.Errorf("collision bucket does not match radix root profile")
+			}
 			finishMaterialization := observation.Start(ctx, observation.PhaseMaterialization)
 			markers, err := s.loadBucketEntries(ctx, namespace, bucketRoot)
 			var materializedBytes uint64
@@ -194,11 +296,29 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 				}
 			}
 			if index < 0 {
-				return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
+				if version == bucketRefV1 {
+					return mapping.Binding{}, nil, fmt.Errorf("legacy v1 collision bucket cannot produce a sound absence proof")
+				}
+				witness, err := s.proveBucketAbsence(bucketRoot, markers, key)
+				if err != nil {
+					return mapping.Binding{}, nil, err
+				}
+				envelope.Bucket = witness
+				finishSerialization := observation.Start(ctx, observation.PhaseSerialization)
+				proofBytes, err := json.Marshal(envelope)
+				finishSerialization(1, uint64(len(envelope.Steps))+uint64(len(markers)), uint64(len(proofBytes)))
+				if err != nil {
+					return mapping.Binding{}, nil, err
+				}
+				return mapping.Binding{Present: false}, structure.Proof(proofBytes), nil
 			}
 
+			proofMarkers := markers
+			if version == bucketRefV2 {
+				proofMarkers = bucketVector(markers, s.commitment.Scheme().MaxValues())
+			}
 			finishOpen := observation.Start(ctx, observation.PhaseOpen)
-			value, proof, err := s.commitment.ProveSlot(bucketRoot, markers, uint64(index))
+			value, proof, err := s.commitment.ProveSlot(bucketRoot, proofMarkers, uint64(index))
 			finishOpen(1, 1, uint64(len(proof)))
 			if err != nil {
 				return mapping.Binding{}, nil, err
@@ -217,21 +337,138 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 			return mapping.Binding{Value: leafValue, Present: true}, structure.Proof(proofBytes), nil
 		}
 
+		if !matchesRadixRootProfile(slotCID, rootVersion, rootBackend) {
+			return mapping.Binding{}, nil, fmt.Errorf("internal node does not match radix root profile")
+		}
 		currentRoot = slotCID
 	}
 
 	return mapping.Binding{}, nil, fmt.Errorf("%w: path %s", ErrPathNotFound, key.String())
 }
 
-func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, proof structure.Proof) (bool, error) {
-	if !expected.Present {
-		return false, fmt.Errorf("non-membership verification is not implemented")
+func (s *Map) proveBucketAbsence(root cid.Cid, markers []cid.Cid, key arcset.Path) (*bucketWitness, error) {
+	capacity := s.commitment.Scheme().MaxValues()
+	if len(markers) < 2 || len(markers) > capacity {
+		return nil, fmt.Errorf("invalid bucket size %d", len(markers))
 	}
+	padded := make([]cid.Cid, capacity)
+	entries := make([][]byte, len(markers))
+	var previous arcset.Path
+	for index, marker := range markers {
+		path, value, err := decodeLeafMarker(marker)
+		if err != nil {
+			return nil, err
+		}
+		canonical, err := encodeLeafMarker(path, value)
+		if err != nil {
+			return nil, err
+		}
+		if !canonical.Equals(marker) {
+			return nil, fmt.Errorf("bucket entry %d is not canonically encoded", index)
+		}
+		if index > 0 && path <= previous {
+			return nil, fmt.Errorf("bucket entries are not in canonical path order")
+		}
+		if path == key {
+			return nil, fmt.Errorf("bucket contains queried path %s", key.String())
+		}
+		previous = path
+		padded[index] = marker
+		entries[index] = cidBytes(marker)
+	}
+	batches := make([][]byte, 0, (capacity+bucketProofBatch-1)/bucketProofBatch)
+	for start := 0; start < capacity; start += bucketProofBatch {
+		end := min(start+bucketProofBatch, capacity)
+		indices := make([]uint64, end-start)
+		for offset := range indices {
+			indices[offset] = uint64(start + offset)
+		}
+		proved, proof, err := s.commitment.ProveSlots(root, padded, indices)
+		if err != nil {
+			return nil, err
+		}
+		if len(proved) != len(indices) {
+			return nil, fmt.Errorf("bucket absence batch returned %d cells, want %d", len(proved), len(indices))
+		}
+		for offset := range proved {
+			if !proved[offset].Equal(commitment.CellFromCID(padded[start+offset])) {
+				return nil, fmt.Errorf("bucket absence proof cell %d mismatch", start+offset)
+			}
+		}
+		batches = append(batches, proof)
+	}
+	return &bucketWitness{Entries: entries, Proof: []byte{}, Batches: batches}, nil
+}
+
+func (s *Map) verifyBucketAbsence(root cid.Cid, key arcset.Path, witness *bucketWitness) (bool, error) {
+	capacity := s.commitment.Scheme().MaxValues()
+	if witness == nil || len(witness.Entries) < 2 || len(witness.Entries) > capacity {
+		return false, nil
+	}
+	padded := make([]cid.Cid, capacity)
+	var previous arcset.Path
+	for index, encoded := range witness.Entries {
+		marker, err := cid.Cast(encoded)
+		if err != nil {
+			return false, err
+		}
+		path, value, err := decodeLeafMarker(marker)
+		if err != nil {
+			return false, err
+		}
+		canonical, err := encodeLeafMarker(path, value)
+		if err != nil {
+			return false, err
+		}
+		if !canonical.Equals(marker) {
+			return false, nil
+		}
+		if index > 0 && path <= previous {
+			return false, nil
+		}
+		if path == key {
+			return false, nil
+		}
+		previous = path
+		padded[index] = marker
+	}
+	cells := cellsFromCIDs(padded)
+	batchCount := (capacity + bucketProofBatch - 1) / bucketProofBatch
+	if len(witness.Batches) != batchCount || len(witness.Proof) != 0 {
+		return false, nil
+	}
+	for batch, start := 0, 0; start < capacity; batch, start = batch+1, start+bucketProofBatch {
+		end := min(start+bucketProofBatch, capacity)
+		indices := make([]uint64, end-start)
+		for offset := range indices {
+			indices[offset] = uint64(start + offset)
+		}
+		ok, err := s.commitment.Scheme().BatchVerify(root, indices, cells[start:end], witness.Batches[batch])
+		if err != nil || !ok {
+			return ok, err
+		}
+	}
+	return true, nil
+}
+
+func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, proof structure.Proof) (bool, error) {
 	if !root.Defined() {
 		return false, fmt.Errorf("root is undefined")
 	}
 	if key.IsEmpty() {
 		return false, fmt.Errorf("key is empty")
+	}
+	if expected.Present && !expected.Value.Defined() {
+		return false, fmt.Errorf("expected membership value is undefined")
+	}
+	if !expected.Present && expected.Value.Defined() {
+		return false, fmt.Errorf("expected absence value must be undefined")
+	}
+	rootVersion := maltcid.VersionIDOf(root)
+	expectedBucketVersion, profileOK := bucketVersionForMALTVersion(rootVersion)
+	rootBackend := maltcid.BackendKindOf(root)
+	if !profileOK || !matchesRadixRootProfile(root, rootVersion, rootBackend) {
+		return false, fmt.Errorf("root does not encode a supported radix map profile")
 	}
 
 	var envelope proofEnvelope
@@ -247,9 +484,13 @@ func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, pr
 		return false, fmt.Errorf("proof has too many radix steps")
 	}
 	currentRoot := root
-	expectedLeaf, err := encodeLeafMarker(key, expected.Value)
-	if err != nil {
-		return false, err
+	var expectedLeaf cid.Cid
+	var err error
+	if expected.Present {
+		expectedLeaf, err = encodeLeafMarker(key, expected.Value)
+		if err != nil {
+			return false, err
+		}
 	}
 
 	for depth, step := range envelope.Steps {
@@ -270,28 +511,43 @@ func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, pr
 			return ok, err
 		}
 		if !slotCID.Defined() {
-			return false, nil
+			return !expected.Present && depth == len(envelope.Steps)-1 && envelope.Bucket == nil, nil
 		}
 
-		if leafPath, leafValue, ok, err := tryDecodeLeafMarker(slotCID); err != nil {
+		if leafPath, leafValue, isLeaf, err := tryDecodeLeafMarker(slotCID); err != nil {
 			return false, err
-		} else if ok {
+		} else if isLeaf {
 			if depth != len(envelope.Steps)-1 || envelope.Bucket != nil {
 				return false, nil
 			}
-			return leafPath == key && leafValue.Equals(expected.Value), nil
+			if expected.Present {
+				return leafPath == key && leafValue.Equals(expected.Value), nil
+			}
+			return leafPath != key, nil
 		}
 
-		if bucketRoot, ok, err := tryDecodeBucketRef(slotCID); err != nil {
+		if bucketRoot, bucketVersion, isBucket, err := decodeBucketRef(slotCID); err != nil {
 			return false, err
-		} else if ok {
+		} else if isBucket {
+			if bucketVersion != expectedBucketVersion || !matchesRadixRootProfile(bucketRoot, rootVersion, rootBackend) {
+				return false, nil
+			}
 			if depth != len(envelope.Steps)-1 || envelope.Bucket == nil {
+				return false, nil
+			}
+			if !expected.Present {
+				return s.verifyBucketAbsence(bucketRoot, key, envelope.Bucket)
+			}
+			if len(envelope.Bucket.Entries) != 0 || len(envelope.Bucket.Batches) != 0 {
 				return false, nil
 			}
 			return s.commitment.Scheme().VerifyProof(bucketRoot, commitment.CellFromCID(expectedLeaf), envelope.Bucket.Proof)
 		}
 
 		if depth == len(envelope.Steps)-1 {
+			return false, nil
+		}
+		if !matchesRadixRootProfile(slotCID, rootVersion, rootBackend) {
 			return false, nil
 		}
 		currentRoot = slotCID
@@ -303,6 +559,9 @@ func (s *Map) Verify(root cid.Cid, key arcset.Path, expected mapping.Binding, pr
 func (s *Map) Update(ctx context.Context, namespace string, root cid.Cid, key arcset.Path, oldValue, newValue cid.Cid) (cid.Cid, error) {
 	if !root.Defined() {
 		return cid.Undef, fmt.Errorf("root is undefined")
+	}
+	if err := s.validateMutationRootVersion(root); err != nil {
+		return cid.Undef, err
 	}
 	if key.IsEmpty() {
 		return cid.Undef, fmt.Errorf("key is empty")
@@ -354,7 +613,7 @@ func (s *Map) updateWithoutPersist(ctx context.Context, namespace string, root c
 
 	nextSlots := cloneCIDs(rootSlots)
 	nextSlots[slotIndex] = nextSlot
-	newRoot, err := s.commitment.Scheme().Commit(cellsFromCIDs(nextSlots))
+	newRoot, err := s.commitSlots(nextSlots)
 	if err != nil {
 		return cid.Undef, nil, nil, err
 	}
@@ -394,7 +653,7 @@ func (s *Map) updateWithoutPersistCached(ctx context.Context, namespace string, 
 
 	nextSlots := cloneCIDs(rootSlots)
 	nextSlots[slotIndex] = nextSlot
-	newRoot, err := s.commitment.Scheme().Commit(cellsFromCIDs(nextSlots))
+	newRoot, err := s.commitSlots(nextSlots)
 	if err != nil {
 		return cid.Undef, nil, nil, err
 	}
@@ -455,10 +714,10 @@ func (s *Map) updateSubtreeWithoutPersistCached(
 		}
 	}
 
-	if bucketRoot, ok, err := tryDecodeBucketRef(current); err != nil {
+	if bucketRoot, version, ok, err := decodeBucketRef(current); err != nil {
 		return cid.Undef, nil, nil, err
 	} else if ok {
-		return s.updateBucketWithoutPersist(ctx, namespace, bucketRoot, key, oldValue, newValue)
+		return s.updateBucketWithoutPersist(ctx, namespace, bucketRoot, version, key, oldValue, newValue)
 	}
 
 	if depth >= s.geometry.MapDepth(len(digest)) {
@@ -501,6 +760,9 @@ func (s *Map) updateSubtreeWithoutPersistCached(
 func (s *Map) BatchUpdate(ctx context.Context, namespace string, root cid.Cid, updates []mapping.BatchUpdate) (cid.Cid, error) {
 	if !root.Defined() {
 		return cid.Undef, fmt.Errorf("root is undefined")
+	}
+	if err := s.validateMutationRootVersion(root); err != nil {
+		return cid.Undef, err
 	}
 	if len(updates) == 0 {
 		return root, nil
@@ -611,10 +873,10 @@ func (s *Map) updateSubtreeWithoutPersist(
 		}
 	}
 
-	if bucketRoot, ok, err := tryDecodeBucketRef(current); err != nil {
+	if bucketRoot, version, ok, err := decodeBucketRef(current); err != nil {
 		return cid.Undef, nil, nil, err
 	} else if ok {
-		return s.updateBucketWithoutPersist(ctx, namespace, bucketRoot, key, oldValue, newValue)
+		return s.updateBucketWithoutPersist(ctx, namespace, bucketRoot, version, key, oldValue, newValue)
 	}
 
 	if depth >= s.geometry.MapDepth(len(digest)) {
@@ -644,7 +906,7 @@ func (s *Map) updateSubtreeWithoutPersist(
 }
 
 // updateBucketWithoutPersist updates a bucket without persisting to ArcSet materializer.
-func (s *Map) updateBucketWithoutPersist(ctx context.Context, namespace string, bucketRoot cid.Cid, key arcset.Path, oldValue, newValue cid.Cid) (cid.Cid, []pendingNode, []pendingBucket, error) {
+func (s *Map) updateBucketWithoutPersist(ctx context.Context, namespace string, bucketRoot cid.Cid, version bucketRefVersion, key arcset.Path, oldValue, newValue cid.Cid) (cid.Cid, []pendingNode, []pendingBucket, error) {
 	markers, err := s.loadBucketEntries(ctx, namespace, bucketRoot)
 	if err != nil {
 		return cid.Undef, nil, nil, err
@@ -673,7 +935,7 @@ func (s *Map) updateBucketWithoutPersist(ctx context.Context, namespace string, 
 		if exists {
 			return cid.Undef, nil, nil, fmt.Errorf("path %s exists; absent-to-absent update is invalid", key.String())
 		}
-		refCID, err := encodeBucketRef(bucketRoot)
+		refCID, err := encodeBucketRefVersion(bucketRoot, version)
 		return refCID, nil, nil, err
 	case exists:
 		if !oldValue.Defined() {
@@ -699,7 +961,7 @@ func (s *Map) updateBucketWithoutPersist(ctx context.Context, namespace string, 
 			return cid.Undef, nil, nil, fmt.Errorf("path %s is absent", key.String())
 		}
 		if !newValue.Defined() {
-			refCID, err := encodeBucketRef(bucketRoot)
+			refCID, err := encodeBucketRefVersion(bucketRoot, version)
 			return refCID, nil, nil, err
 		}
 		newMarker, err := encodeLeafMarker(key, newValue)
@@ -753,23 +1015,16 @@ func (s *Map) updateBucket(ctx context.Context, namespace string, bucketRoot cid
 		if len(markers) == 1 {
 			return nextMarker, nil
 		}
-		root, err := s.commitment.Scheme().Replace(cellsFromCIDs(markers), uint64(index), commitment.CellFromCID(markers[index]), commitment.CellFromCID(nextMarker))
-		if err != nil {
-			return cid.Undef, err
-		}
 		next := cloneCIDs(markers)
 		next[index] = nextMarker
-		if err := s.storeBucketEntries(ctx, namespace, root, next); err != nil {
-			return cid.Undef, err
-		}
-		return encodeBucketRef(root)
+		return s.commitBucketMarkers(ctx, namespace, next)
 
 	default:
 		if oldValue.Defined() {
 			return cid.Undef, fmt.Errorf("path %s is absent", key.String())
 		}
 		if !newValue.Defined() {
-			return encodeBucketRef(bucketRoot)
+			return s.encodeBucketRef(bucketRoot)
 		}
 		nextMarker, err := encodeLeafMarker(key, newValue)
 		if err != nil {
@@ -855,7 +1110,7 @@ func (s *Map) buildSubtreeWithoutPersist(ctx context.Context, namespace string, 
 		allBuckets = append(allBuckets, buckets...)
 	}
 
-	root, err := s.commitment.Scheme().Commit(cellsFromCIDs(slots))
+	root, err := s.commitSlots(slots)
 	if err != nil {
 		return cid.Undef, nil, nil, err
 	}
@@ -900,7 +1155,7 @@ func (s *Map) buildSubtree(ctx context.Context, namespace string, bindings []lea
 }
 
 func (s *Map) commitNode(ctx context.Context, namespace string, slots []cid.Cid) (cid.Cid, error) {
-	root, err := s.commitment.Scheme().Commit(cellsFromCIDs(slots))
+	root, err := s.commitSlots(slots)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -940,7 +1195,7 @@ func (s *Map) commitOrCollapseNodeWithoutPersist(ctx context.Context, namespace 
 		}
 	}
 
-	root, err := s.commitment.Scheme().Commit(cellsFromCIDs(slots))
+	root, err := s.commitSlots(slots)
 	if err != nil {
 		return cid.Undef, nil, nil, err
 	}
@@ -992,13 +1247,13 @@ func (s *Map) commitBucketMarkersWithoutPersist(ctx context.Context, namespace s
 		return cid.Undef, nil, nil, fmt.Errorf("bucket size %d exceeds commitment capacity %d", len(markers), s.commitment.Scheme().MaxValues())
 	}
 
-	root, err := s.commitment.Scheme().Commit(cellsFromCIDs(markers))
+	root, err := s.commitSlots(s.bucketCommitVector(markers))
 	if err != nil {
 		return cid.Undef, nil, nil, err
 	}
 
 	buckets := []pendingBucket{{root: root, markers: markers}}
-	refCID, err := encodeBucketRef(root)
+	refCID, err := s.encodeBucketRef(root)
 	if err != nil {
 		return cid.Undef, nil, nil, err
 	}
@@ -1016,14 +1271,14 @@ func (s *Map) commitBucketMarkers(ctx context.Context, namespace string, markers
 		return cid.Undef, fmt.Errorf("bucket size %d exceeds commitment capacity %d", len(markers), s.commitment.Scheme().MaxValues())
 	}
 
-	root, err := s.commitment.Scheme().Commit(cellsFromCIDs(markers))
+	root, err := s.commitSlots(s.bucketCommitVector(markers))
 	if err != nil {
 		return cid.Undef, err
 	}
 	if err := s.storeBucketEntries(ctx, namespace, root, markers); err != nil {
 		return cid.Undef, err
 	}
-	return encodeBucketRef(root)
+	return s.encodeBucketRef(root)
 }
 
 func extractBindings(view mapping.View) ([]leafBinding, error) {
@@ -1096,11 +1351,22 @@ func (s *Map) loadValidatedNode(ctx context.Context, namespace string, root cid.
 	if err != nil {
 		return nil, err
 	}
-	recomputed, err := s.commitment.Scheme().Commit(cellsFromCIDs(slots))
+	cells := cellsFromCIDs(slots)
+	if rootProver, ok := s.commitment.Scheme().(commitment.IndexRootProver); ok {
+		if _, _, err := rootProver.ProveAtRoot(root, cells, 0); err != nil {
+			return nil, fmt.Errorf("materialized node state does not match root %s", root.String())
+		}
+		return slots, nil
+	}
+	recomputed, err := s.commitment.Scheme().Commit(cells)
 	if err != nil {
 		return nil, err
 	}
-	if !recomputed.Equals(root) {
+	equal, err := maltcid.EqualCommitment(recomputed, root)
+	if err != nil {
+		return nil, err
+	}
+	if !equal {
 		return nil, fmt.Errorf("materialized node state does not match root %s", root.String())
 	}
 	return slots, nil
@@ -1155,6 +1421,13 @@ func (s *Map) loadBucketEntries(ctx context.Context, namespace string, root cid.
 	if err != nil {
 		return nil, err
 	}
+	capacity := nodegeometry.KZGNodeWidth
+	if s.commitment != nil && s.commitment.Scheme() != nil {
+		capacity = s.commitment.Scheme().MaxValues()
+	}
+	if count < 2 || count > uint64(capacity) {
+		return nil, fmt.Errorf("bucket count %d is outside [2,%d]", count, capacity)
+	}
 
 	paths := make([]arcset.Path, count)
 	for i := uint64(0); i < count; i++ {
@@ -1196,7 +1469,7 @@ func (s *Map) storeBucketEntries(ctx context.Context, namespace string, root cid
 		// reachability-based reclamation can follow the parent slot into the
 		// bucket entries. The raw root remains part of each entry path because
 		// it is also the commitment verified by bucket proofs.
-		refCID, err := encodeBucketRef(root)
+		refCID, err := s.encodeBucketRef(root)
 		if err != nil {
 			return err
 		}
@@ -1215,6 +1488,15 @@ func cellsFromCIDs(values []cid.Cid) []commitment.Cell {
 
 func cloneCIDs(values []cid.Cid) []cid.Cid {
 	return append([]cid.Cid(nil), values...)
+}
+
+func bucketVector(markers []cid.Cid, capacity int) []cid.Cid {
+	if capacity < len(markers) {
+		capacity = len(markers)
+	}
+	values := make([]cid.Cid, capacity)
+	copy(values, markers)
+	return values
 }
 
 func cidVectorBytes(values []cid.Cid) uint64 {
@@ -1324,11 +1606,19 @@ func decodeLeafMarkerCID(cell commitment.Cell) (arcset.Path, cid.Cid, error) {
 }
 
 func encodeBucketRef(root cid.Cid) (cid.Cid, error) {
+	return encodeBucketRefVersion(root, bucketRefV2)
+}
+
+func encodeBucketRefVersion(root cid.Cid, version bucketRefVersion) (cid.Cid, error) {
 	if !root.Defined() {
 		return cid.Undef, fmt.Errorf("bucket root is undefined")
 	}
-	payload := make([]byte, 0, len(bucketRefPrefix)+len(root.Bytes()))
-	payload = append(payload, []byte(bucketRefPrefix)...)
+	prefix, err := bucketRefPrefix(version)
+	if err != nil {
+		return cid.Undef, err
+	}
+	payload := make([]byte, 0, len(prefix)+len(root.Bytes()))
+	payload = append(payload, []byte(prefix)...)
 	payload = append(payload, root.Bytes()...)
 	sum, err := mh.Sum(payload, mh.IDENTITY, len(payload))
 	if err != nil {
@@ -1338,18 +1628,38 @@ func encodeBucketRef(root cid.Cid) (cid.Cid, error) {
 }
 
 func tryDecodeBucketRef(marker cid.Cid) (cid.Cid, bool, error) {
+	root, _, ok, err := decodeBucketRef(marker)
+	return root, ok, err
+}
+
+func decodeBucketRef(marker cid.Cid) (cid.Cid, bucketRefVersion, bool, error) {
 	payload, err := decodeIdentityPayload(marker)
 	if err != nil {
-		if !marker.Defined() {
-			return cid.Undef, false, nil
-		}
-		return cid.Undef, false, nil
+		return cid.Undef, 0, false, nil
 	}
-	if len(payload) < len(bucketRefPrefix) || string(payload[:len(bucketRefPrefix)]) != bucketRefPrefix {
-		return cid.Undef, false, nil
+	var version bucketRefVersion
+	var prefix string
+	switch {
+	case len(payload) >= len(bucketRefPrefixV2) && string(payload[:len(bucketRefPrefixV2)]) == bucketRefPrefixV2:
+		version, prefix = bucketRefV2, bucketRefPrefixV2
+	case len(payload) >= len(bucketRefPrefixV1) && string(payload[:len(bucketRefPrefixV1)]) == bucketRefPrefixV1:
+		version, prefix = bucketRefV1, bucketRefPrefixV1
+	default:
+		return cid.Undef, 0, false, nil
 	}
-	root, err := cid.Cast(payload[len(bucketRefPrefix):])
-	return root, err == nil, err
+	root, err := cid.Cast(payload[len(prefix):])
+	return root, version, err == nil, err
+}
+
+func bucketRefPrefix(version bucketRefVersion) (string, error) {
+	switch version {
+	case bucketRefV1:
+		return bucketRefPrefixV1, nil
+	case bucketRefV2:
+		return bucketRefPrefixV2, nil
+	default:
+		return "", fmt.Errorf("unsupported collision bucket reference version %d", version)
+	}
 }
 
 func encodeBucketCountMarker(count uint64) (cid.Cid, error) {

--- a/auth/semantic/mapping/radix/radix_test.go
+++ b/auth/semantic/mapping/radix/radix_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dewebprotocol/malt/auth/commitment/kzg"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
 	mappingradix "github.com/dewebprotocol/malt/auth/semantic/mapping/radix"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
@@ -113,6 +114,28 @@ func findPathsWithSharedFirstKZGDigit(t *testing.T) (string, string) {
 	return "", ""
 }
 
+func findPathWithSharedFirstDigit(t *testing.T, capacity int, base arcset.Path) arcset.Path {
+	t.Helper()
+	geometry, err := nodegeometry.ForCapacity(capacity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseDigest := sha256.Sum256([]byte(base.String()))
+	baseDigit, ok := geometry.MapDigit(baseDigest[:], 0)
+	if !ok {
+		t.Fatal("base path has no first radix digit")
+	}
+	for index := 0; index < 1<<18; index++ {
+		candidate := arcset.CanonicalizePath(fmt.Sprintf("absent-shared-%d", index))
+		digest := sha256.Sum256([]byte(candidate.String()))
+		if digit, ok := geometry.MapDigit(digest[:], 0); ok && digit == baseDigit && candidate != base {
+			return candidate
+		}
+	}
+	t.Fatal("could not find absent path with shared first digit")
+	return ""
+}
+
 func TestMapCommitProveVerify(t *testing.T) {
 	ctx := context.Background()
 	view := mapping.NewViewFrom(map[string]cid.Cid{
@@ -153,6 +176,57 @@ func TestMapCommitProveVerify(t *testing.T) {
 			ok, err = semantic.Verify(root, arcset.CanonicalizePath("a"), binding, proof)
 			if err == nil && ok {
 				t.Fatal("expected proof to be path-bound")
+			}
+		})
+	}
+}
+
+func TestMapProvesEmptySlotAndConflictingLeafAbsence(t *testing.T) {
+	ctx := context.Background()
+	for name, factory := range mappingSchemes() {
+		t.Run(name, func(t *testing.T) {
+			scheme := factory(t)
+			semantic, err := mappingradix.NewMap(scheme, materialmemory.New(true))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			emptyRoot, err := semantic.Commit(ctx, testNamespace+"-absence-empty-"+name, mapping.NewViewFrom(nil))
+			if err != nil {
+				t.Fatalf("Commit(empty) failed: %v", err)
+			}
+			emptyKey := arcset.CanonicalizePath("definitely-absent")
+			emptyBinding, emptyProof, err := semantic.Prove(ctx, testNamespace+"-absence-empty-"+name, emptyRoot, emptyKey)
+			if err != nil {
+				t.Fatalf("Prove(empty absence) failed: %v", err)
+			}
+			if emptyBinding.Present || emptyBinding.Value.Defined() {
+				t.Fatalf("empty absence binding = %+v", emptyBinding)
+			}
+			if ok, err := semantic.Verify(emptyRoot, emptyKey, emptyBinding, emptyProof); err != nil || !ok {
+				t.Fatalf("Verify(empty absence) = %v, %v", ok, err)
+			}
+
+			presentKey := arcset.CanonicalizePath("present-leaf")
+			presentValue := fakeCID("present-leaf-value-" + name)
+			namespace := testNamespace + "-absence-leaf-" + name
+			root, err := semantic.Commit(ctx, namespace, mapping.NewViewFromPaths(map[arcset.Path]cid.Cid{presentKey: presentValue}))
+			if err != nil {
+				t.Fatalf("Commit(single leaf) failed: %v", err)
+			}
+			absentKey := findPathWithSharedFirstDigit(t, scheme.MaxValues(), presentKey)
+			binding, proof, err := semantic.Prove(ctx, namespace, root, absentKey)
+			if err != nil {
+				t.Fatalf("Prove(conflicting leaf absence) failed: %v", err)
+			}
+			if binding.Present || binding.Value.Defined() {
+				t.Fatalf("conflicting leaf absence binding = %+v", binding)
+			}
+			if ok, err := semantic.Verify(root, absentKey, binding, proof); err != nil || !ok {
+				t.Fatalf("Verify(conflicting leaf absence) = %v, %v", ok, err)
+			}
+			if ok, err := semantic.Verify(root, presentKey, binding, proof); err == nil && ok {
+				t.Fatal("absence proof verified for the present path")
 			}
 		})
 	}

--- a/auth/verifier/portable_test.go
+++ b/auth/verifier/portable_test.go
@@ -17,6 +17,7 @@ import (
 	listtree "github.com/dewebprotocol/malt/auth/semantic/list/tree"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
 	mapradix "github.com/dewebprotocol/malt/auth/semantic/mapping/radix"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
 	authverifier "github.com/dewebprotocol/malt/auth/verifier"
 	"github.com/dewebprotocol/malt/execution"
 	"github.com/dewebprotocol/malt/wire/maltcid"
@@ -90,6 +91,55 @@ func TestPortableVerifierAcceptsRuntimeRadixAndTreeProofs(t *testing.T) {
 
 				pl.Steps[0].Target = portableTestCID(t, "forged-map-target")
 				assertPortableRejected(t, portable, pl)
+			})
+
+			t.Run("map_absence", func(t *testing.T) {
+				tests := []struct {
+					name    string
+					present map[arcset.Path]cid.Cid
+					absent  arcset.Path
+				}{
+					{name: "empty", present: map[arcset.Path]cid.Cid{}, absent: arcset.CanonicalizePath("definitely-absent")},
+				}
+				presentKey := arcset.CanonicalizePath("present-leaf")
+				tests = append(tests, struct {
+					name    string
+					present map[arcset.Path]cid.Cid
+					absent  arcset.Path
+				}{
+					name:    "conflicting_leaf",
+					present: map[arcset.Path]cid.Cid{presentKey: portableTestCID(t, "absence-present-"+name)},
+					absent:  portableSharedFirstDigitPath(t, scheme.MaxValues(), presentKey),
+				})
+				for _, test := range tests {
+					t.Run(test.name, func(t *testing.T) {
+						scope := fmt.Sprintf("portable-map-absence-%s-%s", name, test.name)
+						root, err := maps.Commit(ctx, scope, mapping.NewViewFromPaths(test.present))
+						if err != nil {
+							t.Fatalf("Commit: %v", err)
+						}
+						executor, err := execution.NewExecutor(execution.Options{Scope: scope, Maps: maps})
+						if err != nil {
+							t.Fatalf("NewExecutor: %v", err)
+						}
+						request := malt.MapProofRequest{Root: root, Key: test.absent}
+						result, err := executor.ProveMap(ctx, request)
+						if err != nil {
+							t.Fatalf("ProveMap: %v", err)
+						}
+						if result.Present || result.Target.Defined() || result.ProofList.Steps[0].Kind != prooflist.KindMapAbsence {
+							t.Fatalf("absence result = %+v", result)
+						}
+						if err := malt.VerifyMapProof(ctx, request, result, portable); err != nil {
+							t.Fatalf("VerifyMapProof: %v", err)
+						}
+						wrong := request
+						wrong.Key = arcset.CanonicalizePath("another-missing-key")
+						if err := malt.VerifyMapProof(ctx, wrong, result, portable); err == nil {
+							t.Fatal("VerifyMapProof accepted absence for another key")
+						}
+					})
+				}
 			})
 
 			t.Run("generic_map_coordinates", func(t *testing.T) {
@@ -284,4 +334,26 @@ func portableSharedFirstKZGDigitPaths(t *testing.T) (string, string) {
 	}
 	t.Fatal("could not find portable KZG paths with a shared first digit")
 	return "", ""
+}
+
+func portableSharedFirstDigitPath(t *testing.T, capacity int, base arcset.Path) arcset.Path {
+	t.Helper()
+	geometry, err := nodegeometry.ForCapacity(capacity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseDigest := sha256.Sum256([]byte(base.String()))
+	baseDigit, ok := geometry.MapDigit(baseDigest[:], 0)
+	if !ok {
+		t.Fatal("base path has no first radix digit")
+	}
+	for index := 0; index < 1<<18; index++ {
+		candidate := arcset.CanonicalizePath(fmt.Sprintf("portable-absent-shared-%d", index))
+		digest := sha256.Sum256([]byte(candidate.String()))
+		if digit, ok := geometry.MapDigit(digest[:], 0); ok && digit == baseDigit && candidate != base {
+			return candidate
+		}
+	}
+	t.Fatal("could not find portable absent path with a shared first digit")
+	return ""
 }

--- a/auth/verifier/prooflist.go
+++ b/auth/verifier/prooflist.go
@@ -161,7 +161,7 @@ func (v *Verifier) verifyStep(index int, step prooflist.Step) (bool, error) {
 	case "structure":
 		switch step.EvidenceBackend {
 		case "map":
-			if step.Kind != prooflist.KindMapStep && step.Kind != prooflist.KindPayloadBinding {
+			if step.Kind != prooflist.KindMapStep && step.Kind != prooflist.KindMapAbsence && step.Kind != prooflist.KindPayloadBinding {
 				return false, fmt.Errorf("prooflist step %d structure/map evidence does not match kind %q", index, step.Kind)
 			}
 			return v.verifyMapStep(index, step, structure.Proof(step.Proof))
@@ -188,7 +188,14 @@ func (v *Verifier) verifyMapStep(index int, step prooflist.Step, proof structure
 	if err != nil {
 		return false, fmt.Errorf("prooflist step %d: %w", index, err)
 	}
-	return maps.Verify(step.From, key, mapping.Binding{Value: step.Target, Present: true}, proof)
+	expected := mapping.Binding{Value: step.Target, Present: true}
+	if step.Kind == prooflist.KindMapAbsence {
+		if step.Target.Defined() {
+			return false, fmt.Errorf("prooflist step %d map absence target is defined", index)
+		}
+		expected = mapping.Binding{Present: false}
+	}
+	return maps.Verify(step.From, key, expected, proof)
 }
 
 func validateProofListQuery(pl prooflist.ProofList, verifiedPath proofListVerifiedPath) error {

--- a/auth/verifier/radix.go
+++ b/auth/verifier/radix.go
@@ -11,13 +11,16 @@ import (
 	structure "github.com/dewebprotocol/malt/auth/semantic"
 	"github.com/dewebprotocol/malt/auth/semantic/mapping"
 	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
+	"github.com/dewebprotocol/malt/wire/maltcid"
 	cid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
 
 const (
-	radixLeafPrefix   = "malt:map:radix:leaf:v1:"
-	radixBucketPrefix = "malt:map:radix:bucket:v1:"
+	radixLeafPrefix     = "malt:map:radix:leaf:v1:"
+	radixBucketPrefixV1 = "malt:map:radix:bucket:v1:"
+	radixBucketPrefixV2 = "malt:map:radix:bucket:v2:"
+	radixBucketBatch    = 16
 )
 
 // radixMapVerifier is the storage-free half of the runtime radix-map
@@ -40,7 +43,59 @@ type radixProofStep struct {
 }
 
 type radixBucketWitness struct {
-	Proof []byte `json:"proof"`
+	Entries [][]byte `json:"entries,omitempty"`
+	Proof   []byte   `json:"proof"`
+	Batches [][]byte `json:"batches,omitempty"`
+}
+
+func (v *radixMapVerifier) verifyBucketAbsence(root cid.Cid, key arcset.Path, witness *radixBucketWitness) (bool, error) {
+	capacity := v.scheme.MaxValues()
+	if witness == nil || len(witness.Entries) < 2 || len(witness.Entries) > capacity {
+		return false, nil
+	}
+	values := make([]commitment.Cell, capacity)
+	var previous arcset.Path
+	for index, encoded := range witness.Entries {
+		marker, err := cid.Cast(encoded)
+		if err != nil {
+			return false, err
+		}
+		path, value, err := decodeRadixLeafMarker(marker)
+		if err != nil {
+			return false, err
+		}
+		canonical, err := encodeRadixLeafMarker(path, value)
+		if err != nil {
+			return false, err
+		}
+		if !canonical.Equals(marker) {
+			return false, nil
+		}
+		if index > 0 && path <= previous {
+			return false, nil
+		}
+		if path == key {
+			return false, nil
+		}
+		previous = path
+		values[index] = commitment.CellFromCID(marker)
+	}
+	batchCount := (capacity + radixBucketBatch - 1) / radixBucketBatch
+	if len(witness.Batches) != batchCount || len(witness.Proof) != 0 {
+		return false, nil
+	}
+	for batch, start := 0, 0; start < capacity; batch, start = batch+1, start+radixBucketBatch {
+		end := min(start+radixBucketBatch, capacity)
+		indices := make([]uint64, end-start)
+		for offset := range indices {
+			indices[offset] = uint64(start + offset)
+		}
+		ok, err := v.scheme.BatchVerify(root, indices, values[start:end], cloneProofBytes(witness.Batches[batch]))
+		if err != nil || !ok {
+			return ok, err
+		}
+	}
+	return true, nil
 }
 
 func newRadixMapVerifier(scheme commitment.IndexVerifier, geometry nodegeometry.Geometry) MapVerifier {
@@ -51,17 +106,36 @@ func (v *radixMapVerifier) Verify(root cid.Cid, key arcset.Path, expected mappin
 	if v == nil || v.scheme == nil {
 		return false, fmt.Errorf("radix verifier commitment scheme is nil")
 	}
-	if !expected.Present {
-		return false, fmt.Errorf("non-membership verification is not implemented")
-	}
 	if !root.Defined() {
 		return false, fmt.Errorf("root is undefined")
 	}
 	if key.IsEmpty() {
 		return false, fmt.Errorf("key is empty")
 	}
-	if !expected.Value.Defined() {
-		return false, fmt.Errorf("expected value is undefined")
+	if expected.Present && !expected.Value.Defined() {
+		return false, fmt.Errorf("expected membership value is undefined")
+	}
+	if !expected.Present && expected.Value.Defined() {
+		return false, fmt.Errorf("expected absence value must be undefined")
+	}
+	rootVersion := maltcid.VersionIDOf(root)
+	var expectedBucketVersion uint8
+	switch rootVersion {
+	case maltcid.LegacyMALTVersionID:
+		expectedBucketVersion = 1
+	case maltcid.MALTVersionID:
+		expectedBucketVersion = 2
+	default:
+		return false, fmt.Errorf("root does not encode a supported radix map version")
+	}
+	rootBackend := maltcid.BackendKindOf(root)
+	matchesRootProfile := func(candidate cid.Cid) bool {
+		return maltcid.VersionIDOf(candidate) == rootVersion &&
+			maltcid.SemanticKindOf(candidate) == maltcid.SemanticKindMap &&
+			maltcid.BackendKindOf(candidate) == rootBackend
+	}
+	if !matchesRootProfile(root) {
+		return false, fmt.Errorf("root does not encode a supported radix map profile")
 	}
 
 	var envelope radixProofEnvelope
@@ -77,9 +151,13 @@ func (v *radixMapVerifier) Verify(root cid.Cid, key arcset.Path, expected mappin
 		return false, fmt.Errorf("proof has too many radix steps")
 	}
 	currentRoot := root
-	expectedLeaf, err := encodeRadixLeafMarker(key, expected.Value)
-	if err != nil {
-		return false, err
+	var expectedLeaf cid.Cid
+	var err error
+	if expected.Present {
+		expectedLeaf, err = encodeRadixLeafMarker(key, expected.Value)
+		if err != nil {
+			return false, err
+		}
 	}
 
 	for depth, step := range envelope.Steps {
@@ -100,7 +178,7 @@ func (v *radixMapVerifier) Verify(root cid.Cid, key arcset.Path, expected mappin
 			return ok, err
 		}
 		if !slotCID.Defined() {
-			return false, nil
+			return !expected.Present && depth == len(envelope.Steps)-1 && envelope.Bucket == nil, nil
 		}
 
 		if leafPath, leafValue, isLeaf, err := tryDecodeRadixLeafMarker(slotCID); err != nil {
@@ -109,19 +187,37 @@ func (v *radixMapVerifier) Verify(root cid.Cid, key arcset.Path, expected mappin
 			if depth != len(envelope.Steps)-1 || envelope.Bucket != nil {
 				return false, nil
 			}
-			return leafPath == key && leafValue.Equals(expected.Value), nil
+			if expected.Present {
+				return leafPath == key && leafValue.Equals(expected.Value), nil
+			}
+			return leafPath != key, nil
 		}
 
-		if bucketRoot, isBucket, err := tryDecodeRadixBucketRef(slotCID); err != nil {
+		if bucketRoot, bucketVersion, isBucket, err := decodeRadixBucketRef(slotCID); err != nil {
 			return false, err
 		} else if isBucket {
+			if bucketVersion != expectedBucketVersion || !matchesRootProfile(bucketRoot) {
+				return false, nil
+			}
 			if depth != len(envelope.Steps)-1 || envelope.Bucket == nil {
+				return false, nil
+			}
+			if !expected.Present {
+				if bucketVersion == 1 {
+					return false, nil
+				}
+				return v.verifyBucketAbsence(bucketRoot, key, envelope.Bucket)
+			}
+			if len(envelope.Bucket.Entries) != 0 || len(envelope.Bucket.Batches) != 0 {
 				return false, nil
 			}
 			return v.scheme.VerifyProof(bucketRoot, commitment.CellFromCID(expectedLeaf), cloneProofBytes(envelope.Bucket.Proof))
 		}
 
 		if depth == len(envelope.Steps)-1 {
+			return false, nil
+		}
+		if !matchesRootProfile(slotCID) {
 			return false, nil
 		}
 		currentRoot = slotCID
@@ -185,16 +281,23 @@ func tryDecodeRadixLeafMarker(marker cid.Cid) (arcset.Path, cid.Cid, bool, error
 	return path, value, err == nil, err
 }
 
-func tryDecodeRadixBucketRef(marker cid.Cid) (cid.Cid, bool, error) {
+func decodeRadixBucketRef(marker cid.Cid) (cid.Cid, uint8, bool, error) {
 	payload, err := decodeIdentityPayload(marker)
 	if err != nil {
-		return cid.Undef, false, nil
+		return cid.Undef, 0, false, nil
 	}
-	if len(payload) < len(radixBucketPrefix) || string(payload[:len(radixBucketPrefix)]) != radixBucketPrefix {
-		return cid.Undef, false, nil
+	var version uint8
+	var prefix string
+	switch {
+	case len(payload) >= len(radixBucketPrefixV2) && string(payload[:len(radixBucketPrefixV2)]) == radixBucketPrefixV2:
+		version, prefix = 2, radixBucketPrefixV2
+	case len(payload) >= len(radixBucketPrefixV1) && string(payload[:len(radixBucketPrefixV1)]) == radixBucketPrefixV1:
+		version, prefix = 1, radixBucketPrefixV1
+	default:
+		return cid.Undef, 0, false, nil
 	}
-	root, err := cid.Cast(payload[len(radixBucketPrefix):])
-	return root, err == nil, err
+	root, err := cid.Cast(payload[len(prefix):])
+	return root, version, err == nil, err
 }
 
 func identityCID(payload []byte) (cid.Cid, error) {

--- a/auth/verifier/radix_absence_test.go
+++ b/auth/verifier/radix_absence_test.go
@@ -1,0 +1,163 @@
+package verifier
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materialmemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	mappingradix "github.com/dewebprotocol/malt/auth/semantic/mapping/radix"
+	"github.com/dewebprotocol/malt/auth/semantic/nodegeometry"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+func portableAbsenceCID(seed string) cid.Cid {
+	sum, err := mh.Sum([]byte(seed), mh.SHA2_256, -1)
+	if err != nil {
+		panic(err)
+	}
+	return cid.NewCidV1(cid.Raw, sum)
+}
+
+func portableSharedFirstDigit(t *testing.T, geometry nodegeometry.Geometry, base arcset.Path) arcset.Path {
+	t.Helper()
+	baseDigest := sha256.Sum256([]byte(base.String()))
+	baseDigit, ok := geometry.MapDigit(baseDigest[:], 0)
+	if !ok {
+		t.Fatal("base path has no first radix digit")
+	}
+	for index := 0; index < 1<<18; index++ {
+		candidate := arcset.CanonicalizePath(fmt.Sprintf("portable-absent-%d", index))
+		digest := sha256.Sum256([]byte(candidate.String()))
+		if digit, ok := geometry.MapDigit(digest[:], 0); ok && digit == baseDigit && candidate != base {
+			return candidate
+		}
+	}
+	t.Fatal("could not find portable absence collision")
+	return ""
+}
+
+func TestPortableRadixVerifierAcceptsRuntimeAbsenceProofs(t *testing.T) {
+	factories := map[string]func(*testing.T) commitment.IndexCommitment{
+		"kzg": func(t *testing.T) commitment.IndexCommitment {
+			scheme, err := kzg.NewScheme()
+			if err != nil {
+				t.Fatal(err)
+			}
+			return scheme
+		},
+		"ipa": func(t *testing.T) commitment.IndexCommitment {
+			scheme, err := ipa.NewScheme()
+			if err != nil {
+				t.Fatal(err)
+			}
+			return scheme
+		},
+	}
+	for name, factory := range factories {
+		t.Run(name, func(t *testing.T) {
+			scheme := factory(t)
+			geometry, err := nodegeometry.ForCapacity(scheme.MaxValues())
+			if err != nil {
+				t.Fatal(err)
+			}
+			runtime, err := mappingradix.NewMap(scheme, materialmemory.New(true))
+			if err != nil {
+				t.Fatal(err)
+			}
+			portable := newRadixMapVerifier(scheme, geometry)
+			ctx := context.Background()
+
+			emptyNamespace := "portable-absence-empty-" + name
+			emptyRoot, err := runtime.Commit(ctx, emptyNamespace, mapping.NewViewFrom(nil))
+			if err != nil {
+				t.Fatal(err)
+			}
+			emptyKey := arcset.CanonicalizePath("portable-empty-key")
+			binding, proof, err := runtime.Prove(ctx, emptyNamespace, emptyRoot, emptyKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ok, err := portable.Verify(emptyRoot, emptyKey, binding, proof); err != nil || !ok {
+				t.Fatalf("portable empty absence = %v, %v", ok, err)
+			}
+
+			presentKey := arcset.CanonicalizePath("portable-present")
+			presentValue := portableAbsenceCID("portable-present-" + name)
+			namespace := "portable-absence-leaf-" + name
+			root, err := runtime.Commit(ctx, namespace, mapping.NewViewFromPaths(map[arcset.Path]cid.Cid{presentKey: presentValue}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			absentKey := portableSharedFirstDigit(t, geometry, presentKey)
+			binding, proof, err = runtime.Prove(ctx, namespace, root, absentKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ok, err := portable.Verify(root, absentKey, binding, proof); err != nil || !ok {
+				t.Fatalf("portable conflicting-leaf absence = %v, %v", ok, err)
+			}
+		})
+	}
+}
+
+func TestPortableRadixVerifierChecksCompleteBucketAbsence(t *testing.T) {
+	scheme, err := ipa.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	geometry, err := nodegeometry.ForCapacity(scheme.MaxValues())
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths := []arcset.Path{arcset.CanonicalizePath("a"), arcset.CanonicalizePath("z")}
+	markers := make([]cid.Cid, len(paths))
+	values := make([]commitment.Cell, scheme.MaxValues())
+	entries := make([][]byte, len(paths))
+	for index, path := range paths {
+		markers[index], err = encodeRadixLeafMarker(path, portableAbsenceCID("bucket-"+path.String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		values[index] = commitment.CellFromCID(markers[index])
+		entries[index] = markers[index].Bytes()
+	}
+	root, err := scheme.Commit(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batches := make([][]byte, 0, (scheme.MaxValues()+radixBucketBatch-1)/radixBucketBatch)
+	for start := 0; start < scheme.MaxValues(); start += radixBucketBatch {
+		end := min(start+radixBucketBatch, scheme.MaxValues())
+		indices := make([]uint64, end-start)
+		for offset := range indices {
+			indices[offset] = uint64(start + offset)
+		}
+		_, proof, err := scheme.BatchProveAtRoot(root, values, indices)
+		if err != nil {
+			t.Fatal(err)
+		}
+		batches = append(batches, proof)
+	}
+	verifier := &radixMapVerifier{scheme: scheme, geometry: geometry}
+	witness := &radixBucketWitness{Entries: entries, Batches: batches}
+	absent := arcset.CanonicalizePath("m")
+	if ok, err := verifier.verifyBucketAbsence(root, absent, witness); err != nil || !ok {
+		t.Fatalf("portable complete bucket absence = %v, %v", ok, err)
+	}
+	if ok, err := verifier.verifyBucketAbsence(root, paths[0], witness); err != nil || ok {
+		t.Fatalf("portable bucket proved present key absent = %v, %v", ok, err)
+	}
+	tampered := &radixBucketWitness{Entries: append([][]byte(nil), entries...), Batches: append([][]byte(nil), batches...)}
+	tampered.Entries[0], tampered.Entries[1] = tampered.Entries[1], tampered.Entries[0]
+	if ok, err := verifier.verifyBucketAbsence(root, absent, tampered); err != nil || ok {
+		t.Fatalf("portable reordered bucket witness = %v, %v", ok, err)
+	}
+}

--- a/cmd/malt-verifier-wasm/README.md
+++ b/cmd/malt-verifier-wasm/README.md
@@ -12,6 +12,7 @@ module registers:
 ```text
 globalThis.maltVerifyResolve(verificationJSON) -> resultJSON
 globalThis.maltVerifyRead(verificationJSON) -> resultJSON
+globalThis.maltVerifyMapProof(verificationJSON) -> resultJSON
 globalThis.maltVerifyArtifact(requestJSON) -> resultJSON  # v0.0.4 compatibility
 ```
 
@@ -31,8 +32,9 @@ is not registered. Clients that need cross-backend ProofLists must use the
 default `all` instance.
 
 `maltVerifyResolve` accepts one `malt.resolve/v0alpha1` request/result pair;
-`maltVerifyRead` accepts one `malt.read/v0alpha1` request/result pair. The
-caller constructs the request from its trusted root and intended query before
+`maltVerifyRead` accepts one `malt.read/v0alpha1` request/result pair;
+`maltVerifyMapProof` accepts one `malt.map-proof/v0alpha1` membership or
+non-membership pair. The caller constructs the request from its trusted root and intended query before
 passing the untrusted result to WASM. Schemas live in `protocol/schemas/`.
 
 For example:

--- a/cmd/malt-verifier-wasm/main.go
+++ b/cmd/malt-verifier-wasm/main.go
@@ -70,7 +70,24 @@ func main() {
 		}
 		return encodeProtocolResponse(protocol.VerificationResult{Profile: protocol.ReadProfile, Valid: true})
 	})
+	mapProofFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		if initErr != nil {
+			return encodeProtocolResponse(protocol.VerificationResult{Profile: protocol.MapProofProfile, Error: fmt.Sprintf("initialize verifier: %v", initErr)})
+		}
+		if len(args) != 1 || args[0].Type() != js.TypeString {
+			return encodeProtocolResponse(protocol.VerificationResult{Profile: protocol.MapProofProfile, Error: "maltVerifyMapProof expects one JSON string"})
+		}
+		value, err := protocol.DecodeMapProofVerification([]byte(args[0].String()))
+		if err != nil {
+			return encodeProtocolResponse(protocol.VerificationResult{Profile: protocol.MapProofProfile, Error: fmt.Sprintf("decode map-proof verification: %v", err)})
+		}
+		if err := verifier.VerifyMapProof(context.Background(), value); err != nil {
+			return encodeProtocolResponse(protocol.VerificationResult{Profile: protocol.MapProofProfile, Error: err.Error()})
+		}
+		return encodeProtocolResponse(protocol.VerificationResult{Profile: protocol.MapProofProfile, Valid: true})
+	})
 	js.Global().Set("maltVerifyArtifact", artifactFunction)
+	js.Global().Set("maltVerifyMapProof", mapProofFunction)
 	js.Global().Set("maltVerifyResolve", resolveFunction)
 	js.Global().Set("maltVerifyRead", readFunction)
 	select {}

--- a/cmd/malt-writer-wasm/README.md
+++ b/cmd/malt-writer-wasm/README.md
@@ -22,6 +22,7 @@ const writers = await createMaltWriterWorkers();
 await writers.kzgReady;
 console.log(writers.status("ipa")); // { backend: "ipa", state: "initializing" }
 
+const bootstrapViewJSON = await writers.bootstrap("kzg"); // new empty Bucket only
 const baseRoot = await writers.load("kzg", updateViewJSONUTF8);
 const candidateRoot = await writers.prepare(
   "kzg",
@@ -52,6 +53,8 @@ compute(
   updateViewJSONUTF8,
   semanticIntentJSONUTF8
 ) -> Promise<resultJSON>
+
+bootstrap(backend) -> Promise<bootstrapUpdateViewJSON>
 
 load(backend, updateViewJSONUTF8) -> Promise<baseRoot>
 
@@ -91,7 +94,10 @@ and a single instance never initializes both schemes.
 
 ## Session behavior
 
-Loading recomputes and verifies the complete update view once. Preparing a
+`bootstrap` creates, commits, and retains the canonical empty-map base in the
+client Worker; its first prepared result carries a root-bound base witness so an
+untrusted service can materialize that root without calling `Commit`. Loading
+recomputes and verifies the complete update view once. Preparing a
 mutation uses the retained logical vectors and semantic materialization, but
 does not advance the session. `prepare` returns only the candidate root. The
 caller requests the full result for a retained operation through
@@ -136,6 +142,7 @@ instance:
 
 ```text
 globalThis.maltComputeClientRootV1(...)
+globalThis.maltWriterBootstrapSessionV1()
 globalThis.maltWriterLoadSessionV1(...)
 globalThis.maltWriterPrepareSessionV1(...)
 globalThis.maltWriterGetPreparedResultV1(...)

--- a/cmd/malt-writer-wasm/README.md
+++ b/cmd/malt-writer-wasm/README.md
@@ -109,16 +109,22 @@ candidate. KZG and IPA sessions are unrelated because they live in different
 Workers.
 
 The stateless compute path and `getPreparedResult` return the protocol-owned
-`malt.writer-compute-result/v1`:
+`malt.writer-compute-result/v2`:
 
 ```json
 {
-  "profile": "malt.writer-compute-result/v1",
+  "profile": "malt.writer-compute-result/v2",
   "bundle": {},
+  "materialization": {},
   "next_view": {},
   "metrics": {}
 }
 ```
+
+`materialization` is the root-bound radix proof-serving witness for every map
+transition output. A service must validate it against the canonical bundle and
+derived logical post-view through `radix.ValidateMaterialization` before import;
+it must not treat the witness as trusted storage or a state-transition proof.
 
 The writer computes locally and does not contact a Gateway, publish a root, or
 promote a candidate to trusted state.

--- a/cmd/malt-writer-wasm/browser/malt-writer-worker.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-worker.mjs
@@ -1,6 +1,7 @@
 const SUPPORTED_BACKENDS = new Set(["kzg", "ipa"]);
 const RPC_FUNCTIONS = Object.freeze({
   compute: "maltComputeClientRootV1",
+  bootstrap: "maltWriterBootstrapSessionV1",
   load: "maltWriterLoadSessionV1",
   prepare: "maltWriterPrepareSessionV1",
   getPreparedResult: "maltWriterGetPreparedResultV1",
@@ -9,6 +10,7 @@ const RPC_FUNCTIONS = Object.freeze({
   closeSession: "maltWriterCloseSessionV1",
 });
 const STATEFUL_RPC_METHODS = new Set([
+  "bootstrap",
   "load",
   "prepare",
   "getPreparedResult",

--- a/cmd/malt-writer-wasm/browser/malt-writer-worker.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-worker.mjs
@@ -5,6 +5,7 @@ const RPC_FUNCTIONS = Object.freeze({
   load: "maltWriterLoadSessionV1",
   prepare: "maltWriterPrepareSessionV1",
   getPreparedResult: "maltWriterGetPreparedResultV1",
+  validateReceipt: "maltWriterValidateReceiptV1",
   acceptReceipt: "maltWriterAcceptSessionReceiptV1",
   discard: "maltWriterDiscardSessionCandidateV1",
   closeSession: "maltWriterCloseSessionV1",

--- a/cmd/malt-writer-wasm/browser/malt-writer-workers.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-workers.mjs
@@ -244,6 +244,10 @@ export class MaltWriterWorkers {
     ]);
   }
 
+  bootstrap(backend) {
+    return this.#request(backend, "bootstrap", []);
+  }
+
   load(backend, updateViewJSON) {
     return this.#request(backend, "load", [updateViewJSON]);
   }

--- a/cmd/malt-writer-wasm/browser/malt-writer-workers.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-workers.mjs
@@ -260,6 +260,13 @@ export class MaltWriterWorkers {
     return this.#request(backend, "getPreparedResult", [operationID]);
   }
 
+  validateReceipt(backend, writerResultJSON, materializationReceiptJSON) {
+    return this.#request(backend, "validateReceipt", [
+      writerResultJSON,
+      materializationReceiptJSON,
+    ]);
+  }
+
   acceptReceipt(backend, operationID, materializationReceiptJSON) {
     return this.#request(backend, "acceptReceipt", [
       operationID,

--- a/cmd/malt-writer-wasm/browser/malt-writer-workers.test.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-workers.test.mjs
@@ -132,6 +132,13 @@ test("request errors and session close keep the backend Worker alive", async () 
   const kzg = workers.get("kzg");
   const ipa = workers.get("ipa");
 
+  const bootstrap = writers.bootstrap("kzg");
+  const bootstrapRequest = await kzg.nextRequest();
+  assert.equal(bootstrapRequest.method, "bootstrap");
+  assert.deepEqual(bootstrapRequest.args, []);
+  kzg.respond(bootstrapRequest, { result: '{"profile":"malt.update-view/v1"}' });
+  assert.equal(await bootstrap, '{"profile":"malt.update-view/v1"}');
+
   const invalidLoad = writers.load("kzg", new Uint8Array([1]));
   const invalidRequest = await kzg.nextRequest();
   kzg.respond(invalidRequest, { error: "invalid update view" });

--- a/cmd/malt-writer-wasm/browser/malt-writer-workers.test.mjs
+++ b/cmd/malt-writer-wasm/browser/malt-writer-workers.test.mjs
@@ -139,6 +139,15 @@ test("request errors and session close keep the backend Worker alive", async () 
   kzg.respond(bootstrapRequest, { result: '{"profile":"malt.update-view/v1"}' });
   assert.equal(await bootstrap, '{"profile":"malt.update-view/v1"}');
 
+  const resultJSON = new Uint8Array([1, 2]);
+  const receiptJSON = new Uint8Array([3, 4]);
+  const validate = writers.validateReceipt("ipa", resultJSON, receiptJSON);
+  const validateRequest = await ipa.nextRequest();
+  assert.equal(validateRequest.method, "validateReceipt");
+  assert.deepEqual(validateRequest.args, [resultJSON, receiptJSON]);
+  ipa.respond(validateRequest, { result: "candidate-root" });
+  assert.equal(await validate, "candidate-root");
+
   const invalidLoad = writers.load("kzg", new Uint8Array([1]));
   const invalidRequest = await kzg.nextRequest();
   kzg.respond(invalidRequest, { error: "invalid update view" });

--- a/cmd/malt-writer-wasm/compute.go
+++ b/cmd/malt-writer-wasm/compute.go
@@ -290,7 +290,7 @@ func addViewRoots(retain map[string][]cid.Cid, view mutation.UpdateView) {
 }
 
 func encodeComputeResult(result clientwriter.ComputeResult) ([]byte, error) {
-	response, err := protocol.NewWriterComputeResult(result.Bundle, result.NextView, protocol.WriterComputeMetrics{
+	response, err := protocol.NewWriterComputeResult(result.Bundle, result.Materialization, result.NextView, protocol.WriterComputeMetrics{
 		ViewNormalizationNS:    result.Metrics.ViewNormalizationNS,
 		IntentNormalizationNS:  result.Metrics.IntentNormalizationNS,
 		DigestNS:               result.Metrics.DigestNS,

--- a/cmd/malt-writer-wasm/compute.go
+++ b/cmd/malt-writer-wasm/compute.go
@@ -122,7 +122,9 @@ func (s *sessionComputer) bootstrap(ctx context.Context) ([]byte, error) {
 		}
 		backend = candidate
 	}
-	view, base, err := session.BootstrapMap(ctx, backend)
+	view, base, err := session.BootstrapMap(ctx, backend, mutation.UpdateViewBounds{
+		MaxObjects: 4096, MaxTotalEntries: protocol.MaxClientRootEntries, MaxDepth: 256,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -336,6 +338,26 @@ func addViewRoots(retain map[string][]cid.Cid, view mutation.UpdateView) {
 		scope := "client-root/v1/" + object.ObjectID
 		retain[scope] = append(retain[scope], object.Root)
 	}
+}
+
+func validateMaterializationReceipt(resultJSON, receiptJSON []byte) (string, error) {
+	result, err := protocol.DecodeWriterComputeResult(resultJSON)
+	if err != nil {
+		return "", fmt.Errorf("decode prepared writer result: %w", err)
+	}
+	bundle, err := result.Bundle.Core()
+	if err != nil {
+		return "", fmt.Errorf("decode prepared writer bundle: %w", err)
+	}
+	receipt, err := protocol.DecodeMaterializationReceipt(receiptJSON, bundle)
+	if err != nil {
+		return "", fmt.Errorf("decode materialization receipt: %w", err)
+	}
+	coreReceipt, err := receipt.Core(bundle)
+	if err != nil {
+		return "", fmt.Errorf("validate materialization receipt: %w", err)
+	}
+	return coreReceipt.Candidate.String(), nil
 }
 
 func encodeComputeResult(result clientwriter.ComputeResult) ([]byte, error) {

--- a/cmd/malt-writer-wasm/compute.go
+++ b/cmd/malt-writer-wasm/compute.go
@@ -327,10 +327,20 @@ func (s *sessionComputer) retainMaterializedRoots() {
 	}
 	retain := make(map[string][]cid.Cid)
 	addViewRoots(retain, s.view)
+	if s.session != nil {
+		addWorkingRoots(retain, s.session.WorkingRoots())
+	}
 	for _, candidate := range s.prepared {
 		addViewRoots(retain, candidate.result.NextView)
 	}
 	s.store.RetainRoots(retain)
+}
+
+func addWorkingRoots(retain map[string][]cid.Cid, roots map[string]cid.Cid) {
+	for objectID, root := range roots {
+		scope := "client-root/v1/" + objectID
+		retain[scope] = append(retain[scope], root)
+	}
 }
 
 func addViewRoots(retain map[string][]cid.Cid, view mutation.UpdateView) {

--- a/cmd/malt-writer-wasm/compute.go
+++ b/cmd/malt-writer-wasm/compute.go
@@ -25,6 +25,7 @@ type sessionComputer struct {
 	session               *clientwriter.Session
 	store                 *materializermemory.Store
 	view                  mutation.UpdateView
+	bootstrapBase         *mutation.MapStateMaterialization
 	prepared              map[string]preparedCandidate
 	preparedResponseBytes int
 }
@@ -100,6 +101,47 @@ func (c *computer) compute(ctx context.Context, operationID string, updateViewJS
 	return encodeComputeResult(result)
 }
 
+func (s *sessionComputer) bootstrap(ctx context.Context) ([]byte, error) {
+	if s == nil || s.computer == nil {
+		return nil, fmt.Errorf("client writer session is not initialized")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	runtime, store, err := s.computer.newSessionRuntime()
+	if err != nil {
+		return nil, err
+	}
+	session, err := clientwriter.NewSession(runtime)
+	if err != nil {
+		return nil, err
+	}
+	backend := maltcid.BackendKind("")
+	for candidate := range s.computer.schemes {
+		if backend != "" {
+			return nil, fmt.Errorf("bootstrap writer must load exactly one backend")
+		}
+		backend = candidate
+	}
+	view, base, err := session.BootstrapMap(ctx, backend)
+	if err != nil {
+		return nil, err
+	}
+	if s.store != nil {
+		s.store.RetainRoots(nil)
+	}
+	s.session = session
+	s.store = store
+	s.view = view
+	s.bootstrapBase = &base
+	s.prepared = make(map[string]preparedCandidate)
+	s.preparedResponseBytes = 0
+	wire, err := protocol.NewUpdateView(view)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire)
+}
+
 func (s *sessionComputer) load(ctx context.Context, updateViewJSON []byte) (string, error) {
 	if s == nil || s.computer == nil {
 		return "", fmt.Errorf("client writer session is not initialized")
@@ -133,6 +175,7 @@ func (s *sessionComputer) load(ctx context.Context, updateViewJSON []byte) (stri
 	s.session = session
 	s.store = store
 	s.view = view
+	s.bootstrapBase = nil
 	s.prepared = make(map[string]preparedCandidate)
 	s.preparedResponseBytes = 0
 	return view.BaseRoot.String(), nil
@@ -165,6 +208,10 @@ func (s *sessionComputer) prepare(ctx context.Context, operationID string, seman
 	if err != nil {
 		s.retainMaterializedRoots()
 		return "", fmt.Errorf("prepare client writer session: %w", err)
+	}
+	if s.bootstrapBase != nil {
+		base := *s.bootstrapBase
+		result.Materialization.Base = &base
 	}
 	fullResponse, err := encodeComputeResult(result)
 	if err != nil {
@@ -211,6 +258,7 @@ func (s *sessionComputer) closeSession() {
 	s.session = nil
 	s.store = nil
 	s.view = mutation.UpdateView{}
+	s.bootstrapBase = nil
 	s.prepared = nil
 	s.preparedResponseBytes = 0
 }
@@ -245,6 +293,7 @@ func (s *sessionComputer) acceptReceipt(operationID string, receiptJSON []byte) 
 		return "", fmt.Errorf("retain client writer next view: %w", err)
 	}
 	s.view = next
+	s.bootstrapBase = nil
 	s.prepared = make(map[string]preparedCandidate)
 	s.preparedResponseBytes = 0
 	s.retainMaterializedRoots()

--- a/cmd/malt-writer-wasm/compute_test.go
+++ b/cmd/malt-writer-wasm/compute_test.go
@@ -332,6 +332,203 @@ func TestSessionComputerAdvancesOnlyAfterExactReceipt(t *testing.T) {
 	}
 }
 
+func TestSessionComputerRetainsLegacyWorkingRootsAcrossAcceptedOperations(t *testing.T) {
+	for _, backend := range []maltcid.BackendKind{maltcid.BackendKindKZG, maltcid.BackendKindIPA} {
+		t.Run(string(backend), func(t *testing.T) {
+			ctx := context.Background()
+			computer, err := newComputer(string(backend))
+			if err != nil {
+				t.Fatal(err)
+			}
+			legacyStore := materializermemory.New(true)
+			legacyMap, err := mappingradix.NewMapForVersion(
+				computer.schemes[backend], legacyStore, maltcid.LegacyMALTVersionID,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			childOld := payloadCID(t, string(backend)+"-legacy-child-old")
+			childNew := payloadCID(t, string(backend)+"-legacy-child-new")
+			childRoot, err := legacyMap.Commit(ctx, "client-root/v1/child", mapping.NewViewFrom(map[string]cid.Cid{
+				"value": childOld,
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			childEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
+				Coordinate: wasmMapCoordinate(t, "value"), Target: arcset.NewCASTarget(childOld),
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rootOld := payloadCID(t, string(backend)+"-legacy-root-old")
+			rootNew := payloadCID(t, string(backend)+"-legacy-root-new")
+			rootRoot, err := legacyMap.Commit(ctx, "client-root/v1/root", mapping.NewViewFrom(map[string]cid.Cid{
+				"child": childRoot,
+				"value": rootOld,
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			rootEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{
+				{Coordinate: wasmMapCoordinate(t, "child"), Target: arcset.NewMapTarget(childRoot)},
+				{Coordinate: wasmMapCoordinate(t, "value"), Target: arcset.NewCASTarget(rootOld)},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			view := mutation.UpdateView{
+				Profile: mutation.UpdateViewProfile, StateProfile: mutation.StatefulCompleteVectorsProfile,
+				BaseRoot: rootRoot, Bounds: mutation.UpdateViewBounds{MaxObjects: 4, MaxTotalEntries: 16, MaxDepth: 4},
+				Objects: []mutation.UpdateObject{
+					{ObjectID: "root", Root: rootRoot, Kind: arcset.KindMap, Entries: rootEntries},
+					{ObjectID: "child", Root: childRoot, Kind: arcset.KindMap, Entries: childEntries},
+				},
+			}
+			wireView, err := protocol.NewUpdateView(view)
+			if err != nil {
+				t.Fatal(err)
+			}
+			viewJSON, err := json.Marshal(wireView)
+			if err != nil {
+				t.Fatal(err)
+			}
+			session, err := newSessionComputer(computer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := session.load(ctx, viewJSON); err != nil {
+				t.Fatalf("load legacy view: %v", err)
+			}
+			workingRoots := session.session.WorkingRoots()
+			childWorkingRoot := workingRoots["child"]
+			if !childWorkingRoot.Defined() || maltcid.VersionIDOf(childWorkingRoot) != maltcid.MALTVersionID || childWorkingRoot.Equals(childRoot) {
+				t.Fatalf("child working root = %s, want migrated current root distinct from %s", childWorkingRoot, childRoot)
+			}
+			workingRoots["child"] = cid.Undef
+			if got := session.session.WorkingRoots()["child"]; !got.Equals(childWorkingRoot) {
+				t.Fatal("caller mutation changed the session working-root projection")
+			}
+
+			beforeRoot, afterRoot := arcset.NewCASTarget(rootOld), arcset.NewCASTarget(rootNew)
+			firstIntent := mutation.SemanticIntent{
+				Profile: mutation.SemanticIntentProfile, BaseRoot: rootRoot, TopOutputID: "root-output-1",
+				Transitions: []mutation.IntentTransition{{
+					ID: "root-output-1", ObjectID: "root", OldRoot: rootRoot,
+					Kind: arcset.KindMap, Backend: backend,
+					Changes: []mutation.IntentChange{{
+						Coordinate: wasmMapCoordinate(t, "value"), Before: &beforeRoot, After: &afterRoot,
+					}},
+				}},
+			}
+			firstCandidate := prepareAndAcceptSessionIntent(t, session, "legacy-root-first", firstIntent)
+			if got := wasmObjectRootByID(t, session.view, "child"); !got.Equals(childRoot) {
+				t.Fatalf("first next view child root = %s, want legacy root %s", got, childRoot)
+			}
+
+			beforeChild := arcset.NewMapTarget(childRoot)
+			beforeChildValue, afterChildValue := arcset.NewCASTarget(childOld), arcset.NewCASTarget(childNew)
+			secondIntent := mutation.SemanticIntent{
+				Profile: mutation.SemanticIntentProfile, BaseRoot: firstCandidate, TopOutputID: "root-output-2",
+				Transitions: []mutation.IntentTransition{
+					{
+						ID: "root-output-2", ObjectID: "root", OldRoot: firstCandidate,
+						Kind: arcset.KindMap, Backend: backend,
+						Changes: []mutation.IntentChange{{
+							Coordinate: wasmMapCoordinate(t, "child"), Before: &beforeChild,
+							OutputID: "child-output-2", OutputKind: arcset.TargetKindMap,
+						}},
+					},
+					{
+						ID: "child-output-2", ObjectID: "child", OldRoot: childRoot,
+						Kind: arcset.KindMap, Backend: backend, ExpectedUses: 1,
+						Changes: []mutation.IntentChange{{
+							Coordinate: wasmMapCoordinate(t, "value"), Before: &beforeChildValue, After: &afterChildValue,
+						}},
+					},
+				},
+			}
+			secondCandidate := prepareAndAcceptSessionIntent(t, session, "legacy-child-second", secondIntent)
+			if got := session.session.BaseRoot(); !got.Equals(secondCandidate) {
+				t.Fatalf("accepted base = %s, want %s", got, secondCandidate)
+			}
+		})
+	}
+}
+
+func wasmMapCoordinate(t *testing.T, key string) arcset.CanonicalCoordinate {
+	t.Helper()
+	coordinate, err := arcset.NewMapCoordinate(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return coordinate
+}
+
+func wasmObjectRootByID(t *testing.T, view mutation.UpdateView, objectID string) cid.Cid {
+	t.Helper()
+	for _, object := range view.Objects {
+		if object.ObjectID == objectID {
+			return object.Root
+		}
+	}
+	t.Fatalf("update view has no object %q", objectID)
+	return cid.Undef
+}
+
+func prepareAndAcceptSessionIntent(t *testing.T, session *sessionComputer, operationID string, intent mutation.SemanticIntent) cid.Cid {
+	t.Helper()
+	wireIntent, err := protocol.NewSemanticIntent(session.view, intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intentJSON, err := json.Marshal(wireIntent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.prepare(t.Context(), operationID, intentJSON); err != nil {
+		t.Fatalf("prepare %s: %v", operationID, err)
+	}
+	resultJSON, err := session.getPreparedResult(operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := protocol.DecodeWriterComputeResult(resultJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := result.Bundle.Core()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := bundle.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := protocol.NewMaterializationReceipt(mutation.MaterializationReceipt{
+		Profile: mutation.MaterializationReceiptProfile, OperationID: operationID,
+		BaseRoot: bundle.View.BaseRoot, Candidate: bundle.Candidate,
+		BundleDigest: digest, DurableBoundary: "unit-memory-v1",
+	}, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptJSON, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := session.acceptReceipt(operationID, receiptJSON)
+	if err != nil {
+		t.Fatalf("accept %s: %v", operationID, err)
+	}
+	if accepted != bundle.Candidate.String() {
+		t.Fatalf("accepted root = %s, want %s", accepted, bundle.Candidate)
+	}
+	return bundle.Candidate
+}
+
 func TestSessionComputerDiscardReclaimsCandidateSnapshots(t *testing.T) {
 	view, intent := computeFixture(t, maltcid.BackendKindIPA)
 	wireView, err := protocol.NewUpdateView(view)

--- a/cmd/malt-writer-wasm/compute_test.go
+++ b/cmd/malt-writer-wasm/compute_test.go
@@ -133,6 +133,84 @@ func TestComputerRejectsUnavailableBackendAndInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestSessionComputerBootstrapCarriesBaseMaterialization(t *testing.T) {
+	for _, backend := range []maltcid.BackendKind{maltcid.BackendKindKZG, maltcid.BackendKindIPA} {
+		t.Run(string(backend), func(t *testing.T) {
+			computer, err := newComputer(string(backend))
+			if err != nil {
+				t.Fatalf("newComputer: %v", err)
+			}
+			session, err := newSessionComputer(computer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			viewJSON, err := session.bootstrap(t.Context())
+			if err != nil {
+				t.Fatalf("bootstrap: %v", err)
+			}
+			wireView, err := protocol.DecodeUpdateView(viewJSON)
+			if err != nil {
+				t.Fatalf("DecodeUpdateView: %v", err)
+			}
+			view, err := wireView.Core()
+			if err != nil {
+				t.Fatal(err)
+			}
+			payload := payloadCID(t, "bootstrap-payload-"+string(backend))
+			after := arcset.NewCASTarget(payload)
+			coordinate, err := arcset.NewMapCoordinate("first")
+			if err != nil {
+				t.Fatal(err)
+			}
+			intent := mutation.SemanticIntent{
+				Profile: mutation.SemanticIntentProfile, BaseRoot: view.BaseRoot, TopOutputID: "root-output",
+				Transitions: []mutation.IntentTransition{{
+					ID: "root-output", ObjectID: "root", OldRoot: view.BaseRoot, Kind: arcset.KindMap, Backend: backend,
+					Changes: []mutation.IntentChange{{Coordinate: coordinate, After: &after}},
+				}},
+			}
+			wireIntent, err := protocol.NewSemanticIntent(view, intent)
+			if err != nil {
+				t.Fatalf("NewSemanticIntent: %v", err)
+			}
+			intentJSON, err := json.Marshal(wireIntent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			const operationID = "bootstrap-first-write"
+			if _, err := session.prepare(t.Context(), operationID, intentJSON); err != nil {
+				t.Fatalf("prepare: %v", err)
+			}
+			resultJSON, err := session.getPreparedResult(operationID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := protocol.DecodeWriterComputeResult(resultJSON)
+			if err != nil {
+				t.Fatalf("DecodeWriterComputeResult: %v", err)
+			}
+			if result.Materialization.Base == nil || result.Materialization.Base.Root != view.BaseRoot.String() {
+				t.Fatalf("base materialization = %+v", result.Materialization.Base)
+			}
+			bundle, err := result.Bundle.Core()
+			if err != nil {
+				t.Fatal(err)
+			}
+			materialization, err := result.Materialization.Core(bundle)
+			if err != nil {
+				t.Fatalf("materialization Core: %v", err)
+			}
+			rootBound, ok := computer.schemes[backend].(mappingradix.RootBoundVerifier)
+			if !ok {
+				t.Fatal("writer backend does not support root-bound validation")
+			}
+			if err := mappingradix.ValidateMaterialization(t.Context(), rootBound, view.BaseRoot, mapping.NewViewFromPaths(nil), materialization.Base.Entries); err != nil {
+				t.Fatalf("ValidateMaterialization: %v", err)
+			}
+		})
+	}
+}
+
 func TestSessionComputerAdvancesOnlyAfterExactReceipt(t *testing.T) {
 	view, intent := computeFixture(t, maltcid.BackendKindKZG)
 	wireView, err := protocol.NewUpdateView(view)

--- a/cmd/malt-writer-wasm/main.go
+++ b/cmd/malt-writer-wasm/main.go
@@ -29,6 +29,7 @@ func main() {
 	}
 	js.Global().Set("maltWriterLoadedBackend", backend)
 	registerStatelessCompute(writer, initErr)
+	registerReceiptValidation()
 	registerSessionFunctions(sessionWriter, initErr)
 	js.Global().Set("maltWriterReady", true)
 	select {}
@@ -62,6 +63,27 @@ func registerStatelessCompute(writer *computer, initErr error) {
 		})
 	})
 	js.Global().Set("maltComputeClientRootV1", computeFunction)
+}
+
+func registerReceiptValidation() {
+	validateFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		promise := js.Global().Get("Promise")
+		if len(args) != 2 {
+			return promise.Call("reject", "maltWriterValidateReceiptV1 expects writer-result and materialization-receipt JSON Uint8Arrays")
+		}
+		resultJSON, err := copyBoundedBytes(args[0], "writer-result JSON", protocol.MaxClientRootJSONBytes)
+		if err != nil {
+			return promise.Call("reject", err.Error())
+		}
+		receiptJSON, err := copyBoundedBytes(args[1], "materialization-receipt JSON", protocol.MaxClientRootJSONBytes)
+		if err != nil {
+			return promise.Call("reject", err.Error())
+		}
+		return promiseString(func() (string, error) {
+			return validateMaterializationReceipt(resultJSON, receiptJSON)
+		})
+	})
+	js.Global().Set("maltWriterValidateReceiptV1", validateFunction)
 }
 
 func registerSessionFunctions(writer *sessionComputer, initErr error) {

--- a/cmd/malt-writer-wasm/main.go
+++ b/cmd/malt-writer-wasm/main.go
@@ -66,6 +66,21 @@ func registerStatelessCompute(writer *computer, initErr error) {
 
 func registerSessionFunctions(writer *sessionComputer, initErr error) {
 	prepareGate := make(chan struct{}, 1)
+	bootstrapFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		promise := js.Global().Get("Promise")
+		if initErr != nil {
+			return promise.Call("reject", fmt.Sprintf("initialize MALT writer session: %v", initErr))
+		}
+		if len(args) != 0 {
+			return promise.Call("reject", "maltWriterBootstrapSessionV1 expects no arguments")
+		}
+		return promiseString(func() (string, error) {
+			result, err := writer.bootstrap(context.Background())
+			return string(result), err
+		})
+	})
+	js.Global().Set("maltWriterBootstrapSessionV1", bootstrapFunction)
+
 	loadFunction := js.FuncOf(func(_ js.Value, args []js.Value) any {
 		promise := js.Global().Get("Promise")
 		if initErr != nil {

--- a/cmd/malt-writer-wasm/session_consecutive_test.go
+++ b/cmd/malt-writer-wasm/session_consecutive_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/mutation"
+	"github.com/dewebprotocol/malt/protocol"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+)
+
+func TestSessionComputerAcceptsConsecutiveBootstrapWritesAcrossBackends(t *testing.T) {
+	for _, backend := range []maltcid.BackendKind{maltcid.BackendKindKZG, maltcid.BackendKindIPA} {
+		t.Run(string(backend), func(t *testing.T) {
+			computer, err := newComputer(string(backend))
+			if err != nil {
+				t.Fatal(err)
+			}
+			session, err := newSessionComputer(computer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := session.bootstrap(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+
+			prepareAndAccept := func(operationID, key string) {
+				t.Helper()
+				after := arcset.NewCASTarget(payloadCID(t, operationID+"-payload"))
+				intent := mutation.SemanticIntent{
+					Profile:     mutation.SemanticIntentProfile,
+					BaseRoot:    session.view.BaseRoot,
+					TopOutputID: operationID + "-output",
+					Transitions: []mutation.IntentTransition{{
+						ID: operationID + "-output", ObjectID: "root", OldRoot: session.view.BaseRoot,
+						Kind: arcset.KindMap, Backend: backend,
+						Changes: []mutation.IntentChange{{Coordinate: mustMapCoordinate(t, key), After: &after}},
+					}},
+				}
+				wireIntent, err := protocol.NewSemanticIntent(session.view, intent)
+				if err != nil {
+					t.Fatal(err)
+				}
+				intentJSON, err := json.Marshal(wireIntent)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := session.prepare(t.Context(), operationID, intentJSON); err != nil {
+					t.Fatalf("prepare %s: %v", operationID, err)
+				}
+				raw, err := session.getPreparedResult(operationID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				response, err := protocol.DecodeWriterComputeResult(raw)
+				if err != nil {
+					t.Fatal(err)
+				}
+				bundle, err := response.Bundle.Core()
+				if err != nil {
+					t.Fatal(err)
+				}
+				digest, err := bundle.Digest()
+				if err != nil {
+					t.Fatal(err)
+				}
+				receipt, err := protocol.NewMaterializationReceipt(mutation.MaterializationReceipt{
+					Profile:         mutation.MaterializationReceiptProfile,
+					OperationID:     operationID,
+					BaseRoot:        bundle.View.BaseRoot,
+					Candidate:       bundle.Candidate,
+					BundleDigest:    digest,
+					DurableBoundary: "unit-memory-v1",
+				}, bundle)
+				if err != nil {
+					t.Fatal(err)
+				}
+				receiptJSON, err := json.Marshal(receipt)
+				if err != nil {
+					t.Fatal(err)
+				}
+				validated, err := validateMaterializationReceipt(raw, receiptJSON)
+				if err != nil {
+					t.Fatalf("validate receipt %s: %v", operationID, err)
+				}
+				if validated != bundle.Candidate.String() {
+					t.Fatalf("validated root = %s, want %s", validated, bundle.Candidate)
+				}
+				badReceipt := receipt
+				badReceipt.Candidate = bundle.View.BaseRoot.String()
+				badReceiptJSON, err := json.Marshal(badReceipt)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := validateMaterializationReceipt(raw, badReceiptJSON); err == nil {
+					t.Fatal("stateless validation accepted a mismatched receipt")
+				}
+				accepted, err := session.acceptReceipt(operationID, receiptJSON)
+				if err != nil {
+					t.Fatalf("accept %s: %v", operationID, err)
+				}
+				if accepted != bundle.Candidate.String() {
+					t.Fatalf("accepted root = %s, want %s", accepted, bundle.Candidate)
+				}
+			}
+
+			prepareAndAccept("first-operation", "first")
+			prepareAndAccept("second-operation", "second")
+			if session.view.Objects[0].Entries.Len() != 2 {
+				t.Fatalf("retained root entries = %d, want 2", session.view.Objects[0].Entries.Len())
+			}
+		})
+	}
+}
+
+func mustMapCoordinate(t *testing.T, value string) arcset.CanonicalCoordinate {
+	t.Helper()
+	coordinate, err := arcset.NewMapCoordinate(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return coordinate
+}

--- a/conformance/corpus.go
+++ b/conformance/corpus.go
@@ -17,9 +17,11 @@ import (
 )
 
 const (
-	// ResolveReadV1 is the independent conformance-corpus version. It is not a
-	// replacement for the resolve/read wire profile identifiers.
-	ResolveReadV1 = "malt.resolve-read.conformance/v1"
+	// ResolveReadV1 and ResolveReadV2 are independent conformance-corpus
+	// versions, not replacements for the resolve/read wire profile identifiers.
+	ResolveReadV1      = "malt.resolve-read.conformance/v1"
+	ResolveReadV2      = "malt.resolve-read.conformance/v2"
+	ResolveReadCurrent = ResolveReadV2
 
 	OperationResolve = "resolve"
 	OperationRead    = "read"
@@ -29,11 +31,9 @@ const (
 	BackendIPA  = "ipa"
 )
 
-const corpusPath = "resolve-read/v1/vectors.json"
+//go:generate go run ../internal/conformancegen/cmd -out resolve-read/v2/vectors.json
 
-//go:generate go run ../internal/conformancegen/cmd -out resolve-read/v1/vectors.json
-
-//go:embed resolve-read/v1/*.json
+//go:embed resolve-read/v1/*.json resolve-read/v2/*.json
 var corpusFiles embed.FS
 
 // Corpus is the stable, ordered envelope shared by every verifier adapter.
@@ -83,9 +83,14 @@ type Verifier interface {
 	VerifyRead(context.Context, protocol.ReadVerification) error
 }
 
-// Load returns and validates the embedded v1 corpus.
+// Load returns and validates the current conformance corpus.
 func Load() (Corpus, error) {
-	data, err := Bytes()
+	return LoadVersion(ResolveReadCurrent)
+}
+
+// LoadVersion returns and validates one explicitly supported corpus version.
+func LoadVersion(version string) (Corpus, error) {
+	data, err := BytesVersion(version)
 	if err != nil {
 		return Corpus{}, err
 	}
@@ -93,37 +98,69 @@ func Load() (Corpus, error) {
 	if err := decodeStrict(data, &corpus); err != nil {
 		return Corpus{}, fmt.Errorf("decode conformance corpus: %w", err)
 	}
+	if corpus.SchemaVersion != version {
+		return Corpus{}, fmt.Errorf("conformance corpus version %q does not match requested %q", corpus.SchemaVersion, version)
+	}
 	if err := corpus.Validate(); err != nil {
 		return Corpus{}, err
 	}
 	return corpus, nil
 }
 
-// Bytes returns a detached copy of the canonical checked-in corpus bytes.
+// Bytes returns a detached copy of the current checked-in corpus bytes.
 func Bytes() ([]byte, error) {
-	data, err := corpusFiles.ReadFile(corpusPath)
+	return BytesVersion(ResolveReadCurrent)
+}
+
+// BytesVersion returns a detached copy of one supported checked-in corpus.
+func BytesVersion(version string) ([]byte, error) {
+	directory, err := corpusDirectory(version)
+	if err != nil {
+		return nil, err
+	}
+	data, err := corpusFiles.ReadFile(directory + "/vectors.json")
 	if err != nil {
 		return nil, fmt.Errorf("read embedded conformance corpus: %w", err)
 	}
 	return slices.Clone(data), nil
 }
 
-// Schema returns a detached copy of one checked-in conformance schema.
+// Schema returns a detached copy of one current conformance schema.
 func Schema(name string) ([]byte, error) {
+	return SchemaVersion(ResolveReadCurrent, name)
+}
+
+// SchemaVersion returns a detached schema for one supported corpus version.
+func SchemaVersion(version, name string) ([]byte, error) {
 	if name != "corpus.schema.json" && name != "vector.schema.json" {
 		return nil, fmt.Errorf("unknown conformance schema %q", name)
 	}
-	data, err := corpusFiles.ReadFile("resolve-read/v1/" + name)
+	directory, err := corpusDirectory(version)
+	if err != nil {
+		return nil, err
+	}
+	data, err := corpusFiles.ReadFile(directory + "/" + name)
 	if err != nil {
 		return nil, fmt.Errorf("read conformance schema %q: %w", name, err)
 	}
 	return slices.Clone(data), nil
 }
 
+func corpusDirectory(version string) (string, error) {
+	switch version {
+	case ResolveReadV1:
+		return "resolve-read/v1", nil
+	case ResolveReadV2:
+		return "resolve-read/v2", nil
+	default:
+		return "", fmt.Errorf("unsupported conformance schema version %q", version)
+	}
+}
+
 // Validate checks corpus-level invariants that JSON Schema alone cannot make
 // convenient for small consumers, including stable ID uniqueness.
 func (c Corpus) Validate() error {
-	if c.SchemaVersion != ResolveReadV1 {
+	if c.SchemaVersion != ResolveReadV1 && c.SchemaVersion != ResolveReadV2 {
 		return fmt.Errorf("unsupported conformance schema version %q", c.SchemaVersion)
 	}
 	if len(c.Vectors) == 0 {

--- a/conformance/corpus_test.go
+++ b/conformance/corpus_test.go
@@ -3,6 +3,7 @@ package conformance_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -15,27 +16,31 @@ import (
 	sdkverifier "github.com/dewebprotocol/malt/sdk/verifier"
 )
 
-func TestResolveReadV1Corpus(t *testing.T) {
-	corpus, err := conformance.Load()
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	verifier, err := sdkverifier.NewDefault()
-	if err != nil {
-		t.Fatalf("NewDefault: %v", err)
-	}
-	for _, vector := range corpus.Vectors {
-		vector := vector
-		t.Run(vector.ID, func(t *testing.T) {
-			accepted := conformance.Accepted(context.Background(), verifier, vector)
-			if accepted != vector.Expected.Valid {
-				t.Fatalf("accepted = %t, want %t", accepted, vector.Expected.Valid)
+func TestResolveReadCorpora(t *testing.T) {
+	for _, version := range []string{conformance.ResolveReadV1, conformance.ResolveReadV2} {
+		t.Run(version, func(t *testing.T) {
+			corpus, err := conformance.LoadVersion(version)
+			if err != nil {
+				t.Fatalf("LoadVersion: %v", err)
+			}
+			verifier, err := sdkverifier.NewDefault()
+			if err != nil {
+				t.Fatalf("NewDefault: %v", err)
+			}
+			for _, vector := range corpus.Vectors {
+				vector := vector
+				t.Run(vector.ID, func(t *testing.T) {
+					accepted := conformance.Accepted(context.Background(), verifier, vector)
+					if accepted != vector.Expected.Valid {
+						t.Fatalf("accepted = %t, want %t", accepted, vector.Expected.Valid)
+					}
+				})
 			}
 		})
 	}
 }
 
-func TestResolveReadV1CorpusIsGenerated(t *testing.T) {
+func TestResolveReadV2CorpusIsGenerated(t *testing.T) {
 	want, err := conformance.Bytes()
 	if err != nil {
 		t.Fatalf("Bytes: %v", err)
@@ -49,19 +54,31 @@ func TestResolveReadV1CorpusIsGenerated(t *testing.T) {
 	}
 }
 
-func TestResolveReadV1SchemasAreJSON(t *testing.T) {
-	for _, name := range []string{"corpus.schema.json", "vector.schema.json"} {
-		data, err := conformance.Schema(name)
-		if err != nil {
-			t.Fatalf("Schema(%q): %v", name, err)
-		}
-		if !json.Valid(data) {
-			t.Fatalf("Schema(%q) is not valid JSON", name)
+func TestResolveReadSchemasAreJSON(t *testing.T) {
+	for _, version := range []string{conformance.ResolveReadV1, conformance.ResolveReadV2} {
+		for _, name := range []string{"corpus.schema.json", "vector.schema.json"} {
+			data, err := conformance.SchemaVersion(version, name)
+			if err != nil {
+				t.Fatalf("SchemaVersion(%q, %q): %v", version, name, err)
+			}
+			if !json.Valid(data) {
+				t.Fatalf("SchemaVersion(%q, %q) is not valid JSON", version, name)
+			}
 		}
 	}
 }
 
-func TestResolveReadV1CoverageMatrix(t *testing.T) {
+func TestResolveReadV1CorpusDigestIsImmutable(t *testing.T) {
+	data, err := conformance.BytesVersion(conformance.ResolveReadV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(data)); got != "8fadfc423acdcb78b0c0db520c7320bb72f995e6e5e0dd9da63a41a6c6603e36" {
+		t.Fatalf("v1 corpus digest changed: %s", got)
+	}
+}
+
+func TestResolveReadV2CoverageMatrix(t *testing.T) {
 	corpus, err := conformance.Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -106,7 +123,7 @@ func TestResolveReadV1CoverageMatrix(t *testing.T) {
 	}
 }
 
-func TestResolveReadV1CryptographicTamperInputsRemainDecodable(t *testing.T) {
+func TestResolveReadV2CryptographicTamperInputsRemainDecodable(t *testing.T) {
 	corpus, err := conformance.Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)

--- a/conformance/resolve-read/v2/corpus.schema.json
+++ b/conformance/resolve-read/v2/corpus.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dewebprotocol.github.io/malt/conformance/resolve-read/v2/corpus.schema.json",
+  "title": "MALT Resolve/Read Conformance Corpus v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "vectors"],
+  "properties": {
+    "schema_version": {
+      "const": "malt.resolve-read.conformance/v2"
+    },
+    "vectors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "vector.schema.json"
+      }
+    }
+  }
+}

--- a/conformance/resolve-read/v2/vector.schema.json
+++ b/conformance/resolve-read/v2/vector.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dewebprotocol.github.io/malt/conformance/resolve-read/v2/vector.schema.json",
+  "title": "MALT Resolve/Read Conformance Vector v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "operation",
+    "backend",
+    "category",
+    "verification",
+    "expected"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+    },
+    "operation": {
+      "enum": ["resolve", "read"]
+    },
+    "backend": {
+      "enum": ["none", "kzg", "ipa"]
+    },
+    "category": {
+      "type": "string",
+      "minLength": 1
+    },
+    "verification": {
+      "type": "object"
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["valid"],
+      "properties": {
+        "valid": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/conformance/resolve-read/v2/vectors.json
+++ b/conformance/resolve-read/v2/vectors.json
@@ -1,0 +1,2585 @@
+{
+  "schema_version": "malt.resolve-read.conformance/v2",
+  "vectors": [
+    {
+      "id": "read.ipa.cross-backend-kzg-evidence.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "cross_backend",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJxTHVuK1lVbE1RMEo1RHIzYVMwVVF6cUc1bVdhY0xNdVdnRHo2dWxIY3VHekJWTlROSjI3UUJFZ2tUcVBpeEtpRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.cross-kind.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "cross_kind",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "query": {
+            "kind": "list_index",
+            "index": 0
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "list:0",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FCQ2tVSnZYSjJEQXZhNGdpVmpQbUVwMU55cVpPWU1JN0EyWWVWL1RTM1FHVmZCYUlXUGFabzMwb0x4NU9QTXA4VnFwYzFVVU13eFRHNDZma2RmQ0M1WnE4dE4vckRFZlRsS0tVMUdFUjFMbWY0R0tNQ21WS3hCZEJ5aWlIQkQrSEF2OXk0ekdHdmNnVmdFNnFsemdIcGk0V0hXTVBFZWxQNDI1RGYyUjlzbUZQNU9lTXhybi81Zjc2N2VQRFU4bWJLYXR2WmsrV1ZOeDZmSXdzSXJWbUFzR2pxUTU5Z0szc0FBUlovQUk3NkVNTWkxQklKS01IY3l4ZGhFUlVUVWdEQUU5Wk54NXdaU3UrWkJBZVhaQzJ4K0RVckNzVHBCV053VHV4ZU5PS2FKV3RkZGU0dURUUFQ3OVRWQ2xVVUx5cldDeFd2UmdJSS9FaTQyWXo0NldwdHlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdm5IMFpuQUk1blRHNTZsaFVlRnBOdzVVQUlEdTl1ZFlBSFAyUUpyeG1KaWticUpaRllZMldKRjg4cm9vNFBqQTVyb1k1eTM2azE2cFd6eGM0UTJIK3VsTEJwZmpEeVZGQ2NvM2UwcnhNQXZjNkxyZndHUUlRcWlpNlV5UlNlajhsVC9LeXJiUlBwaVNzR1FRUU9NN3NHUGZYdCtjUjRPVUlrVmxiRjNJYXpXWkxvclhXMU14U2dJZlA5dk5SMDFKdTMvdGQzTU5raEFha0I3dnVKSmk0Z2tHVkF5NjJBMUNoL1dFVU5STFFYR3VzNnliRU1mYmdUejdaRUVtMzFDTzRBek9mZXlmaWpXQUVvcGpqbHhuTjR6UkcvOXJZaHZoZVJ0Y0lTUXFjNUFVZUNua2t5OXNhYzV6eFhqZkwwam9STzZINmRwZXQ2L1Iwc3FmUHhyVmJ4c0FBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.cross-root.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "cross_root",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbofqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FCQ2tVSnZYSjJEQXZhNGdpVmpQbUVwMU55cVpPWU1JN0EyWWVWL1RTM1FHVmZCYUlXUGFabzMwb0x4NU9QTXA4VnFwYzFVVU13eFRHNDZma2RmQ0M1WnE4dE4vckRFZlRsS0tVMUdFUjFMbWY0R0tNQ21WS3hCZEJ5aWlIQkQrSEF2OXk0ekdHdmNnVmdFNnFsemdIcGk0V0hXTVBFZWxQNDI1RGYyUjlzbUZQNU9lTXhybi81Zjc2N2VQRFU4bWJLYXR2WmsrV1ZOeDZmSXdzSXJWbUFzR2pxUTU5Z0szc0FBUlovQUk3NkVNTWkxQklKS01IY3l4ZGhFUlVUVWdEQUU5Wk54NXdaU3UrWkJBZVhaQzJ4K0RVckNzVHBCV053VHV4ZU5PS2FKV3RkZGU0dURUUFQ3OVRWQ2xVVUx5cldDeFd2UmdJSS9FaTQyWXo0NldwdHlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdm5IMFpuQUk1blRHNTZsaFVlRnBOdzVVQUlEdTl1ZFlBSFAyUUpyeG1KaWticUpaRllZMldKRjg4cm9vNFBqQTVyb1k1eTM2azE2cFd6eGM0UTJIK3VsTEJwZmpEeVZGQ2NvM2UwcnhNQXZjNkxyZndHUUlRcWlpNlV5UlNlajhsVC9LeXJiUlBwaVNzR1FRUU9NN3NHUGZYdCtjUjRPVUlrVmxiRjNJYXpXWkxvclhXMU14U2dJZlA5dk5SMDFKdTMvdGQzTU5raEFha0I3dnVKSmk0Z2tHVkF5NjJBMUNoL1dFVU5STFFYR3VzNnliRU1mYmdUejdaRUVtMzFDTzRBek9mZXlmaWpXQUVvcGpqbHhuTjR6UkcvOXJZaHZoZVJ0Y0lTUXFjNUFVZUNua2t5OXNhYzV6eFhqZkwwam9STzZINmRwZXQ2L1Iwc3FmUHhyVmJ4c0FBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.list-index.accept",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "list_index",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbojqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy",
+          "query": {
+            "kind": "list_index",
+            "index": 1
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga",
+          "prooflist": {
+            "root": {
+              "/": "bagbojqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
+            },
+            "query": "list:1",
+            "steps": [
+              {
+                "kind": "list_index",
+                "from": {
+                  "/": "bagbojqabaaqe7u5tdtdeumbreax445prztljqjzkvfe23fsoa7pkr4acplcgchy"
+                },
+                "query": "list:1",
+                "coordinate": "1",
+                "index": 1,
+                "length": 3,
+                "target": {
+                  "/": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6IkFBQUFDQmVoeGFVdVdMbmRpQ1lXYXBMRTdWbDd5eHBNenpUV3diVy81N0t3TCtTTVlwY3d6SmswaVRYakYvSUpmcmdqOExnRnZKdE1uMXlhQXZEN2p3MXFUQVVJa1dUZ2NaY3FJYjZYbzZXckw1NE80eXhTV3J3YndYSkM2dGRrYnZQZ3MxN1NEU0hXZytOaG94SHFWNy9ZeXpZRXFLMkdyZUV5VTdwOVJmTUhMcENiVXlCMGdxOFZvbWxuUUswclBZUDdMMElVQmF1OVhQQWh2UlFWb25zV2tsdzl6dDZVTmc3VmxNTWtEVGVoNVFLdVhxQUxZYkFOakZ0cURuNjY3RmwyM1N3Zkl0Q1gySG5CcjJ1R2dQK1BHcVJISm5zcXBxOEtJLy82OGdpOFJZbTZhckVLd1VyUHNiQUk1N1k1RWdBVWFabTBIckYyeGE1V0x3U2Vic1ROci9kdDExZjhhdnN5U2c4QTY0NmhDWTVza2JIVmM4MDY0WTdzeFF6emw0V1JJbXVmOE4rNjZXQXFaWlRmdnJxUGMzYnBTdUxiMDhGZGhYWmVpd1lhcU1jNkZNaTJJMVNFUXV6c1F2RVZQVWc2eUg1Ui82bDRuejdScWhtNlRQZ3g0MVk5cFBWb3NWTzI1TExmZVlDckh6ODZ2dTBIbGwvM2lwU3ZuSVdhckhmMFIyMXdkUEFqMlNZRFltYlpseHY2dmw0dGJuQS9zNVYyVjlTMzUxcUx4S1dIQUN3cll4NUJpaFp2NXp4d1RGaXRobXE1VzlUTTc0WXNsT2FDdFJadGpTd1ZRbWdldGpWU1RnZU5rclNiTmxCTEppODE1MHYzOU93TjhDSnphN2NXTGw0Y0pURmpMeFROYWZBeEZXY1o3UXZQZzNNL0dVdjY2d2VlTVBzMGNSN0xIcHhUa01XYkVhY3RLMERmRVdkYzVNZ2ZOUFIzUlNiRUZ4eVpVcmZvZ0JJQUFBQUEiLCJzdGVwcyI6W3sidGFyZ2V0IjoiQVZVU0lDZWtiLzNFZ21IazNnMzd6YjdlRHc2VTRLNDRZTUZJZnh4Z2RibTJXZ013IiwicHJvb2YiOiJBQUFBQ0FGaWNzWWRUejd5SzdxbUZLdEl0K2JsbUQvN0pUMnBieFpVWlBkbmluMEFhYXpKa0MwdXZOUlhIQjg2a0xkVmNsSjFTN0JWcGVLckNYeDcvT1N6cmZ0R3dNMkpQMDI4d3VKZE5TdEJHZVAraFlQOTM1UVpRNUViVlBNQUtOYWEyd3NhS2JSU0c3SFRSZjVCN1UzWVhaR0pJYmZZc3pSK3ZNcW5hMkdyNUpXSEVGQ2ZjUEdMOUk3ZHFBL01NcTBNd3BYVXpOeW5BbXhYdlNZZHNtZEZ5d0U0bnBqVWUxdWdwL0ErTUJ6aG9kT1pFZXhQclVVeEFVYm14NDBxaGx0Y2x3djBMN0pUdUE5Vy9lLzFFbXJnSGd1aFU2V1pPb2JrSnprUmluUGc4cGlZVkljeXpyV0ZsNThEdHRJV3NoTlRSUDRLbHlCTFBUaHFLTUdKRGJPU1d1OXQxMWY4YXZzeVNnOEE2NDZoQ1k1c2tiSFZjODA2NFk3c3hRenpsNFdSSWtJREFQMXZXSFo1N0JFaGZ4eUQvS1VUaGhVSURPRG4wbC9pcVhTT0tPZWpERnV3NGhvVi95QmRzSGFNK3hmSmVublZkamNqVjIvNGZZR05nUE9MR3pSSGxpcUVnZGlWK1RDSzVmemlGRW1kRWFIeHVtUGNXVVZRMEJic2hzM09jbk5WNFJERXhTM2FndG1OK05tTWw5MHZ5Qm5PNUYyY1ExVWtDUXVLejFyWFEwQmE5bmlBcDZNdkhaQjUxTDhKaEF0RWRTMGZWNWx5WENLLzJVVmVZR01GRVFVN3ZzcEVUV0xCRE9wWmRGMTNoNEgzZWlMTTFkSHBuU0xPa0hLNDZDVks3SlRiWVg1WFhzNmFRZTg1VXV2TXd0aVBuaW5PZ0ZXWjVVYmxjVFJ3OXgzZlRBMDZ5endaY3Z2cTFtK1VTV3YvRzhONnhhblBqNFFIVkxDS1JBQUFBQUFDIiwic2xvdCI6Mn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.ipa.list-range-bounded.accept",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "list_range",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "query": {
+            "kind": "list_range",
+            "start": 2,
+            "end": 18
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "range_segments": [
+            "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+            },
+            "query": "range:2:18",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "query": "range:2:18",
+                "coordinate": "range:2:18",
+                "start": 2,
+                "end": 18,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga"
+                  },
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6IkFBQUFDRk50RTJKWEErRXlGNnZzRXhEYUVFMldPT0VudURLc1JTbXNkaTBaRUowSEZKM0dFUENKYzlUVXBHVkIxT0k5NHRNVS85b3ZicW4rSktiYWpUL1ZUaVFRa2xWNnRGM1cyS1l6ZGhTVmpuY2VLdERzRkhESzBsQzduV2xTekJ5MUkwRlJRdTZsd1htT3hqc2VVckVpSDhMMVVJYjVVMUFYYVRoUCs0c3VaWW9hUzIwVW4rdEF4a0lrNCsxWEFGcitLaEhudnZva2FZY3BUN2RaSlpUVTNjaHNURjhjVHhSc2daMmxHWWRmc1ozWVF6OGtZT1NIUjZ4QXhmbDR3ZUlXd21pZEVKMEFTRWlJbFNkbVR5NWt3c205WTFqWVBsemx6M3lISDdzWjdwOU1URkxBc2xjRmVQVHNYcnp2eS85WjBBME9uUTZnSkE1SkFBeDVEdWFIc21GaFpERVZvSndhVk1hb2tqRzZlWmZwOXA0Vk80OThScDQrU05pQ0lRMG5reDBxbWlTR1EwMENtMzhreHVIOVU1VVh5ODYwQ3dQcmxmeGhOOExiOStmY1ZEY3VRNDZUK25oeDFLS01hWEloZklRakNlU05ramRXbkFFOWMyYW9QZXc1cDZUOWV3eTdwNEJKdU1XT29hVzNLZ1VpVWVsVHgwdzFHNVhLLzhFTFNVbktGcURjU0o5NDdsamk1NC9CbC92UkQyQWNXaTZEbjFvYmtxQW1YOGdtUUszVFg3dEtYd08rYmkwYmo3UWVsY0hWcjg5TVNkZGtsT3V3N3A1LzI4NHZ6Snd4Nmp2akxENHM1NzEyRkRGZzFRRHJjOG1RblB2eXJtVkYvNmRIUENNQ2NjL1ZMY0FSbklBd2Vid2t2UWFmYlRGT3VrOXVQcUNEeWpVYjd5YVVBTm52eVpodTVaQmF4dXZvQjhQSEt2YisrTEEyUGhVMk0rOXl5clRxMUJ3QUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNklrRkJRVUZEUms1MFJUSktXRUVyUlhsR05uWnpSWGhFWVVWRk1sZFBUMFZ1ZFVSTGMxSlRiWE5rYVRCYVJVb3dTRVpLTTBkRlVFTktZemxVVlhCSFZrSXhUMGs1TkhSTlZTODViM1ppY1c0clNrdGlZV3BVTDFaVWFWRlJhMnhXTm5SR00xY3lTMWw2WkdoVFZtcHVZMlZMZEVSelJraEVTekJzUXpkdVYyeFRla0o1TVVrd1JsSlJkVFpzZDFodFQzaHFjMlZWY2tWcFNEaE1NVlZKWWpWVk1VRllZVlJvVUNzMGMzVmFXVzloVXpJd1ZXNHJkRUY0YTBsck5Dc3hXRUZHY2l0TGFFaHVkblp2YTJGWlkzQlVOMlJhU2xwVVZUTmphSE5VUmpoalZIaFNjMmRhTW14SFdXUm1jMW96V1ZGNk9HdFpUMU5JVWpaNFFYaG1iRFIzWlVsWGQyMXBaRVZLTUVGVFJXbEpiRk5rYlZSNU5XdDNjMjA1V1RGcVdWQnNlbXg2TTNsSVNEZHpXamR3T1UxVVJreEJjMnhqUm1WUVZITlljbnAyZVM4NVdqQkJNRTl1VVRablNrRTFTa0ZCZURWRWRXRkljMjFHYUZwRVJWWnZTbmRoVmsxaGIydHFSelpsV21ad09YQTBWazgwT1RoU2NEUXJVMDVwUTBsUk1HNXJlREJ4YldsVFIxRXdNRU50TXpocmVIVklPVlUxVlZoNU9EWXdRM2RRY214bWVHaE9PRXhpT1N0bVkxWkVZM1ZSTkRaVUsyNW9lREZMUzAxaFdFbG9aa2xSYWtObFUwNXJhbVJYYmtGRk9XTXlZVzlRWlhjMWNEWlVPV1YzZVRkd05FSktkVTFYVDI5aFZ6TkxaMVZwVldWc1ZIZ3dkekZITlZoTEx6aEZURk5WYmt0R2NVUmpVMG81TkRkc2FtazFOQzlDYkM5MlVrUXlRV05YYVRaRWJqRnZZbXR4UVcxWU9HZHRVVXN6VkZnM2RFdFlkMDhyWW1rd1ltbzNVV1ZzWTBoV2NqZzVUVk5rWkd0c1QzVjNOM0ExTHpJNE5IWjZTbmQ0Tm1wMmFreEVOSE0xTnpFeVJrUkdaekZSUkhKak9HMVJibEIyZVhKdFZrWXZObVJJVUVOTlEyTmpMMVpNWTBGU2JrbEJkMlZpZDJ0MlVXRm1ZbFJHVDNWck9YVlFjVU5FZVdwVllqZDVZVlZCVG01MmVWcG9kVFZhUW1GNGRYWnZRamhRU0V0Mllpc3JURUV5VUdoVk1rMHJPWGw1Y2xSeE1VSjNRVUZCUVVFaUxDSnRaWFJoWkdGMFlWOTBZWEpuWlhRaU9pSkJWbFZCVGtjeGFHSklVVFppUjJ4NlpFUndkV0l5VW14TVZ6RnNaRWRGTmtGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFYZEJRVUZCUVVGQlFVRlZRVUZCUVVGQlFVRkJRV2M5SWl3aWMzUmxjSE1pT2x0N0luUmhjbWRsZENJNklrRldWVk5KU2pCa1ZsUTRhblJ6UlRac05XVnhPVmN3Y1d0dlFYSnpSa1JMWWpNdmNXNTFObk0wYm5Kd2EzVTRkeUlzSW5CeWIyOW1Jam9pUVVGQlFVTkZUbTVQV1haTGFra3JjMEZoVjFFNWRUZG9VVzR5WlRKRGJEbGtOVTFxVlU5blEzWnNiRkZKZUVKTlVtTjBjRXB4YW5FelEyWjBVbHBSU0UxMldYUnlTSGhSU1d3MVUwZDRaWFpzTjNSMVVYZEtUa0o1WTNWV1pXcHhVMVl5VWlzNGFtMHhaR0ZXVFZkTlF6QnpRVkpoTm1wTmEwbE5LekZWTjJocmIxZGlWRVl5TmpWQmRGWjFkbFF2V21aUFJERmxXRWxCV1RsdGJFOW9WakozUzB4T2FVSjZWekpUVlVGMmFXZFJWVU5sT1ZoNlFYUTFMMWxsWjJGV1dqVnNTSEZ4Um5reFMwRkpWVVpYSzJSbGJIRXpWM2s1TW1sSlEwaDZjbUp6VDFrelNqRTVRMjh5VEc1VlZpOUJWWFZUVW5KRmNrOUZRamRXVjBSd1NFbFNiRGc0VW1ZMVlYRTNjMWd5WTBkTmNrSnFNbU5JZFhvNGRrRXhhM1ZWWVZwNkwzUnpOVTVpWTNreWRtbHhibUl3YmsxS0wydDVhakppVURab2RUbFdkVk5qV1VGMVNFSm1aRmMwTmpKbGIxUlZSelZKVkhCa2FXeG9Xa1JGVm05S2QyRldUV0Z2YTJwSE5tVmFabkE1Y0RSV1R6UTVPRkp3TkN0VFRtbERTVkV3Ym10NmJVRTBWMHB3WjA4cmEyOWhWQzh3UVRneU1WazBRWHAxVEc5eGExcDVWMmxPTlVabWJHMVhhRUZVWVhOdVVUWTRjako1VFZSUVNYWXJlbGwxZERaSFNFTjBabWxxTW1OYWIxUktVbGd2UW1KNVJsbDJjM053VmxkT1pVZDVPRU5FZVhWb2JFRm1NVFJJVGxWWk4xZHZiV0p6UkV4SmRITTJjSG8xWlZaeVJsSXpTMHB3YmtOaVNqRXhhR3MxVVZadFZtVjRUMHhYT1RCblVGQjVZMDlDT1ZselJYRnpaVGQwYTJ0TFRsWTRMM2xtUm5rM2QyZGxZVk5VZDI1R1VGQlVXR05JYm1KbVluQjViVVJ5YkZnMlprWm9TeTkzY0ZoQlJHVXlja2MwZVV0SGVuRlpMMkkyWkhaQlpXUndVVXBuU0daVlJrcEZaR3hTTmxCUVozRTNiREFyTlVVNFJWaDVjbGxoVlUxRlpFdE5PVlpKVXpOdWVWWXpaMmhMWjFkWU5sQkdaMkpwUWtwSGRXSk9VVlJMT0RjMVluRjFTVGc0TmxRdk5IRnRkMDVEV1RSSmFUSjJlazlOTW05U05GVlFaek5SUW1kQlFVRkJRaUlzSW5Oc2IzUWlPakY5WFgwPSJ9LHsiaW5kZXgiOjEsInByb29mIjoiZXlKdFpYUmhaR0YwWVY5d2NtOXZaaUk2SWtGQlFVRkRSazUwUlRKS1dFRXJSWGxHTm5aelJYaEVZVVZGTWxkUFQwVnVkVVJMYzFKVGJYTmthVEJhUlVvd1NFWktNMGRGVUVOS1l6bFVWWEJIVmtJeFQwazVOSFJOVlM4NWIzWmljVzRyU2t0aVlXcFVMMVpVYVZGUmEyeFdOblJHTTFjeVMxbDZaR2hUVm1wdVkyVkxkRVJ6UmtoRVN6QnNRemR1VjJ4VGVrSjVNVWt3UmxKUmRUWnNkMWh0VDNocWMyVlZja1ZwU0RoTU1WVkpZalZWTVVGWVlWUm9VQ3MwYzNWYVdXOWhVekl3Vlc0cmRFRjRhMGxyTkNzeFdFRkdjaXRMYUVodWRuWnZhMkZaWTNCVU4yUmFTbHBVVlROamFITlVSamhqVkhoU2MyZGFNbXhIV1dSbWMxb3pXVkY2T0d0WlQxTklValo0UVhobWJEUjNaVWxYZDIxcFpFVktNRUZUUldsSmJGTmtiVlI1Tld0M2MyMDVXVEZxV1ZCc2VteDZNM2xJU0RkeldqZHdPVTFVUmt4QmMyeGpSbVZRVkhOWWNucDJlUzg1V2pCQk1FOXVVVFpuU2tFMVNrRkJlRFZFZFdGSWMyMUdhRnBFUlZadlNuZGhWazFoYjJ0cVJ6WmxXbVp3T1hBMFZrODBPVGhTY0RRclUwNXBRMGxSTUc1cmVEQnhiV2xUUjFFd01FTnRNemhyZUhWSU9WVTFWVmg1T0RZd1EzZFFjbXhtZUdoT09FeGlPU3RtWTFaRVkzVlJORFpVSzI1b2VERkxTMDFoV0Vsb1prbFJha05sVTA1cmFtUlhia0ZGT1dNeVlXOVFaWGMxY0RaVU9XVjNlVGR3TkVKS2RVMVhUMjloVnpOTFoxVnBWV1ZzVkhnd2R6RkhOVmhMTHpoRlRGTlZia3RHY1VSalUwbzVORGRzYW1rMU5DOUNiQzkyVWtReVFXTlhhVFpFYmpGdlltdHhRVzFZT0dkdFVVc3pWRmczZEV0WWQwOHJZbWt3WW1vM1VXVnNZMGhXY2pnNVRWTmtaR3RzVDNWM04zQTFMekk0TkhaNlNuZDRObXAyYWt4RU5ITTFOekV5UmtSR1p6RlJSSEpqT0cxUmJsQjJlWEp0VmtZdk5tUklVRU5OUTJOakwxWk1ZMEZTYmtsQmQyVmlkMnQyVVdGbVlsUkdUM1ZyT1hWUWNVTkVlV3BWWWpkNVlWVkJUbTUyZVZwb2RUVmFRbUY0ZFhadlFqaFFTRXQyWWlzclRFRXlVR2hWTWswck9YbDVjbFJ4TVVKM1FVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2lRVUZCUVVORWNYbE9jMmxITldNeVIydG9SVWxJZEU0elQydFFZMmxQUlZGcVJWRjVWbmR4VEcxTVJscDJVRlYwUWxaUFlVOHZiV1pFZWtaNGRtOWFZM2cyVVU5YWFIZDVZVmg1VUdkVk5VWkZiekk1Y1hsR2RXeENiMEp3ZFRWSFRYZHlZbVJMVkVVMFNYYzJUbFV5VW01emRrcDNNV05hUkRkYVRHUjNOazB4VVV0blVHbzRkM0l2U0RKMGFEVklaakpRWVZoU2VESnJUVXRDYldjM2MyMDJiVkZDUm0xblVtdFlOVVowWWtkTmFFZG9UMlpVVm13MWVVVXdRVkU1WXk4eFQzUnZZVnAzSzFwWWVVOVphbXhxVTJNNFlrdHBWakJOV1ZobFVIUnFMekZzUVM5WVdpOVRUM1EyTlV0dEwyazNjbXRMVTFoaE1pczFUVXN2V2twNU9VeGhhR1VyVm1SV09HUmtaWEJJUkcxdllXdE5WeXN2UzA4MlIxSktWWEJNVm5kWWRXRXJWak14Y2tGdVFVTXhOVkJaVG01eFJtaDNOemRsVXpsWWRtMHJXSFI2THpaaFNVMU1kMlJZT1hjeVNIUlhUM1VyVGtab1drUkZWbTlLZDJGV1RXRnZhMnBITm1WYVpuQTVjRFJXVHpRNU9GSndOQ3RUVG1sRFNWRXdibXN5ZUhodGFGUnBiVWt2ZVdNNFVXcFhaRmRISzFVelozZGxjVmxuV1hGc1RFUXdZbVZYTmtZclNqaHNRVEZhVUZobU9DdGtUbFIyT0Zkd2EzaDVjR2gwUTAwMk1pOHhOM1pUUkROU1RYRjFiRVJpVTNRMGMzTXdjVTFPTkd0Rk1tZ3ZaMjFCZUUwelNEbDVkblJwZGtSelUyZDJlREl3VldONmVXUmpla3Q1U1hwSmNWTnRTMmRQV1RkU2RtbFZWaTltTUVGdmFVcFplVEZTU0hwbGJWcExNVGRXSzFFNVVsaG5SbEZHYlVZNFNGWnhVMjlpTjFsYVNFdFBlbmMzVVc5cFVGQlNVSFp1TlZOcU9FeG1NMFJ6WWtRMk9GSnpaMnQ2VnpCalRWaG1kalZQUWxKeVl6RlpibFp5ZDFWRlZrOXRhV1UyWnpOUlJGbG5PWGcwVkdwT01sQlZRV0ZNYlV0ekwwNTFWVE5OVHlzMWNtVldWblpQYzNGMmFrcHJlSHBGTHpBM2VYQlpiM0JCVW5ZeGNYWkNWMEZGTTFWS2JIVTJjVmxJVDNwMlNqUjZaazVVUkZsdll6TnRZalkzTDNWVU1WQTVaMUZCUVVGQlF5SXNJbk5zYjNRaU9qSjlYWDA9In0seyJpbmRleCI6MiwicHJvb2YiOiJleUp0WlhSaFpHRjBZVjl3Y205dlppSTZJa0ZCUVVGRFJrNTBSVEpLV0VFclJYbEdOblp6UlhoRVlVVkZNbGRQVDBWdWRVUkxjMUpUYlhOa2FUQmFSVW93U0VaS00wZEZVRU5LWXpsVVZYQkhWa0l4VDBrNU5IUk5WUzg1YjNaaWNXNHJTa3RpWVdwVUwxWlVhVkZSYTJ4V05uUkdNMWN5UzFsNlpHaFRWbXB1WTJWTGRFUnpSa2hFU3pCc1F6ZHVWMnhUZWtKNU1Va3dSbEpSZFRac2QxaHRUM2hxYzJWVmNrVnBTRGhNTVZWSllqVlZNVUZZWVZSb1VDczBjM1ZhV1c5aFV6SXdWVzRyZEVGNGEwbHJOQ3N4V0VGR2NpdExhRWh1ZG5admEyRlpZM0JVTjJSYVNscFVWVE5qYUhOVVJqaGpWSGhTYzJkYU1teEhXV1JtYzFveldWRjZPR3RaVDFOSVVqWjRRWGhtYkRSM1pVbFhkMjFwWkVWS01FRlRSV2xKYkZOa2JWUjVOV3QzYzIwNVdURnFXVkJzZW14Nk0zbElTRGR6V2pkd09VMVVSa3hCYzJ4alJtVlFWSE5ZY25wMmVTODVXakJCTUU5dVVUWm5Ta0UxU2tGQmVEVkVkV0ZJYzIxR2FGcEVSVlp2U25kaFZrMWhiMnRxUnpabFdtWndPWEEwVms4ME9UaFNjRFFyVTA1cFEwbFJNRzVyZURCeGJXbFRSMUV3TUVOdE16aHJlSFZJT1ZVMVZWaDVPRFl3UTNkUWNteG1lR2hPT0V4aU9TdG1ZMVpFWTNWUk5EWlVLMjVvZURGTFMwMWhXRWxvWmtsUmFrTmxVMDVyYW1SWGJrRkZPV015WVc5UVpYYzFjRFpVT1dWM2VUZHdORUpLZFUxWFQyOWhWek5MWjFWcFZXVnNWSGd3ZHpGSE5WaExMemhGVEZOVmJrdEdjVVJqVTBvNU5EZHNhbWsxTkM5Q2JDOTJVa1F5UVdOWGFUWkViakZ2WW10eFFXMVlPR2R0VVVzelZGZzNkRXRZZDA4cllta3dZbW8zVVdWc1kwaFdjamc1VFZOa1pHdHNUM1YzTjNBMUx6STROSFo2U25kNE5tcDJha3hFTkhNMU56RXlSa1JHWnpGUlJISmpPRzFSYmxCMmVYSnRWa1l2Tm1SSVVFTk5RMk5qTDFaTVkwRlNia2xCZDJWaWQydDJVV0ZtWWxSR1QzVnJPWFZRY1VORWVXcFZZamQ1WVZWQlRtNTJlVnBvZFRWYVFtRjRkWFp2UWpoUVNFdDJZaXNyVEVFeVVHaFZNazByT1hsNWNsUnhNVUozUVVGQlFVRWlMQ0p0WlhSaFpHRjBZVjkwWVhKblpYUWlPaUpCVmxWQlRrY3hhR0pJVVRaaVIyeDZaRVJ3ZFdJeVVteE1WekZzWkVkRk5rRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRWGRCUVVGQlFVRkJRVUZWUVVGQlFVRkJRVUZCUVdjOUlpd2ljM1JsY0hNaU9sdDdJblJoY21kbGRDSTZJa0ZXVlZOSlNEUXJiWE5VVURKc0t6RjZXVnAwT1VGa2FuUjVSblJvWVRnM2QxaE1RbTlFWm5KRE1ERTFjREJpTWlJc0luQnliMjltSWpvaVFVRkJRVU5IY1RZdkwzaDZPV2MzV2xwMFVrOVZjazV6WXpKQ0wzWlVkM0JCY1hoeWRERldSbkZUV1dKalRsSjZRbTFaZGtsaGQzVlZPRXd4VDBkNGRsQkdTMHcwZVhSRlMweDVlVE50UVRoa1R6QnhZMU5TV2k5a1pFVlNWemxZZDNkNmFsSXpjV2R4ZDNnNFJERTFWbXc0TDFodmVFVnZkMDVWU1RoS2RHaHVNbGhOWjFZeFdteDFZMnhvYmtwc1RrWlplSGMzZWtWTU5EQnRORGRrU25jek56SklRVFZRUzBjdlRsUlllWGhOV21obGQwazVXVVJKZVhwcVIzVmxRa3RWV2tWd1ltUkJhMjVFUWtReFNXeG9XRTFJUnpWa1pVTnZaMEpoUVZRelprdGFOR3BZZVhWRGJuTnRlWEJ0VG5KbVIzSTJZbkJYY0c5UlJXTjZOM1lyTm5veVJYSlZhMEU1VkRkTVFuSjVZblUwUzI4clNqbDZMMkp4Um0welp6TnFZVnAzYjFaeFZEQkVWRGxFVUZscVJIQXlURmd6TUhSek5FVkZTVGwzZGt0dWFtRm5LMVUyUmpCUFpsZDFlR2N3VERWTGNWYzRaVlpvV2tSRlZtOUtkMkZXVFdGdmEycEhObVZhWm5BNWNEUldUelE1T0ZKd05DdFRUbWxEU1ZFd2Jtc3lXbTVIVVRWd1ZHWlRVVXR2TUZWTlZreFBNVk5WVEZWek5pdEhSMGhwY0ZwTmJEUTNkbGd3ZGxaelZtcEphRmhKYjBNdlRFbEpXVEZQZWl0dU1XczVhWFpxYW05elFWTjVOa2hRTDA5V1lXY3JVVll3TVU1ek1UWlljVEptWWpkVE1HVjJTV1VyVkdwbFZqRjVlRFpVYzNReE5IbEtPWFJ0WWpVeGFIRk9la1JZVDNGUllqUjRRWHBITlVod2FEWkVTRUZPWkdsaGFFRXdNVVpUZW1KeFdXWTFhRVpxVlhvMGNtSkpiSGRPVkdsMFVGQnZVak5ZVjNoWGVuRTRUSE5qT1ZseU1IaDFPREY0UjJSNU9GQm1iRFk0T1hoVmMyZEdNbGM0YUd4cU4yeGhPRlJ0VmpoMll5dElhbTF2VEdsVVkwbEJTR3hHYTFoQ1puWmtZVUYwVmpKNE1HUk9TbkJZYTNkelpsSnlZak50TW5wTk9HUjBUMmRLUVhoRkwwMTJPV040TWpCeU5uQmpTU3MwYTB0MGNuZzJTa0ZRWTBnclVYZ3ZZbTlHT0hOd1RXWnBSWE5qU1RWeWRUaFdUVXhETnpKcFFrVkJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.ipa.list-range-eof.accept",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "list_range",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "query": {
+            "kind": "list_range",
+            "start": 8
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "range_segments": [
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+            },
+            "query": "range:8:",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "query": "range:8:",
+                "coordinate": "range:8:",
+                "start": 8,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6IkFBQUFDRk50RTJKWEErRXlGNnZzRXhEYUVFMldPT0VudURLc1JTbXNkaTBaRUowSEZKM0dFUENKYzlUVXBHVkIxT0k5NHRNVS85b3ZicW4rSktiYWpUL1ZUaVFRa2xWNnRGM1cyS1l6ZGhTVmpuY2VLdERzRkhESzBsQzduV2xTekJ5MUkwRlJRdTZsd1htT3hqc2VVckVpSDhMMVVJYjVVMUFYYVRoUCs0c3VaWW9hUzIwVW4rdEF4a0lrNCsxWEFGcitLaEhudnZva2FZY3BUN2RaSlpUVTNjaHNURjhjVHhSc2daMmxHWWRmc1ozWVF6OGtZT1NIUjZ4QXhmbDR3ZUlXd21pZEVKMEFTRWlJbFNkbVR5NWt3c205WTFqWVBsemx6M3lISDdzWjdwOU1URkxBc2xjRmVQVHNYcnp2eS85WjBBME9uUTZnSkE1SkFBeDVEdWFIc21GaFpERVZvSndhVk1hb2tqRzZlWmZwOXA0Vk80OThScDQrU05pQ0lRMG5reDBxbWlTR1EwMENtMzhreHVIOVU1VVh5ODYwQ3dQcmxmeGhOOExiOStmY1ZEY3VRNDZUK25oeDFLS01hWEloZklRakNlU05ramRXbkFFOWMyYW9QZXc1cDZUOWV3eTdwNEJKdU1XT29hVzNLZ1VpVWVsVHgwdzFHNVhLLzhFTFNVbktGcURjU0o5NDdsamk1NC9CbC92UkQyQWNXaTZEbjFvYmtxQW1YOGdtUUszVFg3dEtYd08rYmkwYmo3UWVsY0hWcjg5TVNkZGtsT3V3N3A1LzI4NHZ6Snd4Nmp2akxENHM1NzEyRkRGZzFRRHJjOG1RblB2eXJtVkYvNmRIUENNQ2NjL1ZMY0FSbklBd2Vid2t2UWFmYlRGT3VrOXVQcUNEeWpVYjd5YVVBTm52eVpodTVaQmF4dXZvQjhQSEt2YisrTEEyUGhVMk0rOXl5clRxMUJ3QUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNklrRkJRVUZEUms1MFJUSktXRUVyUlhsR05uWnpSWGhFWVVWRk1sZFBUMFZ1ZFVSTGMxSlRiWE5rYVRCYVJVb3dTRVpLTTBkRlVFTktZemxVVlhCSFZrSXhUMGs1TkhSTlZTODViM1ppY1c0clNrdGlZV3BVTDFaVWFWRlJhMnhXTm5SR00xY3lTMWw2WkdoVFZtcHVZMlZMZEVSelJraEVTekJzUXpkdVYyeFRla0o1TVVrd1JsSlJkVFpzZDFodFQzaHFjMlZWY2tWcFNEaE1NVlZKWWpWVk1VRllZVlJvVUNzMGMzVmFXVzloVXpJd1ZXNHJkRUY0YTBsck5Dc3hXRUZHY2l0TGFFaHVkblp2YTJGWlkzQlVOMlJhU2xwVVZUTmphSE5VUmpoalZIaFNjMmRhTW14SFdXUm1jMW96V1ZGNk9HdFpUMU5JVWpaNFFYaG1iRFIzWlVsWGQyMXBaRVZLTUVGVFJXbEpiRk5rYlZSNU5XdDNjMjA1V1RGcVdWQnNlbXg2TTNsSVNEZHpXamR3T1UxVVJreEJjMnhqUm1WUVZITlljbnAyZVM4NVdqQkJNRTl1VVRablNrRTFTa0ZCZURWRWRXRkljMjFHYUZwRVJWWnZTbmRoVmsxaGIydHFSelpsV21ad09YQTBWazgwT1RoU2NEUXJVMDVwUTBsUk1HNXJlREJ4YldsVFIxRXdNRU50TXpocmVIVklPVlUxVlZoNU9EWXdRM2RRY214bWVHaE9PRXhpT1N0bVkxWkVZM1ZSTkRaVUsyNW9lREZMUzAxaFdFbG9aa2xSYWtObFUwNXJhbVJYYmtGRk9XTXlZVzlRWlhjMWNEWlVPV1YzZVRkd05FSktkVTFYVDI5aFZ6TkxaMVZwVldWc1ZIZ3dkekZITlZoTEx6aEZURk5WYmt0R2NVUmpVMG81TkRkc2FtazFOQzlDYkM5MlVrUXlRV05YYVRaRWJqRnZZbXR4UVcxWU9HZHRVVXN6VkZnM2RFdFlkMDhyWW1rd1ltbzNVV1ZzWTBoV2NqZzVUVk5rWkd0c1QzVjNOM0ExTHpJNE5IWjZTbmQ0Tm1wMmFreEVOSE0xTnpFeVJrUkdaekZSUkhKak9HMVJibEIyZVhKdFZrWXZObVJJVUVOTlEyTmpMMVpNWTBGU2JrbEJkMlZpZDJ0MlVXRm1ZbFJHVDNWck9YVlFjVU5FZVdwVllqZDVZVlZCVG01MmVWcG9kVFZhUW1GNGRYWnZRamhRU0V0Mllpc3JURUV5VUdoVk1rMHJPWGw1Y2xSeE1VSjNRVUZCUVVFaUxDSnRaWFJoWkdGMFlWOTBZWEpuWlhRaU9pSkJWbFZCVGtjeGFHSklVVFppUjJ4NlpFUndkV0l5VW14TVZ6RnNaRWRGTmtGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFYZEJRVUZCUVVGQlFVRlZRVUZCUVVGQlFVRkJRV2M5SWl3aWMzUmxjSE1pT2x0N0luUmhjbWRsZENJNklrRldWVk5KU2xWTk5uWm1jVTlSU1M5SWIwWm1XbXRpWm5Jck5rTXhhbk5HYjJFdlpGUkdTSEI2YVROd1UzSk9iU0lzSW5CeWIyOW1Jam9pUVVGQlFVTkVjWGxPYzJsSE5XTXlSMnRvUlVsSWRFNHpUMnRRWTJsUFJWRnFSVkY1Vm5keFRHMU1SbHAyVUZWMFFsWlBZVTh2YldaRWVrWjRkbTlhWTNnMlVVOWFhSGQ1WVZoNVVHZFZOVVpGYnpJNWNYbEdkV3hDYjBKd2RUVkhUWGR5WW1STFZFVTBTWGMyVGxVeVVtNXpka3AzTVdOYVJEZGFUR1IzTmsweFVVdG5VR280ZDNJdlNESjBhRFZJWmpKUVlWaFNlREpyVFV0Q2JXYzNjMjAyYlZGQ1JtMW5VbXRZTlVaMFlrZE5hRWRvVDJaVVZtdzFlVVV3UVZFNVl5OHhUM1J2WVZwM0sxcFllVTlaYW14cVUyTTRZa3RwVmpCTldWaGxVSFJxTHpGc1FTOVlXaTlUVDNRMk5VdHRMMmszY210TFUxaGhNaXMxVFVzdldrcDVPVXhoYUdVclZtUldPR1JrWlhCSVJHMXZZV3ROVnlzdlMwODJSMUpLVlhCTVZuZFlkV0VyVmpNeGNrRnVRVU14TlZCWlRtNXhSbWgzTnpkbFV6bFlkbTByV0hSNkx6WmhTVTFNZDJSWU9YY3lTSFJYVDNVclRrWm9Xa1JGVm05S2QyRldUV0Z2YTJwSE5tVmFabkE1Y0RSV1R6UTVPRkp3TkN0VFRtbERTVkV3Ym1zeWVIaHRhRlJwYlVrdmVXTTRVV3BYWkZkSEsxVXpaM2RsY1ZsbldYRnNURVF3WW1WWE5rWXJTamhzUVRGYVVGaG1PQ3RrVGxSMk9GZHdhM2g1Y0doMFEwMDJNaTh4TjNaVFJETlNUWEYxYkVSaVUzUTBjM013Y1UxT05HdEZNbWd2WjIxQmVFMHpTRGw1ZG5ScGRrUnpVMmQyZURJd1ZXTjZlV1JqZWt0NVNYcEpjVk50UzJkUFdUZFNkbWxWVmk5bU1FRnZhVXBaZVRGU1NIcGxiVnBMTVRkV0sxRTVVbGhuUmxGR2JVWTRTRlp4VTI5aU4xbGFTRXRQZW5jM1VXOXBVRkJTVUhadU5WTnFPRXhtTTBSellrUTJPRkp6WjJ0NlZ6QmpUVmhtZGpWUFFsSnlZekZaYmxaeWQxVkZWazl0YVdVMlp6TlJSRmxuT1hnMFZHcE9NbEJWUVdGTWJVdHpMMDUxVlROTlR5czFjbVZXVm5aUGMzRjJha3ByZUhwRkx6QTNlWEJaYjNCQlVuWXhjWFpDVjBGRk0xVktiSFUyY1ZsSVQzcDJTalI2Wms1VVJGbHZZek50WWpZM0wzVlVNVkE1WjFGQlFVRkJReUlzSW5Oc2IzUWlPako5WFgwPSJ9LHsiaW5kZXgiOjIsInByb29mIjoiZXlKdFpYUmhaR0YwWVY5d2NtOXZaaUk2SWtGQlFVRkRSazUwUlRKS1dFRXJSWGxHTm5aelJYaEVZVVZGTWxkUFQwVnVkVVJMYzFKVGJYTmthVEJhUlVvd1NFWktNMGRGVUVOS1l6bFVWWEJIVmtJeFQwazVOSFJOVlM4NWIzWmljVzRyU2t0aVlXcFVMMVpVYVZGUmEyeFdOblJHTTFjeVMxbDZaR2hUVm1wdVkyVkxkRVJ6UmtoRVN6QnNRemR1VjJ4VGVrSjVNVWt3UmxKUmRUWnNkMWh0VDNocWMyVlZja1ZwU0RoTU1WVkpZalZWTVVGWVlWUm9VQ3MwYzNWYVdXOWhVekl3Vlc0cmRFRjRhMGxyTkNzeFdFRkdjaXRMYUVodWRuWnZhMkZaWTNCVU4yUmFTbHBVVlROamFITlVSamhqVkhoU2MyZGFNbXhIV1dSbWMxb3pXVkY2T0d0WlQxTklValo0UVhobWJEUjNaVWxYZDIxcFpFVktNRUZUUldsSmJGTmtiVlI1Tld0M2MyMDVXVEZxV1ZCc2VteDZNM2xJU0RkeldqZHdPVTFVUmt4QmMyeGpSbVZRVkhOWWNucDJlUzg1V2pCQk1FOXVVVFpuU2tFMVNrRkJlRFZFZFdGSWMyMUdhRnBFUlZadlNuZGhWazFoYjJ0cVJ6WmxXbVp3T1hBMFZrODBPVGhTY0RRclUwNXBRMGxSTUc1cmVEQnhiV2xUUjFFd01FTnRNemhyZUhWSU9WVTFWVmg1T0RZd1EzZFFjbXhtZUdoT09FeGlPU3RtWTFaRVkzVlJORFpVSzI1b2VERkxTMDFoV0Vsb1prbFJha05sVTA1cmFtUlhia0ZGT1dNeVlXOVFaWGMxY0RaVU9XVjNlVGR3TkVKS2RVMVhUMjloVnpOTFoxVnBWV1ZzVkhnd2R6RkhOVmhMTHpoRlRGTlZia3RHY1VSalUwbzVORGRzYW1rMU5DOUNiQzkyVWtReVFXTlhhVFpFYmpGdlltdHhRVzFZT0dkdFVVc3pWRmczZEV0WWQwOHJZbWt3WW1vM1VXVnNZMGhXY2pnNVRWTmtaR3RzVDNWM04zQTFMekk0TkhaNlNuZDRObXAyYWt4RU5ITTFOekV5UmtSR1p6RlJSSEpqT0cxUmJsQjJlWEp0VmtZdk5tUklVRU5OUTJOakwxWk1ZMEZTYmtsQmQyVmlkMnQyVVdGbVlsUkdUM1ZyT1hWUWNVTkVlV3BWWWpkNVlWVkJUbTUyZVZwb2RUVmFRbUY0ZFhadlFqaFFTRXQyWWlzclRFRXlVR2hWTWswck9YbDVjbFJ4TVVKM1FVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2lRVUZCUVVOSGNUWXZMM2g2T1djM1dscDBVazlWY2s1ell6SkNMM1pVZDNCQmNYaHlkREZXUm5GVFdXSmpUbEo2UW0xWmRrbGhkM1ZWT0V3eFQwZDRkbEJHUzB3MGVYUkZTMHg1ZVROdFFUaGtUekJ4WTFOU1dpOWtaRVZTVnpsWWQzZDZhbEl6Y1dkeGQzZzRSREUxVm13NEwxaHZlRVZ2ZDA1VlNUaEtkR2h1TWxoTloxWXhXbXgxWTJ4b2JrcHNUa1paZUhjM2VrVk1OREJ0TkRka1NuY3pOekpJUVRWUVMwY3ZUbFJZZVhoTldtaGxkMGs1V1VSSmVYcHFSM1ZsUWt0VldrVndZbVJCYTI1RVFrUXhTV3hvV0UxSVJ6VmtaVU52WjBKaFFWUXpaa3RhTkdwWWVYVkRibk50ZVhCdFRuSm1SM0kyWW5CWGNHOVJSV042TjNZck5ub3lSWEpWYTBFNVZEZE1Rbko1WW5VMFMyOHJTamw2TDJKeFJtMHpaek5xWVZwM2IxWnhWREJFVkRsRVVGbHFSSEF5VEZnek1IUnpORVZGU1RsM2RrdHVhbUZuSzFVMlJqQlBabGQxZUdjd1REVkxjVmM0WlZab1drUkZWbTlLZDJGV1RXRnZhMnBITm1WYVpuQTVjRFJXVHpRNU9GSndOQ3RUVG1sRFNWRXdibXN5V201SFVUVndWR1pUVVV0dk1GVk5Wa3hQTVZOVlRGVnpOaXRIUjBocGNGcE5iRFEzZGxnd2RsWnpWbXBKYUZoSmIwTXZURWxKV1RGUGVpdHVNV3M1YVhacWFtOXpRVk41TmtoUUwwOVdZV2NyVVZZd01VNXpNVFpZY1RKbVlqZFRNR1YyU1dVclZHcGxWakY1ZURaVWMzUXhOSGxLT1hSdFlqVXhhSEZPZWtSWVQzRlJZalI0UVhwSE5VaHdhRFpFU0VGT1pHbGhhRUV3TVVaVGVtSnhXV1kxYUVacVZYbzBjbUpKYkhkT1ZHbDBVRkJ2VWpOWVYzaFhlbkU0VEhOak9WbHlNSGgxT0RGNFIyUjVPRkJtYkRZNE9YaFZjMmRHTWxjNGFHeHFOMnhoT0ZSdFZqaDJZeXRJYW0xdlRHbFVZMGxCU0d4R2ExaENablprWVVGMFZqSjRNR1JPU25CWWEzZHpabEp5WWpOdE1ucE5PR1IwVDJkS1FYaEZMMDEyT1dONE1qQnlObkJqU1NzMGEwdDBjbmcyU2tGUVkwZ3JVWGd2WW05R09ITndUV1pwUlhOalNUVnlkVGhXVFV4RE56SnBRa1ZCUVVGQlJDSXNJbk5zYjNRaU9qTjlYWDA9In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.ipa.malformed-base64.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          },
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "prooflist": {
+            "query": "profile/name",
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "steps": [
+              {
+                "coordinate": "profile/name",
+                "evidence_backend": "map",
+                "evidence_kind": "structure",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "kind": "map_step",
+                "path": "profile/name",
+                "proof": "not-base64%%%",
+                "query": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                }
+              }
+            ]
+          },
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.map-key.accept",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "map_key",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FCQ2tVSnZYSjJEQXZhNGdpVmpQbUVwMU55cVpPWU1JN0EyWWVWL1RTM1FHVmZCYUlXUGFabzMwb0x4NU9QTXA4VnFwYzFVVU13eFRHNDZma2RmQ0M1WnE4dE4vckRFZlRsS0tVMUdFUjFMbWY0R0tNQ21WS3hCZEJ5aWlIQkQrSEF2OXk0ekdHdmNnVmdFNnFsemdIcGk0V0hXTVBFZWxQNDI1RGYyUjlzbUZQNU9lTXhybi81Zjc2N2VQRFU4bWJLYXR2WmsrV1ZOeDZmSXdzSXJWbUFzR2pxUTU5Z0szc0FBUlovQUk3NkVNTWkxQklKS01IY3l4ZGhFUlVUVWdEQUU5Wk54NXdaU3UrWkJBZVhaQzJ4K0RVckNzVHBCV053VHV4ZU5PS2FKV3RkZGU0dURUUFQ3OVRWQ2xVVUx5cldDeFd2UmdJSS9FaTQyWXo0NldwdHlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdm5IMFpuQUk1blRHNTZsaFVlRnBOdzVVQUlEdTl1ZFlBSFAyUUpyeG1KaWticUpaRllZMldKRjg4cm9vNFBqQTVyb1k1eTM2azE2cFd6eGM0UTJIK3VsTEJwZmpEeVZGQ2NvM2UwcnhNQXZjNkxyZndHUUlRcWlpNlV5UlNlajhsVC9LeXJiUlBwaVNzR1FRUU9NN3NHUGZYdCtjUjRPVUlrVmxiRjNJYXpXWkxvclhXMU14U2dJZlA5dk5SMDFKdTMvdGQzTU5raEFha0I3dnVKSmk0Z2tHVkF5NjJBMUNoL1dFVU5STFFYR3VzNnliRU1mYmdUejdaRUVtMzFDTzRBek9mZXlmaWpXQUVvcGpqbHhuTjR6UkcvOXJZaHZoZVJ0Y0lTUXFjNUFVZUNua2t5OXNhYzV6eFhqZkwwam9STzZINmRwZXQ2L1Iwc3FmUHhyVmJ4c0FBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.ipa.missing-evidence.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.payload.accept",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "payload",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "@payload"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "@payload",
+            "steps": [
+              {
+                "kind": "payload_binding",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "@payload",
+                "coordinate": "@payload",
+                "path": "@payload",
+                "target": {
+                  "/": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6IkFBQUFDR0M4aXVobU95ZVdHL1NlYkJUbzdzVXRRWHdTTUJDd2xnOERVaTNaV3E5T1d4bDB3RjY2STBnbCt6R2pvN1ZDNlFqemdzMzVtSGJRZVZaZ1BVN0h4aTRHWmVTN0FYMGY2cmZDSXBJbWFmNTNKd3hoZmZrVmIxOURCOG1CdXFEODVFLzBQQlBMNGI2MURKcm5LcFA1UXUzcTI3TVM3aDZXTVl1SDd2d0Y4NVdoWXRYU2FzTElTYmJtKzBDbitaN2RyWkNOTjF3OEI3Q0kxNXA2MlB4d1VoWXBEL2tSL1hOdnRid1ZOZ1FqSGJtdmhXYXBlZWxMcDVkSDYweHdwdGJFVmxpVzdrUjE1di9udnFiSjc0UUVRNTY4QzczSkxnVTIyNGUwQmpiYm82VmlJRUFiRHk3bWZQWjdmNkExUmNRMEhrVnRqTHk5b1lPeFYzeUVCcGNvaTlObFhRZHlWMy9zUHNseE9tZlJMOWxyK0huZndOMlhDdUIwdUhPWDdMMUY5Z3lHQmNBZzNaeEw5bzNQU1E3QjBlMm9xdytJUE1KMi9TNzcxSEZLKzFqL0RiQytaek82ZXlKUHVYeHpLU09zWmRhS1VQbEc3SXlzT0d6QjNiMGY3NUV1ckVaa21zUFlTVzZ1YTJwdUhhMi92UWtIdVBLRW9aQ01wV2dvQkxydUZnYlJyejRZN2VYbDV3cTFScHRpTUVHRjVGSVh5aFlsQU95TTdCVkZUNlJwWFg0M2JNem5ZWWRvRVNCaU9iTkQ5U1dlMGgxS0ZIRFZDOEtjMXRoMEZIWWMrVktNRk1DRjRyZTFaUU04YlA0czFZSUViVEpTaXV3aUNWWHRoaXgvWEViVnVaZm13bVQ3SXkraEhLUlJURXlhKzlsa2tIWGtlWktrZk5xM1dCWW5TVWEzQUtnNW1NY2ZDb2RwNkVXdGhwSHpIdktBNi9obVFuYU8yMC9wR3hzQUFBQ1cifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.ipa.proof-tamper.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0FCQ2tVSnZYSjJEQXZhNGdpVmpQbUVwMU55cVpPWU1JN0EyWWVWL1RTM1FHVmZCYUlXUGFabzMwb0x4NU9QTXA4VnFwYzFVVU13eFRHNDZma2RmQ0M1WnE4dE4vckRFZlRsS0tVMUdFUjFMbWY0R0tNQ21WS3hCZEJ5aWlIQkQrSEF2OXk0ekdHdmNnVmdFNnFsemdIcGk0V0hXTVBFZWxQNDI1RGYyUjlzbUZQNU9lTXhybi81Zjc2N2VQRFU4bWJLYXR2WmsrV1ZOeDZmSXdzSXJWbUFzR2pxUTU5Z0szc0FBUlovQUk3NkVNTWkxQklKS01IY3l4ZGhFUlVUVWdEQUU5Wk54NXdaU3UrWkJBZVhaQzJ4K0RVckNzVHBCV053VHV4ZU5PS2FKV3RkZGU0dURUUFQ3OVRWQ2xVVUx5cldDeFd2UmdJSS9FaTQyWXo0NldwdHlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdm5IMFpuQUk1blRHNTZsaFVlRnBOdzVVQUlEdTl1ZFlBSFAyUUpyeG1KaWticUpaRllZMldKRjg4cm9vNFBqQTVyb1k1eTM2azE2cFd6eGM0UTJIK3VsTEJwZmpEeVZGQ2NvM2UwcnhNQXZjNkxyZndHUUlRcWlpNlV5UlNlajhsVC9LeXJiUlBwaVNzR1FRUU9NN3NHUGZYdCtjUjRPVUlrVmxiRjNJYXpXWkxvclhXMU14U2dJZlA5dk5SMDFKdTMvdGQzTU5raEFha0I3dnVKSmk0Z2tHVkF5NjJBMUNoL1dFVU5STFFYR3VzNnliRU1mYmdUejdaRUVtMzFDTzRBek9mZXlmaWpXQUVvcGpqbHhuTjR6UkcvOXJZaHZoZVJ0Y0lTUXFjNUFVZUNua2t5OXNhYzV6eFhqZkwwam9STzZINmRwZXQ2L1Iwc3FmUHhyVmJ4c0FBQUFlIiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.range-segments-tamper.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "query": {
+            "kind": "list_range",
+            "start": 2,
+            "end": 18
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry",
+          "range_segments": [
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+            },
+            "query": "range:2:18",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "query": "range:2:18",
+                "coordinate": "range:2:18",
+                "start": 2,
+                "end": 18,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "bagbojqabaaqajqg6ybw7owde3i2ixaqwnpleg6v723mhnc46sgw4pjrif3zofry"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga"
+                  },
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6IkFBQUFDRk50RTJKWEErRXlGNnZzRXhEYUVFMldPT0VudURLc1JTbXNkaTBaRUowSEZKM0dFUENKYzlUVXBHVkIxT0k5NHRNVS85b3ZicW4rSktiYWpUL1ZUaVFRa2xWNnRGM1cyS1l6ZGhTVmpuY2VLdERzRkhESzBsQzduV2xTekJ5MUkwRlJRdTZsd1htT3hqc2VVckVpSDhMMVVJYjVVMUFYYVRoUCs0c3VaWW9hUzIwVW4rdEF4a0lrNCsxWEFGcitLaEhudnZva2FZY3BUN2RaSlpUVTNjaHNURjhjVHhSc2daMmxHWWRmc1ozWVF6OGtZT1NIUjZ4QXhmbDR3ZUlXd21pZEVKMEFTRWlJbFNkbVR5NWt3c205WTFqWVBsemx6M3lISDdzWjdwOU1URkxBc2xjRmVQVHNYcnp2eS85WjBBME9uUTZnSkE1SkFBeDVEdWFIc21GaFpERVZvSndhVk1hb2tqRzZlWmZwOXA0Vk80OThScDQrU05pQ0lRMG5reDBxbWlTR1EwMENtMzhreHVIOVU1VVh5ODYwQ3dQcmxmeGhOOExiOStmY1ZEY3VRNDZUK25oeDFLS01hWEloZklRakNlU05ramRXbkFFOWMyYW9QZXc1cDZUOWV3eTdwNEJKdU1XT29hVzNLZ1VpVWVsVHgwdzFHNVhLLzhFTFNVbktGcURjU0o5NDdsamk1NC9CbC92UkQyQWNXaTZEbjFvYmtxQW1YOGdtUUszVFg3dEtYd08rYmkwYmo3UWVsY0hWcjg5TVNkZGtsT3V3N3A1LzI4NHZ6Snd4Nmp2akxENHM1NzEyRkRGZzFRRHJjOG1RblB2eXJtVkYvNmRIUENNQ2NjL1ZMY0FSbklBd2Vid2t2UWFmYlRGT3VrOXVQcUNEeWpVYjd5YVVBTm52eVpodTVaQmF4dXZvQjhQSEt2YisrTEEyUGhVMk0rOXl5clRxMUJ3QUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNklrRkJRVUZEUms1MFJUSktXRUVyUlhsR05uWnpSWGhFWVVWRk1sZFBUMFZ1ZFVSTGMxSlRiWE5rYVRCYVJVb3dTRVpLTTBkRlVFTktZemxVVlhCSFZrSXhUMGs1TkhSTlZTODViM1ppY1c0clNrdGlZV3BVTDFaVWFWRlJhMnhXTm5SR00xY3lTMWw2WkdoVFZtcHVZMlZMZEVSelJraEVTekJzUXpkdVYyeFRla0o1TVVrd1JsSlJkVFpzZDFodFQzaHFjMlZWY2tWcFNEaE1NVlZKWWpWVk1VRllZVlJvVUNzMGMzVmFXVzloVXpJd1ZXNHJkRUY0YTBsck5Dc3hXRUZHY2l0TGFFaHVkblp2YTJGWlkzQlVOMlJhU2xwVVZUTmphSE5VUmpoalZIaFNjMmRhTW14SFdXUm1jMW96V1ZGNk9HdFpUMU5JVWpaNFFYaG1iRFIzWlVsWGQyMXBaRVZLTUVGVFJXbEpiRk5rYlZSNU5XdDNjMjA1V1RGcVdWQnNlbXg2TTNsSVNEZHpXamR3T1UxVVJreEJjMnhqUm1WUVZITlljbnAyZVM4NVdqQkJNRTl1VVRablNrRTFTa0ZCZURWRWRXRkljMjFHYUZwRVJWWnZTbmRoVmsxaGIydHFSelpsV21ad09YQTBWazgwT1RoU2NEUXJVMDVwUTBsUk1HNXJlREJ4YldsVFIxRXdNRU50TXpocmVIVklPVlUxVlZoNU9EWXdRM2RRY214bWVHaE9PRXhpT1N0bVkxWkVZM1ZSTkRaVUsyNW9lREZMUzAxaFdFbG9aa2xSYWtObFUwNXJhbVJYYmtGRk9XTXlZVzlRWlhjMWNEWlVPV1YzZVRkd05FSktkVTFYVDI5aFZ6TkxaMVZwVldWc1ZIZ3dkekZITlZoTEx6aEZURk5WYmt0R2NVUmpVMG81TkRkc2FtazFOQzlDYkM5MlVrUXlRV05YYVRaRWJqRnZZbXR4UVcxWU9HZHRVVXN6VkZnM2RFdFlkMDhyWW1rd1ltbzNVV1ZzWTBoV2NqZzVUVk5rWkd0c1QzVjNOM0ExTHpJNE5IWjZTbmQ0Tm1wMmFreEVOSE0xTnpFeVJrUkdaekZSUkhKak9HMVJibEIyZVhKdFZrWXZObVJJVUVOTlEyTmpMMVpNWTBGU2JrbEJkMlZpZDJ0MlVXRm1ZbFJHVDNWck9YVlFjVU5FZVdwVllqZDVZVlZCVG01MmVWcG9kVFZhUW1GNGRYWnZRamhRU0V0Mllpc3JURUV5VUdoVk1rMHJPWGw1Y2xSeE1VSjNRVUZCUVVFaUxDSnRaWFJoWkdGMFlWOTBZWEpuWlhRaU9pSkJWbFZCVGtjeGFHSklVVFppUjJ4NlpFUndkV0l5VW14TVZ6RnNaRWRGTmtGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFYZEJRVUZCUVVGQlFVRlZRVUZCUVVGQlFVRkJRV2M5SWl3aWMzUmxjSE1pT2x0N0luUmhjbWRsZENJNklrRldWVk5KU2pCa1ZsUTRhblJ6UlRac05XVnhPVmN3Y1d0dlFYSnpSa1JMWWpNdmNXNTFObk0wYm5Kd2EzVTRkeUlzSW5CeWIyOW1Jam9pUVVGQlFVTkZUbTVQV1haTGFra3JjMEZoVjFFNWRUZG9VVzR5WlRKRGJEbGtOVTFxVlU5blEzWnNiRkZKZUVKTlVtTjBjRXB4YW5FelEyWjBVbHBSU0UxMldYUnlTSGhSU1d3MVUwZDRaWFpzTjNSMVVYZEtUa0o1WTNWV1pXcHhVMVl5VWlzNGFtMHhaR0ZXVFZkTlF6QnpRVkpoTm1wTmEwbE5LekZWTjJocmIxZGlWRVl5TmpWQmRGWjFkbFF2V21aUFJERmxXRWxCV1RsdGJFOW9WakozUzB4T2FVSjZWekpUVlVGMmFXZFJWVU5sT1ZoNlFYUTFMMWxsWjJGV1dqVnNTSEZ4Um5reFMwRkpWVVpYSzJSbGJIRXpWM2s1TW1sSlEwaDZjbUp6VDFrelNqRTVRMjh5VEc1VlZpOUJWWFZUVW5KRmNrOUZRamRXVjBSd1NFbFNiRGc0VW1ZMVlYRTNjMWd5WTBkTmNrSnFNbU5JZFhvNGRrRXhhM1ZWWVZwNkwzUnpOVTVpWTNreWRtbHhibUl3YmsxS0wydDVhakppVURab2RUbFdkVk5qV1VGMVNFSm1aRmMwTmpKbGIxUlZSelZKVkhCa2FXeG9Xa1JGVm05S2QyRldUV0Z2YTJwSE5tVmFabkE1Y0RSV1R6UTVPRkp3TkN0VFRtbERTVkV3Ym10NmJVRTBWMHB3WjA4cmEyOWhWQzh3UVRneU1WazBRWHAxVEc5eGExcDVWMmxPTlVabWJHMVhhRUZVWVhOdVVUWTRjako1VFZSUVNYWXJlbGwxZERaSFNFTjBabWxxTW1OYWIxUktVbGd2UW1KNVJsbDJjM053VmxkT1pVZDVPRU5FZVhWb2JFRm1NVFJJVGxWWk4xZHZiV0p6UkV4SmRITTJjSG8xWlZaeVJsSXpTMHB3YmtOaVNqRXhhR3MxVVZadFZtVjRUMHhYT1RCblVGQjVZMDlDT1ZselJYRnpaVGQwYTJ0TFRsWTRMM2xtUm5rM2QyZGxZVk5VZDI1R1VGQlVXR05JYm1KbVluQjViVVJ5YkZnMlprWm9TeTkzY0ZoQlJHVXlja2MwZVV0SGVuRlpMMkkyWkhaQlpXUndVVXBuU0daVlJrcEZaR3hTTmxCUVozRTNiREFyTlVVNFJWaDVjbGxoVlUxRlpFdE5PVlpKVXpOdWVWWXpaMmhMWjFkWU5sQkdaMkpwUWtwSGRXSk9VVlJMT0RjMVluRjFTVGc0TmxRdk5IRnRkMDVEV1RSSmFUSjJlazlOTW05U05GVlFaek5SUW1kQlFVRkJRaUlzSW5Oc2IzUWlPakY5WFgwPSJ9LHsiaW5kZXgiOjEsInByb29mIjoiZXlKdFpYUmhaR0YwWVY5d2NtOXZaaUk2SWtGQlFVRkRSazUwUlRKS1dFRXJSWGxHTm5aelJYaEVZVVZGTWxkUFQwVnVkVVJMYzFKVGJYTmthVEJhUlVvd1NFWktNMGRGVUVOS1l6bFVWWEJIVmtJeFQwazVOSFJOVlM4NWIzWmljVzRyU2t0aVlXcFVMMVpVYVZGUmEyeFdOblJHTTFjeVMxbDZaR2hUVm1wdVkyVkxkRVJ6UmtoRVN6QnNRemR1VjJ4VGVrSjVNVWt3UmxKUmRUWnNkMWh0VDNocWMyVlZja1ZwU0RoTU1WVkpZalZWTVVGWVlWUm9VQ3MwYzNWYVdXOWhVekl3Vlc0cmRFRjRhMGxyTkNzeFdFRkdjaXRMYUVodWRuWnZhMkZaWTNCVU4yUmFTbHBVVlROamFITlVSamhqVkhoU2MyZGFNbXhIV1dSbWMxb3pXVkY2T0d0WlQxTklValo0UVhobWJEUjNaVWxYZDIxcFpFVktNRUZUUldsSmJGTmtiVlI1Tld0M2MyMDVXVEZxV1ZCc2VteDZNM2xJU0RkeldqZHdPVTFVUmt4QmMyeGpSbVZRVkhOWWNucDJlUzg1V2pCQk1FOXVVVFpuU2tFMVNrRkJlRFZFZFdGSWMyMUdhRnBFUlZadlNuZGhWazFoYjJ0cVJ6WmxXbVp3T1hBMFZrODBPVGhTY0RRclUwNXBRMGxSTUc1cmVEQnhiV2xUUjFFd01FTnRNemhyZUhWSU9WVTFWVmg1T0RZd1EzZFFjbXhtZUdoT09FeGlPU3RtWTFaRVkzVlJORFpVSzI1b2VERkxTMDFoV0Vsb1prbFJha05sVTA1cmFtUlhia0ZGT1dNeVlXOVFaWGMxY0RaVU9XVjNlVGR3TkVKS2RVMVhUMjloVnpOTFoxVnBWV1ZzVkhnd2R6RkhOVmhMTHpoRlRGTlZia3RHY1VSalUwbzVORGRzYW1rMU5DOUNiQzkyVWtReVFXTlhhVFpFYmpGdlltdHhRVzFZT0dkdFVVc3pWRmczZEV0WWQwOHJZbWt3WW1vM1VXVnNZMGhXY2pnNVRWTmtaR3RzVDNWM04zQTFMekk0TkhaNlNuZDRObXAyYWt4RU5ITTFOekV5UmtSR1p6RlJSSEpqT0cxUmJsQjJlWEp0VmtZdk5tUklVRU5OUTJOakwxWk1ZMEZTYmtsQmQyVmlkMnQyVVdGbVlsUkdUM1ZyT1hWUWNVTkVlV3BWWWpkNVlWVkJUbTUyZVZwb2RUVmFRbUY0ZFhadlFqaFFTRXQyWWlzclRFRXlVR2hWTWswck9YbDVjbFJ4TVVKM1FVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2lRVUZCUVVORWNYbE9jMmxITldNeVIydG9SVWxJZEU0elQydFFZMmxQUlZGcVJWRjVWbmR4VEcxTVJscDJVRlYwUWxaUFlVOHZiV1pFZWtaNGRtOWFZM2cyVVU5YWFIZDVZVmg1VUdkVk5VWkZiekk1Y1hsR2RXeENiMEp3ZFRWSFRYZHlZbVJMVkVVMFNYYzJUbFV5VW01emRrcDNNV05hUkRkYVRHUjNOazB4VVV0blVHbzRkM0l2U0RKMGFEVklaakpRWVZoU2VESnJUVXRDYldjM2MyMDJiVkZDUm0xblVtdFlOVVowWWtkTmFFZG9UMlpVVm13MWVVVXdRVkU1WXk4eFQzUnZZVnAzSzFwWWVVOVphbXhxVTJNNFlrdHBWakJOV1ZobFVIUnFMekZzUVM5WVdpOVRUM1EyTlV0dEwyazNjbXRMVTFoaE1pczFUVXN2V2twNU9VeGhhR1VyVm1SV09HUmtaWEJJUkcxdllXdE5WeXN2UzA4MlIxSktWWEJNVm5kWWRXRXJWak14Y2tGdVFVTXhOVkJaVG01eFJtaDNOemRsVXpsWWRtMHJXSFI2THpaaFNVMU1kMlJZT1hjeVNIUlhUM1VyVGtab1drUkZWbTlLZDJGV1RXRnZhMnBITm1WYVpuQTVjRFJXVHpRNU9GSndOQ3RUVG1sRFNWRXdibXN5ZUhodGFGUnBiVWt2ZVdNNFVXcFhaRmRISzFVelozZGxjVmxuV1hGc1RFUXdZbVZYTmtZclNqaHNRVEZhVUZobU9DdGtUbFIyT0Zkd2EzaDVjR2gwUTAwMk1pOHhOM1pUUkROU1RYRjFiRVJpVTNRMGMzTXdjVTFPTkd0Rk1tZ3ZaMjFCZUUwelNEbDVkblJwZGtSelUyZDJlREl3VldONmVXUmpla3Q1U1hwSmNWTnRTMmRQV1RkU2RtbFZWaTltTUVGdmFVcFplVEZTU0hwbGJWcExNVGRXSzFFNVVsaG5SbEZHYlVZNFNGWnhVMjlpTjFsYVNFdFBlbmMzVVc5cFVGQlNVSFp1TlZOcU9FeG1NMFJ6WWtRMk9GSnpaMnQ2VnpCalRWaG1kalZQUWxKeVl6RlpibFp5ZDFWRlZrOXRhV1UyWnpOUlJGbG5PWGcwVkdwT01sQlZRV0ZNYlV0ekwwNTFWVE5OVHlzMWNtVldWblpQYzNGMmFrcHJlSHBGTHpBM2VYQlpiM0JCVW5ZeGNYWkNWMEZGTTFWS2JIVTJjVmxJVDNwMlNqUjZaazVVUkZsdll6TnRZalkzTDNWVU1WQTVaMUZCUVVGQlF5SXNJbk5zYjNRaU9qSjlYWDA9In0seyJpbmRleCI6MiwicHJvb2YiOiJleUp0WlhSaFpHRjBZVjl3Y205dlppSTZJa0ZCUVVGRFJrNTBSVEpLV0VFclJYbEdOblp6UlhoRVlVVkZNbGRQVDBWdWRVUkxjMUpUYlhOa2FUQmFSVW93U0VaS00wZEZVRU5LWXpsVVZYQkhWa0l4VDBrNU5IUk5WUzg1YjNaaWNXNHJTa3RpWVdwVUwxWlVhVkZSYTJ4V05uUkdNMWN5UzFsNlpHaFRWbXB1WTJWTGRFUnpSa2hFU3pCc1F6ZHVWMnhUZWtKNU1Va3dSbEpSZFRac2QxaHRUM2hxYzJWVmNrVnBTRGhNTVZWSllqVlZNVUZZWVZSb1VDczBjM1ZhV1c5aFV6SXdWVzRyZEVGNGEwbHJOQ3N4V0VGR2NpdExhRWh1ZG5admEyRlpZM0JVTjJSYVNscFVWVE5qYUhOVVJqaGpWSGhTYzJkYU1teEhXV1JtYzFveldWRjZPR3RaVDFOSVVqWjRRWGhtYkRSM1pVbFhkMjFwWkVWS01FRlRSV2xKYkZOa2JWUjVOV3QzYzIwNVdURnFXVkJzZW14Nk0zbElTRGR6V2pkd09VMVVSa3hCYzJ4alJtVlFWSE5ZY25wMmVTODVXakJCTUU5dVVUWm5Ta0UxU2tGQmVEVkVkV0ZJYzIxR2FGcEVSVlp2U25kaFZrMWhiMnRxUnpabFdtWndPWEEwVms4ME9UaFNjRFFyVTA1cFEwbFJNRzVyZURCeGJXbFRSMUV3TUVOdE16aHJlSFZJT1ZVMVZWaDVPRFl3UTNkUWNteG1lR2hPT0V4aU9TdG1ZMVpFWTNWUk5EWlVLMjVvZURGTFMwMWhXRWxvWmtsUmFrTmxVMDVyYW1SWGJrRkZPV015WVc5UVpYYzFjRFpVT1dWM2VUZHdORUpLZFUxWFQyOWhWek5MWjFWcFZXVnNWSGd3ZHpGSE5WaExMemhGVEZOVmJrdEdjVVJqVTBvNU5EZHNhbWsxTkM5Q2JDOTJVa1F5UVdOWGFUWkViakZ2WW10eFFXMVlPR2R0VVVzelZGZzNkRXRZZDA4cllta3dZbW8zVVdWc1kwaFdjamc1VFZOa1pHdHNUM1YzTjNBMUx6STROSFo2U25kNE5tcDJha3hFTkhNMU56RXlSa1JHWnpGUlJISmpPRzFSYmxCMmVYSnRWa1l2Tm1SSVVFTk5RMk5qTDFaTVkwRlNia2xCZDJWaWQydDJVV0ZtWWxSR1QzVnJPWFZRY1VORWVXcFZZamQ1WVZWQlRtNTJlVnBvZFRWYVFtRjRkWFp2UWpoUVNFdDJZaXNyVEVFeVVHaFZNazByT1hsNWNsUnhNVUozUVVGQlFVRWlMQ0p0WlhSaFpHRjBZVjkwWVhKblpYUWlPaUpCVmxWQlRrY3hhR0pJVVRaaVIyeDZaRVJ3ZFdJeVVteE1WekZzWkVkRk5rRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRWGRCUVVGQlFVRkJRVUZWUVVGQlFVRkJRVUZCUVdjOUlpd2ljM1JsY0hNaU9sdDdJblJoY21kbGRDSTZJa0ZXVlZOSlNEUXJiWE5VVURKc0t6RjZXVnAwT1VGa2FuUjVSblJvWVRnM2QxaE1RbTlFWm5KRE1ERTFjREJpTWlJc0luQnliMjltSWpvaVFVRkJRVU5IY1RZdkwzaDZPV2MzV2xwMFVrOVZjazV6WXpKQ0wzWlVkM0JCY1hoeWRERldSbkZUV1dKalRsSjZRbTFaZGtsaGQzVlZPRXd4VDBkNGRsQkdTMHcwZVhSRlMweDVlVE50UVRoa1R6QnhZMU5TV2k5a1pFVlNWemxZZDNkNmFsSXpjV2R4ZDNnNFJERTFWbXc0TDFodmVFVnZkMDVWU1RoS2RHaHVNbGhOWjFZeFdteDFZMnhvYmtwc1RrWlplSGMzZWtWTU5EQnRORGRrU25jek56SklRVFZRUzBjdlRsUlllWGhOV21obGQwazVXVVJKZVhwcVIzVmxRa3RWV2tWd1ltUkJhMjVFUWtReFNXeG9XRTFJUnpWa1pVTnZaMEpoUVZRelprdGFOR3BZZVhWRGJuTnRlWEJ0VG5KbVIzSTJZbkJYY0c5UlJXTjZOM1lyTm5veVJYSlZhMEU1VkRkTVFuSjVZblUwUzI4clNqbDZMMkp4Um0welp6TnFZVnAzYjFaeFZEQkVWRGxFVUZscVJIQXlURmd6TUhSek5FVkZTVGwzZGt0dWFtRm5LMVUyUmpCUFpsZDFlR2N3VERWTGNWYzRaVlpvV2tSRlZtOUtkMkZXVFdGdmEycEhObVZhWm5BNWNEUldUelE1T0ZKd05DdFRUbWxEU1ZFd2Jtc3lXbTVIVVRWd1ZHWlRVVXR2TUZWTlZreFBNVk5WVEZWek5pdEhSMGhwY0ZwTmJEUTNkbGd3ZGxaelZtcEphRmhKYjBNdlRFbEpXVEZQZWl0dU1XczVhWFpxYW05elFWTjVOa2hRTDA5V1lXY3JVVll3TVU1ek1UWlljVEptWWpkVE1HVjJTV1VyVkdwbFZqRjVlRFpVYzNReE5IbEtPWFJ0WWpVeGFIRk9la1JZVDNGUllqUjRRWHBITlVod2FEWkVTRUZPWkdsaGFFRXdNVVpUZW1KeFdXWTFhRVpxVlhvMGNtSkpiSGRPVkdsMFVGQnZVak5ZVjNoWGVuRTRUSE5qT1ZseU1IaDFPREY0UjJSNU9GQm1iRFk0T1hoVmMyZEdNbGM0YUd4cU4yeGhPRlJ0VmpoMll5dElhbTF2VEdsVVkwbEJTR3hHYTFoQ1puWmtZVUYwVmpKNE1HUk9TbkJZYTNkelpsSnlZak50TW5wTk9HUjBUMmRLUVhoRkwwMTJPV040TWpCeU5uQmpTU3MwYTB0MGNuZzJTa0ZRWTBnclVYZ3ZZbTlHT0hOd1RXWnBSWE5qU1RWeWRUaFdUVXhETnpKcFFrVkJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.target-tamper.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FCQ2tVSnZYSjJEQXZhNGdpVmpQbUVwMU55cVpPWU1JN0EyWWVWL1RTM1FHVmZCYUlXUGFabzMwb0x4NU9QTXA4VnFwYzFVVU13eFRHNDZma2RmQ0M1WnE4dE4vckRFZlRsS0tVMUdFUjFMbWY0R0tNQ21WS3hCZEJ5aWlIQkQrSEF2OXk0ekdHdmNnVmdFNnFsemdIcGk0V0hXTVBFZWxQNDI1RGYyUjlzbUZQNU9lTXhybi81Zjc2N2VQRFU4bWJLYXR2WmsrV1ZOeDZmSXdzSXJWbUFzR2pxUTU5Z0szc0FBUlovQUk3NkVNTWkxQklKS01IY3l4ZGhFUlVUVWdEQUU5Wk54NXdaU3UrWkJBZVhaQzJ4K0RVckNzVHBCV053VHV4ZU5PS2FKV3RkZGU0dURUUFQ3OVRWQ2xVVUx5cldDeFd2UmdJSS9FaTQyWXo0NldwdHlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdm5IMFpuQUk1blRHNTZsaFVlRnBOdzVVQUlEdTl1ZFlBSFAyUUpyeG1KaWticUpaRllZMldKRjg4cm9vNFBqQTVyb1k1eTM2azE2cFd6eGM0UTJIK3VsTEJwZmpEeVZGQ2NvM2UwcnhNQXZjNkxyZndHUUlRcWlpNlV5UlNlajhsVC9LeXJiUlBwaVNzR1FRUU9NN3NHUGZYdCtjUjRPVUlrVmxiRjNJYXpXWkxvclhXMU14U2dJZlA5dk5SMDFKdTMvdGQzTU5raEFha0I3dnVKSmk0Z2tHVkF5NjJBMUNoL1dFVU5STFFYR3VzNnliRU1mYmdUejdaRUVtMzFDTzRBek9mZXlmaWpXQUVvcGpqbHhuTjR6UkcvOXJZaHZoZVJ0Y0lTUXFjNUFVZUNua2t5OXNhYzV6eFhqZkwwam9STzZINmRwZXQ2L1Iwc3FmUHhyVmJ4c0FBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.truncated-evidence.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0FCQ2tVSnZYSjJEQXZhNGdpVmpQbUVwMU55cVpPWU1JN0EyWWVWL1RTM1FHVmZCYUlXUGFabzMwb0x4NU9QTXA4VnFwYzFVVU13eFRHNDZma2RmQ0M1WnE4dE4vckRFZlRsS0tVMUdFUjFMbWY0R0tNQ21WS3hCZEJ5aWlIQkQrSEF2OXk0ekdHdmNnVmdFNnFsemdIcGk0V0hXTVBFZWxQNDI1RGYyUjlzbUZQNU9lTXhybi81Zjc2N2VQRFU4bWJLYXR2WmsrV1ZOeDZmSXdzSXJWbUFzR2pxUTU5Z0szc0FBUlovQUk3NkVNTWkxQklKS01IY3l4ZGhFUlVUVWdEQUU5Wk54NXdaU3UrWkJBZVhaQzJ4K0RVckNzVHBCV053VHV4ZU5PS2FKV3RkZGU0dURUUFQ3OVRWQ2xVVUx5cldDeFd2UmdJSS9FaTQyWXo0NldwdHlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdm5IMFpuQUk1blRHNTZsaFVlRnBOdzVVQUlEdTl1ZFlBSFAyUUpyeG1KaWticUpaRllZMldKRjg4cm9vNFBqQTVyb1k1eTM2azE2cFd6eGM0UTJIK3VsTEJwZmpEeVZGQ2NvM2UwcnhNQXZjNkxyZndHUUlRcWlpNlV5UlNlajhsVC9LeXJiUlBwaVNzR1FRUU9NN3NHUGZYdCtjUjRPVUlrVmxiRjNJYXpXWkxvclhXMU14U2dJZlA5dk5SMDFKdTMvdGQzTU5raEFha0I3dnVKSmk0Z2tHVkF5NjJBMUNoL1dFVU5STFFYR3VzNnliRU1mYmdUejdaRUVtMzFDTzRBek9mZXlmaWpXQUVvcGpqbHhuTjR6UkcvOXJZaHZoZVJ0Y0lTUXFjNUFVZUNua2t5OXNhYzV6eFhqZkwwam9STzZINmRwZXQ2L1Iwc3FmUHhyVmJ4c0FBQUE9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.ipa.unknown-field.reject",
+      "operation": "read",
+      "backend": "ipa",
+      "category": "strict_json",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          },
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "prooflist": {
+            "query": "profile/name",
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "steps": [
+              {
+                "coordinate": "profile/name",
+                "evidence_backend": "map",
+                "evidence_kind": "structure",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "kind": "map_step",
+                "path": "profile/name",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FCQ2tVSnZYSjJEQXZhNGdpVmpQbUVwMU55cVpPWU1JN0EyWWVWL1RTM1FHVmZCYUlXUGFabzMwb0x4NU9QTXA4VnFwYzFVVU13eFRHNDZma2RmQ0M1WnE4dE4vckRFZlRsS0tVMUdFUjFMbWY0R0tNQ21WS3hCZEJ5aWlIQkQrSEF2OXk0ekdHdmNnVmdFNnFsemdIcGk0V0hXTVBFZWxQNDI1RGYyUjlzbUZQNU9lTXhybi81Zjc2N2VQRFU4bWJLYXR2WmsrV1ZOeDZmSXdzSXJWbUFzR2pxUTU5Z0szc0FBUlovQUk3NkVNTWkxQklKS01IY3l4ZGhFUlVUVWdEQUU5Wk54NXdaU3UrWkJBZVhaQzJ4K0RVckNzVHBCV053VHV4ZU5PS2FKV3RkZGU0dURUUFQ3OVRWQ2xVVUx5cldDeFd2UmdJSS9FaTQyWXo0NldwdHlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdm5IMFpuQUk1blRHNTZsaFVlRnBOdzVVQUlEdTl1ZFlBSFAyUUpyeG1KaWticUpaRllZMldKRjg4cm9vNFBqQTVyb1k1eTM2azE2cFd6eGM0UTJIK3VsTEJwZmpEeVZGQ2NvM2UwcnhNQXZjNkxyZndHUUlRcWlpNlV5UlNlajhsVC9LeXJiUlBwaVNzR1FRUU9NN3NHUGZYdCtjUjRPVUlrVmxiRjNJYXpXWkxvclhXMU14U2dJZlA5dk5SMDFKdTMvdGQzTU5raEFha0I3dnVKSmk0Z2tHVkF5NjJBMUNoL1dFVU5STFFYR3VzNnliRU1mYmdUejdaRUVtMzFDTzRBek9mZXlmaWpXQUVvcGpqbHhuTjR6UkcvOXJZaHZoZVJ0Y0lTUXFjNUFVZUNua2t5OXNhYzV6eFhqZkwwam9STzZINmRwZXQ2L1Iwc3FmUHhyVmJ4c0FBQUFmIn1dfQ==",
+                "query": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                }
+              }
+            ]
+          },
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+        },
+        "unexpected": true
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.cross-backend-ipa-evidence.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "cross_backend",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FCQ2tVSnZYSjJEQXZhNGdpVmpQbUVwMU55cVpPWU1JN0EyWWVWL1RTM1FHVmZCYUlXUGFabzMwb0x4NU9QTXA4VnFwYzFVVU13eFRHNDZma2RmQ0M1WnE4dE4vckRFZlRsS0tVMUdFUjFMbWY0R0tNQ21WS3hCZEJ5aWlIQkQrSEF2OXk0ekdHdmNnVmdFNnFsemdIcGk0V0hXTVBFZWxQNDI1RGYyUjlzbUZQNU9lTXhybi81Zjc2N2VQRFU4bWJLYXR2WmsrV1ZOeDZmSXdzSXJWbUFzR2pxUTU5Z0szc0FBUlovQUk3NkVNTWkxQklKS01IY3l4ZGhFUlVUVWdEQUU5Wk54NXdaU3UrWkJBZVhaQzJ4K0RVckNzVHBCV053VHV4ZU5PS2FKV3RkZGU0dURUUFQ3OVRWQ2xVVUx5cldDeFd2UmdJSS9FaTQyWXo0NldwdHlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdm5IMFpuQUk1blRHNTZsaFVlRnBOdzVVQUlEdTl1ZFlBSFAyUUpyeG1KaWticUpaRllZMldKRjg4cm9vNFBqQTVyb1k1eTM2azE2cFd6eGM0UTJIK3VsTEJwZmpEeVZGQ2NvM2UwcnhNQXZjNkxyZndHUUlRcWlpNlV5UlNlajhsVC9LeXJiUlBwaVNzR1FRUU9NN3NHUGZYdCtjUjRPVUlrVmxiRjNJYXpXWkxvclhXMU14U2dJZlA5dk5SMDFKdTMvdGQzTU5raEFha0I3dnVKSmk0Z2tHVkF5NjJBMUNoL1dFVU5STFFYR3VzNnliRU1mYmdUejdaRUVtMzFDTzRBek9mZXlmaWpXQUVvcGpqbHhuTjR6UkcvOXJZaHZoZVJ0Y0lTUXFjNUFVZUNua2t5OXNhYzV6eFhqZkwwam9STzZINmRwZXQ2L1Iwc3FmUHhyVmJ4c0FBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.cross-kind.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "cross_kind",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "query": {
+            "kind": "list_index",
+            "index": 0
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "list:0",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJxTHVuK1lVbE1RMEo1RHIzYVMwVVF6cUc1bVdhY0xNdVdnRHo2dWxIY3VHekJWTlROSjI3UUJFZ2tUcVBpeEtpRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.cross-root.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "cross_root",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJxTHVuK1lVbE1RMEo1RHIzYVMwVVF6cUc1bVdhY0xNdVdnRHo2dWxIY3VHekJWTlROSjI3UUJFZ2tUcVBpeEtpRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.list-index.accept",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "list_index",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6jqabaayjae4h7mgutsgl4nlgxl2essqndkfhgylcz2ltn2lbegnycvmutvp72mr5x22o2qxlzvkkp2cq3bia",
+          "query": {
+            "kind": "list_index",
+            "index": 1
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga",
+          "prooflist": {
+            "root": {
+              "/": "baga6jqabaayjae4h7mgutsgl4nlgxl2essqndkfhgylcz2ltn2lbegnycvmutvp72mr5x22o2qxlzvkkp2cq3bia"
+            },
+            "query": "list:1",
+            "steps": [
+              {
+                "kind": "list_index",
+                "from": {
+                  "/": "baga6jqabaayjae4h7mgutsgl4nlgxl2essqndkfhgylcz2ltn2lbegnycvmutvp72mr5x22o2qxlzvkkp2cq3bia"
+                },
+                "query": "list:1",
+                "coordinate": "1",
+                "index": 1,
+                "length": 3,
+                "target": {
+                  "/": "bafkreibhurx73recmhsn4dp3zw7n4dyostqk4odayfeh6hdaow43mwqdga"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6ImdsaTlXejV4aG9CQWpkREZPT2ZQeVJBR05xajBDemZPZGdjWjI1M0M4Q2ZNRTNhTVJnSnBqZi84UVp5VkwwSGhRWHRyZVh0VTY3Qy9GMUQ0MnNjL0x0Tm8yaS9qWFZMQ29MSnlnY2libHI4QUFBQUEiLCJzdGVwcyI6W3sidGFyZ2V0IjoiQVZVU0lDZWtiLzNFZ21IazNnMzd6YjdlRHc2VTRLNDRZTUZJZnh4Z2RibTJXZ013IiwicHJvb2YiOiJ1RmxLWjlsTHlkWE9uVVdSNktqUkVXVUVEZ2dLT2F4L3lGYzB0VW9tYTdBck1XdFZCQzd1UHFsN1dEVmlZZjBwRHhzbXRZU3RadlRvVkxXMVFMYWZZVVpmMkJWT2ZuWFRiQlg0VmprcVRLVUFBQUFDIiwic2xvdCI6Mn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.kzg.list-range-bounded.accept",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "list_range",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
+          "query": {
+            "kind": "list_range",
+            "start": 2,
+            "end": 18
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
+          "range_segments": [
+            "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
+            },
+            "query": "range:2:18",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
+                },
+                "query": "range:2:18",
+                "coordinate": "range:2:18",
+                "start": 2,
+                "end": 18,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga"
+                  },
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6ImpFRWhNMTNpRmdrRGd3WWZrVXArMk53T1lnVitJWEliVzVqcjRFSEE4MnNBZDd3VUNFVXUwNmVBT1p6N2RVNmtFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTakJrVmxRNGFuUnpSVFpzTldWeE9WY3djV3R2UVhKelJrUkxZak12Y1c1MU5uTTBibkp3YTNVNGR5SXNJbkJ5YjI5bUlqb2lhMEpqU0d4SU0wOVJObk41SzFCaFMzVjBLMnBoWmtaUVRrdzRPRmxVTDFScmIwVmljVkJwVmt0V1puZ3lTalpvT0hJMVlrUkdVMnhhUjB4NGVrOTNaMEU0YmtORmNHdEpOa1pwVVVoSmMycG1VblJ0Y2tad1ZIcHZVbE5aTmt4d2N6Z3pSVWhPYTFabllsRkJRVUZCUWlJc0luTnNiM1FpT2pGOVhYMD0ifSx7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2lkVXhEY3pCUU9VUTBOMDVJWldZNVduazFabHA1TWxZMU5FaFFRbmx4U1U0emNXbENTMVZqYmpKRFp5OTVNbW92YldVNWRUQlNhMHQxUVZFNVpTdEhLMVJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2laMjlUYkZJek9YVTJObkJ3UzFoR01YUXpibkJUSzJkdFowb3hNelZYUkV3eVYwTjJWV1ZoZFZkVWFHeHVjVWRYVmxKV1ltVm1jV013VjA1aGNVVktObFJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.kzg.list-range-eof.accept",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "list_range",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
+          "query": {
+            "kind": "list_range",
+            "start": 8
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
+          "range_segments": [
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
+            },
+            "query": "range:8:",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
+                },
+                "query": "range:8:",
+                "coordinate": "range:8:",
+                "start": 8,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6ImpFRWhNMTNpRmdrRGd3WWZrVXArMk53T1lnVitJWEliVzVqcjRFSEE4MnNBZDd3VUNFVXUwNmVBT1p6N2RVNmtFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2lkVXhEY3pCUU9VUTBOMDVJWldZNVduazFabHA1TWxZMU5FaFFRbmx4U1U0emNXbENTMVZqYmpKRFp5OTVNbW92YldVNWRUQlNhMHQxUVZFNVpTdEhLMVJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2laMjlUYkZJek9YVTJObkJ3UzFoR01YUXpibkJUSzJkdFowb3hNelZYUkV3eVYwTjJWV1ZoZFZkVWFHeHVjVWRYVmxKV1ltVm1jV013VjA1aGNVVktObFJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.kzg.malformed-base64.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          },
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "prooflist": {
+            "query": "profile/name",
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "steps": [
+              {
+                "coordinate": "profile/name",
+                "evidence_backend": "map",
+                "evidence_kind": "structure",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "kind": "map_step",
+                "path": "profile/name",
+                "proof": "not-base64%%%",
+                "query": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                }
+              }
+            ]
+          },
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.map-key.accept",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "map_key",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJxTHVuK1lVbE1RMEo1RHIzYVMwVVF6cUc1bVdhY0xNdVdnRHo2dWxIY3VHekJWTlROSjI3UUJFZ2tUcVBpeEtpRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.kzg.missing-evidence.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.payload.accept",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "payload",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "@payload"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "@payload",
+            "steps": [
+              {
+                "kind": "payload_binding",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "@payload",
+                "coordinate": "@payload",
+                "path": "@payload",
+                "target": {
+                  "/": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6InE2eDVJY3cvNFZLRHVNdkthQ3dGbEhIZFBnUXpIaTRuaXVTWlA3ZXNJSms5QStjTkIzWUExODB5ZmxmYzlLcFhQSDd6am0vMm1aOEJBa3RsQWtEQUcxWXVNU2xuYk5xQ3NoWXgyRVFWQWdRQUFBbGcifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "read.kzg.proof-tamper.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJxTHVuK1lVbE1RMEo1RHIzYVMwVVF6cUc1bVdhY0xNdVdnRHo2dWxIY3VHekJWTlROSjI3UUJFZ2tUcVBpeEtpRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh4Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.range-segments-tamper.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
+          "query": {
+            "kind": "list_range",
+            "start": 2,
+            "end": 18
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my",
+          "range_segments": [
+            "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy",
+            "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga",
+            "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+          ],
+          "prooflist": {
+            "root": {
+              "/": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
+            },
+            "query": "range:2:18",
+            "steps": [
+              {
+                "kind": "list_range",
+                "from": {
+                  "/": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
+                },
+                "query": "range:2:18",
+                "coordinate": "range:2:18",
+                "start": 2,
+                "end": 18,
+                "child_count": 3,
+                "total_size": 20,
+                "chunk_size": 8,
+                "target": {
+                  "/": "baga6jqabaayi2fgh3blbrek4c7pripjbgzd3koclrcb3i6wcozowrmmgfiupp3tnmx23p7j2tezipc6wsm3w23my"
+                },
+                "segments": [
+                  {
+                    "/": "bafkreie5dvkt6i5wye5jpf5k6vwsveuafoyfbstpp7vj53vm4j5otexpga"
+                  },
+                  {
+                    "/": "bafkreievbtvpp2rzai7r5ak7mzdn7l7oqlldwbnbv7ouyupjzyw6ssvtmy"
+                  },
+                  {
+                    "/": "bafkreid6h2nmjt62l6243btn6qdwhnzbnwc26o6bola2an7lbngxtj2g6y"
+                  }
+                ],
+                "evidence_kind": "structure",
+                "evidence_backend": "measured_list",
+                "proof": "eyJtZXRhZGF0YV9wcm9vZiI6ImpFRWhNMTNpRmdrRGd3WWZrVXArMk53T1lnVitJWEliVzVqcjRFSEE4MnNBZDd3VUNFVXUwNmVBT1p6N2RVNmtFK2ZGNUxndUVzY3B5RFpFcWtheXFyTlFhWjFSK2hLWEZnVXFFVVdza0pvQUFBQUEiLCJpbmRleF9wcm9vZnMiOlt7ImluZGV4IjowLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTakJrVmxRNGFuUnpSVFpzTldWeE9WY3djV3R2UVhKelJrUkxZak12Y1c1MU5uTTBibkp3YTNVNGR5SXNJbkJ5YjI5bUlqb2lhMEpqU0d4SU0wOVJObk41SzFCaFMzVjBLMnBoWmtaUVRrdzRPRmxVTDFScmIwVmljVkJwVmt0V1puZ3lTalpvT0hJMVlrUkdVMnhhUjB4NGVrOTNaMEU0YmtORmNHdEpOa1pwVVVoSmMycG1VblJ0Y2tad1ZIcHZVbE5aTmt4d2N6Z3pSVWhPYTFabllsRkJRVUZCUWlJc0luTnNiM1FpT2pGOVhYMD0ifSx7ImluZGV4IjoxLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTbFZOTm5abWNVOVJTUzlJYjBabVdtdGlabklyTmtNeGFuTkdiMkV2WkZSR1NIQjZhVE53VTNKT2JTSXNJbkJ5YjI5bUlqb2lkVXhEY3pCUU9VUTBOMDVJWldZNVduazFabHA1TWxZMU5FaFFRbmx4U1U0emNXbENTMVZqYmpKRFp5OTVNbW92YldVNWRUQlNhMHQxUVZFNVpTdEhLMVJyYVZWdVZGZHlPVzgwWmpSaEt5OUlSVkZtUjA5bVptZFFhSFExYWtGRU9YQlRVREJXSzFFclNrMUJRVUZCUXlJc0luTnNiM1FpT2pKOVhYMD0ifSx7ImluZGV4IjoyLCJwcm9vZiI6ImV5SnRaWFJoWkdGMFlWOXdjbTl2WmlJNkltcEZSV2hOTVROcFJtZHJSR2QzV1daclZYQXJNazUzVDFsblZpdEpXRWxpVnpWcWNqUkZTRUU0TW5OQlpEZDNWVU5GVlhVd05tVkJUMXA2TjJSVk5tdEZLMlpHTlV4bmRVVnpZM0I1UkZwRmNXdGhlWEZ5VGxGaFdqRlNLMmhMV0VablZYRkZWVmR6YTBwdlFVRkJRVUVpTENKdFpYUmhaR0YwWVY5MFlYSm5aWFFpT2lKQlZsVkJUa2N4YUdKSVVUWmlSMng2WkVSd2RXSXlVbXhNVnpGc1pFZEZOa0ZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVhkQlFVRkJRVUZCUVVGVlFVRkJRVUZCUVVGQlFXYzlJaXdpYzNSbGNITWlPbHQ3SW5SaGNtZGxkQ0k2SWtGV1ZWTkpTRFFyYlhOVVVESnNLekY2V1ZwME9VRmthblI1Um5Sb1lUZzNkMWhNUW05RVpuSkRNREUxY0RCaU1pSXNJbkJ5YjI5bUlqb2laMjlUYkZJek9YVTJObkJ3UzFoR01YUXpibkJUSzJkdFowb3hNelZYUkV3eVYwTjJWV1ZoZFZkVWFHeHVjVWRYVmxKV1ltVm1jV013VjA1aGNVVktObFJLZURSa1UzcDZkVTFvT1dST1RqWjNkRTQzYms5YWJsUTJUVmN6WkZsMFFWQkVOMDFsYzBoWVUxbEJRVUZCUkNJc0luTnNiM1FpT2pOOVhYMD0ifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.target-tamper.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiapo7irayiptqmbfdalgad7j5ni34chj5fd5qjun2lott6r2l5ccy"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJxTHVuK1lVbE1RMEo1RHIzYVMwVVF6cUc1bVdhY0xNdVdnRHo2dWxIY3VHekJWTlROSjI3UUJFZ2tUcVBpeEtpRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.truncated-evidence.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          }
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "profile/name",
+                "coordinate": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "structure",
+                "evidence_backend": "map",
+                "proof": "eyJzdGVwcyI6W3sicHJvb2YiOiJxTHVuK1lVbE1RMEo1RHIzYVMwVVF6cUc1bVdhY0xNdVdnRHo2dWxIY3VHekJWTlROSjI3UUJFZ2tUcVBpeEtpRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUU9Iiwic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "read.kzg.unknown-field.reject",
+      "operation": "read",
+      "backend": "kzg",
+      "category": "strict_json",
+      "verification": {
+        "request": {
+          "profile": "malt.read/v0alpha1",
+          "query": {
+            "kind": "map_key",
+            "segments": [
+              "profile",
+              "name"
+            ]
+          },
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+        },
+        "result": {
+          "profile": "malt.read/v0alpha1",
+          "prooflist": {
+            "query": "profile/name",
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "steps": [
+              {
+                "coordinate": "profile/name",
+                "evidence_backend": "map",
+                "evidence_kind": "structure",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "kind": "map_step",
+                "path": "profile/name",
+                "proof": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJxTHVuK1lVbE1RMEo1RHIzYVMwVVF6cUc1bVdhY0xNdVdnRHo2dWxIY3VHekJWTlROSjI3UUJFZ2tUcVBpeEtpRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ==",
+                "query": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                }
+              }
+            ]
+          },
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+        },
+        "unexpected": true
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.identity.accept",
+      "operation": "resolve",
+      "backend": "none",
+      "category": "identity",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bafkreihj7frihi7mfoo4ano74bl563eme4koaajxnlvrr4qpyunbf6x4ha",
+          "segments": []
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreihj7frihi7mfoo4ano74bl563eme4koaajxnlvrr4qpyunbf6x4ha",
+          "prooflist": {
+            "root": {
+              "/": "bafkreihj7frihi7mfoo4ano74bl563eme4koaajxnlvrr4qpyunbf6x4ha"
+            },
+            "steps": []
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.ipa.cross-root.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "cross_root",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbofqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgycdvfehcy2foj4hn4obunbbig4x4mu2i7zipkxrd22bsrmarcsq"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNCdDAxcjViZmxvbzdXTFZlVGlsK0x0bDNZNzdXYXpybDlPZ1ZvNDdvVmZVWjNFUGFlWEVqNllYUDYzakMvZFQzRnNJL0IrTXVTdit1dlJEZWpWS1NBSmVJMmF5TUlkZmRtYWtXN0VJOVIvRUdmakhjc2RnMU91NllRc3c4aWk0MHlmVTd4aGE3aThKdXQvbzM5Y0ZnMU5VR3N0N3R4NDl0Q2VPU1VDTE9VK3RXRm95clRmd3hlSTd5MWNISndDalhTNC9wUks5UTRDVGpHY2ViL3ZTWmlVbGxsMTNqdFIxQmJzakVjZ1NLT0x6SXY0b3RQYmY3ck5HRjJwdndVTFpMbXBVVzhQbWJoWitWK2t0dVFnR2tjMmRNdUhYRDlUNUZoNWJzOU1DUmN0T1lXVFh5SDBuSFZ3N21sRGFJR1E2T1d1MTJDSmQ2UWd6TzdJQkNiclh6bVJ5V0duYnM2TGdmeUQySWRTbGhOMnowUExldzBTTFFDc3BGeFRXSEZoRnZodnBXRDB4MkV4OCt1TnpSd2ZSeEZRQXN2Q1ArTGJDWXZ0bGNRVU9hbkppY0JCMnVseXVwTVZyR01kNUxrY1FUaHR3ZlJSZGkxQ2VIakRIbzFnT1hkd0RXckhDc1pBOFh0ZmFwY3J2MWQwSHEyN3lPYlMvZlNsSTJXSVozS25iOXg2WndHYzV3emFrSDBUT05DTnlRUTdiRFBUMHpXV2xXM0hRSW54ZjY5N2JhYXJ1Z1VlSm03YU9uVGJGek1FSTM5WFl5Z2lWMnVadmdoK1BndnBCNnlzc1BNa2RtOTdVK29HcyttZ3VmZGJUcHFMSXJhM0FldmI2aDd1WFo2ZG40bG14TTd0UjhGOUJBSmdYMUw0Wk91ZHBkdytlMHJFaUxIeHFXTTJFQzNWRTBlNk9KaUl2NUpieUZmUUlLcW9ldlpFTzlYNDcvUzRFbWhkWWswclU3UllBQUFCRyJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.ipa.evidence-tamper.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0J0MDFyNWJmbG9vN1dMVmVUaWwrTHRsM1k3N1dhenJsOU9nVm80N29WZlVaM0VQYWVYRWo2WVhQNjNqQy9kVDNGc0kvQitNdVN2K3V2UkRlalZLU0FKZUkyYXlNSWRmZG1ha1c3RUk5Ui9FR2ZqSGNzZGcxT3U2WVFzdzhpaTQweWZVN3hoYTdpOEp1dC9vMzljRmcxTlVHc3Q3dHg0OXRDZU9TVUNMT1UrdFdGb3lyVGZ3eGVJN3kxY0hKd0NqWFM0L3BSSzlRNENUakdjZWIvdlNaaVVsbGwxM2p0UjFCYnNqRWNnU0tPTHpJdjRvdFBiZjdyTkdGMnB2d1VMWkxtcFVXOFBtYmhaK1Yra3R1UWdHa2MyZE11SFhEOVQ1Rmg1YnM5TUNSY3RPWVdUWHlIMG5IVnc3bWxEYUlHUTZPV3UxMkNKZDZRZ3pPN0lCQ2JyWHptUnlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdmh2cFdEMHgyRXg4K3VOelJ3ZlJ4RlFBc3ZDUCtMYkNZdnRsY1FVT2FuSmljQkIydWx5dXBNVnJHTWQ1TGtjUVRodHdmUlJkaTFDZUhqREhvMWdPWGR3RFdySENzWkE4WHRmYXBjcnYxZDBIcTI3eU9iUy9mU2xJMldJWjNLbmI5eDZad0djNXd6YWtIMFRPTkNOeVFRN2JEUFQweldXbFczSFFJbnhmNjk3YmFhcnVnVWVKbTdhT25UYkZ6TUVJMzlYWXlnaVYydVp2Z2grUGd2cEI2eXNzUE1rZG05N1Urb0dzK21ndWZkYlRwcUxJcmEzQWV2YjZoN3VYWjZkbjRsbXhNN3RSOEY5QkFKZ1gxTDRaT3VkcGR3K2UwckVpTEh4cVdNMkVDM1ZFMGU2T0ppSXY1SmJ5RmZRSUtxb2V2WkVPOVg0Ny9TNEVtaGRZazByVTdSWUFBQUJIIiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.ipa.malformed-base64.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "prooflist": {
+            "query": "docs/leaf",
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "steps": [
+              {
+                "evidence": "not-base64%%%",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "kind": "map_step",
+                "path": "docs",
+                "query": "docs",
+                "target": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                }
+              },
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ==",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "kind": "map_step",
+                "path": "leaf",
+                "query": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                }
+              }
+            ]
+          },
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.ipa.map-key.accept",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "map_key",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "segments": [
+            "profile",
+            "name"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJBQUFBQ0FCQ2tVSnZYSjJEQXZhNGdpVmpQbUVwMU55cVpPWU1JN0EyWWVWL1RTM1FHVmZCYUlXUGFabzMwb0x4NU9QTXA4VnFwYzFVVU13eFRHNDZma2RmQ0M1WnE4dE4vckRFZlRsS0tVMUdFUjFMbWY0R0tNQ21WS3hCZEJ5aWlIQkQrSEF2OXk0ekdHdmNnVmdFNnFsemdIcGk0V0hXTVBFZWxQNDI1RGYyUjlzbUZQNU9lTXhybi81Zjc2N2VQRFU4bWJLYXR2WmsrV1ZOeDZmSXdzSXJWbUFzR2pxUTU5Z0szc0FBUlovQUk3NkVNTWkxQklKS01IY3l4ZGhFUlVUVWdEQUU5Wk54NXdaU3UrWkJBZVhaQzJ4K0RVckNzVHBCV053VHV4ZU5PS2FKV3RkZGU0dURUUFQ3OVRWQ2xVVUx5cldDeFd2UmdJSS9FaTQyWXo0NldwdHlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdm5IMFpuQUk1blRHNTZsaFVlRnBOdzVVQUlEdTl1ZFlBSFAyUUpyeG1KaWticUpaRllZMldKRjg4cm9vNFBqQTVyb1k1eTM2azE2cFd6eGM0UTJIK3VsTEJwZmpEeVZGQ2NvM2UwcnhNQXZjNkxyZndHUUlRcWlpNlV5UlNlajhsVC9LeXJiUlBwaVNzR1FRUU9NN3NHUGZYdCtjUjRPVUlrVmxiRjNJYXpXWkxvclhXMU14U2dJZlA5dk5SMDFKdTMvdGQzTU5raEFha0I3dnVKSmk0Z2tHVkF5NjJBMUNoL1dFVU5STFFYR3VzNnliRU1mYmdUejdaRUVtMzFDTzRBek9mZXlmaWpXQUVvcGpqbHhuTjR6UkcvOXJZaHZoZVJ0Y0lTUXFjNUFVZUNua2t5OXNhYzV6eFhqZkwwam9STzZINmRwZXQ2L1Iwc3FmUHhyVmJ4c0FBQUFmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.ipa.missing-evidence.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit"
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.ipa.multihop.accept",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "multihop",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNCdDAxcjViZmxvbzdXTFZlVGlsK0x0bDNZNzdXYXpybDlPZ1ZvNDdvVmZVWjNFUGFlWEVqNllYUDYzakMvZFQzRnNJL0IrTXVTdit1dlJEZWpWS1NBSmVJMmF5TUlkZmRtYWtXN0VJOVIvRUdmakhjc2RnMU91NllRc3c4aWk0MHlmVTd4aGE3aThKdXQvbzM5Y0ZnMU5VR3N0N3R4NDl0Q2VPU1VDTE9VK3RXRm95clRmd3hlSTd5MWNISndDalhTNC9wUks5UTRDVGpHY2ViL3ZTWmlVbGxsMTNqdFIxQmJzakVjZ1NLT0x6SXY0b3RQYmY3ck5HRjJwdndVTFpMbXBVVzhQbWJoWitWK2t0dVFnR2tjMmRNdUhYRDlUNUZoNWJzOU1DUmN0T1lXVFh5SDBuSFZ3N21sRGFJR1E2T1d1MTJDSmQ2UWd6TzdJQkNiclh6bVJ5V0duYnM2TGdmeUQySWRTbGhOMnowUExldzBTTFFDc3BGeFRXSEZoRnZodnBXRDB4MkV4OCt1TnpSd2ZSeEZRQXN2Q1ArTGJDWXZ0bGNRVU9hbkppY0JCMnVseXVwTVZyR01kNUxrY1FUaHR3ZlJSZGkxQ2VIakRIbzFnT1hkd0RXckhDc1pBOFh0ZmFwY3J2MWQwSHEyN3lPYlMvZlNsSTJXSVozS25iOXg2WndHYzV3emFrSDBUT05DTnlRUTdiRFBUMHpXV2xXM0hRSW54ZjY5N2JhYXJ1Z1VlSm03YU9uVGJGek1FSTM5WFl5Z2lWMnVadmdoK1BndnBCNnlzc1BNa2RtOTdVK29HcyttZ3VmZGJUcHFMSXJhM0FldmI2aDd1WFo2ZG40bG14TTd0UjhGOUJBSmdYMUw0Wk91ZHBkdytlMHJFaUxIeHFXTTJFQzNWRTBlNk9KaUl2NUpieUZmUUlLcW9ldlpFTzlYNDcvUzRFbWhkWWswclU3UllBQUFCRyJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.ipa.payload.accept",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "payload",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "segments": [
+            "docs",
+            "@payload"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "docs/@payload",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNCdDAxcjViZmxvbzdXTFZlVGlsK0x0bDNZNzdXYXpybDlPZ1ZvNDdvVmZVWjNFUGFlWEVqNllYUDYzakMvZFQzRnNJL0IrTXVTdit1dlJEZWpWS1NBSmVJMmF5TUlkZmRtYWtXN0VJOVIvRUdmakhjc2RnMU91NllRc3c4aWk0MHlmVTd4aGE3aThKdXQvbzM5Y0ZnMU5VR3N0N3R4NDl0Q2VPU1VDTE9VK3RXRm95clRmd3hlSTd5MWNISndDalhTNC9wUks5UTRDVGpHY2ViL3ZTWmlVbGxsMTNqdFIxQmJzakVjZ1NLT0x6SXY0b3RQYmY3ck5HRjJwdndVTFpMbXBVVzhQbWJoWitWK2t0dVFnR2tjMmRNdUhYRDlUNUZoNWJzOU1DUmN0T1lXVFh5SDBuSFZ3N21sRGFJR1E2T1d1MTJDSmQ2UWd6TzdJQkNiclh6bVJ5V0duYnM2TGdmeUQySWRTbGhOMnowUExldzBTTFFDc3BGeFRXSEZoRnZodnBXRDB4MkV4OCt1TnpSd2ZSeEZRQXN2Q1ArTGJDWXZ0bGNRVU9hbkppY0JCMnVseXVwTVZyR01kNUxrY1FUaHR3ZlJSZGkxQ2VIakRIbzFnT1hkd0RXckhDc1pBOFh0ZmFwY3J2MWQwSHEyN3lPYlMvZlNsSTJXSVozS25iOXg2WndHYzV3emFrSDBUT05DTnlRUTdiRFBUMHpXV2xXM0hRSW54ZjY5N2JhYXJ1Z1VlSm03YU9uVGJGek1FSTM5WFl5Z2lWMnVadmdoK1BndnBCNnlzc1BNa2RtOTdVK29HcyttZ3VmZGJUcHFMSXJhM0FldmI2aDd1WFo2ZG40bG14TTd0UjhGOUJBSmdYMUw0Wk91ZHBkdytlMHJFaUxIeHFXTTJFQzNWRTBlNk9KaUl2NUpieUZmUUlLcW9ldlpFTzlYNDcvUzRFbWhkWWswclU3UllBQUFCRyJ9XX0="
+              },
+              {
+                "kind": "payload_binding",
+                "from": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "@payload",
+                "path": "@payload",
+                "target": {
+                  "/": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6IkFBQUFDR3BTWVpQWmdYcElkbFhVM2ZOTEMrN0xZT2NBbnNHOTNtcVNUTjZka2cwQ0gxWVNSQW45cU5NbTlOK2ErUVh6TEp3S0xaVjhSVXExVldPblg0NUtxakJzdlFLayt6NWZDUWJYMCtjVTBnc2U3aHZ5T2JYaFRWQkZIa0dXOEVYV2ZqR3hVbHFra3psU21hZGtYWlBjR2lCUGtzNjd5TTBzODNFSE8rNHRjbWI4UFdVSVVTdVZxZkxwaEVvQlloRlp4dXpzNmtCZmlZUmFod2ZndWNaS2JNaHlES0lvbmo2dHJnRkI1OG1OZkJsRCttVHNyUDdoQ0F6a1VQQk9UVHVPdFdlOWcrWlV3NEcybHQ3TEJMOWEzZ2haUkhlUFMweHVaVkVqUmlQWXMyUTBDbnBBSnhUVHZZR0o0aGFYNFpEQ3MwM1l2VjF3SjYvbDJYNlhUV1MxNmh0Qmh4Ym53eTVhVEdtbFAzRnh4RlVwdHovV3o1ZllyREtQUnpKYXNmNXdEMUZlbHRIRXFiS0poNExCNU1PRkY1QU4yZ0NrcjFrWDJaZHluT0g2QndiMUsvOHpLRlpodzhaTGQ3M08xTEhiY210dVpJSXlSREIwbVJPMFRPd3NHTTVQV1ltcDZnMmVyTThyRWM0emtSV1o2NWRMWUNCRXRkdGd4NzhxSUFzczBWVUJqN1phK0J6ckE2TXlVQndkWVYrTm51V3ZLZWVselhDR0lYK0V0TkhEVlBoL3RGTFJmankwRUZFTG1OcjRwai9BdytoVGp3SmZIMzBhTDlPWmxDZG9wTzdGeHhPVjE1UldqdHovckpYK0JrUjRGV3d0M3JFUlE1UlNvb0dTN2lwT29LbUwrbCsyTER3VzZGTW5NWEhoenRMWDJVSmMrNTZlSVgvU0hMbkdWSEJJelB0SmlLS2VVK0J6VnlYcGY2alZnVFN2dk43NDlhTjVQdGR6QXdJQUFBQ1cifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.ipa.truncated-evidence.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJBQUFBQ0J0MDFyNWJmbG9vN1dMVmVUaWwrTHRsM1k3N1dhenJsOU9nVm80N29WZlVaM0VQYWVYRWo2WVhQNjNqQy9kVDNGc0kvQitNdVN2K3V2UkRlalZLU0FKZUkyYXlNSWRmZG1ha1c3RUk5Ui9FR2ZqSGNzZGcxT3U2WVFzdzhpaTQweWZVN3hoYTdpOEp1dC9vMzljRmcxTlVHc3Q3dHg0OXRDZU9TVUNMT1UrdFdGb3lyVGZ3eGVJN3kxY0hKd0NqWFM0L3BSSzlRNENUakdjZWIvdlNaaVVsbGwxM2p0UjFCYnNqRWNnU0tPTHpJdjRvdFBiZjdyTkdGMnB2d1VMWkxtcFVXOFBtYmhaK1Yra3R1UWdHa2MyZE11SFhEOVQ1Rmg1YnM5TUNSY3RPWVdUWHlIMG5IVnc3bWxEYUlHUTZPV3UxMkNKZDZRZ3pPN0lCQ2JyWHptUnlXR25iczZMZ2Z5RDJJZFNsaE4yejBQTGV3MFNMUUNzcEZ4VFdIRmhGdmh2cFdEMHgyRXg4K3VOelJ3ZlJ4RlFBc3ZDUCtMYkNZdnRsY1FVT2FuSmljQkIydWx5dXBNVnJHTWQ1TGtjUVRodHdmUlJkaTFDZUhqREhvMWdPWGR3RFdySENzWkE4WHRmYXBjcnYxZDBIcTI3eU9iUy9mU2xJMldJWjNLbmI5eDZad0djNXd6YWtIMFRPTkNOeVFRN2JEUFQweldXbFczSFFJbnhmNjk3YmFhcnVnVWVKbTdhT25UYkZ6TUVJMzlYWXlnaVYydVp2Z2grUGd2cEI2eXNzUE1rZG05N1Urb0dzK21ndWZkYlRwcUxJcmEzQWV2YjZoN3VYWjZkbjRsbXhNN3RSOEY5QkFKZ1gxTDRaT3VkcGR3K2UwckVpTEh4cVdNMkVDM1ZFMGU2T0ppSXY1SmJ5RmZRSUtxb2V2WkVPOVg0Ny9TNEVtaGRZazByVTdSWUFBQUE9Iiwic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.ipa.unknown-field.reject",
+      "operation": "resolve",
+      "backend": "ipa",
+      "category": "strict_json",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "prooflist": {
+            "query": "docs/leaf",
+            "root": {
+              "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+            },
+            "steps": [
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlMaXdBRUFJQWxZcmpJdXdjZzBKbk9lS1VDcGc2L1RPcVc1Tk1KamNXaWI2UE01Q3NwcCIsInByb29mIjoiQUFBQUNCdDAxcjViZmxvbzdXTFZlVGlsK0x0bDNZNzdXYXpybDlPZ1ZvNDdvVmZVWjNFUGFlWEVqNllYUDYzakMvZFQzRnNJL0IrTXVTdit1dlJEZWpWS1NBSmVJMmF5TUlkZmRtYWtXN0VJOVIvRUdmakhjc2RnMU91NllRc3c4aWk0MHlmVTd4aGE3aThKdXQvbzM5Y0ZnMU5VR3N0N3R4NDl0Q2VPU1VDTE9VK3RXRm95clRmd3hlSTd5MWNISndDalhTNC9wUks5UTRDVGpHY2ViL3ZTWmlVbGxsMTNqdFIxQmJzakVjZ1NLT0x6SXY0b3RQYmY3ck5HRjJwdndVTFpMbXBVVzhQbWJoWitWK2t0dVFnR2tjMmRNdUhYRDlUNUZoNWJzOU1DUmN0T1lXVFh5SDBuSFZ3N21sRGFJR1E2T1d1MTJDSmQ2UWd6TzdJQkNiclh6bVJ5V0duYnM2TGdmeUQySWRTbGhOMnowUExldzBTTFFDc3BGeFRXSEZoRnZodnBXRDB4MkV4OCt1TnpSd2ZSeEZRQXN2Q1ArTGJDWXZ0bGNRVU9hbkppY0JCMnVseXVwTVZyR01kNUxrY1FUaHR3ZlJSZGkxQ2VIakRIbzFnT1hkd0RXckhDc1pBOFh0ZmFwY3J2MWQwSHEyN3lPYlMvZlNsSTJXSVozS25iOXg2WndHYzV3emFrSDBUT05DTnlRUTdiRFBUMHpXV2xXM0hRSW54ZjY5N2JhYXJ1Z1VlSm03YU9uVGJGek1FSTM5WFl5Z2lWMnVadmdoK1BndnBCNnlzc1BNa2RtOTdVK29HcyttZ3VmZGJUcHFMSXJhM0FldmI2aDd1WFo2ZG40bG14TTd0UjhGOUJBSmdYMUw0Wk91ZHBkdytlMHJFaUxIeHFXTTJFQzNWRTBlNk9KaUl2NUpieUZmUUlLcW9ldlpFTzlYNDcvUzRFbWhkWWswclU3UllBQUFCRyJ9XX0=",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagbofqabaaqgwhum4flxrwk542kyhcasb7fuzkraewdkfctensjonmo6lo3ydwq"
+                },
+                "kind": "map_step",
+                "path": "docs",
+                "query": "docs",
+                "target": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                }
+              },
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJBQUFBQ0dwU1laUFpnWHBJZGxYVTNmTkxDKzdMWU9jQW5zRzkzbXFTVE42ZGtnMENDZzJRbUt1TWdsK1g0SnhtTTJpTklXb1k2ZUhDWWVSaERKUFNsVHNwRTBSWlZna3M4dnZOOGJqT0dlamdQNk5hU0xqaExMbEZ2TmVuQWhBN1NPV0FIMjNZRlNwTnJuUmtVQkpUOXZObHhvUVVieUg4eFozclZsVms3bGllZnBFQUZjK3NXQW42SjVndXByYkxOcHd3OGNodWZZTTFxN3lRTCtvUjdOam1wd2xnbW83aGFzNS9KdmxZa2lqdmEyc2Npd1lESVB6MUcyMDJDWE10SldIYThVVE1YT0YzSkVIcHBYN29YaDcvTzYwN3U2Nlc5MzJnai90MUdweHVhc3BOWTdaa200bUphd1BIWEJjOWI3YkJuTUR4ZzdORzhiZ2dFOXdDZktJL1pJb1pmRHQ4emFXWWs1N3hqQVRFcHUrZDdQa3U5SkhQQW9TMzhERVUybjRRN1MyUG9ydnkvejRSWi9YU01SQ2tNcXBxbmxJdzJyTXBpdXRBOFdMK0ovdjFaMTVXZVg2RFNTMUN0Q3dKMFpWNVdONC9CSnZKOGtLMnZWeXZVN3o2VDdCZDVqWDRncXRWWi9xRU96M0pDcE94S1pJVnZVcUJOaHVzS3hLUGRaVG9DMnVZaWRma1pxalkwRXdiQ1ovWTR5RzVDejdQSWcwVzBGQ25aZGlFRHNXZ1pqWGdNWkZNd1IwSEtaU0JMMGdMSEVRMytVL2JScWtVRmNEL0YrdmVkRFkrZnlmaWhxL1BVeENVb21kS0NKWFZMdGM0eTFCV3JWMDlRMm9YcXd5TENXK3lmZWFVN2JqcENnZkxJdzl1bDFiUnpwU2hLQXZlekU4M2NHRG9sYm5CbDE5M1Q4YnNIV2JRdStXeHVBNk50b2NKQXFONklLSk0waXk5bWM3SWpoQUFBQUNmIn1dfQ==",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "bagbofqabaaqaswfogixmdsbuezzz4kkavgb27uz2uw4tjqtdofujx2hthefmu2i"
+                },
+                "kind": "map_step",
+                "path": "leaf",
+                "query": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                }
+              }
+            ]
+          },
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+        },
+        "unexpected": true
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.cross-root.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "cross_root",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "baga6fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylbot6fuybiw4c2nuc6zl5ampcvz4mhcgsp7lqqv2fndbq6e5fmpwpmjoqic4fx3qaox5ycs6e7qqa"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIaXdBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSIsInByb29mIjoic2N0SmZnN08zbURkOHFzRkFqcWczaGlSUjR5OVY1bUF3dnRSVEFySW1BeDBpRnhmVlpBZWtueHlVRmhkNDRzcURsVUs0Q3dnaWNqOHFqMkZ5bmxuY3M3aUozelFyZ3h1Y2taZmhGbWkrVmdBQUFSciJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.evidence-tamper.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "tamper",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJzY3RKZmc3TzNtRGQ4cXNGQWpxZzNoaVJSNHk5VjVtQXd2dFJUQXJJbUF4MGlGeGZWWkFla254eVVGaGQ0NHNxRGxVSzRDd2dpY2o4cWoyRnlubG5jczdpSjN6UXJneHVja1pmaEZtaStWZ0FBQVJxIiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIaXdBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.malformed-base64.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "prooflist": {
+            "query": "docs/leaf",
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "steps": [
+              {
+                "evidence": "not-base64%%%",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "kind": "map_step",
+                "path": "docs",
+                "query": "docs",
+                "target": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                }
+              },
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ==",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "kind": "map_step",
+                "path": "leaf",
+                "query": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                }
+              }
+            ]
+          },
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.map-key.accept",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "map_key",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "segments": [
+            "profile",
+            "name"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "profile/name",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "profile/name",
+                "path": "profile/name",
+                "target": {
+                  "/": "bafkreiftpp7ibki32u4paba5x7iohmljl6pfu7q7ndicbl2xkjnsvpim34"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFTVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBeHdjbTltYVd4bEwyNWhiV1VCVlJJZ3MzditnS2tiMVRqd0JCMi8wT094YVYrZVduNGZhTkFncjFkU1d5cTlETjg9IiwicHJvb2YiOiJxTHVuK1lVbE1RMEo1RHIzYVMwVVF6cUc1bVdhY0xNdVdnRHo2dWxIY3VHekJWTlROSjI3UUJFZ2tUcVBpeEtpRUd4Tzdia2JvYlFIMkZnRlQrSlRmTUNtZUYxMW1uZGp6QVB2d3laYVRHQUFBQUh3In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.kzg.missing-evidence.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "evidence_kind": "explicit"
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.multihop.accept",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "multihop",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIaXdBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSIsInByb29mIjoic2N0SmZnN08zbURkOHFzRkFqcWczaGlSUjR5OVY1bUF3dnRSVEFySW1BeDBpRnhmVlpBZWtueHlVRmhkNDRzcURsVUs0Q3dnaWNqOHFqMkZ5bmxuY3M3aUozelFyZ3h1Y2taZmhGbWkrVmdBQUFSciJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.kzg.payload.accept",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "payload",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "segments": [
+            "docs",
+            "@payload"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "docs/@payload",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIaXdBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSIsInByb29mIjoic2N0SmZnN08zbURkOHFzRkFqcWczaGlSUjR5OVY1bUF3dnRSVEFySW1BeDBpRnhmVlpBZWtueHlVRmhkNDRzcURsVUs0Q3dnaWNqOHFqMkZ5bmxuY3M3aUozelFyZ3h1Y2taZmhGbWkrVmdBQUFSciJ9XX0="
+              },
+              {
+                "kind": "payload_binding",
+                "from": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "query": "@payload",
+                "path": "@payload",
+                "target": {
+                  "/": "bafkreids3wdkfkgd7e2uuuj5en6od3gvg2p2sf3r42atqle33fverj47zi"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFSVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBaEFjR0Y1Ykc5aFpBRlZFaUJ5M1lhaXFNUDVOVXBSUFNOODRlelZOcCtwRjNIbWdUZ3NtOWxxU0tlZnlnPT0iLCJwcm9vZiI6ImdieTZHRnZnUVVzazloL1ZhcEtuWWoweHFZeFN0MzFla3VHclEwRG9zQndxYy9PV1cyckRVNFhnRXdkZWFJV0ZQSDd6am0vMm1aOEJBa3RsQWtEQUcxWXVNU2xuYk5xQ3NoWXgyRVFWQWdRQUFBbGcifV19"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true
+      }
+    },
+    {
+      "id": "resolve.kzg.truncated-evidence.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "malformed_evidence",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba",
+          "prooflist": {
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "query": "docs/leaf",
+            "steps": [
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "query": "docs",
+                "path": "docs",
+                "target": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sicHJvb2YiOiJzY3RKZmc3TzNtRGQ4cXNGQWpxZzNoaVJSNHk5VjVtQXd2dFJUQXJJbUF4MGlGeGZWWkFla254eVVGaGQ0NHNxRGxVSzRDd2dpY2o4cWoyRnlubG5jczdpSjN6UXJneHVja1pmaEZtaStWZ0FBQVE9Iiwic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIaXdBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSJ9XX0="
+              },
+              {
+                "kind": "map_step",
+                "from": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "query": "leaf",
+                "path": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                },
+                "evidence_kind": "explicit",
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ=="
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": false
+      }
+    },
+    {
+      "id": "resolve.kzg.unknown-field.reject",
+      "operation": "resolve",
+      "backend": "kzg",
+      "category": "strict_json",
+      "verification": {
+        "request": {
+          "profile": "malt.resolve/v0alpha1",
+          "root": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm",
+          "segments": [
+            "docs",
+            "leaf"
+          ]
+        },
+        "result": {
+          "profile": "malt.resolve/v0alpha1",
+          "prooflist": {
+            "query": "docs/leaf",
+            "root": {
+              "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+            },
+            "steps": [
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFWRzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUmtiMk56QVlIaXdBRUFNSTlRSmduanJFU3h4Tno1YnJCWXc0cWFlNERETURJZ2F4VDJENFp2TVMrWFR3NVlMRmZjMHNiZ05ONVQ4YzNHSnc9PSIsInByb29mIjoic2N0SmZnN08zbURkOHFzRkFqcWczaGlSUjR5OVY1bUF3dnRSVEFySW1BeDBpRnhmVlpBZWtueHlVRmhkNDRzcURsVUs0Q3dnaWNqOHFqMkZ5bmxuY3M3aUozelFyZ3h1Y2taZmhGbWkrVmdBQUFSciJ9XX0=",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "baga6fqabaaylc3hak6yjwa5r3eti5gsbvzcxhncvengd7o2k3ed75cuvtf7m7ljsjxuamsmkghqzq2j5sme6nlwm"
+                },
+                "kind": "map_step",
+                "path": "docs",
+                "query": "docs",
+                "target": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                }
+              },
+              {
+                "evidence": "eyJzdGVwcyI6W3sic2xvdCI6IkFWVUFRVzFoYkhRNmJXRndPbkpoWkdsNE9teGxZV1k2ZGpFNkFBUnNaV0ZtQVZVU0lFRFVPdThmci9rK2lremZxaVMzUzZlQ2lieW1ncjJPb2tzSGhtR051WmdJIiwicHJvb2YiOiJweDd2VFdlQVlhb0R1NWM0K0xaeHVQZ29NeXNKcGNTWkU0TWYxMWU1Q253OFdSUDdMdUFFNk5BODRuME5WMm8rU2tTRUJMdFZWSnEyK1hVemozOTgyQVdHS25PSWhGVDRuQjRzaE5PdStNZ0FBQW41In1dfQ==",
+                "evidence_kind": "explicit",
+                "from": {
+                  "/": "baga6fqabaayi6ubgbhr2yrfrytops3vqldbyvgt3qdbtamranmkpmd4gn4ys7f2pbzmcyv642ldoang6kpy43rrh"
+                },
+                "kind": "map_step",
+                "path": "leaf",
+                "query": "leaf",
+                "target": {
+                  "/": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+                }
+              }
+            ]
+          },
+          "target": "bafkreica2q5o6h5p7e7iutg7vislos5hqke3zjucxwhkesyhqzqy3omyba"
+        },
+        "unexpected": true
+      },
+      "expected": {
+        "valid": false
+      }
+    }
+  ]
+}

--- a/core.go
+++ b/core.go
@@ -124,6 +124,36 @@ type ReadResult struct {
 	ProofList prooflist.ProofList
 }
 
+// MapProofRequest binds one keyed-map membership or non-membership proof to a
+// caller-supplied trusted root.
+type MapProofRequest struct {
+	Root cid.Cid
+	Key  arcset.Path
+}
+
+// Validate checks the transport-neutral map-proof request.
+func (r MapProofRequest) Validate() error {
+	if !r.Root.Defined() {
+		return fmt.Errorf("trusted root is undefined")
+	}
+	key, err := arcset.NewPath(r.Key.String())
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidQuery, err)
+	}
+	if key != r.Key {
+		return fmt.Errorf("%w: map key %q is not canonical", ErrInvalidQuery, r.Key)
+	}
+	return nil
+}
+
+// MapProofResult carries either a present target or an authenticated absence.
+// Target is defined if and only if Present is true.
+type MapProofResult struct {
+	Present   bool
+	Target    cid.Cid
+	ProofList prooflist.ProofList
+}
+
 // ResolveRequest binds one canonical segment path to a caller-supplied trusted
 // root. Applications append reserved coordinates such as @payload explicitly;
 // an empty segment sequence always denotes root identity.
@@ -158,6 +188,11 @@ type WriteResult = mutation.WriteReceipt
 // Reader is the application-neutral root-relative read port.
 type Reader interface {
 	Read(context.Context, ReadRequest) (ReadResult, error)
+}
+
+// MapProver is the application-neutral membership/non-membership proof port.
+type MapProver interface {
+	ProveMap(context.Context, MapProofRequest) (MapProofResult, error)
 }
 
 // Resolver is the application-neutral path-resolution port. Implementations

--- a/docs/policy/compatibility.md
+++ b/docs/policy/compatibility.md
@@ -14,7 +14,9 @@ profiles rejected.
 | `stateful-complete-vectors-v1` | Experimental state profile required by the current update-view contract |
 | `malt.semantic-intent/v1` | Experimental post-v0.0.6 output-free update intent |
 | `malt.client-root-bundle/v1` | Experimental post-v0.0.6 exact-root submission; not a transition proof |
-| `malt.writer-compute-result/v1` | Experimental post-v0.0.6 browser-local bundle and next-view result |
+| `malt.client-root-materialization/v1` | Experimental root-bound map proof-serving witness; not a transition proof |
+| `malt.writer-compute-result/v1` | Legacy browser-local bundle and next-view result; decode compatibility only |
+| `malt.writer-compute-result/v2` | Experimental browser-local bundle, map materialization, and next-view result |
 | `malt.materialization-receipt/v1` | Experimental post-v0.0.6 exact-bundle durability acknowledgement |
 | ProofList JSON and proof semantics | Experimental, verifier-facing |
 | Typed MALT root CIDs/codecs | Experimental, verifier-facing |
@@ -48,10 +50,21 @@ documentation in the same PR:
 - mutation, client-root, or receipt value semantics;
 - payload-binding and measured-list evidence.
 
-Typed-root decoders accept only the current registered `MALTVersionID`,
-semantic IDs, backend suite IDs, and combinations. Earlier experimental codec
-allocations are not compatibility inputs and must not be recognized through
-fallback mappings.
+Typed-root constructors emit the current registered `MALTVersionID=3`.
+Decoders explicitly retain v2 typed roots for read/proof compatibility and
+reject every other unknown version, semantic ID, backend suite ID, and
+combination; there is no heuristic fallback mapping.
+
+Radix map profiles bind the entire internal tree to one typed-root version and
+backend: v2 roots use v1 variable-length collision-bucket references, while v3
+roots use v2 fixed-domain references. Readers recognize both profiles but reject
+mixed-version internal children or a bucket reference that does not match its
+parent profile. Only the v3/fixed-domain profile supports collision-bucket
+non-membership proofs. Incremental map/list mutation APIs require the input root
+version to match the semantics instance. The client writer handles v2 updates
+by exactly replaying the complete v2 view, fully rebuilding it as v3, and
+applying changes only to that v3 working root; direct partial v2-to-v3 mutation
+is rejected so unchanged v2 child CIDs cannot leak into a v3 root.
 
 v0.0.6 intentionally removes application and deployment packages from this
 module. Consumers of the former CLI/daemon/UnixFS/server/storage packages must

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -13,8 +13,9 @@ behavior, wire formats, and proof semantics in this folder.
 The current transport-neutral proof-bearing contracts are
 `malt.resolve/v0alpha1` and `malt.read/v0alpha1`. The post-release client-root
 contracts are `malt.update-view/v1`, `malt.semantic-intent/v1`,
-`malt.client-root-bundle/v1`, `malt.writer-compute-result/v1`, and
-`malt.materialization-receipt/v1`. The v0.0.4 `malt.artifact/v0alpha2` profile
+`malt.client-root-bundle/v1`, `malt.client-root-materialization/v1`,
+`malt.writer-compute-result/v2`, and `malt.materialization-receipt/v1`. The
+v0.0.4 `malt.artifact/v0alpha2` profile
 remains frozen for compatibility. See [MIP-1012](../mips/mip-1012-segment-path-resolution.md) and
 [MIP-1013](../mips/mip-1013-client-gateway-core-boundary.md).
 
@@ -30,7 +31,8 @@ remains frozen for compatibility. See [MIP-1012](../mips/mip-1012-segment-path-r
 - [Commitment model](./commitment.md)
 - [Commitment and proof encoding](./commitment-proof-encoding.md)
 - [CID and wire format](./cid-and-wire-format.md)
-- [Resolve/Read conformance corpus v1](./resolve-read-conformance-v1.md)
+- [Resolve/Read conformance corpus v2](./resolve-read-conformance-v2.md)
+- [Frozen Resolve/Read conformance corpus v1](./resolve-read-conformance-v1.md)
 
 ## Protocol Schema Index
 
@@ -38,6 +40,7 @@ Every filename returned by `protocol.SchemaNames()` is indexed here:
 
 <!-- schema-catalog:protocol:start -->
 - [`client-root-bundle.schema.json`](../../protocol/schemas/client-root-bundle.schema.json)
+- [`client-root-materialization.schema.json`](../../protocol/schemas/client-root-materialization.schema.json)
 - [`materialization-receipt.schema.json`](../../protocol/schemas/materialization-receipt.schema.json)
 - [`prooflist.schema.json`](../../protocol/schemas/prooflist.schema.json)
 - [`read-request.schema.json`](../../protocol/schemas/read-request.schema.json)
@@ -49,6 +52,7 @@ Every filename returned by `protocol.SchemaNames()` is indexed here:
 - [`semantic-intent.schema.json`](../../protocol/schemas/semantic-intent.schema.json)
 - [`update-view.schema.json`](../../protocol/schemas/update-view.schema.json)
 - [`verification-result.schema.json`](../../protocol/schemas/verification-result.schema.json)
+- [`writer-compute-result-v2.schema.json`](../../protocol/schemas/writer-compute-result-v2.schema.json)
 - [`writer-compute-result.schema.json`](../../protocol/schemas/writer-compute-result.schema.json)
 <!-- schema-catalog:protocol:end -->
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -11,7 +11,8 @@ positioning, start with [Concepts](../concepts/README.md). Keep normative
 behavior, wire formats, and proof semantics in this folder.
 
 The current transport-neutral proof-bearing contracts are
-`malt.resolve/v0alpha1` and `malt.read/v0alpha1`. The post-release client-root
+`malt.resolve/v0alpha1`, `malt.read/v0alpha1`, and
+`malt.map-proof/v0alpha1`. The post-release client-root
 contracts are `malt.update-view/v1`, `malt.semantic-intent/v1`,
 `malt.client-root-bundle/v1`, `malt.client-root-materialization/v1`,
 `malt.writer-compute-result/v2`, and `malt.materialization-receipt/v1`. The
@@ -41,6 +42,9 @@ Every filename returned by `protocol.SchemaNames()` is indexed here:
 <!-- schema-catalog:protocol:start -->
 - [`client-root-bundle.schema.json`](../../protocol/schemas/client-root-bundle.schema.json)
 - [`client-root-materialization.schema.json`](../../protocol/schemas/client-root-materialization.schema.json)
+- [`map-proof-request.schema.json`](../../protocol/schemas/map-proof-request.schema.json)
+- [`map-proof-result.schema.json`](../../protocol/schemas/map-proof-result.schema.json)
+- [`map-proof-verification.schema.json`](../../protocol/schemas/map-proof-verification.schema.json)
 - [`materialization-receipt.schema.json`](../../protocol/schemas/materialization-receipt.schema.json)
 - [`prooflist.schema.json`](../../protocol/schemas/prooflist.schema.json)
 - [`read-request.schema.json`](../../protocol/schemas/read-request.schema.json)

--- a/docs/spec/cid-and-wire-format.md
+++ b/docs/spec/cid-and-wire-format.md
@@ -5,8 +5,8 @@ objects remain ordinary CAS CIDs.
 
 ## Status
 
-Experimental and implementation-bound. The current layout is the only accepted
-typed-root encoding, but it is not yet a stable release contract.
+Experimental and implementation-bound. Constructors emit the current layout;
+the immediately preceding v2 layout remains accepted for read/proof compatibility.
 
 ## MALT Root Codec Namespace
 
@@ -37,7 +37,7 @@ codec = 0x300000
       | backend_id
 ```
 
-The current `MALTVersionID` is `2`. It identifies this typed-root layout;
+The current `MALTVersionID` is `3`. It identifies this typed-root layout;
 it is not the CID version, a source release, a Resolve/Read profile, or a
 conformance-corpus version. Adding a semantic kind or backend suite does not
 change it. It changes only when the interpretation of the root codec or
@@ -72,10 +72,10 @@ ID even when it belongs to the same broad cryptographic family.
 
 | Name | Value | Semantic kind | Backend |
 | --- | ---: | --- | --- |
-| `malt-map-kzg` | `0x302101` | map | KZG |
-| `malt-list-kzg` | `0x302201` | list | KZG |
-| `malt-map-ipa` | `0x302102` | map | IPA |
-| `malt-list-ipa` | `0x302202` | list | IPA |
+| `malt-map-kzg` | `0x303101` | map | KZG |
+| `malt-list-kzg` | `0x303201` | list | KZG |
+| `malt-map-ipa` | `0x303102` | map | IPA |
+| `malt-list-ipa` | `0x303202` | list | IPA |
 
 The implementation owner is `wire/maltcid`.
 
@@ -109,22 +109,31 @@ alone must never select or override the backend.
 A supported typed root must satisfy all of these checks:
 
 1. its codec is in `0x300000-0x30FFFF`;
-2. `V` equals the current `MALTVersionID`;
+2. `V` equals the current `MALTVersionID` or the explicitly registered legacy v2 ID;
 3. `S` and `BB` are nonzero registered IDs and their combination is
    supported;
 4. the multihash code is identity;
 5. the identity digest length matches the selected backend descriptor.
 
-Unknown versions, semantics, backends, combinations, and codecs outside the
-typed-root subrange fail closed. Classifiers must validate the complete codec
+Unknown versions other than registered v2 compatibility, unknown semantics,
+backends, combinations, and codecs outside the typed-root subrange fail closed. Classifiers must validate the complete codec
 before returning either semantic or backend; independently masking one field
 is insufficient.
+
+Version 3 introduces fixed-domain collision buckets for sound map
+non-membership proofs. New constructors emit v3 roots. Version-2 roots remain
+classified and verifiable; their legacy variable-length collision buckets
+remain membership-readable but cannot provide collision-bucket non-membership
+proofs. Incremental mutation requires the root version to match the semantic
+instance. A v2 update therefore requires exact complete-view replay followed by
+a full v3 rebuild before any change; partial path-only v2-to-v3 rewrites are
+rejected because they would retain unchanged v2 child CIDs under a v3 root.
 
 Version 2 makes semantic node geometry backend-sized: KZG map and list nodes
 use all 4096 positions in the current KZG suite, while IPA nodes retain the
 current suite's 256 positions. Map radix digits and list branching therefore
 also depend on the backend suite. Version-1 experimental roots are not
-recognized by version-2 decoders and must be rebuilt together with their
+recognized by current decoders and must be rebuilt together with their
 materialized node state.
 
 Verifiers must also reject roots or proof steps whose semantic kind, backend

--- a/docs/spec/client-root-contract.md
+++ b/docs/spec/client-root-contract.md
@@ -37,6 +37,7 @@ incompatible wire revision requires a new profile identifier.
 caller-selected accepted base root
   -> caller-bounded, untrusted complete UpdateView
   -> locally verified complete semantic vectors
+  -> for a new state only: client-computed canonical empty-map base witness
   -> application-produced SemanticIntent
   -> locally computed transition outputs and candidate root
   -> root-bound map materialization for every map transition output
@@ -181,8 +182,10 @@ decodes bounded UTF-8 JSON `Uint8Array` values for an `UpdateView` and
 `malt.writer-compute-result/v2` carrying the canonical bundle, root-bound map
 materialization, complete next view, and diagnostic local timings. The
 materialization contains backend-owned radix cache coordinates for every map
-transition output; it is untrusted until validated against the declared output
-root and complete logical post-view. The WASM adapter does not contact a
+transition output. The first result after `Session.BootstrapMap` additionally
+contains `materialization.base`, a witness for the canonical empty-map base.
+Both are untrusted until validated against their declared roots and complete
+logical views. The WASM adapter does not contact a
 service or change publication or trusted-root state. The v1 result schema is
 retained for decode compatibility but is no longer emitted.
 
@@ -197,9 +200,10 @@ The client-root JSON decoders reject:
 - semantic values that satisfy JSON Schema shape but violate the Core
   invariants above.
 
-All JSON DTO fields are required. Optional semantic values use explicit
-`present` or `absent` state objects rather than omitted properties or JSON
-`null`.
+Fields are required unless their schema explicitly marks them optional.
+Existing semantic before/after values use explicit `present` or `absent` state
+objects. The sole optional client-root materialization member is `base`; it is
+omitted outside bootstrap and explicit JSON `null` is rejected.
 
 Before structural validation, every client-root document is limited to 64 MiB.
 The wire contract additionally caps:
@@ -231,12 +235,15 @@ A service importing client-computed map roots must independently:
 3. require exactly one materialization witness for every map output and call
    `radix.ValidateMaterialization` against that declared output root and logical
    post-view;
-4. reject unsupported output kinds unless it has an equivalent root-bound
+4. when `materialization.base` is present, require a single-object canonical
+   empty-map bootstrap view and validate that base witness at the declared base
+   root without calling `Commit`;
+5. reject unsupported output kinds unless it has an equivalent root-bound
    importer for them;
-5. check the required payload CIDs at its declared durability boundary;
-6. atomically persist every accepted proof-serving witness entry and the
+6. check the required payload CIDs at its declared durability boundary;
+7. atomically persist every accepted proof-serving witness entry and the
    service head/publication state named by its durability boundary; and
-7. return a `MaterializationReceipt` only after that boundary succeeds.
+8. return a `MaterializationReceipt` only after that boundary succeeds.
 
 `radix.ValidateMaterialization` depends on `IndexVerifier` and
 `IndexRootProver`; it opens caller-supplied vectors through `ProveAtRoot` and
@@ -279,10 +286,18 @@ MALT core.
 
 ## Creation Boundary
 
-The client-root contract updates an existing accepted top root. Creating an
-initial semantic structure has no authenticated base root and therefore uses a
-separate application or service bootstrap capability. Such a capability must
-not be exposed as part of the portable client-root profiles.
+A browser writer may create the canonical empty-map base through
+`sdk/writer.Session.BootstrapMap` (or `maltWriterBootstrapSessionV1`). The
+commitment is computed in the selected client backend. The returned update view
+is retained in the same stateful session, and its first prepared
+`malt.writer-compute-result/v2` carries `materialization.base`.
+
+Core accepts that optional witness only when the bundle view contains exactly
+one object named `root`, its kind is map, its logical vector is empty, and its
+root equals the bundle base. A service validates and atomically imports the
+base and first candidate witnesses through root-bound proof operations; it does
+not call `Commit` or substitute another bootstrap root. Whether a Bucket is
+still eligible for first-root creation remains service concurrency policy.
 
 ## Related Documents
 

--- a/docs/spec/client-root-contract.md
+++ b/docs/spec/client-root-contract.md
@@ -19,7 +19,8 @@ Go source APIs stable at v1.
 | complete old-state closure | `malt.update-view/v1` | `update-view.schema.json` |
 | output-free requested change | `malt.semantic-intent/v1` | `semantic-intent.schema.json` |
 | exact locally computed submission | `malt.client-root-bundle/v1` | `client-root-bundle.schema.json` |
-| browser-local computation result | `malt.writer-compute-result/v1` | `writer-compute-result.schema.json` |
+| map proof-serving witness | `malt.client-root-materialization/v1` | `client-root-materialization.schema.json` |
+| browser-local computation result | `malt.writer-compute-result/v2` | `writer-compute-result-v2.schema.json` |
 | durable exact-bundle acknowledgement | `malt.materialization-receipt/v1` | `materialization-receipt.schema.json` |
 
 Canonical in-process values live in `mutation`. Their JSON projections and
@@ -38,6 +39,7 @@ caller-selected accepted base root
   -> locally verified complete semantic vectors
   -> application-produced SemanticIntent
   -> locally computed transition outputs and candidate root
+  -> root-bound map materialization for every map transition output
   -> exact ClientRootBundle
   -> service accepts that exact candidate or rejects the bundle
   -> exact MaterializationReceipt
@@ -176,9 +178,13 @@ Browser clients may invoke the same computation through
 `cmd/malt-writer-wasm`. Its `maltComputeClientRootV1` entry point strictly
 decodes bounded UTF-8 JSON `Uint8Array` values for an `UpdateView` and
 `SemanticIntent`, runs `sdk/writer`, and returns a strictly validated
-`malt.writer-compute-result/v1` carrying the canonical bundle, complete next
-view, and diagnostic local timings. The WASM adapter does not contact a service
-or change publication or trusted-root state.
+`malt.writer-compute-result/v2` carrying the canonical bundle, root-bound map
+materialization, complete next view, and diagnostic local timings. The
+materialization contains backend-owned radix cache coordinates for every map
+transition output; it is untrusted until validated against the declared output
+root and complete logical post-view. The WASM adapter does not contact a
+service or change publication or trusted-root state. The v1 result schema is
+retained for decode compatibility but is no longer emitted.
 
 ## Strict JSON Decoding And Limits
 
@@ -207,23 +213,36 @@ The wire contract additionally caps:
 | changes | 1,048,576 |
 | payload CIDs | 1,048,576 |
 | encoded CID string | 4,096 bytes |
+| materialization entries | 4,194,304 |
 
 The positive bounds inside an `UpdateView` may be lower than those hard
 ceilings. Both the declared bounds and the independent wire ceilings are
 enforced.
 
-## Service Replay And Receipt
+## Service Validation, Import, And Receipt
 
-A service claiming exact-bundle replay and materialization must independently:
+A service importing client-computed map roots must independently:
 
-1. validate the complete update view and its declared old roots;
-2. recompute the normalized intent and every transition output;
-3. require the replayed candidate to equal the submitted candidate;
-4. check the required payload CIDs at its declared durability boundary;
-5. complete every write named by its documented durability boundary without
-   acknowledging a partial exact bundle; and
-6. return a `MaterializationReceipt` only after that declared durable boundary
-   succeeds.
+1. bind the bundle base to its authoritative current state and validate the
+   complete view, canonical digests, normalized intent, output identities, and
+   candidate selection;
+2. derive each map transition's complete logical post-view from the validated
+   before-image and normalized changes;
+3. require exactly one materialization witness for every map output and call
+   `radix.ValidateMaterialization` against that declared output root and logical
+   post-view;
+4. reject unsupported output kinds unless it has an equivalent root-bound
+   importer for them;
+5. check the required payload CIDs at its declared durability boundary;
+6. atomically persist every accepted proof-serving witness entry and the
+   service head/publication state named by its durability boundary; and
+7. return a `MaterializationReceipt` only after that boundary succeeds.
+
+`radix.ValidateMaterialization` depends on `IndexVerifier` and
+`IndexRootProver`; it opens caller-supplied vectors through `ProveAtRoot` and
+does not call `Commit`. The service therefore verifies and imports the exact
+client root instead of recomputing a replacement candidate. The witness is
+proof-serving state, not a portable transition proof.
 
 Core defines the receipt value and its binding to one exact canonical bundle,
 not the service's transaction, idempotency, persistence, or HTTP mechanism.

--- a/docs/spec/commitment-proof-encoding.md
+++ b/docs/spec/commitment-proof-encoding.md
@@ -1,7 +1,7 @@
 # Commitment And Proof Encoding
 
 This document fixes the implementation-bound byte encodings exercised by the
-Resolve/Read conformance corpus v1. It complements the typed-root rules in
+Resolve/Read conformance corpus v2. It complements the typed-root rules in
 [CID and wire format](./cid-and-wire-format.md) and the semantic contract in
 [ProofList format](./prooflist-format.md).
 
@@ -159,7 +159,11 @@ envelope itself is JSON-encoded:
   "steps": [
     {"slot": "<CID bytes>", "proof": "<primitive single proof>"}
   ],
-  "bucket": {"proof": "<primitive single proof>"}
+  "bucket": {
+    "entries": ["<canonical leaf-marker CID bytes>"],
+    "proof": "<membership proof or empty>",
+    "batches": ["<absence batch proof>"]
+  }
 }
 ```
 
@@ -183,11 +187,35 @@ The marker encodings are raw CIDv1 values with identity multihashes over:
 
 - leaf: `malt:map:radix:leaf:v1:` || key-byte-length as big-endian `uint16` ||
   canonical key UTF-8 || target CID bytes;
-- bucket reference: `malt:map:radix:bucket:v1:` || bucket-root CID bytes.
+- current bucket reference: `malt:map:radix:bucket:v2:` || bucket-root CID bytes;
+- legacy read-compatible bucket reference: `malt:map:radix:bucket:v1:` || bucket-root CID bytes.
 
-A bucket witness opens the expected leaf marker from the bucket commitment;
-its primitive proof carries the bucket index. Current map proofs authenticate
-membership only.
+Map proofs authenticate both membership and non-membership. Non-membership
+terminates at a proved empty radix slot, a proved terminal leaf for a different
+canonical key, or a collision bucket. A membership bucket witness leaves
+`entries` and `batches` absent and opens the expected leaf marker through
+`proof`, whose primitive encoding carries the bucket index.
+
+A v2 collision bucket commits a fixed-width vector: canonical leaf markers
+followed by explicit empty cells through the backend capacity. Its absence
+witness carries every canonical marker in `entries` and covers the complete
+fixed-width vector with ordered `batches`; each batch covers at most 16
+consecutive indices. Verification rejects noncanonical marker encodings,
+duplicate or out-of-order keys, a queried key present in the bucket, missing or
+extra batches, any nonempty tail cell, and any invalid batch opening. `proof`
+must be empty for bucket absence.
+
+The reader and portable verifier continue to recognize v1 bucket references
+for membership proofs under a v2 typed map root. Every internal node and bucket
+root must retain that parent root version and backend; a v3 root carrying a v1
+bucket reference, or any mixed-version child, is noncanonical and rejected.
+Because the legacy variable-length bucket commitment did not authenticate a
+fixed empty tail, it cannot produce the new sound collision-bucket
+non-membership proof. Direct incremental mutation rejects a root whose typed
+version differs from the semantic instance; the client writer migrates a v2
+object by exact complete-view replay and a full v3 rebuild, which rewrites every
+collision bucket into the v2 fixed-domain reference before it applies the
+requested change.
 
 In a resolve ProofList this envelope is stored in `step.evidence` with
 `evidence_kind="explicit"`; the primitive backend is inferred from the typed

--- a/docs/spec/prooflist-format.md
+++ b/docs/spec/prooflist-format.md
@@ -7,7 +7,8 @@ relations from a trusted root.
 ## Status
 
 ProofList has no standalone operation discriminator. It is embedded in the
-profiled `malt.resolve/v0alpha1` and `malt.read/v0alpha1` results. Its named JSON
+profiled `malt.resolve/v0alpha1`, `malt.read/v0alpha1`, and
+`malt.map-proof/v0alpha1` results. Its named JSON
 Schema is checked in at `protocol/schemas/prooflist.schema.json`; incompatible
 result-contract revisions require a new enclosing profile.
 
@@ -25,14 +26,17 @@ The current Go shape is `auth/proof/prooflist.ProofList`:
 | `Steps` | `steps` | Ordered proof steps. |
 
 `ValidateShape(RequireSteps())` rejects an undefined root, an empty step list,
-unknown step kinds, undefined `from` or `target` CIDs, and any step whose
-`from` CID does not continue from the current target.
+unknown step kinds, undefined `from` CIDs, undefined `target` CIDs on
+traversal steps, and any step whose `from` CID does not continue from the
+current target. The sole exception is a terminal `map_absence` step, whose
+target must be undefined and serializes as JSON `null`.
 
 ## Step Kinds
 
 | Kind | Role |
 | --- | --- |
 | `map_step` | Authenticates a keyed map relation. |
+| `map_absence` | Terminal proof that an exact keyed map relation is absent; requires `structure/map` evidence and an undefined target. |
 | `payload_binding` | Authenticates the optional reserved terminal `@payload` map binding when a layout uses it. |
 | `list_index` | Authenticates one list index binding. |
 | `list_range` | Authenticates measured-list byte range metadata and covered segments. |
@@ -67,8 +71,10 @@ Steps form a linear chain unless they are terminal list evidence:
 
 1. The first step starts at `root`.
 2. Non-list traversal steps advance the current target to `step.target`.
-3. List index or list range evidence may appear at the terminal phase.
-4. No later traversal step may appear after list index or list range evidence.
+3. A `map_absence` step is terminal, does not advance to a target, and must use
+   `structure/map` evidence.
+4. List index or list range evidence may appear at the terminal phase.
+5. No later traversal step may appear after terminal map or list evidence.
 
 This shape validation is structural. `auth/verifier` then selects a
 verification-only backend from the typed root and checks the map/list evidence.
@@ -115,8 +121,8 @@ accept/reject behavior is locked by the
 
 ## Serialization And Transport
 
-ProofLists are embedded in the operation-specific `malt.resolve/v0alpha1` and
-`malt.read/v0alpha1` results. Core does not define HTTP headers, omission
+ProofLists are embedded in the operation-specific `malt.resolve/v0alpha1`,
+`malt.read/v0alpha1`, and `malt.map-proof/v0alpha1` results. Core does not define HTTP headers, omission
 switches, content routes, or cache variance. A transport must preserve the
 serialized request/result fields required by local verification.
 

--- a/docs/spec/prooflist-format.md
+++ b/docs/spec/prooflist-format.md
@@ -111,7 +111,7 @@ These encodings remain experimental and consumers must pin a MALT release.
 The byte-level map/list envelopes inside `evidence` and `proof` are specified in
 [Commitment and proof encoding](./commitment-proof-encoding.md). Cross-language
 accept/reject behavior is locked by the
-[Resolve/Read conformance corpus v1](./resolve-read-conformance-v1.md).
+[Resolve/Read conformance corpus v2](./resolve-read-conformance-v2.md).
 
 ## Serialization And Transport
 

--- a/docs/spec/resolve-read-conformance-v2.md
+++ b/docs/spec/resolve-read-conformance-v2.md
@@ -1,8 +1,8 @@
-# Resolve/Read Conformance Corpus V1
+# Resolve/Read Conformance Corpus V2
 
-The v1 corpus is the language-neutral executable contract for local
+The v2 corpus is the language-neutral executable contract for local
 verification of `malt.resolve/v0alpha1` and `malt.read/v0alpha1` values. The
-canonical files live under `conformance/resolve-read/v1/` in this repository:
+canonical files live under `conformance/resolve-read/v2/` in this repository:
 `vectors.json`, `corpus.schema.json`, and `vector.schema.json`.
 
 ## Ownership And Versioning
@@ -12,20 +12,22 @@ Gateway, native client, browser/WASM, and future language SDK tests consume the
 same checked-in bytes; they do not redefine proof semantics or maintain edited
 copies.
 
-The corpus version is `malt.resolve-read.conformance/v1`. It is independent of
-the two enclosed operation profiles and of the typed-root `MALTVersionID=2`.
-This corpus shipped with v0.0.6 and is immutable: a vector ID, its input, and
-its expected verdict cannot change. Later behavioral or encoding changes use a
-new corpus version. Error strings, timing, and implementation-specific
-exception types are not conformance outputs.
+The corpus version is `malt.resolve-read.conformance/v2`. It is independent of
+the two enclosed operation profiles and of typed-root `MALTVersionID=3`; the
+verifier separately retains explicit v2 typed-root compatibility. Before this
+corpus is released, an intentional encoding change may regenerate it as part
+of the same reviewed change. After release, a vector ID, its input, and its
+expected verdict are immutable; later changes require v3. Error strings,
+timing, and implementation-specific exception types are not conformance
+outputs.
 
 ## File And Envelope
 
-`conformance/resolve-read/v1/vectors.json` has this shape:
+`conformance/resolve-read/v2/vectors.json` has this shape:
 
 ```json
 {
-  "schema_version": "malt.resolve-read.conformance/v1",
+  "schema_version": "malt.resolve-read.conformance/v2",
   "vectors": [
     {
       "id": "resolve.identity.accept",
@@ -57,7 +59,7 @@ The corpus itself is valid JSON. Negative cases remain parseable JSON objects.
 Malformed-evidence cases remove, truncate, or corrupt encoded proof bytes;
 strict-JSON cases add an unknown verification field. Semantic and
 cryptographic tampering remain separately categorized. Syntactically invalid
-JSON is outside v1.
+JSON is outside v2.
 
 Consumers must select the verifier from `operation`; they must not infer the
 operation from fields inside `verification`, and they must not use `backend` to

--- a/docs/spec/resolve-read-contracts.md
+++ b/docs/spec/resolve-read-contracts.md
@@ -17,7 +17,7 @@ JSON Schemas live in `protocol/schemas/` and are embedded through
 
 Cross-language accept/reject behavior for these complete request/result pairs
 is locked by the
-[Resolve/Read conformance corpus v1](./resolve-read-conformance-v1.md).
+[Resolve/Read conformance corpus v2](./resolve-read-conformance-v2.md).
 
 ## Resolve
 

--- a/docs/spec/resolve-read-contracts.md
+++ b/docs/spec/resolve-read-contracts.md
@@ -10,14 +10,16 @@ not a generic operation envelope.
 | --- | --- | --- |
 | path resolution | `malt.resolve/v0alpha1` | `malt.ResolveRequest`, `malt.ResolveResult`, `malt.VerifyResolve` |
 | primitive semantic read | `malt.read/v0alpha1` | `malt.ReadRequest`, `malt.ReadResult`, `malt.VerifyRead` |
+| map membership or non-membership | `malt.map-proof/v0alpha1` | `malt.MapProofRequest`, `malt.MapProofResult`, `malt.VerifyMapProof` |
 
 Serialized values live in `github.com/dewebprotocol/malt/protocol`. Checked-in
 JSON Schemas live in `protocol/schemas/` and are embedded through
 `protocol.Schema` and `protocol.SchemaNames`.
 
-Cross-language accept/reject behavior for these complete request/result pairs
-is locked by the
+Cross-language accept/reject behavior for resolve and read is locked by the
 [Resolve/Read conformance corpus v2](./resolve-read-conformance-v2.md).
+Map-proof behavior is covered by KZG/IPA runtime, portable-verifier, protocol,
+and WASM registration tests; it does not alter the frozen resolve/read corpus.
 
 ## Resolve
 
@@ -101,6 +103,32 @@ The result carries `target`, optional ordered `range_segments`, and
 `prooflist`. `VerifyRead` binds those fields to the original typed request.
 Read is intentionally primitive; multi-root prefix consumption belongs to
 resolve.
+
+## Map Membership And Non-Membership
+
+`Read` preserves its existing target-oriented behavior: a missing map key
+returns `ErrQueryNotFound`. A caller that needs proof of either outcome uses the
+separate map-proof contract:
+
+```json
+{
+  "profile": "malt.map-proof/v0alpha1",
+  "root": "b...map",
+  "key": ["name"]
+}
+```
+
+A present result carries `present: true`, a target CID, and a normal
+`map_step` (or terminal `payload_binding`) step. An absent result carries
+`present: false`, omits the result target, and terminates with a
+`map_absence` step whose `target` is JSON `null`. The step contains
+`structure/map` evidence proving `mapping.Binding{Present:false}` at the exact
+root and key; `null` is not evidence by itself.
+
+`VerifyMapProof` binds the caller-selected root and canonical key to the
+presence discriminator, conditional target, one proof step, and its
+cryptographic evidence. A proof for another key, a membership proof relabeled
+as absence, or an absence proof relabeled as membership is rejected.
 
 ## Transport Projection
 

--- a/docs/spec/semantic.md
+++ b/docs/spec/semantic.md
@@ -89,9 +89,14 @@ facade:
 - `execution.Executor.Resolve`, `Read`, and `Apply` are the separate, untrusted
   execution facade.
 
-When a map implementation reports `mapping.ErrPathNotFound`, `execution.Executor.Read`
-returns an error recognizable through `errors.Is(err, malt.ErrQueryNotFound)`
-or `malt.IsQueryNotFound`. Other execution-plane errors are returned unchanged.
+Map `Prove` returns either a membership binding or a root-bound non-membership
+binding (`Present=false`). Radix non-membership terminates at an authenticated
+empty slot, a conflicting leaf, or a collision bucket whose complete canonical
+vector (including empty tail slots) is batch-opened. `execution.Executor.Read`
+keeps its established application contract: it converts an absent binding, or
+the compatibility sentinel `mapping.ErrPathNotFound`, into an error recognizable
+through `errors.Is(err, malt.ErrQueryNotFound)` or `malt.IsQueryNotFound`. Other
+execution-plane errors are returned unchanged.
 
 Client/application adapters compose primitive arc operations into domain
 traversal. A Unix path is therefore a UnixFS client concern, not a generic core

--- a/execution/executor.go
+++ b/execution/executor.go
@@ -110,6 +110,44 @@ func (e *Executor) Read(ctx context.Context, req malt.ReadRequest) (malt.ReadRes
 	}
 }
 
+// ProveMap returns either a membership proof or an authenticated
+// non-membership proof without changing Read's not-found behavior.
+func (e *Executor) ProveMap(ctx context.Context, req malt.MapProofRequest) (malt.MapProofResult, error) {
+	if e == nil {
+		return malt.MapProofResult{}, fmt.Errorf("MALT executor is nil")
+	}
+	if err := req.Validate(); err != nil {
+		return malt.MapProofResult{}, err
+	}
+	if e.maps == nil {
+		return malt.MapProofResult{}, fmt.Errorf("%w: map reader", ErrCapabilityUnavailable)
+	}
+	binding, proof, err := e.maps.Prove(ctx, e.scope, req.Root, req.Key)
+	if err != nil {
+		return malt.MapProofResult{}, err
+	}
+	kind := prooflist.KindMapAbsence
+	if binding.Present {
+		if !binding.Value.Defined() {
+			return malt.MapProofResult{}, fmt.Errorf("map proof returned a present binding with an undefined target")
+		}
+		kind = prooflist.KindMapStep
+		if req.Key == arcset.PayloadPath {
+			kind = prooflist.KindPayloadBinding
+		}
+	} else if binding.Value.Defined() {
+		return malt.MapProofResult{}, fmt.Errorf("map proof returned an absent binding with a defined target")
+	}
+	step := prooflist.Step{
+		Kind: kind, From: req.Root, Query: req.Key.String(), Coordinate: req.Key.String(), Path: req.Key.String(),
+		Target: binding.Value, EvidenceKind: "structure", EvidenceBackend: "map", Proof: cloneProof(proof),
+	}
+	return malt.MapProofResult{
+		Present: binding.Present, Target: binding.Value,
+		ProofList: prooflist.ProofList{Root: req.Root, Query: req.Key.String(), Steps: []prooflist.Step{step}},
+	}, nil
+}
+
 func (e *Executor) Apply(ctx context.Context, mut mutation.SemanticMutation) (mutation.WriteReceipt, error) {
 	if e == nil {
 		return mutation.WriteReceipt{}, fmt.Errorf("MALT executor is nil")

--- a/execution/executor_test.go
+++ b/execution/executor_test.go
@@ -59,6 +59,43 @@ func TestExecutorReadMapAndVerifyBindsRequest(t *testing.T) {
 	}
 }
 
+func TestExecutorProveMapReturnsAndBindsAbsence(t *testing.T) {
+	root := testCID(t, "absence-root")
+	key := arcset.CanonicalizePath("profile/missing")
+	maps := &fakeAbsentMaps{root: root, key: key, proof: []byte("absence-proof")}
+	engine, err := execution.NewExecutor(execution.Options{Scope: "absence-scope", Maps: maps})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := malt.MapProofRequest{Root: root, Key: key}
+	result, err := engine.ProveMap(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Present || result.Target.Defined() || maps.scope != "absence-scope" {
+		t.Fatalf("absence result/scope = %+v/%q", result, maps.scope)
+	}
+	step := result.ProofList.Steps[0]
+	if step.Kind != prooflist.KindMapAbsence || step.Target.Defined() {
+		t.Fatalf("absence step = %+v", step)
+	}
+	if err := malt.VerifyMapProof(context.Background(), request, result, acceptingVerifier{}); err != nil {
+		t.Fatalf("VerifyMapProof: %v", err)
+	}
+
+	tampered := result
+	tampered.Present = true
+	tampered.Target = testCID(t, "forged")
+	if err := malt.VerifyMapProof(context.Background(), request, tampered, acceptingVerifier{}); err == nil {
+		t.Fatal("VerifyMapProof accepted an absent proof as membership")
+	}
+	wrongKey := request
+	wrongKey.Key = arcset.CanonicalizePath("profile/other")
+	if err := malt.VerifyMapProof(context.Background(), wrongKey, result, acceptingVerifier{}); err == nil {
+		t.Fatal("VerifyMapProof accepted an absence proof for another key")
+	}
+}
+
 func TestExecutorResolveAndVerifyBindsRequest(t *testing.T) {
 	root := testCID(t, "resolve-root")
 	target := testCID(t, "resolve-target")
@@ -360,6 +397,21 @@ type fakeMaps struct {
 	target cid.Cid
 	proof  structure.Proof
 	scope  string
+}
+
+type fakeAbsentMaps struct {
+	root  cid.Cid
+	key   arcset.Path
+	proof structure.Proof
+	scope string
+}
+
+func (m *fakeAbsentMaps) Prove(_ context.Context, scope string, root cid.Cid, key arcset.Path) (mapping.Binding, structure.Proof, error) {
+	m.scope = scope
+	if !root.Equals(m.root) || key != m.key {
+		return mapping.Binding{}, nil, arcset.ErrNotFound
+	}
+	return mapping.Binding{Present: false}, append(structure.Proof(nil), m.proof...), nil
 }
 
 type errorMaps struct {

--- a/graph/runtime/backend_dispatch.go
+++ b/graph/runtime/backend_dispatch.go
@@ -61,6 +61,18 @@ func (d *mapBackendDispatcher) BatchUpdate(ctx context.Context, namespace string
 	return backend.BatchUpdate(ctx, namespace, root, updates)
 }
 
+func (d *mapBackendDispatcher) ExportMaterialization(ctx context.Context, namespace string, root cid.Cid, view mapping.View) (*arcset.CanonicalArcSet, error) {
+	backend, err := d.forRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	exporter, ok := backend.(mapping.MaterializationExporter)
+	if !ok {
+		return nil, fmt.Errorf("commitment backend %q does not export map materialization", maltcid.BackendKindOf(root))
+	}
+	return exporter.ExportMaterialization(ctx, namespace, root, view)
+}
+
 func (d *mapBackendDispatcher) defaultSemantics() (mapping.Semantics, error) {
 	backend := d.backends[d.defaultBackend]
 	if backend == nil {

--- a/graph/runtime/graph.go
+++ b/graph/runtime/graph.go
@@ -64,11 +64,11 @@ func NewGraph(id string, materializer materializer.MutableStore, opts ...Option)
 		maps := make(map[maltcid.BackendKind]mapping.Semantics, len(o.Backends))
 		lists := make(map[maltcid.BackendKind]list.MeasuredSemantics, len(o.Backends))
 		for kind, scheme := range o.Backends {
-			maps[kind], err = mappingradix.NewMap(scheme, materializer)
+			maps[kind], err = mappingradix.NewMapForVersion(scheme, materializer, o.MALTVersion)
 			if err != nil {
 				return nil, fmt.Errorf("create %s mapping semantic: %w", kind, err)
 			}
-			lists[kind], err = listtree.NewList(scheme, materializer)
+			lists[kind], err = listtree.NewListForVersion(scheme, materializer, o.MALTVersion)
 			if err != nil {
 				return nil, fmt.Errorf("create %s list semantic: %w", kind, err)
 			}
@@ -87,11 +87,11 @@ func NewGraph(id string, materializer materializer.MutableStore, opts ...Option)
 		}
 
 		var err error
-		semantic, err = mappingradix.NewMap(scheme, materializer)
+		semantic, err = mappingradix.NewMapForVersion(scheme, materializer, o.MALTVersion)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create mapping semantic: %w", err)
 		}
-		listSemantic, err = listtree.NewList(scheme, materializer)
+		listSemantic, err = listtree.NewListForVersion(scheme, materializer, o.MALTVersion)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create list semantic: %w", err)
 		}

--- a/graph/runtime/options.go
+++ b/graph/runtime/options.go
@@ -14,10 +14,14 @@ type Options struct {
 	Backends       map[maltcid.BackendKind]commitment.IndexCommitment
 	DefaultBackend maltcid.BackendKind
 	Namespace      string
+	MALTVersion    uint8
 }
 
 func defaultOptions() *Options {
-	return &Options{Backends: make(map[maltcid.BackendKind]commitment.IndexCommitment)}
+	return &Options{
+		Backends:    make(map[maltcid.BackendKind]commitment.IndexCommitment),
+		MALTVersion: maltcid.MALTVersionID,
+	}
 }
 
 // WithCommitmentScheme sets the commitment scheme for this Graph.
@@ -47,6 +51,15 @@ func WithCommitmentBackend(kind maltcid.BackendKind, scheme commitment.IndexComm
 func WithDefaultCommitmentBackend(kind maltcid.BackendKind) Option {
 	return func(o *Options) {
 		o.DefaultBackend = kind
+	}
+}
+
+// WithMALTVersion selects the typed-root version emitted by map/list commits.
+// It exists for exact replay of supported legacy complete views; new graphs
+// should use the default current version.
+func WithMALTVersion(version uint8) Option {
+	return func(o *Options) {
+		o.MALTVersion = version
 	}
 }
 

--- a/graph/writer/batch_atomicity_test.go
+++ b/graph/writer/batch_atomicity_test.go
@@ -160,9 +160,9 @@ func TestSemanticBatchUpdate_MidBatchFailure(t *testing.T) {
 	}
 
 	// key-new must NOT be findable under the original root either.
-	_, _, err = maps.Prove(ctx, namespace, root, arcset.CanonicalizePath("key-new"))
-	if err == nil {
-		t.Error("atomicity violated: key-new was persisted despite mid-batch failure")
+	absent, _, err := maps.Prove(ctx, namespace, root, arcset.CanonicalizePath("key-new"))
+	if err != nil || absent.Present {
+		t.Errorf("atomicity violated: key-new absence = %+v, %v", absent, err)
 	}
 
 	// key-a must still have original value

--- a/internal/conformancegen/generator.go
+++ b/internal/conformancegen/generator.go
@@ -86,7 +86,7 @@ func Generate() ([]byte, error) {
 		return 0
 	})
 
-	corpus := conformance.Corpus{SchemaVersion: conformance.ResolveReadV1, Vectors: vectors}
+	corpus := conformance.Corpus{SchemaVersion: conformance.ResolveReadV2, Vectors: vectors}
 	if err := corpus.Validate(); err != nil {
 		return nil, fmt.Errorf("validate generated corpus: %w", err)
 	}
@@ -121,7 +121,7 @@ func identityVector() (conformance.Vector, error) {
 func generateBackend(name string, scheme commitment.IndexCommitment) (*backendFixture, error) {
 	ctx := context.Background()
 
-	mapScope := "conformance-v1-" + name + "-map"
+	mapScope := "conformance-v2-" + name + "-map"
 	mapGraph, err := newGraph(mapScope, scheme)
 	if err != nil {
 		return nil, err

--- a/mutation/materialization.go
+++ b/mutation/materialization.go
@@ -20,11 +20,19 @@ type MapMaterialization struct {
 	Entries      *arcset.CanonicalArcSet
 }
 
+// MapStateMaterialization carries root-bound proof-serving state for the
+// complete map base included in a bootstrap writer result.
+type MapStateMaterialization struct {
+	Root    cid.Cid
+	Entries *arcset.CanonicalArcSet
+}
+
 // ClientRootMaterialization carries root-bound proof-serving witnesses for
 // every map output in one exact client-root bundle. List outputs are omitted
 // until their tree materialization receives an equivalent witness profile.
 type ClientRootMaterialization struct {
 	Profile string
+	Base    *MapStateMaterialization
 	Maps    []MapMaterialization
 }
 
@@ -37,6 +45,27 @@ func NewClientRootMaterialization(bundle ClientRootBundle, value ClientRootMater
 	}
 	if value.Profile != ClientRootMaterializationProfile {
 		return ClientRootMaterialization{}, fmt.Errorf("client-root materialization profile must be %q", ClientRootMaterializationProfile)
+	}
+	var base *MapStateMaterialization
+	if value.Base != nil {
+		if !value.Base.Root.Defined() || !value.Base.Root.Equals(canonicalBundle.View.BaseRoot) {
+			return ClientRootMaterialization{}, fmt.Errorf("base materialization root mismatch")
+		}
+		if len(canonicalBundle.View.Objects) != 1 {
+			return ClientRootMaterialization{}, fmt.Errorf("base materialization requires a single-object bootstrap view")
+		}
+		object := canonicalBundle.View.Objects[0]
+		if object.ObjectID != "root" || !object.Root.Equals(value.Base.Root) || object.Kind != arcset.KindMap || object.Entries == nil || object.Entries.Len() != 0 || object.Commit.FixedList != nil {
+			return ClientRootMaterialization{}, fmt.Errorf("base materialization requires the canonical empty-map bootstrap object")
+		}
+		if value.Base.Entries == nil || value.Base.Entries.Kind() != arcset.KindMap {
+			return ClientRootMaterialization{}, fmt.Errorf("base materialization entries must be a canonical map")
+		}
+		entries, err := arcset.NewCanonicalArcSet(arcset.KindMap, value.Base.Entries.Entries())
+		if err != nil {
+			return ClientRootMaterialization{}, fmt.Errorf("base materialization entries: %w", err)
+		}
+		base = &MapStateMaterialization{Root: value.Base.Root, Entries: entries}
 	}
 	outputByID := make(map[string]cid.Cid, len(canonicalBundle.Outputs))
 	for _, output := range canonicalBundle.Outputs {
@@ -78,5 +107,5 @@ func NewClientRootMaterialization(bundle ClientRootBundle, value ClientRootMater
 		maps[index] = MapMaterialization{TransitionID: materialization.TransitionID, Root: materialization.Root, Entries: entries}
 	}
 	slices.SortFunc(maps, func(a, b MapMaterialization) int { return strings.Compare(a.TransitionID, b.TransitionID) })
-	return ClientRootMaterialization{Profile: ClientRootMaterializationProfile, Maps: maps}, nil
+	return ClientRootMaterialization{Profile: ClientRootMaterializationProfile, Base: base, Maps: maps}, nil
 }

--- a/mutation/materialization.go
+++ b/mutation/materialization.go
@@ -1,0 +1,82 @@
+package mutation
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	cid "github.com/ipfs/go-cid"
+)
+
+const ClientRootMaterializationProfile = "malt.client-root-materialization/v1"
+
+// MapMaterialization carries the exact internal proof-serving state for one
+// map transition output. Entries are implementation-owned radix cache paths,
+// not logical map coordinates.
+type MapMaterialization struct {
+	TransitionID string
+	Root         cid.Cid
+	Entries      *arcset.CanonicalArcSet
+}
+
+// ClientRootMaterialization carries root-bound proof-serving witnesses for
+// every map output in one exact client-root bundle. List outputs are omitted
+// until their tree materialization receives an equivalent witness profile.
+type ClientRootMaterialization struct {
+	Profile string
+	Maps    []MapMaterialization
+}
+
+// NewClientRootMaterialization validates and canonicalizes one witness against
+// the exact transition/output identities in bundle.
+func NewClientRootMaterialization(bundle ClientRootBundle, value ClientRootMaterialization) (ClientRootMaterialization, error) {
+	canonicalBundle, err := NewClientRootBundle(bundle)
+	if err != nil {
+		return ClientRootMaterialization{}, err
+	}
+	if value.Profile != ClientRootMaterializationProfile {
+		return ClientRootMaterialization{}, fmt.Errorf("client-root materialization profile must be %q", ClientRootMaterializationProfile)
+	}
+	outputByID := make(map[string]cid.Cid, len(canonicalBundle.Outputs))
+	for _, output := range canonicalBundle.Outputs {
+		outputByID[output.TransitionID] = output.Root
+	}
+	mapTransitions := make(map[string]struct{})
+	for _, transition := range canonicalBundle.Intent.Transitions {
+		if transition.Kind == arcset.KindMap {
+			mapTransitions[transition.ID] = struct{}{}
+		}
+	}
+	if len(value.Maps) != len(mapTransitions) {
+		return ClientRootMaterialization{}, fmt.Errorf("client-root map materialization count mismatch")
+	}
+	maps := make([]MapMaterialization, len(value.Maps))
+	seen := make(map[string]struct{}, len(value.Maps))
+	for index, materialization := range value.Maps {
+		if !validClientRootID(materialization.TransitionID) {
+			return ClientRootMaterialization{}, fmt.Errorf("invalid materialization transition id %q", materialization.TransitionID)
+		}
+		if _, duplicate := seen[materialization.TransitionID]; duplicate {
+			return ClientRootMaterialization{}, fmt.Errorf("duplicate materialization transition id %q", materialization.TransitionID)
+		}
+		seen[materialization.TransitionID] = struct{}{}
+		if _, ok := mapTransitions[materialization.TransitionID]; !ok {
+			return ClientRootMaterialization{}, fmt.Errorf("materialization transition %q is not a map output", materialization.TransitionID)
+		}
+		expectedRoot := outputByID[materialization.TransitionID]
+		if !materialization.Root.Defined() || !materialization.Root.Equals(expectedRoot) {
+			return ClientRootMaterialization{}, fmt.Errorf("materialization transition %q root mismatch", materialization.TransitionID)
+		}
+		if materialization.Entries == nil || materialization.Entries.Kind() != arcset.KindMap {
+			return ClientRootMaterialization{}, fmt.Errorf("materialization transition %q entries must be a canonical map", materialization.TransitionID)
+		}
+		entries, err := arcset.NewCanonicalArcSet(arcset.KindMap, materialization.Entries.Entries())
+		if err != nil {
+			return ClientRootMaterialization{}, fmt.Errorf("materialization transition %q entries: %w", materialization.TransitionID, err)
+		}
+		maps[index] = MapMaterialization{TransitionID: materialization.TransitionID, Root: materialization.Root, Entries: entries}
+	}
+	slices.SortFunc(maps, func(a, b MapMaterialization) int { return strings.Compare(a.TransitionID, b.TransitionID) })
+	return ClientRootMaterialization{Profile: ClientRootMaterializationProfile, Maps: maps}, nil
+}

--- a/protocol/client_root.go
+++ b/protocol/client_root.go
@@ -40,6 +40,7 @@ const (
 	MaxClientRootChanges     = 1 << 20
 	MaxClientRootPayloadCIDs = 1 << 20
 	MaxClientRootCIDBytes    = 4096
+	MaxClientRootPathBytes   = 4096
 )
 
 // Presence makes optional wire values explicit. An absent value has empty

--- a/protocol/client_root_decode.go
+++ b/protocol/client_root_decode.go
@@ -148,13 +148,17 @@ func decodeClientRootJSON(data []byte, target any) error {
 // are deliberately required; optional semantic values use explicit presence
 // discriminators instead of optional JSON properties.
 func validateRequiredJSONShape(data []byte, targetType reflect.Type) error {
+	return validateRequiredJSONShapeWithPresence(data, targetType, nil)
+}
+
+func validateRequiredJSONShapeWithPresence(data []byte, targetType reflect.Type, presence map[string]struct{}) error {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
 	token, err := decoder.Token()
 	if err != nil {
 		return err
 	}
-	if err := validateJSONToken(decoder, token, targetType, "$", true); err != nil {
+	if err := validateJSONToken(decoder, token, targetType, "$", true, presence); err != nil {
 		return err
 	}
 	if _, err := decoder.Token(); err != io.EOF {
@@ -166,9 +170,12 @@ func validateRequiredJSONShape(data []byte, targetType reflect.Type) error {
 	return nil
 }
 
-func validateJSONToken(decoder *json.Decoder, token json.Token, targetType reflect.Type, path string, required bool) error {
+func validateJSONToken(decoder *json.Decoder, token json.Token, targetType reflect.Type, path string, required bool, presence map[string]struct{}) error {
 	for targetType.Kind() == reflect.Pointer {
 		targetType = targetType.Elem()
+	}
+	if targetType == reflect.TypeFor[nullableJSONRawMessage]() {
+		return skipJSONToken(decoder, token)
 	}
 	if token == nil {
 		return fmt.Errorf("%s must not be null", path)
@@ -201,11 +208,14 @@ func validateJSONToken(decoder *json.Decoder, token json.Token, targetType refle
 				return fmt.Errorf("%s has duplicate field %q", path, name)
 			}
 			seen[name] = struct{}{}
+			if presence != nil {
+				presence[path+"."+name] = struct{}{}
+			}
 			valueToken, err := decoder.Token()
 			if err != nil {
 				return err
 			}
-			if err := validateJSONToken(decoder, valueToken, field.typ, path+"."+name, !field.optional); err != nil {
+			if err := validateJSONToken(decoder, valueToken, field.typ, path+"."+name, !field.optional, presence); err != nil {
 				return err
 			}
 		}
@@ -237,7 +247,7 @@ func validateJSONToken(decoder *json.Decoder, token json.Token, targetType refle
 			if err != nil {
 				return err
 			}
-			if err := validateJSONToken(decoder, valueToken, targetType.Elem(), fmt.Sprintf("%s[%d]", path, index), true); err != nil {
+			if err := validateJSONToken(decoder, valueToken, targetType.Elem(), fmt.Sprintf("%s[%d]", path, index), true, presence); err != nil {
 				return err
 			}
 			index++

--- a/protocol/client_root_decode.go
+++ b/protocol/client_root_decode.go
@@ -171,10 +171,7 @@ func validateJSONToken(decoder *json.Decoder, token json.Token, targetType refle
 		targetType = targetType.Elem()
 	}
 	if token == nil {
-		if required {
-			return fmt.Errorf("%s must not be null", path)
-		}
-		return nil
+		return fmt.Errorf("%s must not be null", path)
 	}
 	switch targetType.Kind() {
 	case reflect.Struct:

--- a/protocol/client_root_decode.go
+++ b/protocol/client_root_decode.go
@@ -70,6 +70,37 @@ func DecodeMaterializationReceipt(data []byte, bundle mutation.ClientRootBundle)
 // DecodeWriterComputeResult strictly decodes and validates one browser writer
 // result.
 func DecodeWriterComputeResult(data []byte) (WriterComputeResult, error) {
+	if len(data) == 0 {
+		return WriterComputeResult{}, fmt.Errorf("decode writer compute result: client-root JSON is empty")
+	}
+	if len(data) > MaxClientRootJSONBytes {
+		return WriterComputeResult{}, fmt.Errorf("decode writer compute result: client-root JSON exceeds %d bytes", MaxClientRootJSONBytes)
+	}
+	if !utf8.Valid(data) {
+		return WriterComputeResult{}, fmt.Errorf("decode writer compute result: client-root JSON is not valid UTF-8")
+	}
+	var envelope struct {
+		Profile string `json:"profile"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return WriterComputeResult{}, fmt.Errorf("decode writer compute result profile: %w", err)
+	}
+	if envelope.Profile == WriterComputeResultProfileV1 {
+		var legacy writerComputeResultV1
+		if err := decodeClientRootJSON(data, &legacy); err != nil {
+			return WriterComputeResult{}, fmt.Errorf("decode writer compute result: %w", err)
+		}
+		value := WriterComputeResult{
+			Profile:  legacy.Profile,
+			Bundle:   legacy.Bundle,
+			NextView: legacy.NextView,
+			Metrics:  legacy.Metrics,
+		}
+		if err := value.Validate(); err != nil {
+			return WriterComputeResult{}, err
+		}
+		return value, nil
+	}
 	var value WriterComputeResult
 	if err := decodeClientRootJSON(data, &value); err != nil {
 		return WriterComputeResult{}, fmt.Errorf("decode writer compute result: %w", err)
@@ -254,6 +285,10 @@ func maxClientRootSliceItems(targetType reflect.Type) int {
 		return MaxClientRootChanges
 	case reflect.TypeFor[TransitionOutput]():
 		return MaxClientRootTransitions
+	case reflect.TypeFor[MapMaterializationWire]():
+		return MaxClientRootTransitions
+	case reflect.TypeFor[MaterializationEntryWire]():
+		return MaxClientRootMaterializationEntries
 	case reflect.TypeFor[string]():
 		return MaxClientRootPayloadCIDs
 	default:

--- a/protocol/client_root_decode.go
+++ b/protocol/client_root_decode.go
@@ -173,6 +173,9 @@ func validateJSONToken(decoder *json.Decoder, token json.Token, targetType refle
 	if token == nil {
 		return fmt.Errorf("%s must not be null", path)
 	}
+	if targetType == reflect.TypeFor[json.RawMessage]() {
+		return skipJSONToken(decoder, token)
+	}
 	switch targetType.Kind() {
 	case reflect.Struct:
 		delim, ok := token.(json.Delim)
@@ -265,6 +268,55 @@ func validateJSONToken(decoder *json.Decoder, token json.Token, targetType refle
 	default:
 		return fmt.Errorf("%s has unsupported decoder type %s", path, targetType)
 	}
+}
+
+func skipJSONToken(decoder *json.Decoder, token json.Token) error {
+	delim, structured := token.(json.Delim)
+	if !structured {
+		return nil
+	}
+	switch delim {
+	case '{':
+		for decoder.More() {
+			if _, err := decoder.Token(); err != nil {
+				return err
+			}
+			value, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if err := skipJSONToken(decoder, value); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim('}') {
+			return fmt.Errorf("invalid JSON object terminator")
+		}
+	case '[':
+		for decoder.More() {
+			value, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if err := skipJSONToken(decoder, value); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim(']') {
+			return fmt.Errorf("invalid JSON array terminator")
+		}
+	default:
+		return fmt.Errorf("invalid JSON delimiter %q", delim)
+	}
+	return nil
 }
 
 func maxClientRootSliceItems(targetType reflect.Type) int {

--- a/protocol/client_root_test.go
+++ b/protocol/client_root_test.go
@@ -320,7 +320,25 @@ func TestWriterComputeResultRoundTripsAndBindsNextView(t *testing.T) {
 		}
 	}
 	metrics := protocol.WriterComputeMetrics{CommitmentUpdateNS: 7, TotalNS: 11}
-	wire, err := protocol.NewWriterComputeResult(bundle, nextView, metrics)
+	entries, err := arcset.NewCanonicalArcSet(arcset.KindMap, []arcset.ArcEntry{{
+		Coordinate: protocolMapCoordinate(t, "radix/node"),
+		Target:     arcset.NewUnknownTarget(bundle.Candidate),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	materialization, err := mutation.NewClientRootMaterialization(bundle, mutation.ClientRootMaterialization{
+		Profile: mutation.ClientRootMaterializationProfile,
+		Maps: []mutation.MapMaterialization{{
+			TransitionID: "child-output",
+			Root:         bundle.Outputs[0].Root,
+			Entries:      entries,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire, err := protocol.NewWriterComputeResult(bundle, materialization, nextView, metrics)
 	if err != nil {
 		t.Fatalf("NewWriterComputeResult failed: %v", err)
 	}
@@ -339,19 +357,88 @@ func TestWriterComputeResultRoundTripsAndBindsNextView(t *testing.T) {
 		t.Fatalf("unexpected writer compute result: %+v", decoded)
 	}
 
+	longPath := wire
+	longPath.Materialization.Maps = append([]protocol.MapMaterializationWire(nil), wire.Materialization.Maps...)
+	longPath.Materialization.Maps[0].Entries = append([]protocol.MaterializationEntryWire(nil), wire.Materialization.Maps[0].Entries...)
+	longPath.Materialization.Maps[0].Entries[0].Path = strings.Repeat("a", protocol.MaxClientRootPathBytes+1)
+	if err := longPath.Validate(); err == nil {
+		t.Fatal("writer compute result accepted an oversized materialization path")
+	}
+
 	wire.NextView.BaseRoot = bundle.View.BaseRoot.String()
 	if err := wire.Validate(); err == nil {
 		t.Fatal("writer compute result accepted a next view at the wrong root")
 	}
 }
 
+func TestWriterComputeResultV2RequiresMaterializationAndV1StillDecodes(t *testing.T) {
+	bundle, _ := protocolClientRootFixture(t)
+	nextView, err := mutation.NormalizeUpdateView(bundle.View)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nextView.BaseRoot = bundle.Candidate
+	for index := range nextView.Objects {
+		if nextView.Objects[index].Root.Equals(bundle.View.BaseRoot) {
+			nextView.Objects[index].Root = bundle.Candidate
+		}
+	}
+	wireBundle, err := protocol.NewClientRootBundle(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wireView, err := protocol.NewUpdateView(nextView)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyRaw, err := json.Marshal(map[string]any{
+		"profile": protocol.WriterComputeResultProfileV1,
+		"bundle":  wireBundle, "next_view": wireView, "metrics": protocol.WriterComputeMetrics{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := protocol.DecodeWriterComputeResult(legacyRaw)
+	if err != nil || legacy.Profile != protocol.WriterComputeResultProfileV1 {
+		t.Fatalf("decode v1 result = %+v, %v", legacy, err)
+	}
+	roundTripRaw, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var roundTripObject map[string]json.RawMessage
+	if err := json.Unmarshal(roundTripRaw, &roundTripObject); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := roundTripObject["materialization"]; exists {
+		t.Fatal("v1 writer result acquired a v2 materialization member")
+	}
+	if roundTrip, err := protocol.DecodeWriterComputeResult(roundTripRaw); err != nil || roundTrip.Profile != protocol.WriterComputeResultProfileV1 {
+		t.Fatalf("round-trip v1 result = %+v, %v", roundTrip, err)
+	}
+	if _, err := protocol.DecodeWriterComputeResult([]byte(`{"profile":"malt.writer-compute-result/v2"}`)); err == nil {
+		t.Fatal("v2 result without materialization was accepted")
+	}
+}
+
+func TestWriterComputeResultRejectsOversizedMaterializationBeforeDecode(t *testing.T) {
+	const item = `{"transition_id":"x","root":"x","entries":[]},`
+	maps := strings.TrimSuffix(strings.Repeat(item, protocol.MaxClientRootTransitions+1), ",")
+	raw := []byte(`{"profile":"malt.writer-compute-result/v2","materialization":{"profile":"malt.client-root-materialization/v1","maps":[` + maps + `]},"bundle":{},"next_view":{},"metrics":{}}`)
+	if _, err := protocol.DecodeWriterComputeResult(raw); err == nil || !strings.Contains(err.Error(), "materialization.maps exceeds 65536 items") {
+		t.Fatalf("oversized materialization maps error = %v", err)
+	}
+}
+
 func TestClientRootSchemasAreEmbedded(t *testing.T) {
 	want := map[string]bool{
-		"update-view.schema.json":             false,
-		"semantic-intent.schema.json":         false,
-		"client-root-bundle.schema.json":      false,
-		"materialization-receipt.schema.json": false,
-		"writer-compute-result.schema.json":   false,
+		"update-view.schema.json":                 false,
+		"semantic-intent.schema.json":             false,
+		"client-root-bundle.schema.json":          false,
+		"client-root-materialization.schema.json": false,
+		"materialization-receipt.schema.json":     false,
+		"writer-compute-result.schema.json":       false,
+		"writer-compute-result-v2.schema.json":    false,
 	}
 	for _, name := range protocol.SchemaNames() {
 		if _, ok := want[name]; ok {

--- a/protocol/client_root_test.go
+++ b/protocol/client_root_test.go
@@ -365,6 +365,14 @@ func TestWriterComputeResultRoundTripsAndBindsNextView(t *testing.T) {
 		t.Fatal("writer compute result accepted an oversized materialization path")
 	}
 
+	noncanonicalPath := wire
+	noncanonicalPath.Materialization.Maps = append([]protocol.MapMaterializationWire(nil), wire.Materialization.Maps...)
+	noncanonicalPath.Materialization.Maps[0].Entries = append([]protocol.MaterializationEntryWire(nil), wire.Materialization.Maps[0].Entries...)
+	noncanonicalPath.Materialization.Maps[0].Entries[0].Path = "radix//node"
+	if err := noncanonicalPath.Validate(); err == nil || !strings.Contains(err.Error(), "path is not canonical") {
+		t.Fatalf("noncanonical materialization path error = %v", err)
+	}
+
 	wire.NextView.BaseRoot = bundle.View.BaseRoot.String()
 	if err := wire.Validate(); err == nil {
 		t.Fatal("writer compute result accepted a next view at the wrong root")

--- a/protocol/client_root_test.go
+++ b/protocol/client_root_test.go
@@ -419,6 +419,18 @@ func TestWriterComputeResultV2RequiresMaterializationAndV1StillDecodes(t *testin
 	if _, err := protocol.DecodeWriterComputeResult([]byte(`{"profile":"malt.writer-compute-result/v2"}`)); err == nil {
 		t.Fatal("v2 result without materialization was accepted")
 	}
+	legacyWithBase := legacy
+	legacyWithBase.Materialization.Base = &protocol.MapStateMaterializationWire{Root: bundle.View.BaseRoot.String(), Entries: []protocol.MaterializationEntryWire{}}
+	if err := legacyWithBase.Validate(); err == nil {
+		t.Fatal("v1 writer result accepted a bootstrap base materialization")
+	}
+}
+
+func TestWriterComputeResultRejectsExplicitNullBootstrapBase(t *testing.T) {
+	raw := []byte(`{"profile":"malt.writer-compute-result/v2","materialization":{"profile":"malt.client-root-materialization/v1","base":null,"maps":[]},"bundle":{},"next_view":{},"metrics":{}}`)
+	if _, err := protocol.DecodeWriterComputeResult(raw); err == nil || !strings.Contains(err.Error(), "materialization.base must not be null") {
+		t.Fatalf("explicit null base error = %v", err)
+	}
 }
 
 func TestWriterComputeResultRejectsOversizedMaterializationBeforeDecode(t *testing.T) {

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 )
 
 // MaxVerificationJSONBytes bounds portable verifier inputs before JSON
@@ -45,6 +46,9 @@ func DecodeMapProofRequest(data []byte) (MapProofRequest, error) {
 	if err := decodeVerificationJSON(data, &value); err != nil {
 		return MapProofRequest{}, fmt.Errorf("decode map-proof request: %w", err)
 	}
+	if err := validateRequiredJSONShape(data, reflect.TypeFor[mapProofRequestJSONShape]()); err != nil {
+		return MapProofRequest{}, fmt.Errorf("decode map-proof request: %w", err)
+	}
 	if err := value.Validate(); err != nil {
 		return MapProofRequest{}, err
 	}
@@ -55,6 +59,9 @@ func DecodeMapProofRequest(data []byte) (MapProofRequest, error) {
 func DecodeMapProofResult(data []byte) (MapProofResult, error) {
 	var value MapProofResult
 	if err := decodeVerificationJSON(data, &value); err != nil {
+		return MapProofResult{}, fmt.Errorf("decode map-proof result: %w", err)
+	}
+	if err := validateRequiredJSONShape(data, reflect.TypeFor[mapProofResultJSONShape]()); err != nil {
 		return MapProofResult{}, fmt.Errorf("decode map-proof result: %w", err)
 	}
 	if err := value.Validate(); err != nil {
@@ -69,10 +76,31 @@ func DecodeMapProofVerification(data []byte) (MapProofVerification, error) {
 	if err := decodeVerificationJSON(data, &value); err != nil {
 		return MapProofVerification{}, fmt.Errorf("decode map-proof verification: %w", err)
 	}
+	if err := validateRequiredJSONShape(data, reflect.TypeFor[mapProofVerificationJSONShape]()); err != nil {
+		return MapProofVerification{}, fmt.Errorf("decode map-proof verification: %w", err)
+	}
 	if err := value.Validate(); err != nil {
 		return MapProofVerification{}, err
 	}
 	return value, nil
+}
+
+type mapProofRequestJSONShape struct {
+	Profile string   `json:"profile"`
+	Root    string   `json:"root"`
+	Key     []string `json:"key"`
+}
+
+type mapProofResultJSONShape struct {
+	Profile   string          `json:"profile"`
+	Present   bool            `json:"present"`
+	Target    string          `json:"target,omitempty"`
+	ProofList json.RawMessage `json:"prooflist"`
+}
+
+type mapProofVerificationJSONShape struct {
+	Request mapProofRequestJSONShape `json:"request"`
+	Result  mapProofResultJSONShape  `json:"result"`
 }
 
 func decodeVerificationJSON(data []byte, target any) error {

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -61,7 +61,11 @@ func DecodeMapProofResult(data []byte) (MapProofResult, error) {
 	if err := decodeVerificationJSON(data, &value); err != nil {
 		return MapProofResult{}, fmt.Errorf("decode map-proof result: %w", err)
 	}
-	if err := validateRequiredJSONShape(data, reflect.TypeFor[mapProofResultJSONShape]()); err != nil {
+	presence := make(map[string]struct{})
+	if err := validateRequiredJSONShapeWithPresence(data, reflect.TypeFor[mapProofResultJSONShape](), presence); err != nil {
+		return MapProofResult{}, fmt.Errorf("decode map-proof result: %w", err)
+	}
+	if err := validateMapProofTargetPresence(value.Present, presence, "$.target"); err != nil {
 		return MapProofResult{}, fmt.Errorf("decode map-proof result: %w", err)
 	}
 	if err := value.Validate(); err != nil {
@@ -76,7 +80,11 @@ func DecodeMapProofVerification(data []byte) (MapProofVerification, error) {
 	if err := decodeVerificationJSON(data, &value); err != nil {
 		return MapProofVerification{}, fmt.Errorf("decode map-proof verification: %w", err)
 	}
-	if err := validateRequiredJSONShape(data, reflect.TypeFor[mapProofVerificationJSONShape]()); err != nil {
+	presence := make(map[string]struct{})
+	if err := validateRequiredJSONShapeWithPresence(data, reflect.TypeFor[mapProofVerificationJSONShape](), presence); err != nil {
+		return MapProofVerification{}, fmt.Errorf("decode map-proof verification: %w", err)
+	}
+	if err := validateMapProofTargetPresence(value.Result.Present, presence, "$.result.target"); err != nil {
 		return MapProofVerification{}, fmt.Errorf("decode map-proof verification: %w", err)
 	}
 	if err := value.Validate(); err != nil {
@@ -92,15 +100,55 @@ type mapProofRequestJSONShape struct {
 }
 
 type mapProofResultJSONShape struct {
-	Profile   string          `json:"profile"`
-	Present   bool            `json:"present"`
-	Target    string          `json:"target,omitempty"`
-	ProofList json.RawMessage `json:"prooflist"`
+	Profile   string             `json:"profile"`
+	Present   bool               `json:"present"`
+	Target    string             `json:"target,omitempty"`
+	ProofList proofListJSONShape `json:"prooflist"`
 }
+
+type proofListJSONShape struct {
+	Root  json.RawMessage      `json:"root"`
+	Query string               `json:"query,omitempty"`
+	Steps []proofStepJSONShape `json:"steps"`
+}
+
+type proofStepJSONShape struct {
+	Kind            string                 `json:"kind"`
+	From            json.RawMessage        `json:"from"`
+	Query           string                 `json:"query,omitempty"`
+	Coordinate      string                 `json:"coordinate,omitempty"`
+	Path            string                 `json:"path,omitempty"`
+	Index           *uint64                `json:"index,omitempty"`
+	Length          *uint64                `json:"length,omitempty"`
+	Start           *uint64                `json:"start,omitempty"`
+	End             *uint64                `json:"end,omitempty"`
+	ChildCount      *uint64                `json:"child_count,omitempty"`
+	TotalSize       *uint64                `json:"total_size,omitempty"`
+	ChunkSize       *uint64                `json:"chunk_size,omitempty"`
+	Target          nullableJSONRawMessage `json:"target"`
+	Segments        []json.RawMessage      `json:"segments,omitempty"`
+	EvidenceKind    string                 `json:"evidence_kind,omitempty"`
+	EvidenceBackend string                 `json:"evidence_backend,omitempty"`
+	Evidence        string                 `json:"evidence,omitempty"`
+	Proof           string                 `json:"proof,omitempty"`
+}
+
+type nullableJSONRawMessage json.RawMessage
 
 type mapProofVerificationJSONShape struct {
 	Request mapProofRequestJSONShape `json:"request"`
 	Result  mapProofResultJSONShape  `json:"result"`
+}
+
+func validateMapProofTargetPresence(present bool, presence map[string]struct{}, path string) error {
+	_, carried := presence[path]
+	if present && !carried {
+		return fmt.Errorf("%s is required for a present map-proof result", path)
+	}
+	if !present && carried {
+		return fmt.Errorf("%s must be omitted for an absent map-proof result", path)
+	}
+	return nil
 }
 
 func decodeVerificationJSON(data []byte, target any) error {

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -39,6 +39,42 @@ func DecodeReadVerification(data []byte) (ReadVerification, error) {
 	return value, nil
 }
 
+// DecodeMapProofRequest strictly decodes one caller-selected map-proof request.
+func DecodeMapProofRequest(data []byte) (MapProofRequest, error) {
+	var value MapProofRequest
+	if err := decodeVerificationJSON(data, &value); err != nil {
+		return MapProofRequest{}, fmt.Errorf("decode map-proof request: %w", err)
+	}
+	if err := value.Validate(); err != nil {
+		return MapProofRequest{}, err
+	}
+	return value, nil
+}
+
+// DecodeMapProofResult strictly decodes one untrusted map-proof result.
+func DecodeMapProofResult(data []byte) (MapProofResult, error) {
+	var value MapProofResult
+	if err := decodeVerificationJSON(data, &value); err != nil {
+		return MapProofResult{}, fmt.Errorf("decode map-proof result: %w", err)
+	}
+	if err := value.Validate(); err != nil {
+		return MapProofResult{}, err
+	}
+	return value, nil
+}
+
+// DecodeMapProofVerification strictly decodes one map-proof request/result pair.
+func DecodeMapProofVerification(data []byte) (MapProofVerification, error) {
+	var value MapProofVerification
+	if err := decodeVerificationJSON(data, &value); err != nil {
+		return MapProofVerification{}, fmt.Errorf("decode map-proof verification: %w", err)
+	}
+	if err := value.Validate(); err != nil {
+		return MapProofVerification{}, err
+	}
+	return value, nil
+}
+
 func decodeVerificationJSON(data []byte, target any) error {
 	if len(data) == 0 {
 		return fmt.Errorf("verification JSON is empty")

--- a/protocol/decode_test.go
+++ b/protocol/decode_test.go
@@ -101,6 +101,25 @@ func TestDecodeMapProofVerificationStrictAndTargetConditional(t *testing.T) {
 	if _, err := protocol.DecodeMapProofVerification([]byte(withUnknown)); err == nil {
 		t.Fatal("DecodeMapProofVerification accepted an unknown result field")
 	}
+	emptyTarget := strings.Replace(string(raw), `"present":false`, `"present":false,"target":""`, 1)
+	if _, err := protocol.DecodeMapProofVerification([]byte(emptyTarget)); err == nil || !strings.Contains(err.Error(), "must be omitted") {
+		t.Fatalf("explicit-empty absent target error = %v", err)
+	}
+	resultRaw, err := json.Marshal(value.Result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directEmptyTarget := strings.Replace(string(resultRaw), `"present":false`, `"present":false,"target":""`, 1)
+	if _, err := protocol.DecodeMapProofResult([]byte(directEmptyTarget)); err == nil || !strings.Contains(err.Error(), "must be omitted") {
+		t.Fatalf("direct explicit-empty absent target error = %v", err)
+	}
+	missingStepTarget := strings.Replace(string(raw), `"target":null,`, ``, 1)
+	if missingStepTarget == string(raw) {
+		t.Fatalf("map absence fixture has no explicit null step target: %s", raw)
+	}
+	if _, err := protocol.DecodeMapProofVerification([]byte(missingStepTarget)); err == nil || !strings.Contains(err.Error(), `missing required field "target"`) {
+		t.Fatalf("missing map_absence step target error = %v", err)
+	}
 	nullTarget := strings.Replace(string(raw), `"present":false`, `"present":false,"target":null`, 1)
 	if _, err := protocol.DecodeMapProofVerification([]byte(nullTarget)); err == nil || !strings.Contains(err.Error(), "must not be null") {
 		t.Fatalf("explicit-null target error = %v", err)

--- a/protocol/decode_test.go
+++ b/protocol/decode_test.go
@@ -68,3 +68,41 @@ func TestDecodeVerificationRejectsEmptyAndOversizedInputs(t *testing.T) {
 		t.Fatal("DecodeReadVerification accepted an oversized input")
 	}
 }
+
+func TestDecodeMapProofVerificationStrictAndTargetConditional(t *testing.T) {
+	root := protocolTestCID(t, "strict-map-proof-root")
+	value := protocol.MapProofVerification{
+		Request: protocol.MapProofRequest{Profile: protocol.MapProofProfile, Root: root.String(), Key: []string{"missing"}},
+		Result: protocol.MapProofResult{
+			Profile: protocol.MapProofProfile,
+			Present: false,
+			ProofList: prooflist.ProofList{Root: root, Query: "missing", Steps: []prooflist.Step{{
+				Kind: prooflist.KindMapAbsence, From: root, Path: "missing",
+				EvidenceKind: "structure", EvidenceBackend: "map", Proof: []byte("absence"),
+			}}},
+		},
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), `"present":false,"target":`) {
+		t.Fatalf("absent map-proof result serialized a result target: %s", raw)
+	}
+	decoded, err := protocol.DecodeMapProofVerification(raw)
+	if err != nil {
+		t.Fatalf("DecodeMapProofVerification: %v", err)
+	}
+	if decoded.Result.Present || decoded.Result.Target != "" || decoded.Result.ProofList.Steps[0].Target.Defined() {
+		t.Fatalf("decoded absence = %+v", decoded.Result)
+	}
+
+	withUnknown := strings.Replace(string(raw), `"present":false`, `"present":false,"unexpected":true`, 1)
+	if _, err := protocol.DecodeMapProofVerification([]byte(withUnknown)); err == nil {
+		t.Fatal("DecodeMapProofVerification accepted an unknown result field")
+	}
+	presentWithoutTarget := strings.Replace(string(raw), `"present":false`, `"present":true`, 1)
+	if _, err := protocol.DecodeMapProofVerification([]byte(presentWithoutTarget)); err == nil {
+		t.Fatal("DecodeMapProofVerification accepted a present result without target")
+	}
+}

--- a/protocol/decode_test.go
+++ b/protocol/decode_test.go
@@ -101,6 +101,19 @@ func TestDecodeMapProofVerificationStrictAndTargetConditional(t *testing.T) {
 	if _, err := protocol.DecodeMapProofVerification([]byte(withUnknown)); err == nil {
 		t.Fatal("DecodeMapProofVerification accepted an unknown result field")
 	}
+	nullTarget := strings.Replace(string(raw), `"present":false`, `"present":false,"target":null`, 1)
+	if _, err := protocol.DecodeMapProofVerification([]byte(nullTarget)); err == nil || !strings.Contains(err.Error(), "must not be null") {
+		t.Fatalf("explicit-null target error = %v", err)
+	}
+	duplicatePresent := strings.Replace(string(raw), `"present":false`, `"present":false,"present":false`, 1)
+	if _, err := protocol.DecodeMapProofVerification([]byte(duplicatePresent)); err == nil || !strings.Contains(err.Error(), "duplicate field") {
+		t.Fatalf("duplicate present error = %v", err)
+	}
+	requestRoot := `"root":"` + root.String() + `"`
+	duplicateRoot := strings.Replace(string(raw), requestRoot, requestRoot+`,`+requestRoot, 1)
+	if _, err := protocol.DecodeMapProofVerification([]byte(duplicateRoot)); err == nil || !strings.Contains(err.Error(), "duplicate field") {
+		t.Fatalf("duplicate root error = %v", err)
+	}
 	presentWithoutTarget := strings.Replace(string(raw), `"present":false`, `"present":true`, 1)
 	if _, err := protocol.DecodeMapProofVerification([]byte(presentWithoutTarget)); err == nil {
 		t.Fatal("DecodeMapProofVerification accepted a present result without target")

--- a/protocol/map_proof.go
+++ b/protocol/map_proof.go
@@ -1,0 +1,127 @@
+package protocol
+
+import (
+	"fmt"
+
+	malt "github.com/dewebprotocol/malt"
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/auth/proof/prooflist"
+	cid "github.com/ipfs/go-cid"
+)
+
+const MapProofProfile = "malt.map-proof/v0alpha1"
+
+// MapProofRequest is the serialized projection of one caller-selected map
+// membership or non-membership request.
+type MapProofRequest struct {
+	Profile string   `json:"profile"`
+	Root    string   `json:"root"`
+	Key     []string `json:"key"`
+}
+
+// MapProofResult carries either a present target or an authenticated absence.
+type MapProofResult struct {
+	Profile   string              `json:"profile"`
+	Present   bool                `json:"present"`
+	Target    string              `json:"target,omitempty"`
+	ProofList prooflist.ProofList `json:"prooflist"`
+}
+
+// MapProofVerification binds caller-selected root/key inputs to an untrusted
+// membership or non-membership result.
+type MapProofVerification struct {
+	Request MapProofRequest `json:"request"`
+	Result  MapProofResult  `json:"result"`
+}
+
+func NewMapProofRequest(request malt.MapProofRequest) (MapProofRequest, error) {
+	if err := request.Validate(); err != nil {
+		return MapProofRequest{}, err
+	}
+	path, err := malt.ParseSegmentPath(request.Key.String())
+	if err != nil {
+		return MapProofRequest{}, err
+	}
+	return MapProofRequest{Profile: MapProofProfile, Root: request.Root.String(), Key: path.Segments()}, nil
+}
+
+func (r MapProofRequest) Validate() error {
+	if r.Profile != MapProofProfile {
+		return fmt.Errorf("unsupported map-proof profile %q", r.Profile)
+	}
+	root, err := cid.Parse(r.Root)
+	if err != nil {
+		return fmt.Errorf("invalid map-proof root CID: %w", err)
+	}
+	if r.Key == nil || len(r.Key) == 0 {
+		return fmt.Errorf("map-proof key field is required")
+	}
+	path, err := malt.NewSegmentPath(r.Key)
+	if err != nil {
+		return err
+	}
+	return (malt.MapProofRequest{Root: root, Key: arcset.CanonicalizePath(path.String())}).Validate()
+}
+
+func (r MapProofRequest) Core() (malt.MapProofRequest, error) {
+	if err := r.Validate(); err != nil {
+		return malt.MapProofRequest{}, err
+	}
+	root, _ := cid.Parse(r.Root)
+	path, _ := malt.NewSegmentPath(r.Key)
+	return malt.MapProofRequest{Root: root, Key: arcset.CanonicalizePath(path.String())}, nil
+}
+
+func NewMapProofResult(result malt.MapProofResult) (MapProofResult, error) {
+	if !result.ProofList.Root.Defined() {
+		return MapProofResult{}, fmt.Errorf("map-proof ProofList root is undefined")
+	}
+	value := MapProofResult{Profile: MapProofProfile, Present: result.Present, ProofList: result.ProofList}
+	if result.Present {
+		if !result.Target.Defined() {
+			return MapProofResult{}, fmt.Errorf("present map-proof target is undefined")
+		}
+		value.Target = result.Target.String()
+	} else if result.Target.Defined() {
+		return MapProofResult{}, fmt.Errorf("absent map-proof target is defined")
+	}
+	if err := value.Validate(); err != nil {
+		return MapProofResult{}, err
+	}
+	return value, nil
+}
+
+func (r MapProofResult) Validate() error {
+	if r.Profile != MapProofProfile {
+		return fmt.Errorf("unsupported map-proof result profile %q", r.Profile)
+	}
+	if r.Present {
+		if _, err := cid.Parse(r.Target); err != nil {
+			return fmt.Errorf("invalid present map-proof target CID: %w", err)
+		}
+	} else if r.Target != "" {
+		return fmt.Errorf("absent map-proof result must not carry a target")
+	}
+	if !r.ProofList.Root.Defined() {
+		return fmt.Errorf("map-proof ProofList root is undefined")
+	}
+	return r.ProofList.ValidateShape(prooflist.RequireSteps())
+}
+
+func (r MapProofResult) Core() (malt.MapProofResult, error) {
+	if err := r.Validate(); err != nil {
+		return malt.MapProofResult{}, err
+	}
+	target := cid.Undef
+	if r.Present {
+		target, _ = cid.Parse(r.Target)
+	}
+	return malt.MapProofResult{Present: r.Present, Target: target, ProofList: r.ProofList}, nil
+}
+
+func (v MapProofVerification) Validate() error {
+	if err := v.Request.Validate(); err != nil {
+		return err
+	}
+	return v.Result.Validate()
+}

--- a/protocol/materialization.go
+++ b/protocol/materialization.go
@@ -15,8 +15,14 @@ const (
 // ClientRootMaterialization is the JSON projection of the root-bound
 // proof-serving state exported by the browser writer.
 type ClientRootMaterialization struct {
-	Profile string                   `json:"profile"`
-	Maps    []MapMaterializationWire `json:"maps"`
+	Profile string                       `json:"profile"`
+	Base    *MapStateMaterializationWire `json:"base,omitempty"`
+	Maps    []MapMaterializationWire     `json:"maps"`
+}
+
+type MapStateMaterializationWire struct {
+	Root    string                     `json:"root"`
+	Entries []MaterializationEntryWire `json:"entries"`
 }
 
 type MapMaterializationWire struct {
@@ -35,8 +41,21 @@ func NewClientRootMaterialization(bundle mutation.ClientRootBundle, value mutati
 	if err != nil {
 		return ClientRootMaterialization{}, err
 	}
-	maps := make([]MapMaterializationWire, len(canonical.Maps))
+	var base *MapStateMaterializationWire
 	totalEntries := 0
+	if canonical.Base != nil {
+		entries := canonical.Base.Entries.Entries()
+		totalEntries += len(entries)
+		if totalEntries > MaxClientRootMaterializationEntries {
+			return ClientRootMaterialization{}, fmt.Errorf("client-root materialization entry count exceeds %d", MaxClientRootMaterializationEntries)
+		}
+		wireEntries := make([]MaterializationEntryWire, len(entries))
+		for index, entry := range entries {
+			wireEntries[index] = MaterializationEntryWire{Path: entry.Coordinate.String(), CID: entry.Target.CID().String()}
+		}
+		base = &MapStateMaterializationWire{Root: canonical.Base.Root.String(), Entries: wireEntries}
+	}
+	maps := make([]MapMaterializationWire, len(canonical.Maps))
 	for index, materialization := range canonical.Maps {
 		entries := materialization.Entries.Entries()
 		totalEntries += len(entries)
@@ -55,7 +74,7 @@ func NewClientRootMaterialization(bundle mutation.ClientRootBundle, value mutati
 			Entries:      wireEntries,
 		}
 	}
-	return ClientRootMaterialization{Profile: ClientRootMaterializationProfile, Maps: maps}, nil
+	return ClientRootMaterialization{Profile: ClientRootMaterializationProfile, Base: base, Maps: maps}, nil
 }
 
 func (w ClientRootMaterialization) Core(bundle mutation.ClientRootBundle) (mutation.ClientRootMaterialization, error) {
@@ -65,8 +84,24 @@ func (w ClientRootMaterialization) Core(bundle mutation.ClientRootBundle) (mutat
 	if len(w.Maps) > MaxClientRootTransitions {
 		return mutation.ClientRootMaterialization{}, fmt.Errorf("client-root materialization map count exceeds %d", MaxClientRootTransitions)
 	}
-	maps := make([]mutation.MapMaterialization, len(w.Maps))
+	var base *mutation.MapStateMaterialization
 	totalEntries := 0
+	if w.Base != nil {
+		root, err := parseCanonicalCID(w.Base.Root, "base.root")
+		if err != nil {
+			return mutation.ClientRootMaterialization{}, err
+		}
+		totalEntries += len(w.Base.Entries)
+		if totalEntries > MaxClientRootMaterializationEntries {
+			return mutation.ClientRootMaterialization{}, fmt.Errorf("client-root materialization entry count exceeds %d", MaxClientRootMaterializationEntries)
+		}
+		entries, err := decodeMaterializationEntries("base", w.Base.Entries)
+		if err != nil {
+			return mutation.ClientRootMaterialization{}, err
+		}
+		base = &mutation.MapStateMaterialization{Root: root, Entries: entries}
+	}
+	maps := make([]mutation.MapMaterialization, len(w.Maps))
 	for index, materialization := range w.Maps {
 		root, err := parseCanonicalCID(materialization.Root, fmt.Sprintf("maps[%d].root", index))
 		if err != nil {
@@ -76,33 +111,41 @@ func (w ClientRootMaterialization) Core(bundle mutation.ClientRootBundle) (mutat
 		if totalEntries > MaxClientRootMaterializationEntries {
 			return mutation.ClientRootMaterialization{}, fmt.Errorf("client-root materialization entry count exceeds %d", MaxClientRootMaterializationEntries)
 		}
-		entries := make([]arcset.ArcEntry, len(materialization.Entries))
-		for entryIndex, entry := range materialization.Entries {
-			if len(entry.Path) == 0 || len(entry.Path) > MaxClientRootPathBytes {
-				return mutation.ClientRootMaterialization{}, fmt.Errorf("maps[%d].entries[%d].path length is outside 1..%d", index, entryIndex, MaxClientRootPathBytes)
-			}
-			coordinate, err := arcset.NewMapCoordinate(entry.Path)
-			if err != nil {
-				return mutation.ClientRootMaterialization{}, fmt.Errorf("maps[%d].entries[%d].path: %w", index, entryIndex, err)
-			}
-			target, err := parseCanonicalCID(entry.CID, fmt.Sprintf("maps[%d].entries[%d].cid", index, entryIndex))
-			if err != nil {
-				return mutation.ClientRootMaterialization{}, err
-			}
-			entries[entryIndex] = arcset.ArcEntry{Coordinate: coordinate, Target: arcset.NewUnknownTarget(target)}
-		}
-		canonicalEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, entries)
+		entries, err := decodeMaterializationEntries(fmt.Sprintf("maps[%d]", index), materialization.Entries)
 		if err != nil {
-			return mutation.ClientRootMaterialization{}, fmt.Errorf("maps[%d].entries: %w", index, err)
-		}
-		if canonicalEntries.Len() != len(entries) {
-			return mutation.ClientRootMaterialization{}, fmt.Errorf("maps[%d].entries contain duplicate coordinates", index)
+			return mutation.ClientRootMaterialization{}, err
 		}
 		maps[index] = mutation.MapMaterialization{
-			TransitionID: materialization.TransitionID, Root: root, Entries: canonicalEntries,
+			TransitionID: materialization.TransitionID, Root: root, Entries: entries,
 		}
 	}
-	return mutation.NewClientRootMaterialization(bundle, mutation.ClientRootMaterialization{Profile: w.Profile, Maps: maps})
+	return mutation.NewClientRootMaterialization(bundle, mutation.ClientRootMaterialization{Profile: w.Profile, Base: base, Maps: maps})
+}
+
+func decodeMaterializationEntries(label string, wire []MaterializationEntryWire) (*arcset.CanonicalArcSet, error) {
+	entries := make([]arcset.ArcEntry, len(wire))
+	for index, entry := range wire {
+		if len(entry.Path) == 0 || len(entry.Path) > MaxClientRootPathBytes {
+			return nil, fmt.Errorf("%s.entries[%d].path length is outside 1..%d", label, index, MaxClientRootPathBytes)
+		}
+		coordinate, err := arcset.NewMapCoordinate(entry.Path)
+		if err != nil {
+			return nil, fmt.Errorf("%s.entries[%d].path: %w", label, index, err)
+		}
+		target, err := parseCanonicalCID(entry.CID, fmt.Sprintf("%s.entries[%d].cid", label, index))
+		if err != nil {
+			return nil, err
+		}
+		entries[index] = arcset.ArcEntry{Coordinate: coordinate, Target: arcset.NewUnknownTarget(target)}
+	}
+	canonical, err := arcset.NewCanonicalArcSet(arcset.KindMap, entries)
+	if err != nil {
+		return nil, fmt.Errorf("%s.entries: %w", label, err)
+	}
+	if canonical.Len() != len(entries) {
+		return nil, fmt.Errorf("%s.entries contain duplicate coordinates", label)
+	}
+	return canonical, nil
 }
 
 func (w ClientRootMaterialization) Validate(bundle mutation.ClientRootBundle) error {

--- a/protocol/materialization.go
+++ b/protocol/materialization.go
@@ -1,0 +1,111 @@
+package protocol
+
+import (
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/mutation"
+)
+
+const (
+	ClientRootMaterializationProfile    = mutation.ClientRootMaterializationProfile
+	MaxClientRootMaterializationEntries = 1 << 22
+)
+
+// ClientRootMaterialization is the JSON projection of the root-bound
+// proof-serving state exported by the browser writer.
+type ClientRootMaterialization struct {
+	Profile string                   `json:"profile"`
+	Maps    []MapMaterializationWire `json:"maps"`
+}
+
+type MapMaterializationWire struct {
+	TransitionID string                     `json:"transition_id"`
+	Root         string                     `json:"root"`
+	Entries      []MaterializationEntryWire `json:"entries"`
+}
+
+type MaterializationEntryWire struct {
+	Path string `json:"path"`
+	CID  string `json:"cid"`
+}
+
+func NewClientRootMaterialization(bundle mutation.ClientRootBundle, value mutation.ClientRootMaterialization) (ClientRootMaterialization, error) {
+	canonical, err := mutation.NewClientRootMaterialization(bundle, value)
+	if err != nil {
+		return ClientRootMaterialization{}, err
+	}
+	maps := make([]MapMaterializationWire, len(canonical.Maps))
+	totalEntries := 0
+	for index, materialization := range canonical.Maps {
+		entries := materialization.Entries.Entries()
+		totalEntries += len(entries)
+		if totalEntries > MaxClientRootMaterializationEntries {
+			return ClientRootMaterialization{}, fmt.Errorf("client-root materialization entry count exceeds %d", MaxClientRootMaterializationEntries)
+		}
+		wireEntries := make([]MaterializationEntryWire, len(entries))
+		for entryIndex, entry := range entries {
+			wireEntries[entryIndex] = MaterializationEntryWire{
+				Path: entry.Coordinate.String(), CID: entry.Target.CID().String(),
+			}
+		}
+		maps[index] = MapMaterializationWire{
+			TransitionID: materialization.TransitionID,
+			Root:         materialization.Root.String(),
+			Entries:      wireEntries,
+		}
+	}
+	return ClientRootMaterialization{Profile: ClientRootMaterializationProfile, Maps: maps}, nil
+}
+
+func (w ClientRootMaterialization) Core(bundle mutation.ClientRootBundle) (mutation.ClientRootMaterialization, error) {
+	if w.Profile != ClientRootMaterializationProfile {
+		return mutation.ClientRootMaterialization{}, fmt.Errorf("client-root materialization profile must be %q", ClientRootMaterializationProfile)
+	}
+	if len(w.Maps) > MaxClientRootTransitions {
+		return mutation.ClientRootMaterialization{}, fmt.Errorf("client-root materialization map count exceeds %d", MaxClientRootTransitions)
+	}
+	maps := make([]mutation.MapMaterialization, len(w.Maps))
+	totalEntries := 0
+	for index, materialization := range w.Maps {
+		root, err := parseCanonicalCID(materialization.Root, fmt.Sprintf("maps[%d].root", index))
+		if err != nil {
+			return mutation.ClientRootMaterialization{}, err
+		}
+		totalEntries += len(materialization.Entries)
+		if totalEntries > MaxClientRootMaterializationEntries {
+			return mutation.ClientRootMaterialization{}, fmt.Errorf("client-root materialization entry count exceeds %d", MaxClientRootMaterializationEntries)
+		}
+		entries := make([]arcset.ArcEntry, len(materialization.Entries))
+		for entryIndex, entry := range materialization.Entries {
+			if len(entry.Path) == 0 || len(entry.Path) > MaxClientRootPathBytes {
+				return mutation.ClientRootMaterialization{}, fmt.Errorf("maps[%d].entries[%d].path length is outside 1..%d", index, entryIndex, MaxClientRootPathBytes)
+			}
+			coordinate, err := arcset.NewMapCoordinate(entry.Path)
+			if err != nil {
+				return mutation.ClientRootMaterialization{}, fmt.Errorf("maps[%d].entries[%d].path: %w", index, entryIndex, err)
+			}
+			target, err := parseCanonicalCID(entry.CID, fmt.Sprintf("maps[%d].entries[%d].cid", index, entryIndex))
+			if err != nil {
+				return mutation.ClientRootMaterialization{}, err
+			}
+			entries[entryIndex] = arcset.ArcEntry{Coordinate: coordinate, Target: arcset.NewUnknownTarget(target)}
+		}
+		canonicalEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, entries)
+		if err != nil {
+			return mutation.ClientRootMaterialization{}, fmt.Errorf("maps[%d].entries: %w", index, err)
+		}
+		if canonicalEntries.Len() != len(entries) {
+			return mutation.ClientRootMaterialization{}, fmt.Errorf("maps[%d].entries contain duplicate coordinates", index)
+		}
+		maps[index] = mutation.MapMaterialization{
+			TransitionID: materialization.TransitionID, Root: root, Entries: canonicalEntries,
+		}
+	}
+	return mutation.NewClientRootMaterialization(bundle, mutation.ClientRootMaterialization{Profile: w.Profile, Maps: maps})
+}
+
+func (w ClientRootMaterialization) Validate(bundle mutation.ClientRootBundle) error {
+	_, err := w.Core(bundle)
+	return err
+}

--- a/protocol/materialization.go
+++ b/protocol/materialization.go
@@ -132,6 +132,9 @@ func decodeMaterializationEntries(label string, wire []MaterializationEntryWire)
 		if err != nil {
 			return nil, fmt.Errorf("%s.entries[%d].path: %w", label, index, err)
 		}
+		if coordinate.String() != entry.Path {
+			return nil, fmt.Errorf("%s.entries[%d].path is not canonical", label, index)
+		}
 		target, err := parseCanonicalCID(entry.CID, fmt.Sprintf("%s.entries[%d].cid", label, index))
 		if err != nil {
 			return nil, err

--- a/protocol/schemas/client-root-materialization.schema.json
+++ b/protocol/schemas/client-root-materialization.schema.json
@@ -12,6 +12,9 @@
     "profile": {
       "const": "malt.client-root-materialization/v1"
     },
+    "base": {
+      "$ref": "#/$defs/state"
+    },
     "maps": {
       "type": "array",
       "maxItems": 65536,
@@ -21,6 +24,26 @@
     }
   },
   "$defs": {
+    "state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "root",
+        "entries"
+      ],
+      "properties": {
+        "root": {
+          "$ref": "#/$defs/cid"
+        },
+        "entries": {
+          "type": "array",
+          "maxItems": 4194304,
+          "items": {
+            "$ref": "#/$defs/entry"
+          }
+        }
+      }
+    },
     "map": {
       "type": "object",
       "additionalProperties": false,

--- a/protocol/schemas/client-root-materialization.schema.json
+++ b/protocol/schemas/client-root-materialization.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/client-root-materialization/v1/client-root-materialization.schema.json",
+  "title": "MALT Client Root Materialization v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "profile",
+    "maps"
+  ],
+  "properties": {
+    "profile": {
+      "const": "malt.client-root-materialization/v1"
+    },
+    "maps": {
+      "type": "array",
+      "maxItems": 65536,
+      "items": {
+        "$ref": "#/$defs/map"
+      }
+    }
+  },
+  "$defs": {
+    "map": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "transition_id",
+        "root",
+        "entries"
+      ],
+      "properties": {
+        "transition_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+        },
+        "root": {
+          "$ref": "#/$defs/cid"
+        },
+        "entries": {
+          "type": "array",
+          "maxItems": 4194304,
+          "items": {
+            "$ref": "#/$defs/entry"
+          }
+        }
+      }
+    },
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "cid"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096
+        },
+        "cid": {
+          "$ref": "#/$defs/cid"
+        }
+      }
+    },
+    "cid": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096
+    }
+  }
+}

--- a/protocol/schemas/map-proof-request.schema.json
+++ b/protocol/schemas/map-proof-request.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/map-proof/v0alpha1/request.schema.json",
+  "title": "MALT Map Proof Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "root", "key"],
+  "properties": {
+    "profile": {"const": "malt.map-proof/v0alpha1"},
+    "root": {"type": "string", "minLength": 1},
+    "key": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1, "pattern": "^[^/]+$"}
+    }
+  }
+}

--- a/protocol/schemas/map-proof-result.schema.json
+++ b/protocol/schemas/map-proof-result.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/map-proof/v0alpha1/result.schema.json",
+  "title": "MALT Map Proof Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "present", "prooflist"],
+  "properties": {
+    "profile": {"const": "malt.map-proof/v0alpha1"},
+    "present": {"type": "boolean"},
+    "target": {"type": "string", "minLength": 1},
+    "prooflist": {"$ref": "https://deweb.world/schemas/malt/prooflist/v0alpha1/prooflist.schema.json"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"present": {"const": true}}},
+      "then": {"required": ["target"]},
+      "else": {"not": {"required": ["target"]}}
+    }
+  ]
+}

--- a/protocol/schemas/map-proof-verification.schema.json
+++ b/protocol/schemas/map-proof-verification.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/map-proof/v0alpha1/verification.schema.json",
+  "title": "MALT Map Proof Verification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["request", "result"],
+  "properties": {
+    "request": {"$ref": "https://deweb.world/schemas/malt/map-proof/v0alpha1/request.schema.json"},
+    "result": {"$ref": "https://deweb.world/schemas/malt/map-proof/v0alpha1/result.schema.json"}
+  }
+}

--- a/protocol/schemas/prooflist.schema.json
+++ b/protocol/schemas/prooflist.schema.json
@@ -25,7 +25,7 @@
       "additionalProperties": false,
       "required": ["kind", "from", "target"],
       "properties": {
-        "kind": {"enum": ["map_step", "payload_binding", "list_index", "list_range", "blob_binding", "implicit_block", "legacy_unknown"]},
+        "kind": {"enum": ["map_step", "map_absence", "payload_binding", "list_index", "list_range", "blob_binding", "implicit_block", "legacy_unknown"]},
         "from": {"$ref": "#/$defs/cid_link"},
         "query": {"type": "string"},
         "coordinate": {"type": "string"},
@@ -37,7 +37,7 @@
         "child_count": {"type": "integer", "minimum": 0},
         "total_size": {"type": "integer", "minimum": 0},
         "chunk_size": {"type": "integer", "minimum": 0},
-        "target": {"$ref": "#/$defs/cid_link"},
+        "target": {"oneOf": [{"$ref": "#/$defs/cid_link"}, {"type": "null"}]},
         "segments": {"type": "array", "items": {"$ref": "#/$defs/cid_link"}},
         "evidence_kind": {"type": "string"},
         "evidence_backend": {"type": "string"},

--- a/protocol/schemas/writer-compute-result-v2.schema.json
+++ b/protocol/schemas/writer-compute-result-v2.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deweb.world/schemas/malt/writer-compute-result/v2/writer-compute-result.schema.json",
+  "title": "MALT Browser Writer Compute Result v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "bundle", "materialization", "next_view", "metrics"],
+  "properties": {
+    "profile": {"const": "malt.writer-compute-result/v2"},
+    "bundle": {"$ref": "https://deweb.world/schemas/malt/client-root-bundle/v1/client-root-bundle.schema.json"},
+    "materialization": {"$ref": "https://deweb.world/schemas/malt/client-root-materialization/v1/client-root-materialization.schema.json"},
+    "next_view": {"$ref": "https://deweb.world/schemas/malt/update-view/v1/update-view.schema.json"},
+    "metrics": {"$ref": "#/$defs/metrics"}
+  },
+  "$defs": {
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "view_normalization_ns",
+        "intent_normalization_ns",
+        "digest_ns",
+        "commitment_update_ns",
+        "root_computation_ns",
+        "expected_root_encoding_ns",
+        "bundle_validation_ns",
+        "next_view_ns",
+        "total_ns"
+      ],
+      "properties": {
+        "view_normalization_ns": {"type": "integer", "minimum": 0},
+        "intent_normalization_ns": {"type": "integer", "minimum": 0},
+        "digest_ns": {"type": "integer", "minimum": 0},
+        "commitment_update_ns": {"type": "integer", "minimum": 0},
+        "root_computation_ns": {"type": "integer", "minimum": 0},
+        "expected_root_encoding_ns": {"type": "integer", "minimum": 0},
+        "bundle_validation_ns": {"type": "integer", "minimum": 0},
+        "next_view_ns": {"type": "integer", "minimum": 0},
+        "total_ns": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/protocol/types_test.go
+++ b/protocol/types_test.go
@@ -27,6 +27,27 @@ func TestPublishedProtocolSchemasAreJSONObjects(t *testing.T) {
 	}
 }
 
+func TestMapProofSchemasArePublished(t *testing.T) {
+	want := []string{
+		"map-proof-request.schema.json",
+		"map-proof-result.schema.json",
+		"map-proof-verification.schema.json",
+	}
+	names := protocol.SchemaNames()
+	for _, name := range want {
+		found := false
+		for _, candidate := range names {
+			if candidate == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("SchemaNames does not include %s", name)
+		}
+	}
+}
+
 func TestResolveContractRoundTripsCoreValues(t *testing.T) {
 	root := protocolTestCID(t, "root")
 	target := protocolTestCID(t, "target")

--- a/protocol/writer_compute.go
+++ b/protocol/writer_compute.go
@@ -1,12 +1,16 @@
 package protocol
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/dewebprotocol/malt/mutation"
 )
 
-const WriterComputeResultProfile = "malt.writer-compute-result/v1"
+const (
+	WriterComputeResultProfileV1 = "malt.writer-compute-result/v1"
+	WriterComputeResultProfile   = "malt.writer-compute-result/v2"
+)
 
 // WriterComputeMetrics reports browser-local writer phases. These values are
 // diagnostic timing data, not authenticated protocol evidence.
@@ -25,26 +29,56 @@ type WriterComputeMetrics struct {
 // WriterComputeResult is the versioned browser wire result for one exact
 // client-root computation.
 type WriterComputeResult struct {
+	Profile         string                    `json:"profile"`
+	Materialization ClientRootMaterialization `json:"materialization"`
+	Bundle          ClientRootBundle          `json:"bundle"`
+	NextView        UpdateView                `json:"next_view"`
+	Metrics         WriterComputeMetrics      `json:"metrics"`
+}
+
+type writerComputeResultV1 struct {
 	Profile  string               `json:"profile"`
 	Bundle   ClientRootBundle     `json:"bundle"`
 	NextView UpdateView           `json:"next_view"`
 	Metrics  WriterComputeMetrics `json:"metrics"`
 }
 
+// MarshalJSON preserves the selected wire profile. In particular, a decoded
+// v1 value must not acquire the v2-only materialization member when relayed.
+func (r WriterComputeResult) MarshalJSON() ([]byte, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	if r.Profile == WriterComputeResultProfileV1 {
+		return json.Marshal(writerComputeResultV1{
+			Profile: r.Profile, Bundle: r.Bundle, NextView: r.NextView, Metrics: r.Metrics,
+		})
+	}
+	type writerComputeResultV2 WriterComputeResult
+	return json.Marshal(writerComputeResultV2(r))
+}
+
 // NewWriterComputeResult projects canonical core values into the browser wire
 // result and checks the candidate-to-next-view binding.
-func NewWriterComputeResult(bundle mutation.ClientRootBundle, nextView mutation.UpdateView, metrics WriterComputeMetrics) (WriterComputeResult, error) {
+func NewWriterComputeResult(bundle mutation.ClientRootBundle, materialization mutation.ClientRootMaterialization, nextView mutation.UpdateView, metrics WriterComputeMetrics) (WriterComputeResult, error) {
 	wireBundle, err := NewClientRootBundle(bundle)
 	if err != nil {
 		return WriterComputeResult{}, fmt.Errorf("encode writer bundle: %w", err)
+	}
+	wireMaterialization, err := NewClientRootMaterialization(bundle, materialization)
+	if err != nil {
+		return WriterComputeResult{}, fmt.Errorf("encode writer materialization: %w", err)
 	}
 	wireNextView, err := NewUpdateView(nextView)
 	if err != nil {
 		return WriterComputeResult{}, fmt.Errorf("encode writer next view: %w", err)
 	}
 	result := WriterComputeResult{
-		Profile: WriterComputeResultProfile,
-		Bundle:  wireBundle, NextView: wireNextView, Metrics: metrics,
+		Profile:         WriterComputeResultProfile,
+		Bundle:          wireBundle,
+		Materialization: wireMaterialization,
+		NextView:        wireNextView,
+		Metrics:         metrics,
 	}
 	if err := result.Validate(); err != nil {
 		return WriterComputeResult{}, err
@@ -55,12 +89,19 @@ func NewWriterComputeResult(bundle mutation.ClientRootBundle, nextView mutation.
 // Validate checks the complete nested wire values and requires the retained
 // next view to start at the exact bundle candidate.
 func (r WriterComputeResult) Validate() error {
-	if r.Profile != WriterComputeResultProfile {
-		return fmt.Errorf("writer compute result profile must be %q", WriterComputeResultProfile)
+	if r.Profile != WriterComputeResultProfile && r.Profile != WriterComputeResultProfileV1 {
+		return fmt.Errorf("unsupported writer compute result profile %q", r.Profile)
 	}
 	bundle, err := r.Bundle.Core()
 	if err != nil {
 		return fmt.Errorf("writer compute result bundle: %w", err)
+	}
+	if r.Profile == WriterComputeResultProfile {
+		if _, err := r.Materialization.Core(bundle); err != nil {
+			return fmt.Errorf("writer compute result materialization: %w", err)
+		}
+	} else if r.Materialization.Profile != "" || len(r.Materialization.Maps) != 0 {
+		return fmt.Errorf("writer compute result v1 must not carry materialization")
 	}
 	nextView, err := r.NextView.Core()
 	if err != nil {

--- a/protocol/writer_compute.go
+++ b/protocol/writer_compute.go
@@ -100,7 +100,7 @@ func (r WriterComputeResult) Validate() error {
 		if _, err := r.Materialization.Core(bundle); err != nil {
 			return fmt.Errorf("writer compute result materialization: %w", err)
 		}
-	} else if r.Materialization.Profile != "" || len(r.Materialization.Maps) != 0 {
+	} else if r.Materialization.Profile != "" || r.Materialization.Base != nil || len(r.Materialization.Maps) != 0 {
 		return fmt.Errorf("writer compute result v1 must not carry materialization")
 	}
 	nextView, err := r.NextView.Core()

--- a/scripts/run-verifier-wasm-vectors.mjs
+++ b/scripts/run-verifier-wasm-vectors.mjs
@@ -37,6 +37,10 @@ void go.run(instance).catch((error) => {
 });
 
 await waitForVerifierGlobals();
+const invalidMapProof = JSON.parse(globalThis.maltVerifyMapProof("{}"));
+if (invalidMapProof.valid !== false || invalidMapProof.profile !== "malt.map-proof/v0alpha1") {
+  throw new Error("maltVerifyMapProof did not fail closed on an invalid verification envelope");
+}
 
 const vectors =
   selectedBackend === "all"
@@ -115,7 +119,8 @@ async function waitForVerifierGlobals() {
     }
     if (
       typeof globalThis.maltVerifyResolve === "function" &&
-      typeof globalThis.maltVerifyRead === "function"
+      typeof globalThis.maltVerifyRead === "function" &&
+      typeof globalThis.maltVerifyMapProof === "function"
     ) {
       if (globalThis.maltVerifierInitError) {
         throw new Error(`MALT verifier initialization failed: ${globalThis.maltVerifierInitError}`);

--- a/scripts/run-writer-dual-worker-smoke.mjs
+++ b/scripts/run-writer-dual-worker-smoke.mjs
@@ -76,6 +76,12 @@ try {
   );
 
   const encoder = new TextEncoder();
+  const kzgBootstrap = JSON.parse(await writers.bootstrap("kzg"));
+  assert.equal(kzgBootstrap.profile, "malt.update-view/v1");
+  assert.equal(kzgBootstrap.objects.length, 1);
+  assert.equal(kzgBootstrap.objects[0].object_id, "root");
+  assert.equal(kzgBootstrap.objects[0].entries.length, 0);
+
   const kzgFixture = fixtures.find(({ backend }) => backend === "kzg");
   assert.ok(kzgFixture, "missing KZG fixture");
   const loadedRoot = await writers.load(
@@ -106,6 +112,12 @@ try {
 
   await writers.ipaReady;
   const ipaReadyAt = performance.now();
+  const ipaBootstrap = JSON.parse(await writers.bootstrap("ipa"));
+  assert.equal(ipaBootstrap.profile, "malt.update-view/v1");
+  assert.equal(ipaBootstrap.objects.length, 1);
+  assert.equal(ipaBootstrap.objects[0].object_id, "root");
+  assert.equal(ipaBootstrap.objects[0].entries.length, 0);
+
   const ipaFixture = fixtures.find(({ backend }) => backend === "ipa");
   assert.ok(ipaFixture, "missing IPA fixture");
   const ipaLoadedRoot = await writers.load(

--- a/scripts/run-writer-dual-worker-smoke.mjs
+++ b/scripts/run-writer-dual-worker-smoke.mjs
@@ -94,7 +94,7 @@ try {
     encoder.encode(kzgFixture.operation_id),
   );
   const kzgPrepared = JSON.parse(kzgPreparedJSON);
-  assert.equal(kzgPrepared.profile, "malt.writer-compute-result/v1");
+  assert.equal(kzgPrepared.profile, "malt.writer-compute-result/v2");
   assert.deepStrictEqual(kzgPrepared.bundle, kzgFixture.expected_bundle);
   assert.deepStrictEqual(kzgPrepared.next_view, kzgFixture.expected_next_view);
   const kzgWorkFinishedAt = performance.now();
@@ -124,7 +124,7 @@ try {
     encoder.encode(ipaFixture.operation_id),
   );
   const ipaPrepared = JSON.parse(ipaPreparedJSON);
-  assert.equal(ipaPrepared.profile, "malt.writer-compute-result/v1");
+  assert.equal(ipaPrepared.profile, "malt.writer-compute-result/v2");
   assert.deepStrictEqual(ipaPrepared.bundle, ipaFixture.expected_bundle);
   assert.deepStrictEqual(ipaPrepared.next_view, ipaFixture.expected_next_view);
 

--- a/scripts/run-writer-wasm-smoke.mjs
+++ b/scripts/run-writer-wasm-smoke.mjs
@@ -41,6 +41,7 @@ while (Date.now() < deadline) {
   if (
     globalThis.maltWriterReady &&
     typeof globalThis.maltComputeClientRootV1 === "function" &&
+    typeof globalThis.maltWriterBootstrapSessionV1 === "function" &&
     typeof globalThis.maltWriterLoadSessionV1 === "function" &&
     typeof globalThis.maltWriterPrepareSessionV1 === "function" &&
     typeof globalThis.maltWriterGetPreparedResultV1 === "function" &&
@@ -55,6 +56,7 @@ while (Date.now() < deadline) {
 if (
   !globalThis.maltWriterReady ||
   typeof globalThis.maltComputeClientRootV1 !== "function" ||
+  typeof globalThis.maltWriterBootstrapSessionV1 !== "function" ||
   typeof globalThis.maltWriterLoadSessionV1 !== "function" ||
   typeof globalThis.maltWriterPrepareSessionV1 !== "function" ||
   typeof globalThis.maltWriterGetPreparedResultV1 !== "function" ||
@@ -136,6 +138,18 @@ try {
 if (!rejectedInvalidJSON) {
   throw new Error("writer accepted invalid update-view and semantic-intent JSON");
 }
+
+const bootstrapView = JSON.parse(await globalThis.maltWriterBootstrapSessionV1());
+if (
+  bootstrapView.profile !== "malt.update-view/v1" ||
+  bootstrapView.objects?.length !== 1 ||
+  bootstrapView.objects[0]?.object_id !== "root" ||
+  bootstrapView.objects[0]?.kind !== "map" ||
+  bootstrapView.objects[0]?.entries?.length !== 0
+) {
+  throw new Error(`${selectedBackend} bootstrap did not return the canonical empty-map view`);
+}
+await globalThis.maltWriterCloseSessionV1();
 
 const selectedFixtures = fixtures.filter(
   ({ backend }) => backend === selectedBackend,

--- a/scripts/run-writer-wasm-smoke.mjs
+++ b/scripts/run-writer-wasm-smoke.mjs
@@ -164,7 +164,7 @@ for (const fixture of selectedFixtures) {
     semanticIntent,
   );
   const result = JSON.parse(resultJSON);
-  if (result.profile !== "malt.writer-compute-result/v1") {
+  if (result.profile !== "malt.writer-compute-result/v2") {
     throw new Error(`unexpected writer result profile ${JSON.stringify(result.profile)}`);
   }
   if (result.bundle.operation_id !== fixture.operation_id) {

--- a/scripts/run-writer-wasm-smoke.mjs
+++ b/scripts/run-writer-wasm-smoke.mjs
@@ -45,6 +45,7 @@ while (Date.now() < deadline) {
     typeof globalThis.maltWriterLoadSessionV1 === "function" &&
     typeof globalThis.maltWriterPrepareSessionV1 === "function" &&
     typeof globalThis.maltWriterGetPreparedResultV1 === "function" &&
+    typeof globalThis.maltWriterValidateReceiptV1 === "function" &&
     typeof globalThis.maltWriterAcceptSessionReceiptV1 === "function" &&
     typeof globalThis.maltWriterDiscardSessionCandidateV1 === "function" &&
     typeof globalThis.maltWriterCloseSessionV1 === "function"
@@ -60,6 +61,7 @@ if (
   typeof globalThis.maltWriterLoadSessionV1 !== "function" ||
   typeof globalThis.maltWriterPrepareSessionV1 !== "function" ||
   typeof globalThis.maltWriterGetPreparedResultV1 !== "function" ||
+  typeof globalThis.maltWriterValidateReceiptV1 !== "function" ||
   typeof globalThis.maltWriterAcceptSessionReceiptV1 !== "function" ||
   typeof globalThis.maltWriterDiscardSessionCandidateV1 !== "function" ||
   typeof globalThis.maltWriterCloseSessionV1 !== "function"
@@ -291,9 +293,19 @@ for (const fixture of selectedFixtures) {
     fixture.expected_next_view,
     `${fixture.backend} re-prepared next view differs from the reference`,
   );
+  const expectedReceiptJSON = encoder.encode(JSON.stringify(fixture.expected_receipt));
+  const validatedRoot = await globalThis.maltWriterValidateReceiptV1(
+    encoder.encode(preparedAfterDiscardJSON),
+    expectedReceiptJSON,
+  );
+  if (validatedRoot !== fixture.expected_bundle.candidate) {
+    throw new Error(
+      `${fixture.backend} stateless receipt validation returned ${validatedRoot}, expected ${fixture.expected_bundle.candidate}`,
+    );
+  }
   const acceptedRoot = await globalThis.maltWriterAcceptSessionReceiptV1(
     sessionOperationID,
-    encoder.encode(JSON.stringify(fixture.expected_receipt)),
+    expectedReceiptJSON,
   );
   if (acceptedRoot !== fixture.expected_bundle.candidate) {
     throw new Error(

--- a/sdk/verifier/verifier.go
+++ b/sdk/verifier/verifier.go
@@ -50,6 +50,20 @@ func (v *Verifier) VerifyRead(ctx context.Context, value protocol.ReadVerificati
 	return malt.VerifyRead(ctx, request, result, v.proofs)
 }
 
+// VerifyMapProof locally verifies one transport-neutral map membership or
+// non-membership request/result pair.
+func (v *Verifier) VerifyMapProof(ctx context.Context, value protocol.MapProofVerification) error {
+	if err := value.Validate(); err != nil {
+		return err
+	}
+	if v == nil || v.proofs == nil {
+		return fmt.Errorf("client verifier is nil")
+	}
+	request, _ := value.Request.Core()
+	result, _ := value.Result.Core()
+	return malt.VerifyMapProof(ctx, request, result, v.proofs)
+}
+
 func NewDefault() (*Verifier, error) {
 	proofs, err := authverifier.NewDefault()
 	if err != nil {

--- a/sdk/writer/bootstrap.go
+++ b/sdk/writer/bootstrap.go
@@ -1,0 +1,72 @@
+package writer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	"github.com/dewebprotocol/malt/mutation"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+)
+
+// BootstrapMap constructs and verifies the canonical empty map base entirely
+// inside the client writer. The returned root-bound state lets an untrusted
+// service validate and materialize that base without calling Commit.
+func (r *Runtime) BootstrapMap(ctx context.Context, backend maltcid.BackendKind) (VerifiedUpdateView, mutation.MapStateMaterialization, error) {
+	if r == nil {
+		return VerifiedUpdateView{}, mutation.MapStateMaterialization{}, fmt.Errorf("client writer runtime is nil")
+	}
+	graph, ok := r.graphs[backend]
+	if !ok {
+		return VerifiedUpdateView{}, mutation.MapStateMaterialization{}, fmt.Errorf("client writer backend %q is unavailable", backend)
+	}
+	emptyEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, nil)
+	if err != nil {
+		return VerifiedUpdateView{}, mutation.MapStateMaterialization{}, err
+	}
+	emptyView := mapping.NewViewFromPaths(map[arcset.Path]cid.Cid{})
+	root, err := graph.Semantic().Commit(ctx, objectScope("root"), emptyView)
+	if err != nil {
+		return VerifiedUpdateView{}, mutation.MapStateMaterialization{}, fmt.Errorf("commit client bootstrap map: %w", err)
+	}
+	view, err := mutation.NormalizeUpdateView(mutation.UpdateView{
+		Profile: mutation.UpdateViewProfile, StateProfile: mutation.StatefulCompleteVectorsProfile,
+		BaseRoot: root, Bounds: mutation.UpdateViewBounds{MaxObjects: 1, MaxTotalEntries: 1, MaxDepth: 1},
+		Objects: []mutation.UpdateObject{{ObjectID: "root", Root: root, Kind: arcset.KindMap, Entries: emptyEntries}},
+	})
+	if err != nil {
+		return VerifiedUpdateView{}, mutation.MapStateMaterialization{}, fmt.Errorf("normalize client bootstrap view: %w", err)
+	}
+	verified, err := r.VerifyUpdateView(ctx, view)
+	if err != nil {
+		return VerifiedUpdateView{}, mutation.MapStateMaterialization{}, fmt.Errorf("verify client bootstrap view: %w", err)
+	}
+	exporter, ok := graph.Semantic().(mapping.MaterializationExporter)
+	if !ok {
+		return VerifiedUpdateView{}, mutation.MapStateMaterialization{}, fmt.Errorf("client bootstrap backend does not export map materialization")
+	}
+	entries, err := exporter.ExportMaterialization(ctx, objectScope("root"), root, emptyView)
+	if err != nil {
+		return VerifiedUpdateView{}, mutation.MapStateMaterialization{}, fmt.Errorf("export client bootstrap materialization: %w", err)
+	}
+	return verified, mutation.MapStateMaterialization{Root: root, Entries: entries}, nil
+}
+
+// BootstrapMap replaces the session with a browser-computed canonical empty
+// map base. No service-provided update view participates in this bootstrap.
+func (s *Session) BootstrapMap(ctx context.Context, backend maltcid.BackendKind) (mutation.UpdateView, mutation.MapStateMaterialization, error) {
+	if s == nil || s.runtime == nil {
+		return mutation.UpdateView{}, mutation.MapStateMaterialization{}, fmt.Errorf("client writer session is nil")
+	}
+	verified, materialization, err := s.runtime.BootstrapMap(ctx, backend)
+	if err != nil {
+		return mutation.UpdateView{}, mutation.MapStateMaterialization{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.current = verified
+	s.loaded = true
+	return verified.View, materialization, nil
+}

--- a/sdk/writer/bootstrap.go
+++ b/sdk/writer/bootstrap.go
@@ -14,7 +14,7 @@ import (
 // BootstrapMap constructs and verifies the canonical empty map base entirely
 // inside the client writer. The returned root-bound state lets an untrusted
 // service validate and materialize that base without calling Commit.
-func (r *Runtime) BootstrapMap(ctx context.Context, backend maltcid.BackendKind) (VerifiedUpdateView, mutation.MapStateMaterialization, error) {
+func (r *Runtime) BootstrapMap(ctx context.Context, backend maltcid.BackendKind, bounds mutation.UpdateViewBounds) (VerifiedUpdateView, mutation.MapStateMaterialization, error) {
 	if r == nil {
 		return VerifiedUpdateView{}, mutation.MapStateMaterialization{}, fmt.Errorf("client writer runtime is nil")
 	}
@@ -33,7 +33,7 @@ func (r *Runtime) BootstrapMap(ctx context.Context, backend maltcid.BackendKind)
 	}
 	view, err := mutation.NormalizeUpdateView(mutation.UpdateView{
 		Profile: mutation.UpdateViewProfile, StateProfile: mutation.StatefulCompleteVectorsProfile,
-		BaseRoot: root, Bounds: mutation.UpdateViewBounds{MaxObjects: 1, MaxTotalEntries: 1, MaxDepth: 1},
+		BaseRoot: root, Bounds: bounds,
 		Objects: []mutation.UpdateObject{{ObjectID: "root", Root: root, Kind: arcset.KindMap, Entries: emptyEntries}},
 	})
 	if err != nil {
@@ -56,11 +56,11 @@ func (r *Runtime) BootstrapMap(ctx context.Context, backend maltcid.BackendKind)
 
 // BootstrapMap replaces the session with a browser-computed canonical empty
 // map base. No service-provided update view participates in this bootstrap.
-func (s *Session) BootstrapMap(ctx context.Context, backend maltcid.BackendKind) (mutation.UpdateView, mutation.MapStateMaterialization, error) {
+func (s *Session) BootstrapMap(ctx context.Context, backend maltcid.BackendKind, bounds mutation.UpdateViewBounds) (mutation.UpdateView, mutation.MapStateMaterialization, error) {
 	if s == nil || s.runtime == nil {
 		return mutation.UpdateView{}, mutation.MapStateMaterialization{}, fmt.Errorf("client writer session is nil")
 	}
-	verified, materialization, err := s.runtime.BootstrapMap(ctx, backend)
+	verified, materialization, err := s.runtime.BootstrapMap(ctx, backend, bounds)
 	if err != nil {
 		return mutation.UpdateView{}, mutation.MapStateMaterialization{}, err
 	}

--- a/sdk/writer/session.go
+++ b/sdk/writer/session.go
@@ -57,6 +57,26 @@ func (s *Session) BaseRoot() cid.Cid {
 	return s.current.View.BaseRoot
 }
 
+// WorkingRoots returns a detached object-to-root projection of the semantic
+// materialization currently used for the next incremental update. During a
+// legacy view migration these roots may differ from the roots declared by the
+// accepted view, so stateful callers must retain both sets.
+func (s *Session) WorkingRoots() map[string]cid.Cid {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.loaded {
+		return nil
+	}
+	roots := make(map[string]cid.Cid, len(s.current.workingRoots))
+	for objectID, root := range s.current.workingRoots {
+		roots[objectID] = root
+	}
+	return roots
+}
+
 // Prepare computes a candidate against the session's current accepted base.
 func (s *Session) Prepare(ctx context.Context, operationID string, intent mutation.SemanticIntent) (ComputeResult, error) {
 	if s == nil {

--- a/sdk/writer/session.go
+++ b/sdk/writer/session.go
@@ -115,7 +115,16 @@ func (s *Session) AcceptReceipt(receipt mutation.MaterializationReceipt, prepare
 	if !next.BaseRoot.Equals(prepared.Bundle.Candidate) {
 		return fmt.Errorf("prepared next view does not match candidate")
 	}
-	s.current = VerifiedUpdateView{View: next, runtime: s.runtime, digest: nextDigest}
+	if len(prepared.seal.workingRoots) != len(next.Objects) {
+		return fmt.Errorf("prepared working-root seal does not match next view")
+	}
+	nextWorkingRoots, err := workingRootsForView(next, prepared.seal.workingRoots)
+	if err != nil {
+		return fmt.Errorf("prepared working-root seal: %w", err)
+	}
+	s.current = VerifiedUpdateView{
+		View: next, runtime: s.runtime, digest: nextDigest, workingRoots: nextWorkingRoots,
+	}
 	return nil
 }
 

--- a/sdk/writer/session_consecutive_test.go
+++ b/sdk/writer/session_consecutive_test.go
@@ -1,0 +1,143 @@
+package writer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materializermemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/mutation"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+)
+
+func TestBootstrapSessionSupportsNestedFirstWriteAndConsecutiveReceipts(t *testing.T) {
+	for _, backend := range []maltcid.BackendKind{maltcid.BackendKindKZG, maltcid.BackendKindIPA} {
+		t.Run(string(backend), func(t *testing.T) {
+			var (
+				scheme commitment.IndexCommitment
+				err    error
+			)
+			if backend == maltcid.BackendKindKZG {
+				scheme, err = kzg.NewScheme()
+			} else {
+				scheme, err = ipa.NewScheme()
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{backend: scheme})
+			if err != nil {
+				t.Fatal(err)
+			}
+			session, err := NewSession(runtime)
+			if err != nil {
+				t.Fatal(err)
+			}
+			bounds := mutation.UpdateViewBounds{MaxObjects: 8, MaxTotalEntries: 32, MaxDepth: 4}
+			view, _, err := session.BootstrapMap(context.Background(), backend, bounds)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			childOne := arcset.NewCASTarget(writerRawCID(t, string(backend)+"-child-one"))
+			childTwo := arcset.NewCASTarget(writerRawCID(t, string(backend)+"-child-two"))
+			metadata := arcset.NewCASTarget(writerRawCID(t, string(backend)+"-metadata"))
+			firstIntent := mutation.SemanticIntent{
+				Profile:     mutation.SemanticIntentProfile,
+				BaseRoot:    view.BaseRoot,
+				TopOutputID: "root-output-1",
+				Transitions: []mutation.IntentTransition{
+					{
+						ID: "root-output-1", ObjectID: "root", OldRoot: view.BaseRoot,
+						Kind: arcset.KindMap, Backend: backend,
+						Changes: []mutation.IntentChange{
+							{Coordinate: writerMapCoordinate(t, "child"), OutputID: "child-output-1", OutputKind: arcset.TargetKindMap},
+							{Coordinate: writerMapCoordinate(t, "metadata"), After: &metadata},
+						},
+					},
+					{
+						ID: "child-output-1", ObjectID: "child", Kind: arcset.KindMap, Backend: backend, ExpectedUses: 1,
+						Changes: []mutation.IntentChange{
+							{Coordinate: writerMapCoordinate(t, "one"), After: &childOne},
+							{Coordinate: writerMapCoordinate(t, "two"), After: &childTwo},
+						},
+					},
+				},
+			}
+			first, err := session.Prepare(context.Background(), "bootstrap-nested-first", firstIntent)
+			if err != nil {
+				t.Fatalf("first prepare: %v", err)
+			}
+			if first.NextView.Bounds != bounds || len(first.NextView.Objects) != 2 {
+				t.Fatalf("first next view bounds/objects = %+v/%d", first.NextView.Bounds, len(first.NextView.Objects))
+			}
+			acceptTestWriterResult(t, session, first)
+
+			childRoot := objectRootByID(t, first.NextView, "child")
+			beforeChild := arcset.NewMapTarget(childRoot)
+			childThree := arcset.NewCASTarget(writerRawCID(t, string(backend)+"-child-three"))
+			secondIntent := mutation.SemanticIntent{
+				Profile:     mutation.SemanticIntentProfile,
+				BaseRoot:    first.Bundle.Candidate,
+				TopOutputID: "root-output-2",
+				Transitions: []mutation.IntentTransition{
+					{
+						ID: "root-output-2", ObjectID: "root", OldRoot: first.Bundle.Candidate,
+						Kind: arcset.KindMap, Backend: backend,
+						Changes: []mutation.IntentChange{{
+							Coordinate: writerMapCoordinate(t, "child"), Before: &beforeChild,
+							OutputID: "child-output-2", OutputKind: arcset.TargetKindMap,
+						}},
+					},
+					{
+						ID: "child-output-2", ObjectID: "child", OldRoot: childRoot,
+						Kind: arcset.KindMap, Backend: backend, ExpectedUses: 1,
+						Changes: []mutation.IntentChange{{Coordinate: writerMapCoordinate(t, "three"), After: &childThree}},
+					},
+				},
+			}
+			second, err := session.Prepare(context.Background(), "bootstrap-nested-second", secondIntent)
+			if err != nil {
+				t.Fatalf("second prepare after accepted receipt: %v", err)
+			}
+			acceptTestWriterResult(t, session, second)
+			if !session.BaseRoot().Equals(second.Bundle.Candidate) {
+				t.Fatalf("accepted base = %s, want %s", session.BaseRoot(), second.Bundle.Candidate)
+			}
+		})
+	}
+}
+
+func acceptTestWriterResult(t *testing.T, session *Session, result ComputeResult) {
+	t.Helper()
+	digest, err := result.Bundle.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := mutation.MaterializationReceipt{
+		Profile:         mutation.MaterializationReceiptProfile,
+		OperationID:     result.Bundle.OperationID,
+		BaseRoot:        result.Bundle.View.BaseRoot,
+		Candidate:       result.Bundle.Candidate,
+		BundleDigest:    digest,
+		DurableBoundary: "unit-memory-v1",
+	}
+	if err := session.AcceptReceipt(receipt, result); err != nil {
+		t.Fatalf("accept receipt: %v", err)
+	}
+}
+
+func objectRootByID(t *testing.T, view mutation.UpdateView, objectID string) cid.Cid {
+	t.Helper()
+	for _, object := range view.Objects {
+		if object.ObjectID == objectID {
+			return object.Root
+		}
+	}
+	t.Fatalf("update view has no object %q", objectID)
+	return cid.Undef
+}

--- a/sdk/writer/writer.go
+++ b/sdk/writer/writer.go
@@ -27,25 +27,28 @@ import (
 // persistent-free materialization used for local computation. The materializer
 // is not an ArcTable and no result is durable until a service accepts it.
 type Runtime struct {
-	store  materializer.MutableStore
-	graphs map[maltcid.BackendKind]*runtimegraph.RuntimeGraph
+	store        materializer.MutableStore
+	graphs       map[maltcid.BackendKind]*runtimegraph.RuntimeGraph
+	legacyGraphs map[maltcid.BackendKind]*runtimegraph.RuntimeGraph
 }
 
 // VerifiedUpdateView is a normalized view whose complete logical vectors have
 // independently recomputed every declared old root in this runtime.
 type VerifiedUpdateView struct {
-	View    mutation.UpdateView
-	runtime *Runtime
-	digest  [32]byte
+	View         mutation.UpdateView
+	runtime      *Runtime
+	digest       [32]byte
+	workingRoots map[string]cid.Cid
 }
 
 // ComputeResult carries both the exact submission bundle and the complete next
 // view retained by a long-lived client session.
 type ComputeResult struct {
-	Bundle   mutation.ClientRootBundle
-	NextView mutation.UpdateView
-	Metrics  ComputeMetrics
-	seal     computeResultSeal
+	Bundle          mutation.ClientRootBundle
+	Materialization mutation.ClientRootMaterialization
+	NextView        mutation.UpdateView
+	Metrics         ComputeMetrics
+	seal            computeResultSeal
 }
 
 type computeResultSeal struct {
@@ -85,7 +88,11 @@ func NewRuntime(store materializer.MutableStore, schemes map[maltcid.BackendKind
 	if len(schemes) == 0 {
 		return nil, fmt.Errorf("client writer has no commitment backends")
 	}
-	runtime := &Runtime{store: store, graphs: make(map[maltcid.BackendKind]*runtimegraph.RuntimeGraph, len(schemes))}
+	runtime := &Runtime{
+		store:        store,
+		graphs:       make(map[maltcid.BackendKind]*runtimegraph.RuntimeGraph, len(schemes)),
+		legacyGraphs: make(map[maltcid.BackendKind]*runtimegraph.RuntimeGraph, len(schemes)),
+	}
 	for _, backend := range []maltcid.BackendKind{maltcid.BackendKindKZG, maltcid.BackendKindIPA} {
 		scheme, ok := schemes[backend]
 		if !ok {
@@ -104,8 +111,19 @@ func NewRuntime(store materializer.MutableStore, schemes map[maltcid.BackendKind
 			return nil, fmt.Errorf("create client writer %s backend: %w", backend, err)
 		}
 		runtime.graphs[backend] = graph
+		legacyGraph, err := runtimegraph.NewGraph(
+			"client-root-legacy-"+string(backend),
+			store,
+			runtimegraph.WithCommitmentBackend(backend, scheme),
+			runtimegraph.WithDefaultCommitmentBackend(backend),
+			runtimegraph.WithMALTVersion(maltcid.LegacyMALTVersionID),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create legacy client writer %s backend: %w", backend, err)
+		}
+		runtime.legacyGraphs[backend] = legacyGraph
 	}
-	if len(runtime.graphs) != len(schemes) {
+	if len(runtime.graphs) != len(schemes) || len(runtime.legacyGraphs) != len(schemes) {
 		return nil, fmt.Errorf("client writer schemes contain an unsupported backend")
 	}
 	return runtime, nil
@@ -121,21 +139,37 @@ func (r *Runtime) VerifyUpdateView(ctx context.Context, view mutation.UpdateView
 	if err != nil {
 		return VerifiedUpdateView{}, err
 	}
+	workingRoots := make(map[string]cid.Cid, len(canonical.Objects))
 	for _, object := range canonical.Objects {
 		if err := ctx.Err(); err != nil {
 			return VerifiedUpdateView{}, err
 		}
 		backend := maltcid.BackendKindOf(object.Root)
-		graph, ok := r.graphs[backend]
+		currentGraph, ok := r.graphs[backend]
 		if !ok {
 			return VerifiedUpdateView{}, fmt.Errorf("update object %q requires unavailable backend %q", object.ObjectID, backend)
 		}
-		recomputed, err := commitCompleteObject(ctx, graph, objectScope(object.ObjectID), object)
+		verificationGraph := currentGraph
+		switch version := maltcid.VersionIDOf(object.Root); version {
+		case maltcid.MALTVersionID:
+		case maltcid.LegacyMALTVersionID:
+			verificationGraph = r.legacyGraphs[backend]
+		default:
+			return VerifiedUpdateView{}, fmt.Errorf("update object %q uses unsupported MALT version %d", object.ObjectID, version)
+		}
+		recomputed, err := commitCompleteObject(ctx, verificationGraph, objectScope(object.ObjectID), object)
 		if err != nil {
 			return VerifiedUpdateView{}, fmt.Errorf("verify update object %q: %w", object.ObjectID, err)
 		}
 		if !recomputed.Equals(object.Root) {
 			return VerifiedUpdateView{}, fmt.Errorf("verify update object %q: recomputed root %s does not match declared root %s", object.ObjectID, recomputed, object.Root)
+		}
+		workingRoot := recomputed
+		if verificationGraph != currentGraph {
+			workingRoot, err = commitCompleteObject(ctx, currentGraph, objectScope(object.ObjectID), object)
+			if err != nil {
+				return VerifiedUpdateView{}, fmt.Errorf("migrate update object %q materialization: %w", object.ObjectID, err)
+			}
 		}
 		logical, err := completeObjectArcSet(object)
 		if err != nil {
@@ -144,12 +178,18 @@ func (r *Runtime) VerifyUpdateView(ctx context.Context, view mutation.UpdateView
 		if err := r.store.Update(ctx, objectScope(object.ObjectID), recomputed, cid.Undef, logical); err != nil {
 			return VerifiedUpdateView{}, fmt.Errorf("seed update object %q: %w", object.ObjectID, err)
 		}
+		if !workingRoot.Equals(recomputed) {
+			if err := r.store.Update(ctx, objectScope(object.ObjectID), workingRoot, cid.Undef, logical); err != nil {
+				return VerifiedUpdateView{}, fmt.Errorf("seed migrated update object %q: %w", object.ObjectID, err)
+			}
+		}
+		workingRoots[object.ObjectID] = workingRoot
 	}
 	digest, err := canonical.Digest()
 	if err != nil {
 		return VerifiedUpdateView{}, fmt.Errorf("digest verified update view: %w", err)
 	}
-	return VerifiedUpdateView{View: canonical, runtime: r, digest: digest}, nil
+	return VerifiedUpdateView{View: canonical, runtime: r, digest: digest, workingRoots: workingRoots}, nil
 }
 
 // ComputeBundle applies a normalized intent bottom-up and returns the exact
@@ -189,11 +229,18 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 
 	phaseStart = time.Now()
 	objects := make(map[string]mutation.UpdateObject, len(view.Objects)+len(normalized.Transitions))
+	workingRoots := make(map[string]cid.Cid, len(verified.workingRoots)+len(normalized.Transitions))
 	for _, object := range view.Objects {
 		objects[object.ObjectID] = object
+		workingRoot, ok := verified.workingRoots[object.ObjectID]
+		if !ok || !workingRoot.Defined() {
+			return ComputeResult{}, fmt.Errorf("verified update object %q has no working root", object.ObjectID)
+		}
+		workingRoots[object.ObjectID] = workingRoot
 	}
 	outputRoots := make(map[string]cid.Cid, len(normalized.Transitions))
 	outputs := make([]mutation.TransitionOutput, 0, len(normalized.Transitions))
+	materializations := make([]mutation.MapMaterialization, 0, len(normalized.Transitions))
 	payloadSet := make(map[string]cid.Cid)
 	for _, transition := range normalized.Transitions {
 		if err := ctx.Err(); err != nil {
@@ -212,10 +259,18 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 			return ComputeResult{}, fmt.Errorf("transition %q delta: %w", transition.ID, err)
 		}
 		commitmentStarted := time.Now()
+		workingRoot := cid.Undef
+		if transition.OldRoot.Defined() {
+			var ok bool
+			workingRoot, ok = workingRoots[transition.ObjectID]
+			if !ok || !workingRoot.Defined() {
+				return ComputeResult{}, fmt.Errorf("transition %q has no verified working root", transition.ID)
+			}
+		}
 		receipt, err := graph.Writer().Apply(ctx, objectScope(transition.ObjectID), mutation.SemanticMutation{
 			BaseRoot: view.BaseRoot,
 			Deltas: []mutation.ArcSetDelta{{
-				Object:  transition.OldRoot,
+				Object:  workingRoot,
 				Kind:    transition.Kind,
 				Changes: delta,
 				Commit:  transition.Commit,
@@ -233,6 +288,7 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 			return ComputeResult{}, fmt.Errorf("compute transition %q returned backend %q, want %q", transition.ID, maltcid.BackendKindOf(receipt.NewRoot), transition.Backend)
 		}
 		outputRoots[transition.ID] = receipt.NewRoot
+		workingRoots[transition.ObjectID] = receipt.NewRoot
 		outputs = append(outputs, mutation.TransitionOutput{TransitionID: transition.ID, Root: receipt.NewRoot})
 		postEntries, err := applyCompleteVector(objects[transition.ObjectID].Entries, transition.Kind, changes)
 		if err != nil {
@@ -244,6 +300,23 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 			Kind:     transition.Kind,
 			Entries:  postEntries,
 			Commit:   transition.Commit,
+		}
+		if transition.Kind == arcset.KindMap {
+			exporter, ok := graph.Semantic().(mapping.MaterializationExporter)
+			if !ok {
+				return ComputeResult{}, fmt.Errorf("transition %q backend does not export map materialization", transition.ID)
+			}
+			postView, err := mapViewFromEntries(postEntries)
+			if err != nil {
+				return ComputeResult{}, fmt.Errorf("materialize transition %q logical view: %w", transition.ID, err)
+			}
+			entries, err := exporter.ExportMaterialization(ctx, objectScope(transition.ObjectID), receipt.NewRoot, postView)
+			if err != nil {
+				return ComputeResult{}, fmt.Errorf("materialize transition %q: %w", transition.ID, err)
+			}
+			materializations = append(materializations, mutation.MapMaterialization{
+				TransitionID: transition.ID, Root: receipt.NewRoot, Entries: entries,
+			})
 		}
 	}
 	candidate := outputRoots[normalized.TopOutputID]
@@ -278,6 +351,13 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 	if err != nil {
 		return ComputeResult{}, fmt.Errorf("seal client-root bundle: %w", err)
 	}
+	materialization, err := mutation.NewClientRootMaterialization(bundle, mutation.ClientRootMaterialization{
+		Profile: mutation.ClientRootMaterializationProfile,
+		Maps:    materializations,
+	})
+	if err != nil {
+		return ComputeResult{}, err
+	}
 	metrics.BundleValidationNS = writerDurationNS(time.Since(phaseStart))
 	phaseStart = time.Now()
 	next, err := nextReachableView(view, candidate, objects)
@@ -291,9 +371,20 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 	metrics.NextViewNS = writerDurationNS(time.Since(phaseStart))
 	metrics.TotalNS = writerDurationNS(time.Since(totalStart))
 	return ComputeResult{
-		Bundle: bundle, NextView: next, Metrics: metrics,
+		Bundle: bundle, Materialization: materialization, NextView: next, Metrics: metrics,
 		seal: computeResultSeal{runtime: r, bundleDigest: bundleDigest, nextViewDigest: nextViewDigest},
 	}, nil
+}
+
+func mapViewFromEntries(entries *arcset.CanonicalArcSet) (mapping.View, error) {
+	if entries == nil || entries.Kind() != arcset.KindMap {
+		return nil, fmt.Errorf("complete entries must be a canonical map")
+	}
+	values := make(map[arcset.Path]cid.Cid, entries.Len())
+	for _, entry := range entries.Entries() {
+		values[arcset.CanonicalizePath(entry.Coordinate.String())] = entry.Target.CID()
+	}
+	return mapping.NewViewFromPaths(values), nil
 }
 
 func commitCompleteObject(ctx context.Context, graph *runtimegraph.RuntimeGraph, scope string, object mutation.UpdateObject) (cid.Cid, error) {

--- a/sdk/writer/writer.go
+++ b/sdk/writer/writer.go
@@ -55,6 +55,7 @@ type computeResultSeal struct {
 	runtime        *Runtime
 	bundleDigest   [32]byte
 	nextViewDigest [32]byte
+	workingRoots   map[string]cid.Cid
 }
 
 // ComputeMetrics separates the client-local phases required by writer
@@ -368,12 +369,36 @@ func (r *Runtime) ComputeBundle(ctx context.Context, operationID string, verifie
 	if err != nil {
 		return ComputeResult{}, fmt.Errorf("seal retained next view: %w", err)
 	}
+	nextWorkingRoots, err := workingRootsForView(next, workingRoots)
+	if err != nil {
+		return ComputeResult{}, fmt.Errorf("seal retained working roots: %w", err)
+	}
 	metrics.NextViewNS = writerDurationNS(time.Since(phaseStart))
 	metrics.TotalNS = writerDurationNS(time.Since(totalStart))
 	return ComputeResult{
 		Bundle: bundle, Materialization: materialization, NextView: next, Metrics: metrics,
-		seal: computeResultSeal{runtime: r, bundleDigest: bundleDigest, nextViewDigest: nextViewDigest},
+		seal: computeResultSeal{
+			runtime: r, bundleDigest: bundleDigest, nextViewDigest: nextViewDigest,
+			workingRoots: nextWorkingRoots,
+		},
 	}, nil
+}
+
+func workingRootsForView(view mutation.UpdateView, roots map[string]cid.Cid) (map[string]cid.Cid, error) {
+	selected := make(map[string]cid.Cid, len(view.Objects))
+	for _, object := range view.Objects {
+		root, ok := roots[object.ObjectID]
+		if !ok || !root.Defined() {
+			return nil, fmt.Errorf("update object %q has no working root", object.ObjectID)
+		}
+		if maltcid.VersionIDOf(root) != maltcid.MALTVersionID ||
+			maltcid.BackendKindOf(root) != maltcid.BackendKindOf(object.Root) ||
+			maltcid.SemanticKindOf(root) != maltcid.SemanticKindOf(object.Root) {
+			return nil, fmt.Errorf("update object %q working root profile does not match its retained root", object.ObjectID)
+		}
+		selected[object.ObjectID] = root
+	}
+	return selected, nil
 }
 
 func mapViewFromEntries(entries *arcset.CanonicalArcSet) (mapping.View, error) {

--- a/sdk/writer/writer_test.go
+++ b/sdk/writer/writer_test.go
@@ -117,9 +117,13 @@ func TestBootstrapMapCreatesClientOwnedEmptyBase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	view, base, err := session.BootstrapMap(ctx, maltcid.BackendKindKZG)
+	bounds := mutation.UpdateViewBounds{MaxObjects: 8, MaxTotalEntries: 64, MaxDepth: 8}
+	view, base, err := session.BootstrapMap(ctx, maltcid.BackendKindKZG, bounds)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if view.Bounds != bounds {
+		t.Fatalf("bootstrap bounds = %+v, want %+v", view.Bounds, bounds)
 	}
 	if !session.BaseRoot().Equals(view.BaseRoot) || !base.Root.Equals(view.BaseRoot) {
 		t.Fatalf("bootstrap roots = session %s, view %s, witness %s", session.BaseRoot(), view.BaseRoot, base.Root)

--- a/sdk/writer/writer_test.go
+++ b/sdk/writer/writer_test.go
@@ -101,6 +101,40 @@ func TestComputeBundleMatchesIndependentFullRebuildAndRetainsNextView(t *testing
 	}
 }
 
+func TestBootstrapMapCreatesClientOwnedEmptyBase(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := NewSession(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, base, err := session.BootstrapMap(ctx, maltcid.BackendKindKZG)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !session.BaseRoot().Equals(view.BaseRoot) || !base.Root.Equals(view.BaseRoot) {
+		t.Fatalf("bootstrap roots = session %s, view %s, witness %s", session.BaseRoot(), view.BaseRoot, base.Root)
+	}
+	if len(view.Objects) != 1 || view.Objects[0].ObjectID != "root" || view.Objects[0].Kind != arcset.KindMap || view.Objects[0].Entries.Len() != 0 {
+		t.Fatalf("bootstrap view = %+v", view)
+	}
+	if maltcid.BackendKindOf(view.BaseRoot) != maltcid.BackendKindKZG {
+		t.Fatalf("bootstrap backend = %q", maltcid.BackendKindOf(view.BaseRoot))
+	}
+	if err := mappingradix.ValidateMaterialization(ctx, scheme, view.BaseRoot, mapping.NewViewFromPaths(nil), base.Entries); err != nil {
+		t.Fatalf("ValidateMaterialization: %v", err)
+	}
+}
+
 func TestNewRuntimeRequiresBranchingMaterializer(t *testing.T) {
 	scheme, err := kzg.NewScheme()
 	if err != nil {

--- a/sdk/writer/writer_test.go
+++ b/sdk/writer/writer_test.go
@@ -57,6 +57,36 @@ func TestComputeBundleMatchesIndependentFullRebuildAndRetainsNextView(t *testing
 		result.Metrics.ExpectedRootEncodingNS == 0 {
 		t.Fatalf("compute metrics = %#v", result.Metrics)
 	}
+	if result.Materialization.Profile != mutation.ClientRootMaterializationProfile || len(result.Materialization.Maps) != 2 {
+		t.Fatalf("materialization = %#v", result.Materialization)
+	}
+	var mapWitness mutation.MapMaterialization
+	for _, witness := range result.Materialization.Maps {
+		if witness.TransitionID == "child-output" {
+			mapWitness = witness
+			break
+		}
+	}
+	if mapWitness.TransitionID == "" || mapWitness.Entries == nil || mapWitness.Entries.Len() == 0 {
+		t.Fatalf("map materialization = %#v", mapWitness)
+	}
+	var childEntries *arcset.CanonicalArcSet
+	for _, object := range result.NextView.Objects {
+		if object.ObjectID == "child" {
+			childEntries = object.Entries
+			break
+		}
+	}
+	if childEntries == nil {
+		t.Fatal("retained child object is missing")
+	}
+	logicalView, err := mapViewFromEntries(childEntries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mappingradix.ValidateMaterialization(ctx, scheme, mapWitness.Root, logicalView, mapWitness.Entries); err != nil {
+		t.Fatalf("validate exported map materialization without Commit: %v", err)
+	}
 
 	// A fresh runtime must independently accept the retained complete vectors;
 	// this prevents a session-only materialization cache from hiding bad roots.
@@ -195,6 +225,205 @@ func TestFixedListReplaceAndAppendRetainVerifiableMetadataAcrossBackends(t *test
 					}
 					if _, err := fresh.VerifyUpdateView(ctx, result.NextView); err != nil {
 						t.Fatalf("verify retained fixed-list view: %v", err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestComputeBundleCreatesDependencyObjectWithoutWorkingRoot(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentSemantic, err := mappingradix.NewMap(scheme, materializermemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentRoot, err := parentSemantic.Commit(ctx, "parent", mapping.NewViewFrom(map[string]cid.Cid{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyEntries, err := arcset.NewCanonicalArcSet(arcset.KindMap, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := writerRawCID(t, "new-object-payload")
+	view := mutation.UpdateView{
+		Profile: mutation.UpdateViewProfile, StateProfile: mutation.StatefulCompleteVectorsProfile,
+		BaseRoot: parentRoot, Bounds: mutation.UpdateViewBounds{MaxObjects: 4, MaxTotalEntries: 8, MaxDepth: 4},
+		Objects: []mutation.UpdateObject{{ObjectID: "parent", Root: parentRoot, Kind: arcset.KindMap, Entries: emptyEntries}},
+	}
+	afterPayload := arcset.NewCASTarget(payload)
+	intent := mutation.SemanticIntent{
+		Profile: mutation.SemanticIntentProfile, BaseRoot: parentRoot, TopOutputID: "parent-output",
+		Transitions: []mutation.IntentTransition{
+			{
+				ID: "parent-output", ObjectID: "parent", OldRoot: parentRoot, Kind: arcset.KindMap, Backend: maltcid.BackendKindKZG,
+				Changes: []mutation.IntentChange{{
+					Coordinate: writerMapCoordinate(t, "child"), OutputID: "child-output", OutputKind: arcset.TargetKindMap,
+				}},
+			},
+			{
+				ID: "child-output", ObjectID: "child", Kind: arcset.KindMap, Backend: maltcid.BackendKindKZG, ExpectedUses: 1,
+				Changes: []mutation.IntentChange{{Coordinate: writerMapCoordinate(t, "payload"), After: &afterPayload}},
+			},
+		},
+	}
+	runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, err := runtime.VerifyUpdateView(ctx, view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := runtime.ComputeBundle(ctx, "create-child", verified, intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	childSemantic, err := mappingradix.NewMap(scheme, materializermemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	childRoot, err := childSemantic.Commit(ctx, "child", mapping.NewViewFrom(map[string]cid.Cid{"payload": payload}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, err := parentSemantic.Commit(ctx, "parent-expected", mapping.NewViewFrom(map[string]cid.Cid{"child": childRoot}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Bundle.Candidate.Equals(expected) {
+		t.Fatalf("candidate = %s, want %s", result.Bundle.Candidate, expected)
+	}
+}
+
+func TestLegacyV2MapAndListViewsComputeCurrentCandidatesAcrossBackends(t *testing.T) {
+	for _, backend := range []maltcid.BackendKind{maltcid.BackendKindKZG, maltcid.BackendKindIPA} {
+		t.Run(string(backend), func(t *testing.T) {
+			var (
+				scheme commitment.IndexCommitment
+				err    error
+			)
+			if backend == maltcid.BackendKindKZG {
+				scheme, err = kzg.NewScheme()
+			} else {
+				scheme, err = ipa.NewScheme()
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, kind := range []arcset.Kind{arcset.KindMap, arcset.KindList} {
+				t.Run(string(kind), func(t *testing.T) {
+					ctx := context.Background()
+					oldValue := writerRawCID(t, string(backend)+"-"+string(kind)+"-old")
+					untouched := writerRawCID(t, string(backend)+"-"+string(kind)+"-untouched")
+					newValue := writerRawCID(t, string(backend)+"-"+string(kind)+"-new")
+					legacyStore := materializermemory.New(true)
+					var (
+						root     cid.Cid
+						entries  *arcset.CanonicalArcSet
+						change   mutation.IntentChange
+						commit   mutation.CommitDescriptor
+						expected cid.Cid
+					)
+					switch kind {
+					case arcset.KindMap:
+						legacy, err := mappingradix.NewMapForVersion(scheme, legacyStore, maltcid.LegacyMALTVersionID)
+						if err != nil {
+							t.Fatal(err)
+						}
+						root, err = legacy.Commit(ctx, "legacy-object", mapping.NewViewFrom(map[string]cid.Cid{
+							"key": oldValue, "untouched": untouched,
+						}))
+						if err != nil {
+							t.Fatal(err)
+						}
+						entries, err = arcset.NewCanonicalArcSet(kind, []arcset.ArcEntry{
+							{Coordinate: writerMapCoordinate(t, "key"), Target: arcset.NewCASTarget(oldValue)},
+							{Coordinate: writerMapCoordinate(t, "untouched"), Target: arcset.NewCASTarget(untouched)},
+						})
+						if err != nil {
+							t.Fatal(err)
+						}
+						before, after := arcset.NewCASTarget(oldValue), arcset.NewCASTarget(newValue)
+						change = mutation.IntentChange{Coordinate: writerMapCoordinate(t, "key"), Before: &before, After: &after}
+						current, err := mappingradix.NewMap(scheme, materializermemory.New(true))
+						if err != nil {
+							t.Fatal(err)
+						}
+						expected, err = current.Commit(ctx, "legacy-object", mapping.NewViewFrom(map[string]cid.Cid{
+							"key": newValue, "untouched": untouched,
+						}))
+						if err != nil {
+							t.Fatal(err)
+						}
+					case arcset.KindList:
+						legacy, err := listtree.NewListForVersion(scheme, legacyStore, maltcid.LegacyMALTVersionID)
+						if err != nil {
+							t.Fatal(err)
+						}
+						commit = mutation.CommitDescriptor{FixedList: &mutation.FixedListCommit{ChunkSize: 4, TotalSize: 8}}
+						root, err = legacy.CommitFixed(ctx, "legacy-object", []cid.Cid{oldValue, untouched}, 4, 8)
+						if err != nil {
+							t.Fatal(err)
+						}
+						entries, err = arcset.NewCanonicalArcSet(kind, []arcset.ArcEntry{
+							{Coordinate: arcset.NewListCoordinateUint64(0), Target: arcset.NewCASTarget(oldValue)},
+							{Coordinate: arcset.NewListCoordinateUint64(1), Target: arcset.NewCASTarget(untouched)},
+						})
+						if err != nil {
+							t.Fatal(err)
+						}
+						before, after := arcset.NewCASTarget(oldValue), arcset.NewCASTarget(newValue)
+						change = mutation.IntentChange{Coordinate: arcset.NewListCoordinateUint64(0), Before: &before, After: &after}
+						current, err := listtree.NewList(scheme, materializermemory.New(true))
+						if err != nil {
+							t.Fatal(err)
+						}
+						expected, err = current.CommitFixed(ctx, "legacy-object", []cid.Cid{newValue, untouched}, 4, 8)
+						if err != nil {
+							t.Fatal(err)
+						}
+					}
+					if got := maltcid.VersionIDOf(root); got != maltcid.LegacyMALTVersionID {
+						t.Fatalf("legacy root version = %d", got)
+					}
+					view := mutation.UpdateView{
+						Profile: mutation.UpdateViewProfile, StateProfile: mutation.StatefulCompleteVectorsProfile,
+						BaseRoot: root, Bounds: mutation.UpdateViewBounds{MaxObjects: 2, MaxTotalEntries: 8, MaxDepth: 2},
+						Objects: []mutation.UpdateObject{{ObjectID: "legacy-object", Root: root, Kind: kind, Entries: entries, Commit: commit}},
+					}
+					intent := mutation.SemanticIntent{
+						Profile: mutation.SemanticIntentProfile, BaseRoot: root, TopOutputID: "legacy-output",
+						Transitions: []mutation.IntentTransition{{
+							ID: "legacy-output", ObjectID: "legacy-object", OldRoot: root, Kind: kind, Backend: backend,
+							Changes: []mutation.IntentChange{change}, Commit: commit,
+						}},
+					}
+					runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{backend: scheme})
+					if err != nil {
+						t.Fatal(err)
+					}
+					verified, err := runtime.VerifyUpdateView(ctx, view)
+					if err != nil {
+						t.Fatal(err)
+					}
+					result, err := runtime.ComputeBundle(ctx, "legacy-v2-"+string(kind), verified, intent)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !result.Bundle.Candidate.Equals(expected) {
+						t.Fatalf("candidate = %s, want %s", result.Bundle.Candidate, expected)
+					}
+					if maltcid.VersionIDOf(result.Bundle.Candidate) != maltcid.MALTVersionID ||
+						!result.Bundle.View.Objects[0].Root.Equals(root) {
+						t.Fatal("bundle did not preserve v2 evidence while producing a current candidate")
 					}
 				})
 			}

--- a/verify.go
+++ b/verify.go
@@ -132,6 +132,57 @@ func VerifyRead(ctx context.Context, req ReadRequest, result ReadResult, verifie
 	return nil
 }
 
+// VerifyMapProof validates a membership or non-membership proof against the
+// caller-selected root and key.
+func VerifyMapProof(ctx context.Context, req MapProofRequest, result MapProofResult, verifier ProofVerifier) error {
+	if verifier == nil {
+		return fmt.Errorf("portable MALT verifier is nil")
+	}
+	if err := req.Validate(); err != nil {
+		return err
+	}
+	if !result.ProofList.Root.Equals(req.Root) {
+		return fmt.Errorf("ProofList root does not match trusted root")
+	}
+	if result.ProofList.Query != req.Key.String() {
+		return fmt.Errorf("ProofList query %q does not match map key %q", result.ProofList.Query, req.Key)
+	}
+	if len(result.ProofList.Steps) != 1 {
+		return fmt.Errorf("map proof requires exactly one ProofList step, got %d", len(result.ProofList.Steps))
+	}
+	step := result.ProofList.Steps[0]
+	if arcset.CanonicalizePath(step.Path) != req.Key {
+		return fmt.Errorf("map proof path %q does not match %q", step.Path, req.Key)
+	}
+	if result.Present {
+		wantKind := prooflist.KindMapStep
+		if req.Key == arcset.PayloadPath {
+			wantKind = prooflist.KindPayloadBinding
+		}
+		if step.Kind != wantKind {
+			return fmt.Errorf("present map proof kind %q does not match %q", step.Kind, wantKind)
+		}
+		if !result.Target.Defined() || !step.Target.Equals(result.Target) {
+			return fmt.Errorf("ProofList target does not match present map result")
+		}
+	} else {
+		if step.Kind != prooflist.KindMapAbsence {
+			return fmt.Errorf("absent map proof has kind %q, want %q", step.Kind, prooflist.KindMapAbsence)
+		}
+		if result.Target.Defined() || step.Target.Defined() {
+			return fmt.Errorf("absent map proof must not carry a target")
+		}
+	}
+	valid, err := verifier.VerifyProofList(ctx, result.ProofList)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return ErrVerifierRejected
+	}
+	return nil
+}
+
 func validateQueryProofStep(query Query, steps []prooflist.Step) error {
 	if len(steps) != 1 {
 		return fmt.Errorf("typed arc query requires exactly one ProofList step, got %d", len(steps))

--- a/wire/maltcid/codec.go
+++ b/wire/maltcid/codec.go
@@ -12,10 +12,13 @@
 //
 // Current allocations:
 //
-//	malt-map-kzg  = 0x302101
-//	malt-list-kzg = 0x302201
-//	malt-map-ipa  = 0x302102
-//	malt-list-ipa = 0x302202
+//	malt-map-kzg  = 0x303101
+//	malt-list-kzg = 0x303201
+//	malt-map-ipa  = 0x303102
+//	malt-list-ipa = 0x303202
+//
+// Version 2 remains decode-compatible for roots created before fixed-domain
+// collision-bucket absence proofs. New roots are always encoded as version 3.
 package maltcid
 
 import (
@@ -28,7 +31,12 @@ import (
 
 // MALTVersionID identifies the current typed-root wire layout. It is not a
 // source release or protocol-profile version.
-const MALTVersionID uint8 = 2
+const MALTVersionID uint8 = 3
+
+// LegacyMALTVersionID identifies version-2 roots retained for decode, proof,
+// and exact complete-view replay compatibility. Default constructors never emit
+// this version.
+const LegacyMALTVersionID uint8 = 2
 
 const (
 	codecMaltRootBase = 0x300000
@@ -140,7 +148,14 @@ func NewListIPACid(commitment []byte) (cid.Cid, error) {
 
 // NewTypedCID constructs a typed MALT CID for the given semantic/backend kinds.
 func NewTypedCID(semantic SemanticKind, backend BackendKind, commitment []byte) (cid.Cid, error) {
-	codec, descriptor, err := codecFor(semantic, backend)
+	return NewTypedCIDForVersion(MALTVersionID, semantic, backend, commitment)
+}
+
+// NewTypedCIDForVersion constructs a typed MALT CID for a supported wire
+// version. It is intended for exact replay of decode-compatible legacy roots;
+// new application state should use [NewTypedCID].
+func NewTypedCIDForVersion(versionID uint8, semantic SemanticKind, backend BackendKind, commitment []byte) (cid.Cid, error) {
+	codec, descriptor, err := codecForVersion(versionID, semantic, backend)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -272,6 +287,13 @@ type codecParts struct {
 }
 
 func codecFor(semantic SemanticKind, backend BackendKind) (uint64, backendDescriptor, error) {
+	return codecForVersion(MALTVersionID, semantic, backend)
+}
+
+func codecForVersion(versionID uint8, semantic SemanticKind, backend BackendKind) (uint64, backendDescriptor, error) {
+	if versionID != MALTVersionID && versionID != LegacyMALTVersionID {
+		return 0, backendDescriptor{}, fmt.Errorf("unsupported typed cid version %d", versionID)
+	}
 	semanticID, ok := semanticIDForKind(semantic)
 	if !ok {
 		return 0, backendDescriptor{}, fmt.Errorf("unsupported typed cid semantic kind %q", semantic)
@@ -281,7 +303,7 @@ func codecFor(semantic SemanticKind, backend BackendKind) (uint64, backendDescri
 		return 0, backendDescriptor{}, fmt.Errorf("unsupported typed cid backend %q", backend)
 	}
 	codec := uint64(codecMaltRootBase) |
-		uint64(MALTVersionID)<<codecVersionShift |
+		uint64(versionID)<<codecVersionShift |
 		uint64(semanticID)<<codecSemanticShift |
 		uint64(descriptor.id)
 	return codec, descriptor, nil
@@ -293,7 +315,7 @@ func decodeCodec(codec uint64) (codecParts, bool) {
 	}
 	offset := codec - codecMaltRootBase
 	versionID := uint8(offset >> codecVersionShift)
-	if versionID != MALTVersionID {
+	if versionID != MALTVersionID && versionID != LegacyMALTVersionID {
 		return codecParts{}, false
 	}
 	semanticID := uint8((offset >> codecSemanticShift) & 0x0F)
@@ -305,7 +327,7 @@ func decodeCodec(codec uint64) (codecParts, bool) {
 	if !ok {
 		return codecParts{}, false
 	}
-	reconstructed, _, err := codecFor(semantic, descriptor.kind)
+	reconstructed, _, err := codecForVersion(versionID, semantic, descriptor.kind)
 	if err != nil || reconstructed != codec {
 		return codecParts{}, false
 	}

--- a/wire/maltcid/codec_test.go
+++ b/wire/maltcid/codec_test.go
@@ -16,19 +16,19 @@ func TestCodecLayout(t *testing.T) {
 		semantic maltcid.SemanticKind
 		backend  maltcid.BackendKind
 	}{
-		{name: "map_kzg", codec: maltcid.CodecMaltMapKZG, version: 2, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindKZG},
-		{name: "list_kzg", codec: maltcid.CodecMaltListKZG, version: 2, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindKZG},
-		{name: "map_ipa", codec: maltcid.CodecMaltMapIPA, version: 2, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindIPA},
-		{name: "list_ipa", codec: maltcid.CodecMaltListIPA, version: 2, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindIPA},
+		{name: "map_kzg", codec: maltcid.CodecMaltMapKZG, version: 3, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindKZG},
+		{name: "list_kzg", codec: maltcid.CodecMaltListKZG, version: 3, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindKZG},
+		{name: "map_ipa", codec: maltcid.CodecMaltMapIPA, version: 3, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindIPA},
+		{name: "list_ipa", codec: maltcid.CodecMaltListIPA, version: 3, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindIPA},
 	}
 	wantCodecs := map[string]uint64{
-		"map_kzg":  0x302101,
-		"list_kzg": 0x302201,
-		"map_ipa":  0x302102,
-		"list_ipa": 0x302202,
+		"map_kzg":  0x303101,
+		"list_kzg": 0x303201,
+		"map_ipa":  0x303102,
+		"list_ipa": 0x303202,
 	}
-	if maltcid.MALTVersionID != 2 {
-		t.Fatalf("MALTVersionID = %d, want 2", maltcid.MALTVersionID)
+	if maltcid.MALTVersionID != 3 {
+		t.Fatalf("MALTVersionID = %d, want 3", maltcid.MALTVersionID)
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -64,14 +64,14 @@ func TestCodecClassificationRejectsUnsupportedFields(t *testing.T) {
 		{name: "old_flat_list_ipa", codec: 0x300004},
 		{name: "version_zero", codec: 0x300101},
 		{name: "version_one", codec: 0x301101, versionHint: 1},
-		{name: "version_three", codec: 0x303101, versionHint: 3},
+		{name: "version_four", codec: 0x304101, versionHint: 4},
 		{name: "version_fifteen", codec: 0x30F101, versionHint: 15},
-		{name: "semantic_zero", codec: 0x302001, versionHint: 2},
-		{name: "semantic_unknown", codec: 0x302301, versionHint: 2},
-		{name: "semantic_fifteen", codec: 0x302F01, versionHint: 2},
-		{name: "backend_zero", codec: 0x302100, versionHint: 2},
-		{name: "backend_unknown", codec: 0x302103, versionHint: 2},
-		{name: "backend_255", codec: 0x3021FF, versionHint: 2},
+		{name: "semantic_zero", codec: 0x303001, versionHint: 3},
+		{name: "semantic_unknown", codec: 0x303301, versionHint: 3},
+		{name: "semantic_fifteen", codec: 0x303F01, versionHint: 3},
+		{name: "backend_zero", codec: 0x303100, versionHint: 3},
+		{name: "backend_unknown", codec: 0x303103, versionHint: 3},
+		{name: "backend_255", codec: 0x3031FF, versionHint: 3},
 		{name: "outside_root_subrange", codec: 0x311101},
 		{name: "high_bit_alias", codec: 0x100302101},
 	}
@@ -97,6 +97,26 @@ func TestCodecClassificationRejectsUnsupportedFields(t *testing.T) {
 				t.Fatal("ExtractCommitment accepted unsupported codec")
 			}
 		})
+	}
+}
+
+func TestLegacyVersion2CodecsRemainClassified(t *testing.T) {
+	tests := []struct {
+		codec    uint64
+		semantic maltcid.SemanticKind
+		backend  maltcid.BackendKind
+	}{
+		{codec: 0x302101, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindKZG},
+		{codec: 0x302201, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindKZG},
+		{codec: 0x302102, semantic: maltcid.SemanticKindMap, backend: maltcid.BackendKindIPA},
+		{codec: 0x302202, semantic: maltcid.SemanticKindList, backend: maltcid.BackendKindIPA},
+	}
+	for _, test := range tests {
+		root := cidWithIdentityDigest(t, test.codec, commitmentSize(test.backend))
+		if !maltcid.IsMaltCid(root) || maltcid.VersionIDOf(root) != maltcid.LegacyMALTVersionID ||
+			maltcid.SemanticKindOf(root) != test.semantic || maltcid.BackendKindOf(root) != test.backend {
+			t.Fatalf("legacy codec %#x was not classified", test.codec)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- add root-bound radix materialization export and validation so browser-computed roots can be imported by an untrusted Gateway without recomputing commitments
- add public `MapProof` generation/verification for membership and sound non-membership across KZG and IPA: empty slots, conflicting leaves, and fixed-domain v3 collision buckets
- emit typed MALT v3 roots while retaining exact v2 read/proof compatibility; complete v2 views are rebuilt client-side before v3 mutation
- add stateful browser writer sessions with retained verified views, working roots, strict prepared-result/receipt binding, and stateless receipt recovery validation
- reject noncanonical materialization coordinates such as `runtime//...`
- expose `list.ErrNotMeasured` so ordinary lists can safely fall back to index semantics without hiding real range-proof or storage failures

## Coordination

This is the Core dependency for DeWebProtocol/malt-client#15 and the coordinated Gateway browser-writer PR. Keep all three PRs in Draft and merge in dependency order: Core, client, Gateway.

## Compatibility and security

- v2 roots remain readable and verifiable; v2 collision buckets retain membership proofs but intentionally do not claim sound bucket absence
- v3 fixed-domain buckets authenticate the empty tail required for sound absence
- runtime, portable verification, and materialization validation reject mixed versions/backends, partial legacy views, mismatched bucket-reference profiles, and noncanonical witness paths
- prepared results do not advance a session; only an exact durable receipt advances the accepted view and working-root seal
- materialization receipts are operational persistence receipts, not signed portable state-transition proofs or trusted-root promotion

## Validation

- `go test ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- `GOOS=linux GOARCH=386 go test -run '^$' ./...`
- `scripts/test-writer-wasm.sh` (KZG, IPA, stateless/session smoke, dual Worker instances)
- `scripts/test-verifier-wasm-vectors.sh` (all 49 vectors; KZG 25; IPA 25)
- `git diff --check`
- GitHub CI: Go and CodeQL passed
- new independent final review at `ae8e5216e0d9d6cdc065e86e5c24de1b64528214`: no actionable P0-P2 findings
