### PR TITLE
Prepare v0.0.7-rc.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,50 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whitespace
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          zero=0000000000000000000000000000000000000000
+
+          case "$EVENT_NAME" in
+            pull_request)
+              base="$PR_BASE_SHA"
+              head="$PR_HEAD_SHA"
+              mode=merge-base
+              ;;
+            push)
+              base="$PUSH_BEFORE_SHA"
+              head="$GITHUB_SHA"
+              mode=direct
+              ;;
+            *)
+              echo "unsupported event: $EVENT_NAME" >&2
+              exit 2
+              ;;
+          esac
+
+          if [[ -z "$base" || "$base" == "$zero" ]]; then
+            echo "missing usable base SHA for $EVENT_NAME" >&2
+            exit 2
+          fi
+
+          git rev-parse --verify "${base}^{commit}"
+          git rev-parse --verify "${head}^{commit}"
+
+          if [[ "$mode" == merge-base ]]; then
+            git diff --check "${base}...${head}"
+          else
+            git diff --check "$base" "$head"
+          fi
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run 32-bit commitment tests
         run: GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa
 
-      - name: Run verifier WASM conformance vectors
+      - name: Run verifier WASM conformance and Map-proof smoke
         run: sh scripts/test-verifier-wasm-vectors.sh
 
       - name: Run writer WASM smoke

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ application state are outside the trust boundary.
 
 | Layer | Owns | Explicitly excludes |
 | --- | --- | --- |
-| MALT core | arcs/segments, typed roots, commitments, resolve/read/mutation and client-root values, ProofList, verification | HTTP, CAS I/O, ArcTable implementation, application syntax, trusted-root policy |
+| MALT core | arcs/segments, typed roots, commitments, resolve/read/Map-proof/mutation and client-root values, ProofList, verification | HTTP, CAS I/O, ArcTable implementation, application syntax, trusted-root policy |
 | Client | application syntax, accepted roots, request construction, local proof and payload-byte verification, optional client-root computation | proof generation, persistent ArcTable, server policy |
 | Gateway/executor | candidate selection for server-executed mutations, exact client-root replay/materialization, proof generation, ArcTable/KV/CAS, service policy | the final trust decision or substitution of a client-computed root |
 | CAS | immutable CID-addressed bytes | graph semantics and ProofLists |
@@ -35,6 +35,10 @@ sequenceDiagram
   C->>S: GET authenticated target CID
   S-->>C: payload bytes
   C->>C: hash bytes and compare with CID
+  Note over C,G: Independent Map-proof operation
+  C->>G: MapProofRequest(trusted Map root, exact key)
+  G-->>C: MapProofResult(present, optional target, ProofList)
+  C->>C: VerifyMapProof(trusted request, untrusted result)
 ```
 
 The gateway may return any complete valid derivation. If multiple derivations
@@ -45,7 +49,7 @@ selection. Application policy may impose additional constraints.
 
 ```text
 malt (module facade)
-├── protocol                 serialized resolve/read and client-root profiles
+├── protocol                 serialized resolve/read/Map-proof and client-root profiles
 ├── mutation                 portable mutation/client-root/receipt values
 ├── auth
 │   ├── arcset               canonical arcs and ArcSet views
@@ -60,6 +64,7 @@ malt (module facade)
 │   └── runtime              composition over an injected materializer
 ├── sdk/verifier             trusted client facade
 ├── sdk/writer               complete-view client-root computation
+├── cmd/malt-verifier-wasm   browser verification adapter
 ├── cmd/malt-writer-wasm     browser client-root adapter
 ├── wire/maltcid             typed CID rules
 └── artifact                 frozen compatibility profile
@@ -120,8 +125,25 @@ or `list_range`. `ReadResult` contains the target, optional authenticated range
 segment CIDs, and ProofList. `VerifyRead` binds the evidence to the exact
 caller-selected query.
 
-Proof generation is part of resolve/read execution. There is no new generic
-`prove` operation. `malt.artifact/v0alpha2` remains frozen compatibility data.
+### Map proof
+
+`MapProofRequest` contains a caller-selected trusted Map root and exact
+canonical key. `MapProofResult` is untrusted and contains `present`, a
+target if and only if the relation is present, and a root-bound ProofList.
+`execution.Executor.ProveMap` may generate either membership or
+non-membership evidence without changing `Read`'s `ErrQueryNotFound`
+behavior. `VerifyMapProof` requires exactly one proof step and binds the
+ProofList root, query/path, presence state, optional target, step kind, and
+cryptographic evidence to the request.
+
+Non-membership authenticates only the absence of that one exact keyed Map
+relation. It does not prove List-index, graph-path, object, payload-byte, or
+remote-data absence.
+
+Resolve and Read generate their operation-specific evidence during execution.
+Map membership and non-membership use the dedicated Map-proof operation; there
+is no generic `prove` union. `malt.artifact/v0alpha2` remains frozen
+compatibility data.
 
 ### Apply
 
@@ -138,9 +160,11 @@ only through the explicitly named `ReferenceWriter()` capability.
 
 ### Client-root computation
 
-The post-release client-root contract lets a trusted writer validate a bounded
-complete `UpdateView`, normalize an output-free `SemanticIntent`, and compute
-one exact `ClientRootBundle` locally. `sdk/writer` owns that
+The experimental client-root contract included in v0.0.7-rc.1 lets a trusted
+writer validate a bounded, untrusted complete `UpdateView`, normalize an
+output-free `SemanticIntent`, and compute one exact `ClientRootBundle`
+locally. Its `/v1` profile suffixes version experimental serialized contracts
+and do not declare stable MALT or Go source APIs. `sdk/writer` owns that
 application-neutral computation. It uses caller-supplied branching
 materialization only for speculative local state and defines no durable
 ArcTable or publication policy.
@@ -163,16 +187,20 @@ because it has no authenticated base root. See the
 Trusted verification packages must remain deterministic and storage-free:
 
 - `auth/verifier` verifies ProofList evidence;
-- module-root `VerifyResolve` and `VerifyRead` bind caller-selected inputs;
-- `sdk/verifier` exposes the local Go facade;
-- `cmd/malt-verifier-wasm` exposes the same boundary to browsers.
+- module-root `VerifyResolve`, `VerifyRead`, and `VerifyMapProof` bind
+  caller-selected operation inputs to untrusted results and ProofLists;
+- `sdk/verifier` exposes the local Go facade for those operations;
+- `cmd/malt-verifier-wasm` exposes the same Go verification boundary through
+  `maltVerifyResolve`, `maltVerifyRead`, and `maltVerifyMapProof`.
 
 They do not call a gateway, remote verifier, CAS, ArcTable, filesystem, or
 network. Remote verify endpoints are diagnostics only.
 
-Proof verification authenticates a target CID, not arbitrary response bytes.
-The consuming client must hash full payload bytes, or validate each
-application-defined ranged segment, against authenticated CIDs.
+For present relations, proof verification authenticates a target CID, not
+arbitrary response bytes. Successful Map non-membership verification instead
+authenticates only absence of the exact requested keyed relation and carries
+no target. A consuming client must still bind any returned payload bytes to
+authenticated CIDs.
 
 ## Application boundary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,114 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.7-rc.1] - 2026-07-31
