### PR TITLE
Prepare v0.0.7-rc.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.7-rc.2] - 2026-08-10
+
 This release-candidate delta completes the browser Verifier/Writer separation
 introduced in v0.0.7-rc.1.
 
@@ -16,8 +18,11 @@ introduced in v0.0.7-rc.1.
 - Add verifier-only IPA initialization without committer fixed-base tables.
 - Export the canonical IPA parameter-set identifier and digest for release
   provenance.
+- Add `malt.web-writer.provenance/v3` for split Writer artifacts and the Core
+  invariants of one runtime per controller and exact backend/profile targeting.
 - Add reproducible, content-addressed Verifier and Writer WASM release bundles
-  whose filenames and served paths include the full asset-set manifest digest.
+  whose filenames bind the full asset-set and archive digests and whose served
+  paths include the full asset-set manifest digest.
 
 ### Changed
 
@@ -27,6 +32,8 @@ introduced in v0.0.7-rc.1.
   idle fatal failures observable.
 - Pin the audited `go-ipa` source snapshot inside MALT so verifier and committer
   profiles are built from one reviewable implementation.
+- Canonicalize and validate gzip/ustar release archives, provenance, checksums,
+  member metadata, padding, and end blocks before publication.
 
 ### Compatibility
 
@@ -34,6 +41,8 @@ introduced in v0.0.7-rc.1.
   ProofLists, receipts, or proof encodings.
 - Browser integrations built against v0.0.7-rc.1 must adopt the split writer
   filenames and `createMaltWriterWorker` controller API.
+- Writer asset consumers must validate `malt.web-writer.provenance/v3`; device
+  selection and profile retry order remain host policy.
 - Unversioned WASM URLs are not immutable release identities. Consumers should
   load one complete digest-addressed asset set and reload when the application
   entrypoint selects a new digest.
@@ -264,7 +273,8 @@ for the trusted CLI/daemon and UnixFS application, and
 - KZG verification rejects out-of-range proof indices and non-canonical proof
   lengths instead of allowing malformed input to panic or reuse a commitment.
 
