### PR TITLE
Prepare v0.0.7-rc.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.7-rc.4] - 2026-08-13
+
+This release-candidate delta reduces Writer latency for transactions that
+change multiple Map arcs, without changing roots or wire semantics.
+
+### Changed
+
+- Apply all canonical Map changes in one semantic `BatchUpdate` instead of
+  committing the top-level Map after every changed arc.
+- Open and validate the existing root once, update affected subtrees in
+  batch-local state, and compute and persist one final top-level commitment.
+- Preserve ordered updates within the same root slot and exact final-root
+  parity with sequential updates.
+
+### Compatibility
+
+- These changes do not alter MALT roots, CIDs, commitment parameters,
+  commitments, proofs, transcripts, ProofLists, receipts, schemas, or wire
+  encodings.
+- The final root is byte-for-byte identical to applying the same canonical
+  changes sequentially.
+
 ## [0.0.7-rc.3] - 2026-08-13
 
 This release-candidate delta removes the remaining KZG setup bottleneck and
@@ -305,7 +327,8 @@ for the trusted CLI/daemon and UnixFS application, and
 - KZG verification rejects out-of-range proof indices and non-canonical proof
   lengths instead of allowing malformed input to panic or reuse a commitment.
 
-[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.3...HEAD
+[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.4...HEAD
+[0.0.7-rc.4]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.3...v0.0.7-rc.4
 [0.0.7-rc.3]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.2...v0.0.7-rc.3
 [0.0.7-rc.2]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.1...v0.0.7-rc.2
 [0.0.7-rc.1]: https://github.com/DeWebProtocol/malt/compare/v0.0.6...v0.0.7-rc.1

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ line client, daemon, UnixFS model, or website.
 [Client-root contract](./docs/spec/client-root-contract.md) ·
 [ProofList](./docs/spec/prooflist-format.md) ·
 [Compatibility](./docs/policy/compatibility.md) ·
-[v0.0.7-rc.3 release candidate](./docs/releases/v0.0.7.md) · [Roadmap](./ROADMAP.md)
+[v0.0.7-rc.4 release candidate](./docs/releases/v0.0.7.md) · [Roadmap](./ROADMAP.md)
 
-`v0.0.7-rc.3` is the current release candidate. It removes the remaining KZG
-setup bottleneck from the browser Verifier and Writer while preserving the
-roots, commitments, proofs, and wire contracts from rc.2. `/v1` profile
+`v0.0.7-rc.4` is the current release candidate. It batches all Map changes in
+one Writer transaction into one final top-level commitment while preserving
+the roots, commitments, proofs, and wire contracts from rc.3. `/v1` profile
 suffixes do not declare MALT or its Go APIs stable at v1.
 
 ## Boundary
@@ -92,7 +92,7 @@ conformance tests and examples, not deployment.
 ## Install
 
 ```bash
-go get github.com/dewebprotocol/malt@v0.0.7-rc.3
+go get github.com/dewebprotocol/malt@v0.0.7-rc.4
 ```
 
 ### Verify a resolve result

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,14 +13,14 @@ untrusted caller-supplied evidence.
 | Version | Security support |
 | --- | --- |
 | `main` | Best-effort review of current integration code |
-| `v0.0.7-rc.3` | Current experimental release candidate |
-| `v0.0.7-rc.2` | Previous experimental release candidate |
+| `v0.0.7-rc.4` | Current experimental release candidate |
+| `v0.0.7-rc.3` | Previous experimental release candidate |
 | `v0.0.6` | Previous non-prerelease experimental source release |
 | `v0.0.5` and earlier | Not supported |
 
 MALT remains pre-`v1.0.0` and experimental. Security fixes may require
 breaking API, proof, root, or wire-format changes. Consumers evaluating the
-current typed-root and Map-proof contracts should pin `v0.0.7-rc.3` rather
+current typed-root and Map-proof contracts should pin `v0.0.7-rc.4` rather
 than depend on `main`. Consumers remaining on v0.0.6 must not assume its flat
 roots are wire-compatible with this release candidate.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ research narrative remain in `DeWebProtocol/documents`.
 - [Threat model](./policy/threat-model.md)
 - [Compatibility policy](./policy/compatibility.md)
 - [Release process](./policy/releasing.md)
-- [v0.0.7-rc.3 release notes](./releases/v0.0.7.md)
+- [v0.0.7-rc.4 release notes](./releases/v0.0.7.md)
 - [v0.0.6 release notes](./releases/v0.0.6.md)
 - [v0.0.5 release notes](./releases/v0.0.5.md)
 - [v0.0.4 release notes](./releases/v0.0.4.md)

--- a/docs/policy/README.md
+++ b/docs/policy/README.md
@@ -6,7 +6,7 @@ This folder collects implementation-bound policy and release documents.
 - [Compatibility policy](./compatibility.md)
 - [Release process](./releasing.md)
 - [WASM release assets](./wasm-release-assets.md)
-- [v0.0.7-rc.3 release notes and checklist](../releases/v0.0.7.md)
+- [v0.0.7-rc.4 release notes and checklist](../releases/v0.0.7.md)
 - [v0.0.6 release notes and checklist](../releases/v0.0.6.md)
 - [v0.0.5 release notes and checklist](../releases/v0.0.5.md)
 - [v0.0.4 release notes and checklist](../releases/v0.0.4.md)

--- a/docs/policy/releasing.md
+++ b/docs/policy/releasing.md
@@ -7,11 +7,11 @@ MALT core uses source tags for experimental releases.
 Run from the repository root:
 
 Set `MALT_RELEASE_BASE` to the previous authoritative source tag. For
-v0.0.7-rc.3, that tag is `v0.0.7-rc.2`.
+v0.0.7-rc.4, that tag is `v0.0.7-rc.3`.
 
 ```bash
 set -euo pipefail
-MALT_RELEASE_BASE=v0.0.7-rc.2
+MALT_RELEASE_BASE=v0.0.7-rc.3
 git fetch --prune --tags origin
 git rev-parse --verify "${MALT_RELEASE_BASE}^{commit}"
 git merge-base --is-ancestor "$MALT_RELEASE_BASE" HEAD

--- a/docs/releases/v0.0.7.md
+++ b/docs/releases/v0.0.7.md
@@ -1,4 +1,4 @@
-# MALT v0.0.7-rc.3
+# MALT v0.0.7-rc.4
 
 Release date: 2026-08-13
 
@@ -25,7 +25,27 @@ selection or retry policy.
 
 `MALTVersionID=3` is a wire-format version, not the source release version.
 
-## Changes Since v0.0.7-rc.2
+## Changes Since v0.0.7-rc.3
+
+### Batched Map Writer commitments
+
+The graph Writer now converts all canonical changes for one Map object into a
+single semantic `BatchUpdate`. The radix implementation opens and validates
+the existing top-level node once, applies affected subtree changes in
+batch-local state, and computes and persists one final top-level commitment
+after every change succeeds.
+
+Input ordering is preserved, including multiple changes below the same root
+slot. Tests require the batched result to match sequential updates exactly and
+require one final top-level commitment for a multi-arc batch.
+
+This optimization removes repeated top-level KZG or IPA commitment work from
+multi-arc Writer transactions. It is an execution optimization, not an
+aggregated proof or a new transition-proof contract. It does not alter roots,
+CIDs, commitment parameters, commitments, proofs, transcripts, ProofLists,
+receipts, schemas, or wire encodings.
+
+## Changes Since v0.0.7-rc.2 Through v0.0.7-rc.3
 
 ### Fast KZG verifier initialization
 
@@ -83,8 +103,8 @@ archive filenames bind both the extracted asset-set digest and the exact
 compressed archive digest:
 
 ```text
-malt-verifier-v0.0.7-rc.3-<asset-set-sha256>-<archive-sha256>.tar.gz
-malt-writer-v0.0.7-rc.3-<asset-set-sha256>-<archive-sha256>.tar.gz
+malt-verifier-v0.0.7-rc.4-<asset-set-sha256>-<archive-sha256>.tar.gz
+malt-writer-v0.0.7-rc.4-<asset-set-sha256>-<archive-sha256>.tar.gz
 ```
 
 Only complete digest paths are immutable. Consumers must load every file in a
@@ -157,7 +177,7 @@ sound collision-bucket non-membership. The release adds `MapProofRequest`,
 
 ## Compatibility
 
-The rc.2 and rc.3 changes do not alter MALT roots, CIDs, transcripts,
+The rc.2, rc.3, and rc.4 changes do not alter MALT roots, CIDs, transcripts,
 parameter sets, commitments, ProofLists, receipts, or proof encodings. Browser
 integrations built against v0.0.7-rc.1 must adopt the split Writer filenames
 and the `createMaltWriterWorker` controller API. Writer asset consumers must
@@ -207,9 +227,9 @@ The release candidate gate includes:
 ```bash
 set -euo pipefail
 git fetch --prune --tags origin
-git rev-parse --verify 'v0.0.7-rc.2^{commit}'
-git merge-base --is-ancestor v0.0.7-rc.2 HEAD
-git diff --check v0.0.7-rc.2...HEAD
+git rev-parse --verify 'v0.0.7-rc.3^{commit}'
+git merge-base --is-ancestor v0.0.7-rc.3 HEAD
+git diff --check v0.0.7-rc.3...HEAD
 test -z "$(gofmt -l $(find . -name '*.go' -not -path './vendor/*'))"
 go test ./...
 GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa
@@ -217,7 +237,7 @@ sh scripts/test-verifier-wasm-vectors.sh
 scripts/test-writer-wasm.sh
 go vet ./...
 go build -buildvcs=false ./...
-scripts/build-wasm-release.sh v0.0.7-rc.3 dist/wasm-release
+scripts/build-wasm-release.sh v0.0.7-rc.4 dist/wasm-release
 scripts/check-wasm-release.sh dist/wasm-release
 node scripts/test-wasm-release-adversarial.mjs dist/wasm-release
 ```


### PR DESCRIPTION
## Summary

- prepare the MALT v0.0.7-rc.4 source release
- document batched Map Writer commitments introduced by PR #190
- advance release, security, install, comparison, and WASM asset references from rc.3 to rc.4

## Compatibility

This release changes Writer execution scheduling only. It batches canonical
Map changes into one existing semantic `BatchUpdate`, opens the top-level Map
once, and computes one final top-level commitment. It is not an aggregated
proof or a portable transition-proof contract.

Roots, CIDs, commitment parameters, commitments, proofs, transcripts,
ProofLists, receipts, schemas, and wire encodings remain unchanged from rc.3.

## Validation

- `git diff --check v0.0.7-rc.3...HEAD`
- repository-wide `gofmt -l`
- `go test ./...`
- `GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa`
- `sh scripts/test-verifier-wasm-vectors.sh`
- `scripts/test-writer-wasm.sh`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- temporary external consumer build for the module root, `protocol`, `sdk/verifier`, and `auth/arcset/materializer`
- independent release review: no actionable findings
