### PR TITLE
Prepare v0.0.7-rc.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.7-rc.3] - 2026-08-13
+
+This release-candidate delta removes the remaining KZG setup bottleneck and
+optimizes internal KZG commitment, opening, and verification execution without
+changing externally observable commitment or wire semantics.
+
+### Added
+
+- Add a verification-only KZG constructor that loads only the canonical G1
+  generator and the two G2 opening-key points.
+- Add reproducibly generated, committed verifier and Writer setup assets
+  derived from the exact `go-kzg-4844 v1.1.0` trusted setup.
+- Add a generation test that revalidates all 4096 retained G1 points and both
+  retained G2 points, then byte-compares the derived assets with the committed
+  copies.
+
+### Changed
+
+- Replace runtime JSON parsing and decompression of all 4096 KZG Lagrange G1
+  points with build-time validated canonical coordinates for Writer startup.
+- Replace the internal KZG commitment, opening, and verification execution path
+  with equivalent gnark public operations over the validated setup assets.
+- Use the verification-only KZG scheme in the default portable and SDK
+  verifier registries.
+
+### Compatibility
+
+- These changes do not alter MALT roots, CIDs, KZG parameters, commitments,
+  proofs, transcripts, ProofLists, receipts, schemas, or wire encodings.
+- KZG commitments and openings remain byte-for-byte interoperable with the
+  pinned `go-kzg-4844 v1.1.0` implementation.
+
 ## [0.0.7-rc.2] - 2026-08-10
 
 This release-candidate delta completes the browser Verifier/Writer separation
@@ -273,7 +305,8 @@ for the trusted CLI/daemon and UnixFS application, and
 - KZG verification rejects out-of-range proof indices and non-canonical proof
   lengths instead of allowing malformed input to panic or reuse a commitment.
 