+
+This experimental release candidate centers on three protocol changes:
+structured typed-root codecs, backend-sized semantic geometry, and verifiable
+Map non-membership.
+
+### Highlights
+
+#### Structured typed roots: `0x30VSBB`
+
+- Define typed MALT root codecs in the private-use `0x30VSBB` layout, where
+  `V` is the wire-format version, `S` is the semantic kind, and `BB` is the
+  commitment-backend suite.
+- New constructors emit `MALTVersionID=3` roots:
+  - Map/KZG: `0x303101`
+  - List/KZG: `0x303201`
+  - Map/IPA: `0x303102`
+  - List/IPA: `0x303202`
+- Fail closed on unknown versions, semantics, backend suites, combinations,
+  identity-hash sizes, and mixed-profile children.
+- Retain structured version-2 roots for read, proof, and exact complete-view
+  replay compatibility. Default constructors do not emit them.
+
+#### 4096-slot KZG semantic geometry
+
+- Use all 4096 KZG commitment positions in semantic Map and List nodes.
+- Consume SHA-256 Map keys as 12-bit radix digits under KZG.
+- Reserve List position zero for authenticated metadata and use the remaining
+  4095 KZG positions for content.
+- Keep IPA at 256 positions, with 8-bit Map radix digits and 255 List content
+  positions.
+- Share backend-sized geometry between semantic producers, materialization,
+  and portable verifiers.
+
+#### Verifiable Map non-membership
+
+- Add root-bound Map membership and non-membership proofs for KZG and IPA.
+- Authenticate an absent keyed relation through a proved empty radix slot, a
+  conflicting terminal leaf, or a complete fixed-domain collision bucket.
+- Add fixed-domain collision buckets under `MALTVersionID=3`, including
+  authenticated empty tail positions, so collision-bucket non-membership can
+  be verified.
+- Add `MapProofRequest`, `MapProofResult`, `MapProver`,
+  `VerifyMapProof`, the transport-neutral `malt.map-proof/v0alpha1` profile
+  and schemas, and the terminal ProofList step kind `map_absence`.
+- Expose the same Map-proof verification boundary through the Go SDK and
+  browser/WASM verifier.
+
+### Added
+
+- Add deterministic Resolve/Read conformance corpora; v2 is the current corpus
+  for version-3 roots, while v1 is retained as the frozen
+  structured-version-2 corpus.
+- Add complete-view client-root contracts, `sdk/writer`, exact candidate-root
+  bundles, root-bound Map materialization witnesses, and receipt-gated writer
+  sessions.
+- Add a unified browser writer WASM with isolated KZG and IPA workers.
+- Add request-scoped read and writer phase observations for diagnostics.
+
 ### Changed
 
 - Align the default Make target and CI build gate with the SDK-only package
   tree.
-- Use all 4096 KZG positions for semantic map and list nodes. KZG maps now
-  consume SHA-256 keys in 12-bit radix digits and KZG lists branch over 4095
-  content slots; the fixed 256-position IPA suite retains 8-bit map digits and
-  255 list content slots.
-- Advance newly constructed typed MALT roots to `MALTVersionID=3` for
-  fixed-domain collision buckets and sound map non-membership proofs. Version-2
-  roots remain explicitly readable and verifiable. Incremental mutation APIs
-  reject a root/semantics version mismatch; the client writer verifies an exact
-  v2 complete view, fully rebuilds it as v3, and only then applies changes so it
-  cannot emit mixed-version trees. Experimental version-1 roots remain rejected.
+- Narrow materializer and graph-writer dependencies to the capabilities each
+  algorithm consumes.
+- Require stable freshness identities where Go value identity cannot safely
+  identify a materializer.
+- Rebuild a verified structured-version-2 complete view as version 3 before
+  applying client-side changes.
+- Require exact materialization receipts before a stateful writer session
+  advances its retained working view.
+
+### Fixed
+
+- Reject missing authenticated List leaves instead of treating incomplete
+  materialization as semantic absence.
+- Preserve underlying materializer failures instead of collapsing them into
+  not-found results.
+- Reject noncanonical Map-proof targets and materialization coordinates.
+- Preserve collision-bucket and working-root state across writer preparation,
+  receipt recovery, and reachability reclamation.
+- Reject target relabeling, invalid UTF-8, stale intents, mismatched receipts,
+  and mixed backend/version materialization.
 
 ### Removed
 
-- Remove `radix.ProveTimings` and `(*radix.Map).ProveWithTimings`; evaluator
-  timing no longer runs inside the SDK proof path. This is an intentional
-  pre-v1 Go source break.
-- Remove the unused process-global logger, the former HTTP stat/content query
-  path helper, and the stale daemon configuration example. These are
-  intentional pre-v1 Go source removals after the Gateway/client split.
+- Remove `radix.ProveTimings` and `(*radix.Map).ProveWithTimings`.
+- Remove the obsolete process-global `logger` package.
+- Remove the former HTTP-oriented `graph/querypath` helper and stale daemon
+  configuration example.
+- Remove unused `zap` and `multierr` dependencies.
+
+### Compatibility
+
+This is an intentional pre-v1 source- and wire-breaking release candidate.
+
+- v0.0.6 flat root codecs `0x300001` through `0x300004` are not accepted by
+  the structured typed-root decoder. No migration layer is provided; recreate
+  experimental roots and materialized proof-serving state with this release.
+- Structured version-2 roots were introduced on `main` after v0.0.6. They
+  remain readable and verifiable, but new constructors emit version 3.
+  Collision-bucket non-membership requires the version-3 fixed-domain bucket
+  profile.
+- Removed Go APIs do not have forwarding compatibility shims.
+- Client-root `/v1` suffixes version experimental serialized profiles; they do
+  not declare the project or Go APIs stable at v1.
+- Client-root bundles and materialization receipts are not portable
+  state-transition, publication, freshness, or trust proofs.
 
 ## [0.0.6] - 2026-07-14
 
@@ -147,7 +232,8 @@ for the trusted CLI/daemon and UnixFS application, and
 - KZG verification rejects out-of-range proof indices and non-canonical proof
   lengths instead of allowing malformed input to panic or reuse a commitment.
 