-[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.1...HEAD
+[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.2...HEAD
+[0.0.7-rc.2]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.1...v0.0.7-rc.2
 [0.0.7-rc.1]: https://github.com/DeWebProtocol/malt/compare/v0.0.6...v0.0.7-rc.1
 [0.0.6]: https://github.com/DeWebProtocol/malt/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/DeWebProtocol/malt/compare/v0.0.4...v0.0.5

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ line client, daemon, UnixFS model, or website.
 [Client-root contract](./docs/spec/client-root-contract.md) ·
 [ProofList](./docs/spec/prooflist-format.md) ·
 [Compatibility](./docs/policy/compatibility.md) ·
-[v0.0.7-rc.1 release candidate](./docs/releases/v0.0.7.md) · [Roadmap](./ROADMAP.md)
+[v0.0.7-rc.2 release candidate](./docs/releases/v0.0.7.md) · [Roadmap](./ROADMAP.md)
 
-`v0.0.7-rc.1` is the current release candidate. Its Map-proof and client-root
-profiles remain experimental; `/v1` profile suffixes do not declare MALT or
-its Go APIs stable at v1.
+`v0.0.7-rc.2` is the current release candidate. It completes the browser
+Verifier/Writer split and content-addressed WASM delivery while preserving the
+experimental Map-proof and client-root profiles introduced in rc.1. `/v1`
+profile suffixes do not declare MALT or its Go APIs stable at v1.
 
 ## Boundary
 
@@ -91,7 +92,7 @@ conformance tests and examples, not deployment.
 ## Install
 
 ```bash
-go get github.com/dewebprotocol/malt@v0.0.7-rc.1
+go get github.com/dewebprotocol/malt@v0.0.7-rc.2
 ```
 
 ### Verify a resolve result

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,13 +13,14 @@ untrusted caller-supplied evidence.
 | Version | Security support |
 | --- | --- |
 | `main` | Best-effort review of current integration code |
-| `v0.0.7-rc.1` | Current experimental release candidate |
+| `v0.0.7-rc.2` | Current experimental release candidate |
+| `v0.0.7-rc.1` | Previous experimental release candidate |
 | `v0.0.6` | Previous non-prerelease experimental source release |
 | `v0.0.5` and earlier | Not supported |
 
 MALT remains pre-`v1.0.0` and experimental. Security fixes may require
 breaking API, proof, root, or wire-format changes. Consumers evaluating the
-current typed-root and Map-proof contracts should pin `v0.0.7-rc.1` rather
+current typed-root and Map-proof contracts should pin `v0.0.7-rc.2` rather
 than depend on `main`. Consumers remaining on v0.0.6 must not assume its flat
 roots are wire-compatible with this release candidate.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ research narrative remain in `DeWebProtocol/documents`.
 - [Threat model](./policy/threat-model.md)
 - [Compatibility policy](./policy/compatibility.md)
 - [Release process](./policy/releasing.md)
-- [v0.0.7-rc.1 release notes](./releases/v0.0.7.md)
+- [v0.0.7-rc.2 release notes](./releases/v0.0.7.md)
 - [v0.0.6 release notes](./releases/v0.0.6.md)
 - [v0.0.5 release notes](./releases/v0.0.5.md)
 - [v0.0.4 release notes](./releases/v0.0.4.md)

--- a/docs/policy/README.md
+++ b/docs/policy/README.md
@@ -6,7 +6,7 @@ This folder collects implementation-bound policy and release documents.
 - [Compatibility policy](./compatibility.md)
 - [Release process](./releasing.md)
 - [WASM release assets](./wasm-release-assets.md)
-- [v0.0.7-rc.1 release notes and checklist](../releases/v0.0.7.md)
+- [v0.0.7-rc.2 release notes and checklist](../releases/v0.0.7.md)
 - [v0.0.6 release notes and checklist](../releases/v0.0.6.md)
 - [v0.0.5 release notes and checklist](../releases/v0.0.5.md)
 - [v0.0.4 release notes and checklist](../releases/v0.0.4.md)

--- a/docs/policy/releasing.md
+++ b/docs/policy/releasing.md
@@ -7,11 +7,11 @@ MALT core uses source tags for experimental releases.
 Run from the repository root:
 
 Set `MALT_RELEASE_BASE` to the previous authoritative source tag. For
-v0.0.7-rc.1, that tag is `v0.0.6`.
+v0.0.7-rc.2, that tag is `v0.0.7-rc.1`.
 
 ```bash
 set -euo pipefail
-MALT_RELEASE_BASE=v0.0.6
+MALT_RELEASE_BASE=v0.0.7-rc.1
 git fetch --prune --tags origin
 git rev-parse --verify "${MALT_RELEASE_BASE}^{commit}"
 git merge-base --is-ancestor "$MALT_RELEASE_BASE" HEAD

--- a/docs/policy/wasm-release-assets.md
+++ b/docs/policy/wasm-release-assets.md
@@ -49,9 +49,11 @@ entrypoint must reload before starting another verifier or writer runtime.
 Each set binds the exact MALT version and commit, Go version and toolchain,
 build target and flags, and file checksums. Writer provenance additionally
 binds build tags, IPA committer profiles, IPA parameter identity, retained
-table metadata, and Worker fallback policy. Consumers validate these semantic
-fields as well as `SHA256SUMS`; a checksum file that was regenerated alongside
-tampered metadata is not sufficient provenance.
+table metadata, and the Core runtime invariants of one runtime per controller
+and exact backend/profile targeting. Device selection and retrying another
+profile are host policies and are not asserted by Core provenance. Consumers
+validate these semantic fields as well as `SHA256SUMS`; a checksum file that
+was regenerated alongside tampered metadata is not sufficient provenance.
 
 Build and validate both release bundles from a clean checkout:
 

--- a/docs/releases/v0.0.7.md
+++ b/docs/releases/v0.0.7.md
@@ -1,6 +1,6 @@
-# MALT v0.0.7-rc.1
+# MALT v0.0.7-rc.2
 
-Release date: 2026-07-31
+Release date: 2026-08-10
 
 This is a prerelease for integration and verifier testing. MALT remains pre-v1,
 experimental, and not production-ready.
@@ -17,11 +17,56 @@ The source tag is the authoritative release artifact. This candidate publishes:
   [Client-Root Contract](../spec/client-root-contract.md);
 - the frozen Resolve/Read conformance corpus v1 for structured version-2 roots;
   and
-- the current Resolve/Read conformance corpus v2 for version-3 roots.
+- the frozen Resolve/Read conformance corpus v2 for version-3 roots; and
+- reproducible, content-addressed browser Verifier and Writer asset sets.
+
+Split Writer assets use `malt.web-writer.provenance/v3`, which binds their
+profiles and Core-enforced runtime invariants without asserting host device
+selection or retry policy.
 
 `MALTVersionID=3` is a wire-format version, not the source release version.
 
-## Highlights
+## Changes Since v0.0.7-rc.1
+
+### Separate Verifier and Writer runtimes
+
+The browser Verifier no longer initializes Writer-only commitment state or IPA
+fixed-base committer tables. Writer functionality is published as one KZG
+module and three IPA modules using the `direct`, `compact`, and `fast`
+committer profiles. Applications can load the Verifier independently and
+initialize a Writer only when local mutation is required.
+
+All IPA profiles preserve the same parameter set, commitments, typed roots,
+transcripts, proofs, and wire formats. Profile selection never changes an IPA
+operation into KZG.
+
+### Hardened Writer lifecycle
+
+The browser Writer controller now provides lazy backend/profile
+initialization, cancellation-safe startup, explicit single-runtime ownership,
+exact backend/profile targeting, observable idle Worker failures, and
+fail-closed retirement of fatal runtimes. Failed stateful operations are not
+automatically replayed against a replacement runtime. Selecting a profile from
+device signals or retrying another profile remains host policy.
+
+### Content-addressed WASM delivery
+
+Verifier and Writer files are published as coordinated asset sets. Each set is
+identified by the full SHA-256 digest of its exact `SHA256SUMS` bytes. Release
+archive filenames bind both the extracted asset-set digest and the exact
+compressed archive digest:
+
+```text
+malt-verifier-v0.0.7-rc.2-<asset-set-sha256>-<archive-sha256>.tar.gz
+malt-writer-v0.0.7-rc.2-<asset-set-sha256>-<archive-sha256>.tar.gz
+```
+
+Only complete digest paths are immutable. Consumers must load every file in a
+runtime from one asset set, must not mix digests, and must reload when the
+application entrypoint selects a new digest. The full contract is documented
+in [WASM Release Assets](../policy/wasm-release-assets.md).
+
+## Protocol Baseline From v0.0.7-rc.1
 
 ### Structured typed roots: `0x30VSBB`
 
@@ -64,13 +109,14 @@ sound collision-bucket non-membership. The release adds `MapProofRequest`,
 `malt.map-proof/v0alpha1` schemas, the terminal ProofList step
 `map_absence`, and the matching Go SDK and browser/WASM verification boundary.
 
-## Other Changes
+## Other Protocol and SDK Changes
 
 - Add deterministic Resolve/Read conformance corpora for KZG and IPA.
 - Add complete-view client-root values, `sdk/writer`, exact candidate-root
   bundles, root-bound Map materialization witnesses, and receipt-gated writer
   sessions.
-- Add a unified browser writer WASM with isolated KZG and IPA workers.
+- Add the browser Writer boundary that rc.2 now publishes as separate KZG and
+  IPA profile modules.
 - Add request-scoped read and writer observations for diagnostics.
 - Narrow materializer and graph-writer dependencies to the capabilities used by
   each algorithm.
@@ -85,7 +131,14 @@ sound collision-bucket non-membership. The release adds `MapProofRequest`,
 
 ## Compatibility
 
-This is an intentional pre-v1 source- and wire-breaking release candidate.
+The rc.2 changes do not alter MALT roots, CIDs, transcripts, parameter sets,
+commitments, ProofLists, receipts, or proof encodings. Browser integrations
+built against v0.0.7-rc.1 must adopt the split Writer filenames and the
+`createMaltWriterWorker` controller API. Writer asset consumers must validate
+`malt.web-writer.provenance/v3`.
+
+The v0.0.7 release-candidate line remains an intentional pre-v1 source- and
+wire-breaking change relative to v0.0.6.
 
 v0.0.6 emitted the flat experimental codecs `0x300001` through `0x300004`.
 The current decoder intentionally does not classify those roots as structured
@@ -114,6 +167,10 @@ declare MALT or its Go APIs stable at v1.
   buckets.
 - The browser/WASM verifier is the same Go verifier compiled for WebAssembly,
   not an independent cryptographic implementation.
+- Core does not select Writer profiles from browser capability hints or retry a
+  different profile after failure; applications must define that host policy.
+- A running client must reload after its application entrypoint selects a new
+  Verifier or Writer asset-set digest.
 - Client-root bundles and materialization receipts are not portable
   state-transition, publication, freshness, or trust proofs.
 
@@ -124,9 +181,9 @@ The release candidate gate includes:
 ```bash
 set -euo pipefail
 git fetch --prune --tags origin
-git rev-parse --verify 'v0.0.6^{commit}'
-git merge-base --is-ancestor v0.0.6 HEAD
-git diff --check v0.0.6...HEAD
+git rev-parse --verify 'v0.0.7-rc.1^{commit}'
+git merge-base --is-ancestor v0.0.7-rc.1 HEAD
+git diff --check v0.0.7-rc.1...HEAD
 test -z "$(gofmt -l $(find . -name '*.go' -not -path './vendor/*'))"
 go test ./...
 GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa
@@ -134,6 +191,9 @@ sh scripts/test-verifier-wasm-vectors.sh
 scripts/test-writer-wasm.sh
 go vet ./...
 go build -buildvcs=false ./...
+scripts/build-wasm-release.sh v0.0.7-rc.2 dist/wasm-release
+scripts/check-wasm-release.sh dist/wasm-release
+node scripts/test-wasm-release-adversarial.mjs dist/wasm-release
 ```
 
 The verifier WASM gate runs 49 current Resolve/Read vectors plus 8 runtime-
@@ -142,5 +202,8 @@ Resolve/Read plus 4 Map-proof vectors in each backend-selected verifier run.
 The Map-proof cases cover acceptance, proof tampering, cross-root relabeling,
 and a wrong caller-selected key for both KZG and IPA.
 
-Before tagging, compile a temporary external module against the candidate and
-record the exact tagged commit and final CI result in the GitHub prerelease.
+Before tagging, compile a temporary external module against the candidate.
+Build the release assets twice under different ambient Go environments and
+umasks and require byte-identical output. Record the exact tagged commit, final
+CI result, validation results, and published asset checksums in the GitHub
+prerelease.

--- a/scripts/build-wasm-release.sh
+++ b/scripts/build-wasm-release.sh
@@ -148,7 +148,7 @@ PROVENANCE_PATH="${writer_staging}/PROVENANCE.json" node -e '
 	const fs = require("node:fs")
 	const parameters = JSON.parse(process.env.IPA_PARAMETERS_JSON)
 	const provenance = {
-		schema: "malt.web-writer.provenance/v2",
+		schema: "malt.web-writer.provenance/v3",
 		source_repository: "https://github.com/DeWebProtocol/malt.git",
 		source_version: process.env.MALT_VERSION,
 		source_commit: process.env.MALT_COMMIT,
@@ -165,7 +165,7 @@ PROVENANCE_PATH="${writer_staging}/PROVENANCE.json" node -e '
 				fast: {file: "malt-writer-ipa-fast.wasm", build_tags: ["writer_ipa", "malt_no_default_kzg"], linker_profile: "fast", retained_fixed_base_table_bytes: 350355456}
 			}
 		},
-		worker_policy: {maximum_active_committers: 1, ipa_fallback: ["fast", "compact", "direct"], cross_backend_fallback: false},
+		runtime_invariants: {one_runtime_per_controller: true, exact_backend_profile: true},
 		build_environment: {GO111MODULE: "on", GOENV: "off", GOWORK: "off", GOFLAGS: "", GOTOOLCHAIN: "local"},
 		codegen_environment: {CGO_ENABLED: "0", GOEXPERIMENT: "none", GOWASM: "", GOFIPS140: "off"}
 	}

--- a/scripts/check-wasm-release.sh
+++ b/scripts/check-wasm-release.sh
@@ -225,7 +225,7 @@ VERIFIER_ROOT="${verifier_root}" WRITER_ROOT="${writer_root}" node -e '
 	exactFiles(process.env.WRITER_ROOT, writerFiles)
 	exactChecksums(process.env.WRITER_ROOT, writerFiles.filter((name) => name !== "SHA256SUMS"))
 	const writer = JSON.parse(fs.readFileSync(path.join(process.env.WRITER_ROOT, "PROVENANCE.json"), "utf8"))
-	validateBase(writer, "malt.web-writer.provenance/v2")
+	validateBase(writer, "malt.web-writer.provenance/v3")
 	const expectedArtifacts = {
 		kzg: {file: "malt-writer-kzg.wasm", build_tags: ["writer_kzg"]},
 		ipa: {
@@ -237,9 +237,7 @@ VERIFIER_ROOT="${verifier_root}" WRITER_ROOT="${writer_root}" node -e '
 	if (writer.parameters?.id !== "malt.ipa-parameters/v1" ||
 		writer.parameters?.sha256 !== "3799df0a77d1843b13a3a08744165180a12e1cd2dca529bee64ad691ac63adaf" ||
 		JSON.stringify(writer.artifacts) !== JSON.stringify(expectedArtifacts) ||
-		writer.worker_policy?.maximum_active_committers !== 1 ||
-		writer.worker_policy?.cross_backend_fallback !== false ||
-		JSON.stringify(writer.worker_policy?.ipa_fallback) !== JSON.stringify(["fast", "compact", "direct"])) {
+		JSON.stringify(writer.runtime_invariants) !== JSON.stringify({one_runtime_per_controller: true, exact_backend_profile: true})) {
 		throw new Error("invalid writer parameter or Worker provenance")
 	}
 '


### PR DESCRIPTION
## Summary

- finalize the v0.0.7-rc.2 changelog, release notes, indexes, release base, README, and security support table
- frame rc.2 as completion of the browser Verifier/Writer separation and content-addressed WASM delivery while preserving the rc.1 protocol contracts
- publish split Writer asset provenance as malt.web-writer.provenance/v3
- bind only Core-enforced runtime invariants and leave device selection and profile retry behavior to host policy

## Validation

- all-package compile-only gate
- 59 Markdown files checked for relative links
- Bash and Node syntax checks
- two complete v0.0.7-rc.2 builds under different hostile ambient environments and umasks were byte-identical
- complete release checker passed for both builds
- seven noncanonical gzip/ustar adversarial variants were rejected
- Writer controller tests: 12 passed
- independent final review: no actionable findings

This PR prepares the final source commit. The tag and GitHub prerelease will be created only after this PR is merged and the exact final main commit passes release validation.