-[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.2...HEAD
+[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.3...HEAD
+[0.0.7-rc.3]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.2...v0.0.7-rc.3
 [0.0.7-rc.2]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.1...v0.0.7-rc.2
 [0.0.7-rc.1]: https://github.com/DeWebProtocol/malt/compare/v0.0.6...v0.0.7-rc.1
 [0.0.6]: https://github.com/DeWebProtocol/malt/compare/v0.0.5...v0.0.6

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ line client, daemon, UnixFS model, or website.
 [Client-root contract](./docs/spec/client-root-contract.md) ·
 [ProofList](./docs/spec/prooflist-format.md) ·
 [Compatibility](./docs/policy/compatibility.md) ·
-[v0.0.7-rc.2 release candidate](./docs/releases/v0.0.7.md) · [Roadmap](./ROADMAP.md)
+[v0.0.7-rc.3 release candidate](./docs/releases/v0.0.7.md) · [Roadmap](./ROADMAP.md)
 
-`v0.0.7-rc.2` is the current release candidate. It completes the browser
-Verifier/Writer split and content-addressed WASM delivery while preserving the
-experimental Map-proof and client-root profiles introduced in rc.1. `/v1`
-profile suffixes do not declare MALT or its Go APIs stable at v1.
+`v0.0.7-rc.3` is the current release candidate. It removes the remaining KZG
+setup bottleneck from the browser Verifier and Writer while preserving the
+roots, commitments, proofs, and wire contracts from rc.2. `/v1` profile
+suffixes do not declare MALT or its Go APIs stable at v1.
 
 ## Boundary
 
@@ -92,7 +92,7 @@ conformance tests and examples, not deployment.
 ## Install
 
 ```bash
-go get github.com/dewebprotocol/malt@v0.0.7-rc.2
+go get github.com/dewebprotocol/malt@v0.0.7-rc.3
 ```
 
 ### Verify a resolve result

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,14 +13,14 @@ untrusted caller-supplied evidence.
 | Version | Security support |
 | --- | --- |
 | `main` | Best-effort review of current integration code |
-| `v0.0.7-rc.2` | Current experimental release candidate |
-| `v0.0.7-rc.1` | Previous experimental release candidate |
+| `v0.0.7-rc.3` | Current experimental release candidate |
+| `v0.0.7-rc.2` | Previous experimental release candidate |
 | `v0.0.6` | Previous non-prerelease experimental source release |
 | `v0.0.5` and earlier | Not supported |
 
 MALT remains pre-`v1.0.0` and experimental. Security fixes may require
 breaking API, proof, root, or wire-format changes. Consumers evaluating the
-current typed-root and Map-proof contracts should pin `v0.0.7-rc.2` rather
+current typed-root and Map-proof contracts should pin `v0.0.7-rc.3` rather
 than depend on `main`. Consumers remaining on v0.0.6 must not assume its flat
 roots are wire-compatible with this release candidate.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ research narrative remain in `DeWebProtocol/documents`.
 - [Threat model](./policy/threat-model.md)
 - [Compatibility policy](./policy/compatibility.md)
 - [Release process](./policy/releasing.md)
-- [v0.0.7-rc.2 release notes](./releases/v0.0.7.md)
+- [v0.0.7-rc.3 release notes](./releases/v0.0.7.md)
 - [v0.0.6 release notes](./releases/v0.0.6.md)
 - [v0.0.5 release notes](./releases/v0.0.5.md)
 - [v0.0.4 release notes](./releases/v0.0.4.md)

--- a/docs/policy/README.md
+++ b/docs/policy/README.md
@@ -6,7 +6,7 @@ This folder collects implementation-bound policy and release documents.
 - [Compatibility policy](./compatibility.md)
 - [Release process](./releasing.md)
 - [WASM release assets](./wasm-release-assets.md)
-- [v0.0.7-rc.2 release notes and checklist](../releases/v0.0.7.md)
+- [v0.0.7-rc.3 release notes and checklist](../releases/v0.0.7.md)
 - [v0.0.6 release notes and checklist](../releases/v0.0.6.md)
 - [v0.0.5 release notes and checklist](../releases/v0.0.5.md)
 - [v0.0.4 release notes and checklist](../releases/v0.0.4.md)

--- a/docs/policy/releasing.md
+++ b/docs/policy/releasing.md
@@ -7,11 +7,11 @@ MALT core uses source tags for experimental releases.
 Run from the repository root:
 
 Set `MALT_RELEASE_BASE` to the previous authoritative source tag. For
-v0.0.7-rc.2, that tag is `v0.0.7-rc.1`.
+v0.0.7-rc.3, that tag is `v0.0.7-rc.2`.
 
 ```bash
 set -euo pipefail
-MALT_RELEASE_BASE=v0.0.7-rc.1
+MALT_RELEASE_BASE=v0.0.7-rc.2
 git fetch --prune --tags origin
 git rev-parse --verify "${MALT_RELEASE_BASE}^{commit}"
 git merge-base --is-ancestor "$MALT_RELEASE_BASE" HEAD

--- a/docs/releases/v0.0.7.md
+++ b/docs/releases/v0.0.7.md
@@ -1,6 +1,6 @@
-# MALT v0.0.7-rc.2
+# MALT v0.0.7-rc.3
 
-Release date: 2026-08-10
+Release date: 2026-08-13
 
 This is a prerelease for integration and verifier testing. MALT remains pre-v1,
 experimental, and not production-ready.
@@ -16,7 +16,6 @@ The source tag is the authoritative release artifact. This candidate publishes:
 - the experimental client-root profiles documented in
   [Client-Root Contract](../spec/client-root-contract.md);
 - the frozen Resolve/Read conformance corpus v1 for structured version-2 roots;
-  and
 - the frozen Resolve/Read conformance corpus v2 for version-3 roots; and
 - reproducible, content-addressed browser Verifier and Writer asset sets.
 
@@ -26,7 +25,34 @@ selection or retry policy.
 
 `MALTVersionID=3` is a wire-format version, not the source release version.
 
-## Changes Since v0.0.7-rc.1
+## Changes Since v0.0.7-rc.2
+
+### Fast KZG verifier initialization
+
+Portable and browser verifiers now construct a verification-only KZG scheme.
+It loads the canonical G1 generator and the first two G2 opening-key points,
+without parsing or retaining the 4096-point Writer commitment key. The final
+Verifier WASM does not link the 393,216-byte preprocessed Writer setup asset.
+
+### Fast KZG Writer initialization
+
+KZG Writers now decode build-time validated canonical Lagrange G1 coordinates
+instead of parsing the upstream JSON setup and decompressing 4096 points at
+runtime. Both compact assets are derived from the exact pinned
+`go-kzg-4844 v1.1.0` setup. Generation enforces the upstream setup SHA-256,
+performs full curve and subgroup validation, and emits asset fingerprints.
+
+A reconstruction test repeats that derivation and byte-compares the committed
+assets. Compatibility tests use unique values in every KZG slot and compare
+commitments and openings at multiple bit patterns against the pinned upstream
+implementation.
+
+The rc.3 delta changes KZG setup loading and internal commitment, opening, and
+verification execution while preserving externally observable parameters and
+encodings. It does not alter roots, CIDs, commitments, proofs, transcripts,
+ProofLists, receipts, schemas, or wire encodings.
+
+## Changes Since v0.0.7-rc.1 Through v0.0.7-rc.2
 
 ### Separate Verifier and Writer runtimes
 
@@ -57,8 +83,8 @@ archive filenames bind both the extracted asset-set digest and the exact
 compressed archive digest:
 
 ```text
-malt-verifier-v0.0.7-rc.2-<asset-set-sha256>-<archive-sha256>.tar.gz
-malt-writer-v0.0.7-rc.2-<asset-set-sha256>-<archive-sha256>.tar.gz
+malt-verifier-v0.0.7-rc.3-<asset-set-sha256>-<archive-sha256>.tar.gz
+malt-writer-v0.0.7-rc.3-<asset-set-sha256>-<archive-sha256>.tar.gz
 ```
 
 Only complete digest paths are immutable. Consumers must load every file in a
@@ -131,11 +157,11 @@ sound collision-bucket non-membership. The release adds `MapProofRequest`,
 
 ## Compatibility
 
-The rc.2 changes do not alter MALT roots, CIDs, transcripts, parameter sets,
-commitments, ProofLists, receipts, or proof encodings. Browser integrations
-built against v0.0.7-rc.1 must adopt the split Writer filenames and the
-`createMaltWriterWorker` controller API. Writer asset consumers must validate
-`malt.web-writer.provenance/v3`.
+The rc.2 and rc.3 changes do not alter MALT roots, CIDs, transcripts,
+parameter sets, commitments, ProofLists, receipts, or proof encodings. Browser
+integrations built against v0.0.7-rc.1 must adopt the split Writer filenames
+and the `createMaltWriterWorker` controller API. Writer asset consumers must
+validate `malt.web-writer.provenance/v3`.
 
 The v0.0.7 release-candidate line remains an intentional pre-v1 source- and
 wire-breaking change relative to v0.0.6.
@@ -181,9 +207,9 @@ The release candidate gate includes:
 ```bash
 set -euo pipefail
 git fetch --prune --tags origin
-git rev-parse --verify 'v0.0.7-rc.1^{commit}'
-git merge-base --is-ancestor v0.0.7-rc.1 HEAD
-git diff --check v0.0.7-rc.1...HEAD
+git rev-parse --verify 'v0.0.7-rc.2^{commit}'
+git merge-base --is-ancestor v0.0.7-rc.2 HEAD
+git diff --check v0.0.7-rc.2...HEAD
 test -z "$(gofmt -l $(find . -name '*.go' -not -path './vendor/*'))"
 go test ./...
 GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa
@@ -191,7 +217,7 @@ sh scripts/test-verifier-wasm-vectors.sh
 scripts/test-writer-wasm.sh
 go vet ./...
 go build -buildvcs=false ./...
-scripts/build-wasm-release.sh v0.0.7-rc.2 dist/wasm-release
+scripts/build-wasm-release.sh v0.0.7-rc.3 dist/wasm-release
 scripts/check-wasm-release.sh dist/wasm-release
 node scripts/test-wasm-release-adversarial.mjs dist/wasm-release
 ```


### PR DESCRIPTION
## Summary

- document v0.0.7-rc.3 as the KZG setup and internal execution optimization release
- record the verifier-only opening key and preprocessed Writer setup assets
- state the exact 4096 G1 plus two retained G2 generation-validation boundary
- preserve the rc.2 history and update README, security support, release indexes, compare links, and release base
- preserve external roots, CIDs, parameters, commitments, proofs, transcripts, ProofLists, receipts, schemas, and wire encodings

## Validation before PR

- PR #188 merge commit and all CI checks verified
- `go mod verify`
- `git diff --check`
- all repository Markdown relative links resolve
- three independent release-document reviews; final review reported no actionable findings

## Release procedure after merge

The exact final `main` commit will receive the full release gate, two byte-identical WASM release builds under different ambient environments/umasks, tag `v0.0.7-rc.3`, and a GitHub prerelease with all four content-addressed assets.