### PR TITLE
feat(writer): add authenticated session checkpoints

### DIFF
--- a/auth/arcset/materializer/memory/state.go
+++ b/auth/arcset/materializer/memory/state.go
@@ -1,0 +1,191 @@
+package memory
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	cid "github.com/ipfs/go-cid"
+)
+
+// State is a detached representation of one in-memory materializer. It lets a
+// caller checkpoint ephemeral SDK execution state without assigning durable
+// storage or trust policy to MALT Core.
+type State struct {
+	Branching bool         `json:"branching"`
+	Scopes    []ScopeState `json:"scopes"`
+}
+
+type ScopeState struct {
+	Scope     string          `json:"scope"`
+	Current   []Entry         `json:"current"`
+	Nodes     []Entry         `json:"nodes"`
+	NodeRoots []NodeRootState `json:"node_roots"`
+	Roots     []RootState     `json:"roots"`
+}
+
+type Entry struct {
+	Path   arcset.Path `json:"path"`
+	Target cid.Cid     `json:"target"`
+}
+
+type NodeRootState struct {
+	Root  cid.Cid       `json:"root"`
+	Paths []arcset.Path `json:"paths"`
+}
+
+type RootState struct {
+	Root    cid.Cid `json:"root"`
+	Entries []Entry `json:"entries"`
+}
+
+// ExportState returns a deterministic detached copy of the materializer.
+func (s *Store) ExportState() (State, error) {
+	if s == nil {
+		return State{}, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := State{Branching: s.branching, Scopes: make([]ScopeState, 0, len(s.scopes))}
+	scopes := make([]string, 0, len(s.scopes))
+	for scope := range s.scopes {
+		scopes = append(scopes, scope)
+	}
+	sort.Strings(scopes)
+	for _, scope := range scopes {
+		state := s.scopes[scope]
+		wire := ScopeState{
+			Scope:   scope,
+			Current: sortedEntries(state.current),
+			Nodes:   sortedEntries(state.nodes),
+		}
+		nodeRoots := make([]string, 0, len(state.nodeRoots))
+		for root := range state.nodeRoots {
+			nodeRoots = append(nodeRoots, root)
+		}
+		sort.Strings(nodeRoots)
+		for _, rootKey := range nodeRoots {
+			root, err := cid.Cast([]byte(rootKey))
+			if err != nil {
+				return State{}, fmt.Errorf("decode materializer node root: %w", err)
+			}
+			paths := make([]arcset.Path, 0, len(state.nodeRoots[rootKey]))
+			for path := range state.nodeRoots[rootKey] {
+				paths = append(paths, path)
+			}
+			sort.Slice(paths, func(i, j int) bool { return paths[i].String() < paths[j].String() })
+			wire.NodeRoots = append(wire.NodeRoots, NodeRootState{Root: root, Paths: paths})
+		}
+		roots := make([]string, 0, len(state.roots))
+		for root := range state.roots {
+			roots = append(roots, root)
+		}
+		sort.Strings(roots)
+		for _, rootKey := range roots {
+			root, err := cid.Cast([]byte(rootKey))
+			if err != nil {
+				return State{}, fmt.Errorf("decode materializer root: %w", err)
+			}
+			wire.Roots = append(wire.Roots, RootState{Root: root, Entries: sortedEntries(state.roots[rootKey])})
+		}
+		out.Scopes = append(out.Scopes, wire)
+	}
+	return out, nil
+}
+
+// NewFromState validates and restores a detached in-memory state.
+func NewFromState(input State) (*Store, error) {
+	store := New(input.Branching)
+	seenScopes := make(map[string]struct{}, len(input.Scopes))
+	for _, scope := range input.Scopes {
+		if _, duplicate := seenScopes[scope.Scope]; duplicate {
+			return nil, fmt.Errorf("duplicate materializer scope %q", scope.Scope)
+		}
+		seenScopes[scope.Scope] = struct{}{}
+		state := store.ensureScope(scope.Scope)
+		var err error
+		if state.current, err = entriesMap(scope.Current); err != nil {
+			return nil, fmt.Errorf("scope %q current state: %w", scope.Scope, err)
+		}
+		if state.nodes, err = entriesMap(scope.Nodes); err != nil {
+			return nil, fmt.Errorf("scope %q node state: %w", scope.Scope, err)
+		}
+		for _, root := range scope.Roots {
+			if !root.Root.Defined() {
+				return nil, fmt.Errorf("scope %q contains an undefined root", scope.Scope)
+			}
+			key := root.Root.KeyString()
+			if _, duplicate := state.roots[key]; duplicate {
+				return nil, fmt.Errorf("scope %q contains duplicate root %s", scope.Scope, root.Root)
+			}
+			entries, err := entriesMap(root.Entries)
+			if err != nil {
+				return nil, fmt.Errorf("scope %q root %s: %w", scope.Scope, root.Root, err)
+			}
+			state.roots[key] = entries
+		}
+		for _, root := range scope.NodeRoots {
+			if !root.Root.Defined() {
+				return nil, fmt.Errorf("scope %q contains an undefined node root", scope.Scope)
+			}
+			key := root.Root.KeyString()
+			if _, duplicate := state.nodeRoots[key]; duplicate {
+				return nil, fmt.Errorf("scope %q contains duplicate node root %s", scope.Scope, root.Root)
+			}
+			paths := make(map[arcset.Path]struct{}, len(root.Paths))
+			for _, path := range root.Paths {
+				canonical, err := arcset.NewPath(path.String())
+				if err != nil || canonical != path {
+					return nil, fmt.Errorf("scope %q node root %s contains invalid path %q", scope.Scope, root.Root, path)
+				}
+				if _, exists := state.nodes[path]; !exists {
+					return nil, fmt.Errorf("scope %q node root %s references missing path %q", scope.Scope, root.Root, path)
+				}
+				if _, duplicate := state.nodeOwners[path]; duplicate {
+					return nil, fmt.Errorf("scope %q node path %q has multiple owners", scope.Scope, path)
+				}
+				state.nodeOwners[path] = key
+				paths[path] = struct{}{}
+			}
+			state.nodeRoots[key] = paths
+		}
+		if len(state.nodeOwners) != len(state.nodes) {
+			return nil, fmt.Errorf("scope %q contains unowned node paths", scope.Scope)
+		}
+	}
+	return store, nil
+}
+
+func sortedEntries(values map[arcset.Path]cid.Cid) []Entry {
+	paths := make([]arcset.Path, 0, len(values))
+	for path := range values {
+		paths = append(paths, path)
+	}
+	sort.Slice(paths, func(i, j int) bool { return paths[i].String() < paths[j].String() })
+	out := make([]Entry, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, Entry{Path: path, Target: values[path]})
+	}
+	return out
+}
+
+func entriesMap(entries []Entry) (map[arcset.Path]cid.Cid, error) {
+	out := make(map[arcset.Path]cid.Cid, len(entries))
+	for _, entry := range entries {
+		path, err := arcset.NewPath(entry.Path.String())
+		if err != nil || path != entry.Path {
+			return nil, fmt.Errorf("invalid materializer path %q", entry.Path)
+		}
+		if !entry.Target.Defined() {
+			return nil, fmt.Errorf("materializer path %q has an undefined target", entry.Path)
+		}
+		if existing, duplicate := out[path]; duplicate {
+			if !existing.Equals(entry.Target) {
+				return nil, fmt.Errorf("materializer path %q has conflicting targets", entry.Path)
+			}
+			return nil, fmt.Errorf("duplicate materializer path %q", entry.Path)
+		}
+		out[path] = entry.Target
+	}
+	return out, nil
+}

