### PR TITLE
Batch map updates into one root commitment

### DIFF
--- a/auth/semantic/mapping/radix/batch_update_test.go
+++ b/auth/semantic/mapping/radix/batch_update_test.go
@@ -1,0 +1,184 @@
+package radix
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	materialmemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/auth/semantic/mapping"
+	cid "github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+)
+
+func TestBatchUpdateCommitsFinalRootOnceAndMatchesSequentialUpdates(t *testing.T) {
+	ctx := context.Background()
+	baseScheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	counting := &commitCountingRootScheme{
+		IndexCommitment: baseScheme,
+		rootProver:      baseScheme,
+	}
+	batched, err := NewMap(counting, materialmemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sequential, err := NewMap(baseScheme, materialmemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keys := []arcset.Path{arcset.CanonicalizePath("alpha"), arcset.CanonicalizePath("beta")}
+	firstDigest := hashPath(keys[0])
+	secondDigest := hashPath(keys[1])
+	firstSlot, firstOK := batched.geometry.MapDigit(firstDigest[:], 0)
+	secondSlot, secondOK := batched.geometry.MapDigit(secondDigest[:], 0)
+	if !firstOK || !secondOK || firstSlot == secondSlot {
+		t.Fatalf("test keys do not occupy distinct root slots: %d, %d", firstSlot, secondSlot)
+	}
+	oldValues := []cid.Cid{batchUpdateCID(t, "old-alpha"), batchUpdateCID(t, "old-beta")}
+	newValues := []cid.Cid{batchUpdateCID(t, "new-alpha"), batchUpdateCID(t, "new-beta")}
+	initial := mapping.NewViewFromPaths(map[arcset.Path]cid.Cid{
+		keys[0]: oldValues[0],
+		keys[1]: oldValues[1],
+	})
+	batchRoot, err := batched.Commit(ctx, "batch", initial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sequentialRoot, err := sequential.Commit(ctx, "sequential", initial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !batchRoot.Equals(sequentialRoot) {
+		t.Fatalf("initial roots differ: %s != %s", batchRoot, sequentialRoot)
+	}
+
+	counting.commits = 0
+	batchRoot, err = batched.BatchUpdate(ctx, "batch", batchRoot, []mapping.BatchUpdate{
+		{Key: keys[0], OldValue: oldValues[0], NewValue: newValues[0]},
+		{Key: keys[1], OldValue: oldValues[1], NewValue: newValues[1]},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counting.commits != 1 {
+		t.Fatalf("batch commitment calls = %d, want one final root commitment", counting.commits)
+	}
+	for index := range keys {
+		sequentialRoot, err = sequential.Update(
+			ctx,
+			"sequential",
+			sequentialRoot,
+			keys[index],
+			oldValues[index],
+			newValues[index],
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !batchRoot.Equals(sequentialRoot) {
+		t.Fatalf("batch root = %s, sequential root = %s", batchRoot, sequentialRoot)
+	}
+}
+
+func TestBatchUpdateMatchesSequentialUpdatesWithinOneRootSlot(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	batched, err := NewMap(scheme, materialmemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sequential, err := NewMap(scheme, materialmemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keys := sameRootSlotPaths(t, batched)
+	oldValues := []cid.Cid{batchUpdateCID(t, "old-collision-a"), batchUpdateCID(t, "old-collision-b")}
+	newValues := []cid.Cid{batchUpdateCID(t, "new-collision-a"), batchUpdateCID(t, "new-collision-b")}
+	initial := mapping.NewViewFromPaths(map[arcset.Path]cid.Cid{
+		keys[0]: oldValues[0],
+		keys[1]: oldValues[1],
+	})
+	batchRoot, err := batched.Commit(ctx, "batch-collision", initial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sequentialRoot, err := sequential.Commit(ctx, "sequential-collision", initial)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	batchRoot, err = batched.BatchUpdate(ctx, "batch-collision", batchRoot, []mapping.BatchUpdate{
+		{Key: keys[0], OldValue: oldValues[0], NewValue: newValues[0]},
+		{Key: keys[1], OldValue: oldValues[1], NewValue: newValues[1]},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := range keys {
+		sequentialRoot, err = sequential.Update(
+			ctx,
+			"sequential-collision",
+			sequentialRoot,
+			keys[index],
+			oldValues[index],
+			newValues[index],
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !batchRoot.Equals(sequentialRoot) {
+		t.Fatalf("same-slot batch root = %s, sequential root = %s", batchRoot, sequentialRoot)
+	}
+	for index, key := range keys {
+		got, _, err := batched.Prove(ctx, "batch-collision", batchRoot, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !got.Present || !got.Value.Equals(newValues[index]) {
+			t.Fatalf("Prove(%s) = %+v, want %s", key, got, newValues[index])
+		}
+	}
+}
+
+func sameRootSlotPaths(t *testing.T, value *Map) []arcset.Path {
+	t.Helper()
+	bySlot := make(map[uint64]arcset.Path)
+	for index := 0; index < 1<<16; index++ {
+		candidate := arcset.CanonicalizePath(fmt.Sprintf("collision-%d", index))
+		digest := hashPath(candidate)
+		slot, ok := value.geometry.MapDigit(digest[:], 0)
+		if !ok {
+			t.Fatal("map geometry has no root digit")
+		}
+		if previous, exists := bySlot[slot]; exists {
+			return []arcset.Path{previous, candidate}
+		}
+		bySlot[slot] = candidate
+	}
+	t.Fatal("failed to find two paths in one root slot")
+	return nil
+}
+
+func batchUpdateCID(t *testing.T, value string) cid.Cid {
+	t.Helper()
+	digest, err := multihash.Sum([]byte(value), multihash.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cid.NewCidV1(cid.Raw, digest)
+}
+
+var _ commitment.IndexCommitment = (*commitCountingRootScheme)(nil)

--- a/auth/semantic/mapping/radix/radix.go
+++ b/auth/semantic/mapping/radix/radix.go
@@ -754,9 +754,11 @@ func (s *Map) updateSubtreeWithoutPersistCached(
 	return s.commitOrCollapseNodeWithoutPersist(ctx, namespace, nextSlots, nodes, buckets)
 }
 
-// BatchUpdate applies multiple updates atomically by applying them sequentially
-// and returning the final root only if all updates succeed. If any update fails,
-// the entire batch is rejected and no state is persisted to ArcSet materializer.
+// BatchUpdate applies multiple updates atomically and returns the final root
+// only if all updates succeed. The persisted root node is opened once, updates
+// are applied below their root slots, and the final root commitment is computed
+// once after every subtree succeeds. If any update fails, no state is persisted
+// to the ArcSet materializer.
 func (s *Map) BatchUpdate(ctx context.Context, namespace string, root cid.Cid, updates []mapping.BatchUpdate) (cid.Cid, error) {
 	if !root.Defined() {
 		return cid.Undef, fmt.Errorf("root is undefined")
@@ -774,27 +776,44 @@ func (s *Map) BatchUpdate(ctx context.Context, namespace string, root cid.Cid, u
 		return cid.Undef, err
 	}
 
-	// Build a cache of all materialized nodes/buckets as we traverse
-	// This allows subsequent updates in the batch to read from newly created nodes
+	// Build a cache of all materialized nodes/buckets below the root as we
+	// traverse. Subsequent updates in the batch can read newly created nodes
+	// without opening or persisting an intermediate root.
 	nodeCache := make(map[string][]cid.Cid)
-	nodeCache[root.String()] = initialSlots
+	nextRootSlots := cloneCIDs(initialSlots)
 
 	// Accumulate all nodes and buckets that need to be persisted
 	var pendingNodes []pendingNode
 	var pendingBuckets []pendingBucket
 
-	// Apply updates sequentially without persisting
-	currentRoot := root
+	// Apply updates sequentially below their root slots without committing the
+	// top-level node after each coordinate. Changes are canonical and unique at
+	// the mutation boundary, while this method preserves input ordering for its
+	// general public contract.
 	for i, update := range updates {
 		if update.Key.IsEmpty() {
 			return cid.Undef, fmt.Errorf("update %d: key is empty", i)
 		}
-
-		newRoot, nodes, buckets, err := s.updateWithoutPersistCached(ctx, namespace, currentRoot, update.Key, update.OldValue, update.NewValue, nodeCache)
+		digest := hashPath(update.Key)
+		rootSlot, ok := s.geometry.MapDigit(digest[:], 0)
+		if !ok {
+			return cid.Undef, fmt.Errorf("update %d: missing root radix digit", i)
+		}
+		nextSlot, nodes, buckets, err := s.updateSubtreeWithoutPersistCached(
+			ctx,
+			namespace,
+			nextRootSlots[rootSlot],
+			digest,
+			1,
+			update.Key,
+			update.OldValue,
+			update.NewValue,
+			nodeCache,
+		)
 		if err != nil {
 			return cid.Undef, fmt.Errorf("update %d (key=%s): %w", i, update.Key.String(), err)
 		}
-		currentRoot = newRoot
+		nextRootSlots[rootSlot] = nextSlot
 
 		// Add new nodes to cache
 		for _, node := range nodes {
@@ -804,6 +823,14 @@ func (s *Map) BatchUpdate(ctx context.Context, namespace string, root cid.Cid, u
 		pendingNodes = append(pendingNodes, nodes...)
 		pendingBuckets = append(pendingBuckets, buckets...)
 	}
+	if slices.EqualFunc(initialSlots, nextRootSlots, cidEqual) {
+		return root, nil
+	}
+	currentRoot, err := s.commitSlots(nextRootSlots)
+	if err != nil {
+		return cid.Undef, err
+	}
+	pendingNodes = append(pendingNodes, pendingNode{root: currentRoot, slots: nextRootSlots})
 
 	// All updates succeeded - now persist atomically
 	// First persist all nodes

--- a/graph/writer/mutation.go
+++ b/graph/writer/mutation.go
@@ -161,7 +161,7 @@ func (w *Writer) commitMapDelta(ctx context.Context, namespace string, delta Arc
 		return root, nil
 	}
 
-	root := delta.Object
+	updates := make([]mapping.BatchUpdate, 0, len(changes))
 	logical := make(map[arcset.Path]cid.Cid, len(changes))
 	for _, change := range changes {
 		key := arcset.CanonicalizePath(change.Coordinate.String())
@@ -173,12 +173,16 @@ func (w *Writer) commitMapDelta(ctx context.Context, namespace string, delta Arc
 		if change.After != nil {
 			newValue = change.After.CID()
 		}
-		nextRoot, err := w.semantic.Update(ctx, namespace, root, key, oldValue, newValue)
-		if err != nil {
-			return cid.Undef, err
-		}
-		root = nextRoot
+		updates = append(updates, mapping.BatchUpdate{
+			Key:      key,
+			OldValue: oldValue,
+			NewValue: newValue,
+		})
 		logical[key] = newValue
+	}
+	root, err := w.semantic.BatchUpdate(ctx, namespace, delta.Object, updates)
+	if err != nil {
+		return cid.Undef, err
 	}
 	if w.materializer != nil {
 		deltaSet, err := arcset.NewArcSetFromPaths(logical)

--- a/graph/writer/writer_test.go
+++ b/graph/writer/writer_test.go
@@ -158,6 +158,22 @@ type fixedWidthAppendOnlySemantics struct {
 	appender list.FixedWidthAppender
 }
 
+type countingBatchMapSemantics struct {
+	mapping.Semantics
+	updateCalls      int
+	batchUpdateCalls int
+}
+
+func (s *countingBatchMapSemantics) Update(ctx context.Context, namespace string, root cid.Cid, key arcset.Path, oldValue, newValue cid.Cid) (cid.Cid, error) {
+	s.updateCalls++
+	return s.Semantics.Update(ctx, namespace, root, key, oldValue, newValue)
+}
+
+func (s *countingBatchMapSemantics) BatchUpdate(ctx context.Context, namespace string, root cid.Cid, updates []mapping.BatchUpdate) (cid.Cid, error) {
+	s.batchUpdateCalls++
+	return s.Semantics.BatchUpdate(ctx, namespace, root, updates)
+}
+
 func (s fixedWidthAppendOnlySemantics) AppendFixed(ctx context.Context, namespace string, root cid.Cid, key cid.Cid, totalSize uint64) (cid.Cid, uint64, error) {
 	return s.appender.AppendFixed(ctx, namespace, root, key, totalSize)
 }
@@ -435,6 +451,65 @@ func TestWriterApplySemanticMapMutation(t *testing.T) {
 	}
 	if !got.Equals(newChild) {
 		t.Fatalf("child target = %s, want %s", got, newChild)
+	}
+}
+
+func TestWriterApplySemanticMapMutationUsesOneBatch(t *testing.T) {
+	w, _, semantic, _ := newTestWriter(t)
+	ctx := context.Background()
+	namespace := "test-batched-semantic-mutation"
+	oldA := fakeCID("old-a")
+	oldB := fakeCID("old-b")
+	newA := fakeCID("new-a")
+	newB := fakeCID("new-b")
+
+	snapshot, err := arcset.NewArcSet(map[string]cid.Cid{
+		"a": oldA,
+		"b": oldB,
+	})
+	if err != nil {
+		t.Fatalf("NewArcSet failed: %v", err)
+	}
+	root, err := w.CreateStructure(ctx, namespace, snapshot)
+	if err != nil {
+		t.Fatalf("CreateStructure failed: %v", err)
+	}
+	counting := &countingBatchMapSemantics{Semantics: semantic}
+	w.semantic = counting
+
+	receipt, err := w.Apply(ctx, namespace, SemanticMutation{
+		BaseRoot: root,
+		Deltas: []ArcSetDelta{{
+			Object: root,
+			Kind:   arcset.KindMap,
+			Changes: mustWriterDelta(t, arcset.KindMap, []arcset.ArcChange{
+				{
+					Coordinate: mustMapCoordinate(t, "a"),
+					Before:     targetRefPtr(arcset.NewMapTarget(oldA)),
+					After:      targetRefPtr(arcset.NewMapTarget(newA)),
+				},
+				{
+					Coordinate: mustMapCoordinate(t, "b"),
+					Before:     targetRefPtr(arcset.NewMapTarget(oldB)),
+					After:      targetRefPtr(arcset.NewMapTarget(newB)),
+				},
+			}),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	if counting.batchUpdateCalls != 1 || counting.updateCalls != 0 {
+		t.Fatalf("semantic calls = BatchUpdate %d Update %d, want 1/0", counting.batchUpdateCalls, counting.updateCalls)
+	}
+	for path, want := range map[string]cid.Cid{"a": newA, "b": newB} {
+		got, err := w.GetArc(ctx, namespace, receipt.NewRoot, path)
+		if err != nil {
+			t.Fatalf("GetArc(%s) failed: %v", path, err)
+		}
+		if !got.Equals(want) {
+			t.Fatalf("%s target = %s, want %s", path, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

- route graph writer map deltas through `BatchUpdate` once per semantic mutation
- keep batched radix updates below their root slots and compute the final top-level commitment once
- preserve ordered same-slot updates through the batch-local node cache
- add regressions for one final commitment, same-slot collisions, and exact parity with sequential updates

## Why

The browser writer previously recomputed the top-level KZG map commitment for every Arc changed by one transaction. Queued UnixFS mutations can update several authenticated paths at once, so this made local root computation grow unnecessarily with the Arc count.

This keeps the root and wire semantics unchanged while reducing one map transaction to one final top-level commitment.

## Validation

- `go test ./auth/semantic/mapping/radix ./graph/writer ./sdk/writer`
- `go test -p=7 -parallel=7 ./...`
- `go vet -p=7 ./...`
- `go build -p=7 -buildvcs=false ./...`
- `sh scripts/test-writer-wasm.sh`
- independent read-only review: no actionable findings