-[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.6...HEAD
+[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.1...HEAD
+[0.0.7-rc.1]: https://github.com/DeWebProtocol/malt/compare/v0.0.6...v0.0.7-rc.1
 [0.0.6]: https://github.com/DeWebProtocol/malt/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/DeWebProtocol/malt/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/DeWebProtocol/malt/compare/v0.0.3...v0.0.4

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ line client, daemon, UnixFS model, or website.
 [Client-root contract](./docs/spec/client-root-contract.md) ·
 [ProofList](./docs/spec/prooflist-format.md) ·
 [Compatibility](./docs/policy/compatibility.md) ·
-[v0.0.6 release](./docs/releases/v0.0.6.md) · [Roadmap](./ROADMAP.md)
+[v0.0.7-rc.1 release candidate](./docs/releases/v0.0.7.md) · [Roadmap](./ROADMAP.md)
 
-`v0.0.6` is the current tagged release. The client-root profiles and
-`sdk/writer` are experimental post-release contracts on `main`; their `/v1`
-profile suffixes do not declare the Go module or project stable at v1.
+`v0.0.7-rc.1` is the current release candidate. Its Map-proof and client-root
+profiles remain experimental; `/v1` profile suffixes do not declare MALT or
+its Go APIs stable at v1.
 
 ## Boundary
 
@@ -35,7 +35,8 @@ MALT core owns:
 - canonical segment and arc semantics;
 - typed map/list roots and CID rules;
 - map/list commitment, proof, and verification algorithms;
-- `malt.resolve/v0alpha1` and `malt.read/v0alpha1` values and JSON Schemas;
+- `malt.resolve/v0alpha1`, `malt.read/v0alpha1`, and
+  `malt.map-proof/v0alpha1` values and JSON Schemas;
 - complete-view client-root values, schemas, and local candidate computation;
 - ProofList generation/verification semantics;
 - portable mutation and receipt values;
@@ -90,7 +91,7 @@ conformance tests and examples, not deployment.
 ## Install
 
 ```bash
-go get github.com/dewebprotocol/malt@v0.0.6
+go get github.com/dewebprotocol/malt@v0.0.7-rc.1
 ```
 
 ### Verify a resolve result
@@ -116,13 +117,13 @@ in the application client.
 
 | Package | Role |
 | --- | --- |
-| module root `malt` | Stable typed resolve/read/query values and verification entry points |
+| module root `malt` | Minimal typed resolve/read/map-proof values and verification entry points |
 | `auth/arcset` | Canonical typed arcs, targets, sets, and iteration |
 | `auth/commitment` | KZG/IPA commitment capabilities |
 | `auth/semantic` | Map/list semantic contracts and reference algorithms |
 | `auth/proof` | ProofList/evidence formats |
 | `auth/verifier` | Storage-free ProofList verification |
-| `protocol` | Versioned serialized resolve/read and client-root profiles and schemas |
+| `protocol` | Versioned serialized resolve/read/map-proof and client-root profiles and schemas |
 | `mutation` | Portable mutation, client-root, and receipt values |
 | `execution` | Untrusted resolve/read/apply composition |
 | `graph` | Resolver, semantic mutation, bootstrap, and explicit reference-writer algorithms over injected capabilities |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,25 +15,32 @@ v0.0.6 turns this repository into an SDK-only core:
   `malt-client`; managed browser application behavior lives in
   `gateway/console`.
 
-## Post-v0.0.6 main
+## v0.0.7 release-candidate boundary
 
-Current `main` additionally contains the experimental complete-view
-client-root profiles, `sdk/writer` local candidate computation, and optional
-request-scoped phase observations. These contracts are not part of the
-immutable v0.0.6 tag. Before a later release, they need a language-neutral
-accept/reject conformance corpus as well as the checked-in schemas and Go tests.
+v0.0.7-rc.1 adds:
+
+- structured typed roots in the private-use `0x30VSBB` codec layout;
+- backend-sized semantic geometry, including 4096 KZG positions;
+- exact Map membership and non-membership proofs through
+  `malt.map-proof/v0alpha1`;
+- the experimental complete-view client-root profiles and `sdk/writer` local
+  candidate computation;
+- unified verifier and writer browser/WASM builds; and
+- optional request-scoped phase observations.
+
+The Resolve/Read v2 corpus is first frozen by this release candidate. The WASM
+gate also runs runtime-generated Map-proof smoke vectors for KZG and IPA.
+Before a final v0.0.7, a dedicated language-neutral Map-proof and client-root
+corpus remains a stabilization follow-up rather than an RC compatibility claim.
 
 ## Next core work
 
-1. Expand resolve/read conformance vectors across KZG and IPA: root identity,
-   multi-hop resolution, segment grouping, map reads, list reads, measured
-   ranges, malformed evidence, cross-root splicing, and payload bindings.
-2. Publish the same vectors as language-neutral JSON so Go, WASM, and future
-   TypeScript/Rust clients can prove behavioral parity.
-3. Define verifiable mutation transition semantics before introducing a new
+1. Define language-neutral Map-proof and client-root conformance corpora for
+   independent Go, WASM, TypeScript, and Rust consumers.
+2. Define verifiable mutation transition semantics before introducing a new
    mutation artifact/profile. Current receipts remain operational only.
-4. Harden variable-size measured-list evidence and native multi-open proofs.
-5. Stabilize the minimal materializer capability without standardizing any
+3. Harden variable-size measured-list evidence and native multi-open proofs.
+4. Stabilize the minimal materializer capability without standardizing any
    ArcTable persistence format.
 
 ## Product integration work outside core

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,13 +13,15 @@ untrusted caller-supplied evidence.
 | Version | Security support |
 | --- | --- |
 | `main` | Best-effort review of current integration code |
-| `v0.0.6` | Current supported experimental source release |
-| `v0.0.5` | Previous experimental source release |
-| `v0.0.4` and earlier | Not supported |
+| `v0.0.7-rc.1` | Current experimental release candidate |
+| `v0.0.6` | Previous non-prerelease experimental source release |
+| `v0.0.5` and earlier | Not supported |
 
 MALT remains pre-`v1.0.0` and experimental. Security fixes may require
-breaking API, proof, root, or wire-format changes. Reproducible consumers
-should pin `v0.0.6` rather than depend on `main`.
+breaking API, proof, root, or wire-format changes. Consumers evaluating the
+current typed-root and Map-proof contracts should pin `v0.0.7-rc.1` rather
+than depend on `main`. Consumers remaining on v0.0.6 must not assume its flat
+roots are wire-compatible with this release candidate.
 
 ## Reporting a Vulnerability
 

--- a/cmd/malt-verifier-wasm/README.md
+++ b/cmd/malt-verifier-wasm/README.md
@@ -37,6 +37,12 @@ default `all` instance.
 non-membership pair. The caller constructs the request from its trusted root and intended query before
 passing the untrusted result to WASM. Schemas live in `protocol/schemas/`.
 
+The release gate `scripts/test-verifier-wasm-vectors.sh` runs the current
+Resolve/Read v2 conformance corpus together with runtime-generated Map-proof
+non-membership smoke vectors. It checks the same WASM artifact with all
+backends enabled and in backend-selected KZG and IPA runs, including
+acceptance, proof-tamper, cross-root, and wrong-key cases.
+
 For example:
 
 ```json

--- a/cmd/malt-verifier-wasm/map_proof_fixture_test.go
+++ b/cmd/malt-verifier-wasm/map_proof_fixture_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	malt "github.com/dewebprotocol/malt"
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materialmemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/ipa"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	mapradix "github.com/dewebprotocol/malt/auth/semantic/mapping/radix"
+	"github.com/dewebprotocol/malt/execution"
+	"github.com/dewebprotocol/malt/protocol"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+const mapProofFixtureOperation = "map_proof"
+
+type wasmMapProofFixtureSet struct {
+	Vectors []wasmMapProofFixture `json:"vectors"`
+}
+
+type wasmMapProofFixture struct {
+	ID           string                        `json:"id"`
+	Operation    string                        `json:"operation"`
+	Backend      maltcid.BackendKind           `json:"backend"`
+	Category     string                        `json:"category"`
+	Verification protocol.MapProofVerification `json:"verification"`
+	Expected     wasmMapProofExpected          `json:"expected"`
+}
+
+type wasmMapProofExpected struct {
+	Valid bool `json:"valid"`
+}
+
+func TestGenerateMapProofWASMFixtures(t *testing.T) {
+	outputPath := os.Getenv("MALT_VERIFIER_WASM_MAP_PROOF_FIXTURE_OUT")
+	if outputPath == "" {
+		t.Skip("MALT_VERIFIER_WASM_MAP_PROOF_FIXTURE_OUT is not set")
+	}
+
+	fixtures := wasmMapProofFixtureSet{}
+	for _, backend := range []maltcid.BackendKind{maltcid.BackendKindKZG, maltcid.BackendKindIPA} {
+		fixtures.Vectors = append(fixtures.Vectors, mapProofWASMFixtures(t, backend)...)
+	}
+	data, err := json.Marshal(fixtures)
+	if err != nil {
+		t.Fatalf("marshal Map-proof WASM fixtures: %v", err)
+	}
+	if err := os.WriteFile(outputPath, data, 0o600); err != nil {
+		t.Fatalf("write Map-proof WASM fixtures: %v", err)
+	}
+}
+
+func mapProofWASMFixtures(t *testing.T, backend maltcid.BackendKind) []wasmMapProofFixture {
+	t.Helper()
+	ctx := context.Background()
+	scope := "wasm-map-proof-" + string(backend)
+	semantic, err := mapradix.NewMap(mapProofFixtureScheme(t, backend), materialmemory.New(true))
+	if err != nil {
+		t.Fatalf("create %s Map semantic: %v", backend, err)
+	}
+	target := mapProofFixtureCID(t, "present-"+string(backend))
+	root, err := semantic.Commit(ctx, scope, mapping.NewViewFrom(map[string]cid.Cid{"present": target}))
+	if err != nil {
+		t.Fatalf("commit %s Map fixture: %v", backend, err)
+	}
+	executor, err := execution.NewExecutor(execution.Options{Scope: scope, Maps: semantic})
+	if err != nil {
+		t.Fatalf("create %s executor: %v", backend, err)
+	}
+	request := malt.MapProofRequest{Root: root, Key: arcset.CanonicalizePath("missing")}
+	result, err := executor.ProveMap(ctx, request)
+	if err != nil {
+		t.Fatalf("prove %s Map absence: %v", backend, err)
+	}
+	if result.Present || result.Target.Defined() {
+		t.Fatalf("%s Map absence result is present: %+v", backend, result)
+	}
+	wireRequest, err := protocol.NewMapProofRequest(request)
+	if err != nil {
+		t.Fatalf("encode %s Map-proof request: %v", backend, err)
+	}
+	wireResult, err := protocol.NewMapProofResult(result)
+	if err != nil {
+		t.Fatalf("encode %s Map-proof result: %v", backend, err)
+	}
+	accepted := protocol.MapProofVerification{Request: wireRequest, Result: wireResult}
+
+	otherRoot, err := semantic.Commit(ctx, scope, mapping.NewViewFrom(map[string]cid.Cid{
+		"other": mapProofFixtureCID(t, "other-"+string(backend)),
+	}))
+	if err != nil {
+		t.Fatalf("commit alternate %s Map fixture: %v", backend, err)
+	}
+
+	proofTamper := cloneMapProofVerification(t, accepted)
+	tamperMapProofEvidence(t, &proofTamper)
+	crossRoot := cloneMapProofVerification(t, accepted)
+	crossRoot.Request.Root = otherRoot.String()
+	crossRoot.Result.ProofList.Root = otherRoot
+	crossRoot.Result.ProofList.Steps[0].From = otherRoot
+	wrongKey := cloneMapProofVerification(t, accepted)
+	wrongKey.Request.Key = []string{"another-missing"}
+
+	prefix := "map-proof." + string(backend) + ".absence."
+	return []wasmMapProofFixture{
+		mapProofFixture(prefix+"accept", backend, "absence", accepted, true),
+		mapProofFixture(prefix+"proof-tamper.reject", backend, "tamper", proofTamper, false),
+		mapProofFixture(prefix+"cross-root.reject", backend, "cross_root", crossRoot, false),
+		mapProofFixture(prefix+"wrong-key.reject", backend, "wrong_key", wrongKey, false),
+	}
+}
+
+func mapProofFixture(id string, backend maltcid.BackendKind, category string, verification protocol.MapProofVerification, valid bool) wasmMapProofFixture {
+	return wasmMapProofFixture{
+		ID: id, Operation: mapProofFixtureOperation, Backend: backend, Category: category,
+		Verification: verification, Expected: wasmMapProofExpected{Valid: valid},
+	}
+}
+
+func cloneMapProofVerification(t *testing.T, value protocol.MapProofVerification) protocol.MapProofVerification {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal Map-proof fixture: %v", err)
+	}
+	var cloned protocol.MapProofVerification
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		t.Fatalf("clone Map-proof fixture: %v", err)
+	}
+	return cloned
+}
+
+func tamperMapProofEvidence(t *testing.T, value *protocol.MapProofVerification) {
+	t.Helper()
+	if value == nil || len(value.Result.ProofList.Steps) != 1 {
+		t.Fatal("Map-proof fixture does not contain exactly one proof step")
+	}
+	var envelope struct {
+		Steps []struct {
+			Slot  []byte `json:"slot,omitempty"`
+			Proof []byte `json:"proof"`
+		} `json:"steps"`
+		Bucket json.RawMessage `json:"bucket,omitempty"`
+	}
+	if err := json.Unmarshal(value.Result.ProofList.Steps[0].Proof, &envelope); err != nil {
+		t.Fatalf("decode Map-proof evidence: %v", err)
+	}
+	if len(envelope.Steps) == 0 || len(envelope.Steps[0].Proof) < 4 {
+		t.Fatal("Map-proof evidence has no mutable primitive proof")
+	}
+	envelope.Steps[0].Proof[len(envelope.Steps[0].Proof)-1] ^= 0x01
+	tampered, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("encode tampered Map-proof evidence: %v", err)
+	}
+	value.Result.ProofList.Steps[0].Proof = tampered
+}
+
+func mapProofFixtureScheme(t *testing.T, backend maltcid.BackendKind) commitment.IndexCommitment {
+	t.Helper()
+	var (
+		scheme commitment.IndexCommitment
+		err    error
+	)
+	switch backend {
+	case maltcid.BackendKindKZG:
+		scheme, err = kzg.NewScheme()
+	case maltcid.BackendKindIPA:
+		scheme, err = ipa.NewScheme()
+	default:
+		t.Fatalf("unsupported Map-proof fixture backend %q", backend)
+	}
+	if err != nil {
+		t.Fatalf("create %s commitment scheme: %v", backend, err)
+	}
+	return scheme
+}
+
+func mapProofFixtureCID(t *testing.T, seed string) cid.Cid {
+	t.Helper()
+	digest, err := mh.Sum([]byte("malt-map-proof-wasm-fixture:"+seed), mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatalf("hash Map-proof fixture CID: %v", err)
+	}
+	return cid.NewCidV1(cid.Raw, digest)
+}

--- a/conformance/corpus_test.go
+++ b/conformance/corpus_test.go
@@ -78,6 +78,16 @@ func TestResolveReadV1CorpusDigestIsImmutable(t *testing.T) {
 	}
 }
 
+func TestResolveReadV2CorpusDigestIsImmutable(t *testing.T) {
+	data, err := conformance.BytesVersion(conformance.ResolveReadV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(data)); got != "f96aad71c4b60a3073f823bb2aa0b05307f18400630e1920ad25889beb4600d5" {
+		t.Fatalf("v2 corpus digest changed: %s", got)
+	}
+}
+
 func TestResolveReadV2CoverageMatrix(t *testing.T) {
 	corpus, err := conformance.Load()
 	if err != nil {

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ research narrative remain in `DeWebProtocol/documents`.
 - [Threat model](./policy/threat-model.md)
 - [Compatibility policy](./policy/compatibility.md)
 - [Release process](./policy/releasing.md)
+- [v0.0.7-rc.1 release notes](./releases/v0.0.7.md)
 - [v0.0.6 release notes](./releases/v0.0.6.md)
 - [v0.0.5 release notes](./releases/v0.0.5.md)
 - [v0.0.4 release notes](./releases/v0.0.4.md)
@@ -61,9 +62,10 @@ The current public-core contracts are
 [MIP-1012: Segment Path Resolution](./mips/mip-1012-segment-path-resolution.md),
 the final
 [MIP-1013: Client, Gateway, And Core Responsibility Boundary](./mips/mip-1013-client-gateway-core-boundary.md),
-the operation-specific resolve/read profiles introduced by that MIP, the
-experimental post-v0.0.6
-[client-root contract](./spec/client-root-contract.md), and the frozen v0.0.4
+the operation-specific resolve/read profiles introduced by that MIP,
+`malt.map-proof/v0alpha1`, and the experimental
+[client-root contract](./spec/client-root-contract.md) included in
+v0.0.7-rc.1, together with the frozen v0.0.4
 artifact compatibility profile recorded by
 [MIP-1004](./mips/mip-1004-resolve-prooflist-artifact-schema.md).
 

--- a/docs/policy/README.md
+++ b/docs/policy/README.md
@@ -5,6 +5,7 @@ This folder collects implementation-bound policy and release documents.
 - [Threat model](./threat-model.md)
 - [Compatibility policy](./compatibility.md)
 - [Release process](./releasing.md)
+- [v0.0.7-rc.1 release notes and checklist](../releases/v0.0.7.md)
 - [v0.0.6 release notes and checklist](../releases/v0.0.6.md)
 - [v0.0.5 release notes and checklist](../releases/v0.0.5.md)
 - [v0.0.4 release notes and checklist](../releases/v0.0.4.md)

--- a/docs/policy/compatibility.md
+++ b/docs/policy/compatibility.md
@@ -10,14 +10,15 @@ profiles rejected.
 | Root `malt` typed facade | Experimental |
 | `malt.resolve/v0alpha1` | Profiled; incompatible wire revisions require a new profile |
 | `malt.read/v0alpha1` | Profiled; incompatible wire revisions require a new profile |
-| `malt.update-view/v1` | Experimental post-v0.0.6 complete semantic closure |
+| `malt.map-proof/v0alpha1` | Experimental in v0.0.7-rc.1; exact Map membership and non-membership |
+| `malt.update-view/v1` | Experimental in v0.0.7-rc.1; complete semantic closure |
 | `stateful-complete-vectors-v1` | Experimental state profile required by the current update-view contract |
-| `malt.semantic-intent/v1` | Experimental post-v0.0.6 output-free update intent |
-| `malt.client-root-bundle/v1` | Experimental post-v0.0.6 exact-root submission; not a transition proof |
-| `malt.client-root-materialization/v1` | Experimental root-bound map proof-serving witness; not a transition proof |
+| `malt.semantic-intent/v1` | Experimental in v0.0.7-rc.1; output-free update intent |
+| `malt.client-root-bundle/v1` | Experimental in v0.0.7-rc.1; exact-root submission, not a transition proof |
+| `malt.client-root-materialization/v1` | Experimental in v0.0.7-rc.1; root-bound Map proof-serving witness, not a transition proof |
 | `malt.writer-compute-result/v1` | Legacy browser-local bundle and next-view result; decode compatibility only |
-| `malt.writer-compute-result/v2` | Experimental browser-local bundle, map materialization, and next-view result |
-| `malt.materialization-receipt/v1` | Experimental post-v0.0.6 exact-bundle durability acknowledgement |
+| `malt.writer-compute-result/v2` | Experimental in v0.0.7-rc.1; browser-local bundle, Map materialization, and next-view result |
+| `malt.materialization-receipt/v1` | Experimental in v0.0.7-rc.1; exact-bundle durability acknowledgement |
 | ProofList JSON and proof semantics | Experimental, verifier-facing |
 | Typed MALT root CIDs/codecs | Experimental, verifier-facing |
 | `SegmentPath` projection | `/`-joined UTF-8 segments; experimental |
@@ -34,8 +35,8 @@ than extending that union.
 
 The `/v1` suffixes on the client-root profiles version those serialized
 contracts. They do not mean that MALT, the Go module, or the source APIs have
-reached a stable v1 release. The profiles are present on post-v0.0.6 `main` and
-are not part of the immutable v0.0.6 tag.
+reached a stable v1 release. These experimental profiles are included in
+v0.0.7-rc.1 and are not part of the immutable v0.0.6 tag.
 
 ## Pre-v1 changes
 
@@ -50,7 +51,18 @@ documentation in the same PR:
 - mutation, client-root, or receipt value semantics;
 - payload-binding and measured-list evidence.
 
-Typed-root constructors emit the current registered `MALTVersionID=3`.
+The root-codec compatibility boundaries are intentionally explicit:
+
+- v0.0.6 emitted flat experimental codecs `0x300001` through `0x300004`.
+  The structured decoder does not accept those roots. No migration layer is
+  provided in this pre-v1 release; recreate experimental roots and their
+  materialized proof-serving state.
+- Structured version-2 codecs (`0x302...`) were introduced on `main` after
+  v0.0.6. They are not v0.0.6 roots and remain readable and verifiable.
+- Current constructors emit structured version-3 codecs (`0x303...`) in the
+  project private-use `0x30VSBB` layout.
+
+Typed-root constructors emit `MALTVersionID=3`.
 Decoders explicitly retain v2 typed roots for read/proof compatibility and
 reject every other unknown version, semantic ID, backend suite ID, and
 combination; there is no heuristic fallback mapping.
@@ -65,6 +77,13 @@ version to match the semantics instance. The client writer handles v2 updates
 by exactly replaying the complete v2 view, fully rebuilding it as v3, and
 applying changes only to that v3 working root; direct partial v2-to-v3 mutation
 is rejected so unchanged v2 child CIDs cannot leak into a v3 root.
+
+Map non-membership proves only the absence of one exact keyed relation in a
+Map. It does not prove List-index, graph-path, object, payload-byte, or remote
+data absence, and ordinary `Read` retains its `ErrQueryNotFound` behavior.
+There is no List non-membership API. Empty-slot and conflicting-leaf absence
+work for compatible roots; collision-bucket non-membership requires the
+version-3 fixed-domain bucket profile.
 
 v0.0.6 intentionally removes application and deployment packages from this
 module. Consumers of the former CLI/daemon/UnixFS/server/storage packages must

--- a/docs/policy/releasing.md
+++ b/docs/policy/releasing.md
@@ -10,9 +10,11 @@ Run from the repository root:
 git diff --check
 test -z "$(gofmt -l $(find . -name '*.go' -not -path './vendor/*'))"
 go test ./...
+GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa
+sh scripts/test-verifier-wasm-vectors.sh
+scripts/test-writer-wasm.sh
 go vet ./...
 go build -buildvcs=false ./...
-scripts/build-verifier-wasm.sh dist/verifier
 ```
 
 Also compile a temporary external Go module against the candidate tag or

--- a/docs/policy/releasing.md
+++ b/docs/policy/releasing.md
@@ -6,8 +6,16 @@ MALT core uses source tags for experimental releases.
 
 Run from the repository root:
 
+Set `MALT_RELEASE_BASE` to the previous authoritative source tag. For
+v0.0.7-rc.1, that tag is `v0.0.6`.
+
 ```bash
-git diff --check
+set -euo pipefail
+MALT_RELEASE_BASE=v0.0.6
+git fetch --prune --tags origin
+git rev-parse --verify "${MALT_RELEASE_BASE}^{commit}"
+git merge-base --is-ancestor "$MALT_RELEASE_BASE" HEAD
+git diff --check "${MALT_RELEASE_BASE}...HEAD"
 test -z "$(gofmt -l $(find . -name '*.go' -not -path './vendor/*'))"
 go test ./...
 GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa

--- a/docs/policy/threat-model.md
+++ b/docs/policy/threat-model.md
@@ -8,7 +8,8 @@ freshness.
 
 - an accepted root selected by client/application policy;
 - verifier code and cryptographic parameters;
-- the exact resolve/read request independently constructed by the client;
+- the exact operation request independently constructed or checked by the
+  client, including the canonical key for a Map-proof request;
 - application policy deciding which root is authorized and current.
 
 ## Untrusted components
@@ -16,8 +17,14 @@ freshness.
 - gateways, executors, and remote diagnostic verifiers;
 - ArcTable/materializer implementations and caches;
 - CAS/object-store responses;
-- network transport and serialized results;
-- candidate roots and mutation receipts returned by a service.
+- network transport, serialized results, result presence/target fields, and
+  ProofLists;
+- any root, key, or request envelope selected or echoed by an untrusted service
+  unless independently matched to client policy;
+- service-supplied complete UpdateViews and imported Map materialization before
+  local validation;
+- candidate roots and mutation or materialization receipts returned by a
+  service.
 
 These components may affect latency and availability. They must not cause a
 correct local verifier to accept the wrong result for the trusted request.
@@ -29,8 +36,11 @@ For a trusted root and request, MALT aims to provide:
 - typed map/list relation integrity;
 - complete root-to-target resolve binding;
 - primitive map/list read binding;
+- exact keyed Map membership or non-membership binding, including consistency
+  between the presence state, optional target, and proof-step kind;
 - ordered ProofList and commitment-proof verification;
-- rejection of cross-root, cross-query, cross-kind, or reordered evidence;
+- rejection of cross-root, cross-key, cross-query, cross-kind, presence-state,
+  target, or reordered evidence;
 - payload CID authentication.
 
 Payload CID authentication does not hash arbitrary returned response bytes.
@@ -47,7 +57,9 @@ Core does not guarantee:
 - payload availability, durability, confidentiality, or access control;
 - tenant isolation, quotas, pinning, GC, or deployment security;
 - ArcTable/KV consistency;
-- stable pre-v1 source or wire compatibility.
+- stable pre-v1 source or wire compatibility;
+- List-index, graph-path, object, payload-byte, or remote-data absence inferred
+  from a Map non-membership proof.
 
 ## Attack cases
 
@@ -56,6 +68,19 @@ Core does not guarantee:
 The verifier binds the returned target, ProofList root/query, ordered step
 continuity, operation kind, and caller request. A valid proof for another root,
 query, primitive read, or target must be rejected.
+
+### Map-proof request relabeling
+
+For Map-proof verification, the accepted root and exact canonical key are
+trusted inputs chosen independently by the caller. `present`, the optional
+target, and the ProofList are untrusted. `VerifyMapProof` binds those returned
+values and the cryptographic evidence to the caller's root and key. Relabeling
+valid evidence to another root or key, toggling the presence state, or
+attaching a target to an absence result must be rejected.
+
+Passing a gateway-authored request/result envelope to a local verifier without
+first matching its request to the client's accepted root and intended key does
+not authenticate the relation the client intended to query.
 
 ### Fabricated materializer state
 
@@ -92,3 +117,12 @@ preference policy; this is not a proof-soundness requirement.
 A mutation receipt is operational evidence, not a transition proof. Clients
 must not automatically promote a gateway-returned root solely because the
 receipt names it.
+
+### Client-root bundle and receipt
+
+The client-root surface included in v0.0.7-rc.1 is experimental. Local
+computation derives an exact candidate from a validated complete view and
+normalized intent, while receipt acceptance may advance only the local writer
+session defined by that contract. A bundle or receipt is not a portable
+state-transition, publication, freshness, authorization, or trust proof and
+does not promote an application's accepted root.

--- a/docs/releases/v0.0.7.md
+++ b/docs/releases/v0.0.7.md
@@ -1,0 +1,142 @@
+# MALT v0.0.7-rc.1
+
+Release date: 2026-07-31
+
+This is a prerelease for integration and verifier testing. MALT remains pre-v1,
+experimental, and not production-ready.
+
+## Release Contract
+
+The source tag is the authoritative release artifact. This candidate publishes:
+
+- the Go module at `github.com/dewebprotocol/malt`;
+- structured typed MALT roots in the private-use `0x30VSBB` codec layout;
+- the `malt.resolve/v0alpha1`, `malt.read/v0alpha1`, and
+  `malt.map-proof/v0alpha1` verification profiles;
+- the experimental client-root profiles documented in
+  [Client-Root Contract](../spec/client-root-contract.md);
+- the frozen Resolve/Read conformance corpus v1 for structured version-2 roots;
+  and
+- the current Resolve/Read conformance corpus v2 for version-3 roots.
+
+`MALTVersionID=3` is a wire-format version, not the source release version.
+
+## Highlights
+
+### Structured typed roots: `0x30VSBB`
+
+Typed MALT root codecs now use the project private-use `0x30VSBB` layout, where
+`V` identifies the wire version, `S` the semantic kind, and `BB` the commitment
+backend suite. New constructors emit these version-3 codecs:
+
+| Semantic kind | KZG | IPA |
+| --- | --- | --- |
+| Map | `0x303101` | `0x303102` |
+| List | `0x303201` | `0x303202` |
+
+Decoders fail closed on unknown versions, semantics, backend suites,
+combinations, identity-hash sizes, and mixed-profile children. Structured
+version-2 roots remain readable and verifiable, but default constructors do not
+emit them.
+
+### 4096-slot KZG semantic geometry
+
+KZG Map and List nodes now use all 4096 commitment positions. KZG Maps consume
+SHA-256 keys as 12-bit radix digits. KZG Lists reserve position zero for
+authenticated metadata and expose 4095 content positions. IPA remains a
+256-position suite, using 8-bit Map digits and 255 List content positions.
+
+The same backend-sized geometry is used by semantic producers,
+materialization, and portable verification.
+
+### Verifiable Map non-membership
+
+The new Map-proof contract verifies both membership and non-membership for KZG
+and IPA roots. An exact absent keyed relation can be authenticated by:
+
+- a proved empty radix slot;
+- a conflicting terminal leaf; or
+- a complete fixed-domain collision bucket.
+
+Version-3 collision buckets authenticate their empty tail positions, enabling
+sound collision-bucket non-membership. The release adds `MapProofRequest`,
+`MapProofResult`, `MapProver`, `VerifyMapProof`, the
+`malt.map-proof/v0alpha1` schemas, the terminal ProofList step
+`map_absence`, and the matching Go SDK and browser/WASM verification boundary.
+
+## Other Changes
+
+- Add deterministic Resolve/Read conformance corpora for KZG and IPA.
+- Add complete-view client-root values, `sdk/writer`, exact candidate-root
+  bundles, root-bound Map materialization witnesses, and receipt-gated writer
+  sessions.
+- Add a unified browser writer WASM with isolated KZG and IPA workers.
+- Add request-scoped read and writer observations for diagnostics.
+- Narrow materializer and graph-writer dependencies to the capabilities used by
+  each algorithm.
+- Rebuild a verified structured-version-2 complete view as version 3 before
+  applying client-side changes.
+- Reject incomplete List materialization, noncanonical Map-proof coordinates,
+  target relabeling, invalid UTF-8, stale intents, mismatched receipts, and
+  mixed backend/version materialization.
+- Remove `radix.ProveTimings`, `(*radix.Map).ProveWithTimings`, the obsolete
+  process-global `logger` package, the former `graph/querypath` helper, and the
+  unused `zap` and `multierr` dependencies.
+
+## Compatibility
+
+This is an intentional pre-v1 source- and wire-breaking release candidate.
+
+v0.0.6 emitted the flat experimental codecs `0x300001` through `0x300004`.
+The current decoder intentionally does not classify those roots as structured
+MALT roots. This release does not provide a flat-root migration layer;
+experimental roots and their materialized proof-serving state should be
+recreated.
+
+Structured version-2 roots (`0x302...`) were introduced on `main` after
+v0.0.6 and are not v0.0.6 roots. They remain available for read, proof, and
+exact complete-view replay. New constructors emit version 3, and
+collision-bucket non-membership requires the version-3 fixed-domain bucket
+profile.
+
+Removed Go APIs have no forwarding compatibility shims. The `/v1` suffixes on
+client-root profiles version serialized experimental profiles; they do not
+declare MALT or its Go APIs stable at v1.
+
+## Known Limits
+
+- Non-membership proves only whether one exact keyed relation is absent from a
+  Map. It does not prove List-index, graph-path, object, payload-byte, or remote
+  data absence.
+- Ordinary `Read` keeps its existing missing-key result,
+  `ErrQueryNotFound`; there is no corresponding List non-membership API.
+- Collision-bucket non-membership is available only for version-3 fixed-domain
+  buckets.
+- The browser/WASM verifier is the same Go verifier compiled for WebAssembly,
+  not an independent cryptographic implementation.
+- Client-root bundles and materialization receipts are not portable
+  state-transition, publication, freshness, or trust proofs.
+
+## Release Validation
+
+The release candidate gate includes:
+
+```bash
+git diff --check
+test -z "$(gofmt -l $(find . -name '*.go' -not -path './vendor/*'))"
+go test ./...
+GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa
+sh scripts/test-verifier-wasm-vectors.sh
+scripts/test-writer-wasm.sh
+go vet ./...
+go build -buildvcs=false ./...
+```
+
+The verifier WASM gate runs 49 current Resolve/Read vectors plus 8 runtime-
+generated Map non-membership smoke vectors with both backends enabled, and 25
+Resolve/Read plus 4 Map-proof vectors in each backend-selected verifier run.
+The Map-proof cases cover acceptance, proof tampering, cross-root relabeling,
+and a wrong caller-selected key for both KZG and IPA.
+
+Before tagging, compile a temporary external module against the candidate and
+record the exact tagged commit and final CI result in the GitHub prerelease.

--- a/docs/releases/v0.0.7.md
+++ b/docs/releases/v0.0.7.md
@@ -122,7 +122,11 @@ declare MALT or its Go APIs stable at v1.
 The release candidate gate includes:
 
 ```bash
-git diff --check
+set -euo pipefail
+git fetch --prune --tags origin
+git rev-parse --verify 'v0.0.6^{commit}'
+git merge-base --is-ancestor v0.0.6 HEAD
+git diff --check v0.0.6...HEAD
 test -z "$(gofmt -l $(find . -name '*.go' -not -path './vendor/*'))"
 go test ./...
 GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -12,11 +12,12 @@ behavior, wire formats, and proof semantics in this folder.
 
 The current transport-neutral proof-bearing contracts are
 `malt.resolve/v0alpha1`, `malt.read/v0alpha1`, and
-`malt.map-proof/v0alpha1`. The post-release client-root
+`malt.map-proof/v0alpha1`. The experimental client-root
 contracts are `malt.update-view/v1`, `malt.semantic-intent/v1`,
 `malt.client-root-bundle/v1`, `malt.client-root-materialization/v1`,
 `malt.writer-compute-result/v2`, and `malt.materialization-receipt/v1`. The
-v0.0.4 `malt.artifact/v0alpha2` profile
+client-root contracts are included in v0.0.7-rc.1. The v0.0.4
+`malt.artifact/v0alpha2` profile
 remains frozen for compatibility. See [MIP-1012](../mips/mip-1012-segment-path-resolution.md) and
 [MIP-1013](../mips/mip-1013-client-gateway-core-boundary.md).
 

--- a/docs/spec/client-root-contract.md
+++ b/docs/spec/client-root-contract.md
@@ -7,10 +7,10 @@ state-transition proof.
 
 ## Status
 
-This is an experimental post-v0.0.6 contract on `main`; it is not part of the
-immutable v0.0.6 release and has not yet been published as v0.0.7. The `/v1`
-suffixes below version the serialized profiles. They do not declare MALT or its
-Go source APIs stable at v1.
+This contract is included in v0.0.7-rc.1 as an experimental pre-v1 surface.
+The `/v1` suffixes below version serialized profiles; they do not declare
+MALT or its Go source APIs stable at v1. Client-root bundles and receipts
+retain the explicit non-claims defined below.
 
 ## Profiles And Schemas
 

--- a/docs/spec/resolve-read-conformance-v1.md
+++ b/docs/spec/resolve-read-conformance-v1.md
@@ -12,12 +12,13 @@ Gateway, native client, browser/WASM, and future language SDK tests consume the
 same checked-in bytes; they do not redefine proof semantics or maintain edited
 copies.
 
-The corpus version is `malt.resolve-read.conformance/v1`. It is independent of
-the two enclosed operation profiles and of the typed-root `MALTVersionID=2`.
-This corpus shipped with v0.0.6 and is immutable: a vector ID, its input, and
-its expected verdict cannot change. Later behavioral or encoding changes use a
-new corpus version. Error strings, timing, and implementation-specific
-exception types are not conformance outputs.
+The corpus version is `malt.resolve-read.conformance/v1`. It is independent
+of the enclosed operation profiles and uses structured typed-root
+`MALTVersionID=2`. It was introduced on `main` after v0.0.6 and did not
+ship with that tag. It is now frozen as the structured-version-2 corpus: a
+vector ID, its input, and its expected verdict cannot change. v0.0.7-rc.1
+publishes the v2 corpus as the current version. Error strings, timing, and
+implementation-specific exception types are not conformance outputs.
 
 ## File And Envelope
 

--- a/docs/spec/resolve-read-conformance-v2.md
+++ b/docs/spec/resolve-read-conformance-v2.md
@@ -14,12 +14,11 @@ copies.
 
 The corpus version is `malt.resolve-read.conformance/v2`. It is independent of
 the two enclosed operation profiles and of typed-root `MALTVersionID=3`; the
-verifier separately retains explicit v2 typed-root compatibility. Before this
-corpus is released, an intentional encoding change may regenerate it as part
-of the same reviewed change. After release, a vector ID, its input, and its
-expected verdict are immutable; later changes require v3. Error strings,
-timing, and implementation-specific exception types are not conformance
-outputs.
+verifier separately retains explicit v2 typed-root compatibility. This corpus
+is first released with v0.0.7-rc.1. From that tag, a vector ID, its input, and
+its expected verdict are immutable; later behavioral or encoding changes
+require a new corpus version. Error strings, timing, and
+implementation-specific exception types are not conformance outputs.
 
 ## File And Envelope
 

--- a/scripts/run-verifier-wasm-vectors.mjs
+++ b/scripts/run-verifier-wasm-vectors.mjs
@@ -2,10 +2,11 @@ import { webcrypto } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
-const [wasmPath, wasmExecPath, corpusPath, selectedBackend = "all"] = process.argv.slice(2);
+const [wasmPath, wasmExecPath, corpusPath, selectedBackend = "all", mapProofFixturePath] =
+  process.argv.slice(2);
 if (!wasmPath || !wasmExecPath || !corpusPath) {
   console.error(
-    "usage: node run-verifier-wasm-vectors.mjs <verifier.wasm> <wasm_exec.js> <vectors.json> [all|kzg|ipa]",
+    "usage: node run-verifier-wasm-vectors.mjs <verifier.wasm> <wasm_exec.js> <vectors.json> [all|kzg|ipa] [map-proof-fixtures.json]",
   );
   process.exit(2);
 }
@@ -26,6 +27,12 @@ const corpus = JSON.parse(await readFile(corpusPath, "utf8"));
 if (!Array.isArray(corpus.vectors) || corpus.vectors.length === 0) {
   throw new Error(`${corpusPath} does not contain a non-empty vectors array`);
 }
+const mapProofFixtures = mapProofFixturePath
+  ? JSON.parse(await readFile(mapProofFixturePath, "utf8"))
+  : { vectors: [] };
+if (!Array.isArray(mapProofFixtures.vectors)) {
+  throw new Error(`${mapProofFixturePath} does not contain a vectors array`);
+}
 
 globalThis.maltVerifierBackend = selectedBackend;
 const go = new globalThis.Go();
@@ -42,10 +49,11 @@ if (invalidMapProof.valid !== false || invalidMapProof.profile !== "malt.map-pro
   throw new Error("maltVerifyMapProof did not fail closed on an invalid verification envelope");
 }
 
+const allVectors = [...corpus.vectors, ...mapProofFixtures.vectors];
 const vectors =
   selectedBackend === "all"
-    ? corpus.vectors
-    : corpus.vectors.filter(
+    ? allVectors
+    : allVectors.filter(
         (vector) => vector.backend === selectedBackend || vector.backend === "none",
       );
 const seen = new Set();
@@ -71,14 +79,17 @@ for (const vector of vectors) {
 }
 
 if (failures.length > 0) {
-  console.error(`WASM ${selectedBackend} conformance failed (${failures.length}/${vectors.length}):`);
+  console.error(`WASM ${selectedBackend} verification failed (${failures.length}/${vectors.length}):`);
   for (const failure of failures) {
     console.error(`- ${failure}`);
   }
   process.exit(1);
 }
 
-console.log(`WASM ${selectedBackend} conformance passed (${vectors.length} vectors)`);
+const mapProofCount = vectors.filter((vector) => vector.operation === "map_proof").length;
+console.log(
+  `WASM ${selectedBackend} verification passed (${vectors.length - mapProofCount} Resolve/Read conformance vectors; ${mapProofCount} Map-proof smoke vectors)`,
+);
 process.exit(0);
 
 function selectVerifier(operation) {
@@ -87,6 +98,8 @@ function selectVerifier(operation) {
       return globalThis.maltVerifyResolve;
     case "read":
       return globalThis.maltVerifyRead;
+    case "map_proof":
+      return globalThis.maltVerifyMapProof;
     default:
       throw new Error(`unsupported operation ${JSON.stringify(operation)}`);
   }

--- a/scripts/test-verifier-wasm-vectors.sh
+++ b/scripts/test-verifier-wasm-vectors.sh
@@ -6,17 +6,28 @@ work_dir=$(mktemp -d "${TMPDIR:-/tmp}/malt-wasm-vectors.XXXXXX")
 trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
 
 sh "$repo_root/scripts/build-verifier-wasm.sh" "$work_dir/verifier"
+(
+  cd "$repo_root"
+  MALT_VERIFIER_WASM_MAP_PROOF_FIXTURE_OUT="$work_dir/map-proof-fixtures.json" \
+    go test ./cmd/malt-verifier-wasm \
+    -run '^TestGenerateMapProofWASMFixtures$' \
+    -count=1
+)
 node "$repo_root/scripts/run-verifier-wasm-vectors.mjs" \
   "$work_dir/verifier/malt-verifier.wasm" \
   "$work_dir/verifier/wasm_exec.js" \
-  "$repo_root/conformance/resolve-read/v1/vectors.json"
+  "$repo_root/conformance/resolve-read/v2/vectors.json" \
+  all \
+  "$work_dir/map-proof-fixtures.json"
 node "$repo_root/scripts/run-verifier-wasm-vectors.mjs" \
   "$work_dir/verifier/malt-verifier.wasm" \
   "$work_dir/verifier/wasm_exec.js" \
-  "$repo_root/conformance/resolve-read/v1/vectors.json" \
-  kzg
+  "$repo_root/conformance/resolve-read/v2/vectors.json" \
+  kzg \
+  "$work_dir/map-proof-fixtures.json"
 node "$repo_root/scripts/run-verifier-wasm-vectors.mjs" \
   "$work_dir/verifier/malt-verifier.wasm" \
   "$work_dir/verifier/wasm_exec.js" \
-  "$repo_root/conformance/resolve-read/v1/vectors.json" \
-  ipa
+  "$repo_root/conformance/resolve-read/v2/vectors.json" \
+  ipa \
+  "$work_dir/map-proof-fixtures.json"


### PR DESCRIPTION
## Summary

- freeze the v0.0.7-rc.1 changelog, release notes, compatibility policy, conformance history, security status, and release gate around three headline changes: private-use `0x30VSBB` typed roots, 4096-slot KZG semantic geometry, and verifiable Map non-membership
- document the intentional pre-v1 boundary between v0.0.6 flat roots, post-v0.0.6 structured v2 roots, and current structured v3 roots without introducing a migration layer
- add runtime-generated, root-bound Map absence fixtures for KZG and IPA to the browser/WASM verifier gate, covering acceptance, proof tampering, cross-root relabeling, and a wrong caller-selected key
- run the verifier gate against the current Resolve/Read v2 corpus in all-backend and backend-selected KZG/IPA modes

## Review follow-up

- freeze the released v2 corpus bytes with SHA-256 `f96aad71c4b60a3073f823bb2aa0b05307f18400630e1920ad25889beb4600d5`
- update architecture and threat-model boundaries for caller-selected Map-proof root/key, untrusted presence/target/ProofList values, Go/WASM verification, exact Map-only absence, and experimental client-root non-claims
- make release whitespace checks cover committed ranges, fail closed, and add event-aware PR/main-push coverage to CI

## Verification

- `git diff --check v0.0.6...HEAD`
- `git diff --check 012bd924e57f950207d72036ec0119b350e2db73...HEAD`
- full-tree `gofmt -l`
- `go test ./...`
- v1/v2 immutable corpus digest tests
- `GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa`
- `sh scripts/test-verifier-wasm-vectors.sh`
  - all: 49 Resolve/Read + 8 Map-proof
  - KZG: 25 Resolve/Read + 4 Map-proof
  - IPA: 25 Resolve/Read + 4 Map-proof
- `scripts/test-writer-wasm.sh`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- workflow YAML parse and local PR/push whitespace-path simulations
- temporary external consumer compile
- relative Markdown link check
- independent read-only reviews after each fix cycle; final pass reported no actionable findings

## Release follow-up

This PR does not create a tag or GitHub Release. After merge, wait for the exact new `main` SHA to pass CI, perform downstream exact-tag checks, then tag that validated SHA as `v0.0.7-rc.1` and create a prerelease.