--- a/auth/arcset/materializer/memory/state_test.go
+++ b/auth/arcset/materializer/memory/state_test.go
@@ -1,0 +1,139 @@
+package memory
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/dewebprotocol/malt/auth/arcset"
+	cid "github.com/ipfs/go-cid"
+)
+
+func TestStateRoundTripPreservesRootsAndNodeOwnership(t *testing.T) {
+	ctx := context.Background()
+	store := New(true)
+	root := testCID(t, "root")
+	nodeRoot := testCID(t, "node-root")
+	target := testCID(t, "target")
+	if err := store.Update(ctx, "scope", root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
+		"payload": target,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateNode(ctx, "scope", nodeRoot, arcset.NewSetFrom(map[string]cid.Cid{
+		"runtime/nodes/slot/7": target,
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	exported, err := store.ExportState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := NewFromState(exported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	next, err := restored.ExportState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(next, exported) {
+		t.Fatalf("restored state differs:\n got: %#v\nwant: %#v", next, exported)
+	}
+	if got, err := restored.Get(ctx, "scope", root, "payload"); err != nil || !got.Equals(target) {
+		t.Fatalf("restored logical arc = %s, %v", got, err)
+	}
+	if got, err := restored.Get(ctx, "scope", cid.Undef, "runtime/nodes/slot/7"); err != nil || !got.Equals(target) {
+		t.Fatalf("restored node arc = %s, %v", got, err)
+	}
+	if owner := restored.scopes["scope"].nodeOwners["runtime/nodes/slot/7"]; owner != nodeRoot.KeyString() {
+		t.Fatalf("restored node owner = %q, want %q", owner, nodeRoot.KeyString())
+	}
+}
+
+func TestStateRoundTripPreservesNonBranchingMode(t *testing.T) {
+	ctx := context.Background()
+	store := New(false)
+	root := testCID(t, "non-branching-root")
+	target := testCID(t, "non-branching-target")
+	if err := store.Update(ctx, "scope", root, cid.Undef, arcset.NewSetFrom(map[string]cid.Cid{
+		"payload": target,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	exported, err := store.ExportState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := NewFromState(exported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored.SupportsConcurrentBranches() {
+		t.Fatal("restored non-branching materializer unexpectedly supports concurrent branches")
+	}
+	next, err := restored.ExportState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(next, exported) {
+		t.Fatalf("restored non-branching state differs:\n got: %#v\nwant: %#v", next, exported)
+	}
+}
+
+func TestUpdateNodeRejectsSecondOwnerWithoutMutatingState(t *testing.T) {
+	ctx := context.Background()
+	store := New(true)
+	firstRoot := testCID(t, "first-node-root")
+	secondRoot := testCID(t, "second-node-root")
+	firstTarget := testCID(t, "first-node-target")
+	secondTarget := testCID(t, "second-node-target")
+	path := "runtime/nodes/shared"
+	if err := store.UpdateNode(ctx, "scope", firstRoot, arcset.NewSetFrom(map[string]cid.Cid{
+		path: firstTarget,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateNode(ctx, "scope", secondRoot, arcset.NewSetFrom(map[string]cid.Cid{
+		path: secondTarget,
+	})); err == nil {
+		t.Fatal("a second node-root owner was accepted")
+	}
+	if got, err := store.Get(ctx, "scope", cid.Undef, arcset.Path(path)); err != nil || !got.Equals(firstTarget) {
+		t.Fatalf("first owner changed after rejected update: got %s, err %v", got, err)
+	}
+	if err := store.UpdateNode(ctx, "scope", secondRoot, arcset.NewSetFrom(map[string]cid.Cid{
+		path: cid.Undef,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := store.Get(ctx, "scope", cid.Undef, arcset.Path(path)); err != nil || !got.Equals(firstTarget) {
+		t.Fatalf("non-owner delete changed first owner: got %s, err %v", got, err)
+	}
+	exported, err := store.ExportState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := NewFromState(exported)
+	if err != nil {
+		t.Fatalf("state after rejected second owner is not restorable: %v", err)
+	}
+	if owner := restored.scopes["scope"].nodeOwners[arcset.Path(path)]; owner != firstRoot.KeyString() {
+		t.Fatalf("restored node owner = %q, want %q", owner, firstRoot.KeyString())
+	}
+}
+
+func TestNewFromStateRejectsUnauthenticatableShape(t *testing.T) {
+	target := testCID(t, "target")
+	_, err := NewFromState(State{
+		Branching: true,
+		Scopes: []ScopeState{{
+			Scope: "scope",
+			Nodes: []Entry{{Path: "node/path", Target: target}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("state with an unowned node path was accepted")
+	}
+}

--- a/auth/arcset/materializer/memory/store.go
+++ b/auth/arcset/materializer/memory/store.go
@@ -5,6 +5,7 @@ package memory
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/dewebprotocol/malt/auth/arcset"
@@ -19,10 +20,11 @@ type Store struct {
 }
 
 type scopeState struct {
-	current   map[arcset.Path]cid.Cid
-	nodes     map[arcset.Path]cid.Cid
-	nodeRoots map[string]map[arcset.Path]struct{}
-	roots     map[string]map[arcset.Path]cid.Cid
+	current    map[arcset.Path]cid.Cid
+	nodes      map[arcset.Path]cid.Cid
+	nodeRoots  map[string]map[arcset.Path]struct{}
+	nodeOwners map[arcset.Path]string
+	roots      map[string]map[arcset.Path]cid.Cid
 }
 
 // New creates an in-memory materializer. branching controls whether snapshots
@@ -132,22 +134,36 @@ func (s *Store) UpdateNode(_ context.Context, scope string, root cid.Cid, values
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	state := s.ensureScope(scope)
-	paths := state.nodeRoots[root.KeyString()]
+	rootKey := root.KeyString()
+	paths := state.nodeRoots[rootKey]
 	if paths == nil {
 		paths = make(map[arcset.Path]struct{}, len(delta))
-		state.nodeRoots[root.KeyString()] = paths
 	}
+	for path, target := range delta {
+		if !target.Defined() {
+			continue
+		}
+		if owner, owned := state.nodeOwners[path]; owned && owner != rootKey {
+			return fmt.Errorf("node materializer path %q is already owned by another root", path)
+		}
+	}
+	state.nodeRoots[rootKey] = paths
 	for path, target := range delta {
 		if target.Defined() {
 			state.nodes[path] = target
 			paths[path] = struct{}{}
+			state.nodeOwners[path] = rootKey
 		} else {
+			if owner, owned := state.nodeOwners[path]; !owned || owner != rootKey {
+				continue
+			}
 			delete(state.nodes, path)
 			delete(paths, path)
+			delete(state.nodeOwners, path)
 		}
 	}
 	if len(paths) == 0 {
-		delete(state.nodeRoots, root.KeyString())
+		delete(state.nodeRoots, rootKey)
 	}
 	return nil
 }
@@ -256,6 +272,7 @@ func (s *Store) RetainRoots(retain map[string][]cid.Cid) int {
 			}
 			for path := range paths {
 				delete(state.nodes, path)
+				delete(state.nodeOwners, path)
 			}
 			delete(state.nodeRoots, key)
 			removed++
@@ -330,10 +347,11 @@ func (s *Store) ensureScope(scope string) *scopeState {
 	state := s.scopes[scope]
 	if state == nil {
 		state = &scopeState{
-			current:   map[arcset.Path]cid.Cid{},
-			nodes:     map[arcset.Path]cid.Cid{},
-			nodeRoots: map[string]map[arcset.Path]struct{}{},
-			roots:     map[string]map[arcset.Path]cid.Cid{},
+			current:    map[arcset.Path]cid.Cid{},
+			nodes:      map[arcset.Path]cid.Cid{},
+			nodeRoots:  map[string]map[arcset.Path]struct{}{},
+			nodeOwners: map[arcset.Path]string{},
+			roots:      map[string]map[arcset.Path]cid.Cid{},
 		}
 		s.scopes[scope] = state
 	}

--- a/sdk/writer/checkpoint.go
+++ b/sdk/writer/checkpoint.go
@@ -1,0 +1,151 @@
+package writer
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sort"
+
+	"github.com/dewebprotocol/malt/mutation"
+	cid "github.com/ipfs/go-cid"
+)
+
+const (
+	// AuthenticatedCheckpointProfile identifies the in-process writer checkpoint
+	// seal. Persistence and protection of the authentication key remain owned by
+	// the trusted client; this profile is not a service transition proof.
+	AuthenticatedCheckpointProfile = "malt.writer-authenticated-checkpoint/v1"
+	checkpointKeyBytes             = 32
+)
+
+// AuthenticatedCheckpoint binds one verified update view and its working roots
+// to the digest of caller-owned materializer state. The checkpoint can only be
+// restored with the same 32-byte client key that created it.
+type AuthenticatedCheckpoint struct {
+	Profile               string
+	View                  mutation.UpdateView
+	WorkingRoots          map[string]cid.Cid
+	MaterializationDigest [32]byte
+	MAC                   [32]byte
+}
+
+// Checkpoint seals the currently verified session state to materializationDigest.
+// The caller must protect key independently from the cached materializer bytes.
+func (s *Session) Checkpoint(materializationDigest [32]byte, key []byte) (AuthenticatedCheckpoint, error) {
+	if s == nil {
+		return AuthenticatedCheckpoint{}, fmt.Errorf("client writer session is nil")
+	}
+	if len(key) != checkpointKeyBytes {
+		return AuthenticatedCheckpoint{}, fmt.Errorf("client writer checkpoint key must be %d bytes", checkpointKeyBytes)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.loaded {
+		return AuthenticatedCheckpoint{}, fmt.Errorf("client writer session has no update view")
+	}
+	view, viewDigest, err := validateVerifiedUpdateView(s.runtime, s.current)
+	if err != nil {
+		return AuthenticatedCheckpoint{}, err
+	}
+	if len(s.current.workingRoots) != len(view.Objects) {
+		return AuthenticatedCheckpoint{}, fmt.Errorf("verified update view working roots are incomplete")
+	}
+	roots, err := workingRootsForView(view, s.current.workingRoots)
+	if err != nil {
+		return AuthenticatedCheckpoint{}, err
+	}
+	mac, err := checkpointMAC(key, viewDigest, materializationDigest, roots)
+	if err != nil {
+		return AuthenticatedCheckpoint{}, err
+	}
+	return AuthenticatedCheckpoint{
+		Profile:               AuthenticatedCheckpointProfile,
+		View:                  view,
+		WorkingRoots:          roots,
+		MaterializationDigest: materializationDigest,
+		MAC:                   mac,
+	}, nil
+}
+
+// RestoreCheckpoint installs a previously authenticated local checkpoint
+// without recomputing every complete vector. The caller must first restore the
+// exact materializer bytes whose digest is bound by checkpoint. A cache miss,
+// corrupt materialization, or unavailable key must fall back to Session.Load.
+func (s *Session) RestoreCheckpoint(ctx context.Context, checkpoint AuthenticatedCheckpoint, key []byte) error {
+	if s == nil {
+		return fmt.Errorf("client writer session is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if checkpoint.Profile != AuthenticatedCheckpointProfile {
+		return fmt.Errorf("unsupported client writer checkpoint profile %q", checkpoint.Profile)
+	}
+	if len(key) != checkpointKeyBytes {
+		return fmt.Errorf("client writer checkpoint key must be %d bytes", checkpointKeyBytes)
+	}
+	view, err := mutation.NormalizeUpdateView(checkpoint.View)
+	if err != nil {
+		return fmt.Errorf("normalize client writer checkpoint view: %w", err)
+	}
+	if len(checkpoint.WorkingRoots) != len(view.Objects) {
+		return fmt.Errorf("client writer checkpoint working roots are incomplete")
+	}
+	roots, err := workingRootsForView(view, checkpoint.WorkingRoots)
+	if err != nil {
+		return fmt.Errorf("client writer checkpoint working roots: %w", err)
+	}
+	viewDigest, err := view.Digest()
+	if err != nil {
+		return fmt.Errorf("digest client writer checkpoint view: %w", err)
+	}
+	want, err := checkpointMAC(key, viewDigest, checkpoint.MaterializationDigest, roots)
+	if err != nil {
+		return err
+	}
+	if !hmac.Equal(checkpoint.MAC[:], want[:]) {
+		return fmt.Errorf("client writer checkpoint authentication failed")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.current = VerifiedUpdateView{
+		View: view, runtime: s.runtime, digest: viewDigest, workingRoots: roots,
+	}
+	s.loaded = true
+	return nil
+}
+
+func checkpointMAC(key []byte, viewDigest, materializationDigest [32]byte, roots map[string]cid.Cid) ([32]byte, error) {
+	ids := make([]string, 0, len(roots))
+	for objectID := range roots {
+		ids = append(ids, objectID)
+	}
+	sort.Strings(ids)
+
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(AuthenticatedCheckpointProfile))
+	h.Write([]byte{0})
+	h.Write(viewDigest[:])
+	h.Write(materializationDigest[:])
+	var size [4]byte
+	binary.BigEndian.PutUint32(size[:], uint32(len(ids)))
+	h.Write(size[:])
+	for _, objectID := range ids {
+		if uint64(len(objectID)) > uint64(^uint32(0)) {
+			return [32]byte{}, fmt.Errorf("client writer checkpoint object id is too large")
+		}
+		binary.BigEndian.PutUint32(size[:], uint32(len(objectID)))
+		h.Write(size[:])
+		h.Write([]byte(objectID))
+		rootBytes := roots[objectID].Bytes()
+		binary.BigEndian.PutUint32(size[:], uint32(len(rootBytes)))
+		h.Write(size[:])
+		h.Write(rootBytes)
+	}
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}

--- a/sdk/writer/checkpoint_test.go
+++ b/sdk/writer/checkpoint_test.go
@@ -1,0 +1,146 @@
+package writer
+
+import (
+	"context"
+	"crypto/sha256"
+	"testing"
+
+	materializermemory "github.com/dewebprotocol/malt/auth/arcset/materializer/memory"
+	"github.com/dewebprotocol/malt/auth/commitment"
+	"github.com/dewebprotocol/malt/auth/commitment/kzg"
+	"github.com/dewebprotocol/malt/wire/maltcid"
+	cid "github.com/ipfs/go-cid"
+)
+
+type checkpointCommitCounter struct {
+	commitment.IndexCommitment
+	commits int
+}
+
+func (c *checkpointCommitCounter) Commit(values []commitment.Cell) (cid.Cid, error) {
+	c.commits++
+	return c.IndexCommitment.Commit(values)
+}
+
+func (c *checkpointCommitCounter) ProveAtRoot(root cid.Cid, values []commitment.Cell, index uint64) (commitment.Cell, []byte, error) {
+	return c.IndexCommitment.(commitment.IndexRootProver).ProveAtRoot(root, values, index)
+}
+
+func (c *checkpointCommitCounter) BatchProveAtRoot(
+	root cid.Cid,
+	values []commitment.Cell,
+	indices []uint64,
+) ([]commitment.Cell, []byte, error) {
+	return c.IndexCommitment.(commitment.IndexRootProver).BatchProveAtRoot(root, values, indices)
+}
+
+func TestAuthenticatedCheckpointRestoresMaterializedWriterState(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, intent, expectedCandidate, _ := mapWriterFixture(t, ctx, scheme)
+	store := materializermemory.New(true)
+	runtime, err := NewRuntime(store, map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := NewSession(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := session.Load(ctx, view); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.ExportState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	materializationDigest := sha256.Sum256([]byte("exact serialized materializer state"))
+	key := []byte("0123456789abcdef0123456789abcdef")
+	checkpoint, err := session.Checkpoint(materializationDigest, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restoredStore, err := materializermemory.NewFromState(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counter := &checkpointCommitCounter{IndexCommitment: scheme}
+	restoredRuntime, err := NewRuntime(restoredStore, map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: counter,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := NewSession(restoredRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := restored.RestoreCheckpoint(ctx, checkpoint, key); err != nil {
+		t.Fatal(err)
+	}
+	if counter.commits != 0 {
+		t.Fatalf("RestoreCheckpoint replayed %d complete-vector commitments", counter.commits)
+	}
+	result, err := restored.Prepare(ctx, "checkpoint-restore", intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Bundle.Candidate.Equals(expectedCandidate) {
+		t.Fatalf("restored candidate = %s, want %s", result.Bundle.Candidate, expectedCandidate)
+	}
+}
+
+func TestAuthenticatedCheckpointRejectsWrongKeyAndMutatedBindings(t *testing.T) {
+	ctx := context.Background()
+	scheme, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, _, _, _ := mapWriterFixture(t, ctx, scheme)
+	runtime, err := NewRuntime(materializermemory.New(true), map[maltcid.BackendKind]commitment.IndexCommitment{
+		maltcid.BackendKindKZG: scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := NewSession(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := session.Load(ctx, view); err != nil {
+		t.Fatal(err)
+	}
+	key := []byte("0123456789abcdef0123456789abcdef")
+	checkpoint, err := session.Checkpoint(sha256.Sum256([]byte("state")), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fresh, err := NewSession(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fresh.RestoreCheckpoint(ctx, checkpoint, []byte("fedcba9876543210fedcba9876543210")); err == nil {
+		t.Fatal("checkpoint restored with the wrong key")
+	}
+	mutatedDigest := checkpoint
+	mutatedDigest.MaterializationDigest[0] ^= 0xff
+	if err := fresh.RestoreCheckpoint(ctx, mutatedDigest, key); err == nil {
+		t.Fatal("checkpoint restored after materialization digest mutation")
+	}
+	mutatedRoots := checkpoint
+	mutatedRoots.WorkingRoots = make(map[string]cid.Cid, len(checkpoint.WorkingRoots))
+	for objectID, root := range checkpoint.WorkingRoots {
+		mutatedRoots.WorkingRoots[objectID] = root
+	}
+	delete(mutatedRoots.WorkingRoots, "child")
+	if err := fresh.RestoreCheckpoint(ctx, mutatedRoots, key); err == nil {
+		t.Fatal("checkpoint restored with incomplete working roots")
+	}
+}


### PR DESCRIPTION
## What changed

- export and restore deterministic in-memory ArcSet materializer state
- seal verified writer update views and working roots to the exact materialization digest with a client-held HMAC key
- restore authenticated writer sessions without replaying complete-vector commitments
- enforce O(1) node-path ownership checks and rebuild the reverse index during state import

## Why

Gateway Console currently replays the full update view after a refresh before writer actions are ready. This Core API lets a trusted client persist an encrypted, root-bound checkpoint and restore it without repeating the expensive commitment replay. Persistence and key protection remain client responsibilities; this is not a portable transition proof.

## Validation

- go test ./...
- go vet ./...
- go build ./...
- GOARCH=386 CGO_ENABLED=0 go test ./auth/arcset/materializer/memory ./sdk/writer
- git diff --check
- independent final review: no actionable findings