### PR TITLE
Prepare v0.0.7-rc.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.7-rc.5] - 2026-08-16
+
+This release-candidate delta lets trusted clients persist and authenticate
+verified Writer session state without changing protocol or wire semantics.
+
+### Added
+
+- Add deterministic export and strict restore validation for the in-memory
+  ArcSet materializer.
+- Add authenticated Writer session checkpoints that bind the normalized update
+  view, working roots, and caller-supplied materialization digest with a
+  caller-owned 32-byte key.
+- Restore a valid checkpoint without recomputing every complete vector, while
+  requiring cache misses, corrupt state, and unavailable keys to fall back to
+  normal session loading.
+
+### Compatibility
+
+- Checkpoints are a local SDK execution cache, not portable transition,
+  publication, freshness, or trust proofs.
+- The client owns checkpoint persistence, key protection, and verification that
+  restored materializer bytes match the digest authenticated by the checkpoint.
+- These changes do not alter MALT roots, CIDs, commitment parameters,
+  commitments, proofs, transcripts, ProofLists, receipts, schemas, or wire
+  encodings.
+
 ## [0.0.7-rc.4] - 2026-08-13
 
 This release-candidate delta reduces Writer latency for transactions that
@@ -327,7 +353,8 @@ for the trusted CLI/daemon and UnixFS application, and
 - KZG verification rejects out-of-range proof indices and non-canonical proof
   lengths instead of allowing malformed input to panic or reuse a commitment.
 
-[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.4...HEAD
+[Unreleased]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.5...HEAD
+[0.0.7-rc.5]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.4...v0.0.7-rc.5
 [0.0.7-rc.4]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.3...v0.0.7-rc.4
 [0.0.7-rc.3]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.2...v0.0.7-rc.3
 [0.0.7-rc.2]: https://github.com/DeWebProtocol/malt/compare/v0.0.7-rc.1...v0.0.7-rc.2

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ line client, daemon, UnixFS model, or website.
 [Client-root contract](./docs/spec/client-root-contract.md) ·
 [ProofList](./docs/spec/prooflist-format.md) ·
 [Compatibility](./docs/policy/compatibility.md) ·
-[v0.0.7-rc.4 release candidate](./docs/releases/v0.0.7.md) · [Roadmap](./ROADMAP.md)
+[v0.0.7-rc.5 release candidate](./docs/releases/v0.0.7.md) · [Roadmap](./ROADMAP.md)
 
-`v0.0.7-rc.4` is the current release candidate. It batches all Map changes in
-one Writer transaction into one final top-level commitment while preserving
-the roots, commitments, proofs, and wire contracts from rc.3. `/v1` profile
-suffixes do not declare MALT or its Go APIs stable at v1.
+`v0.0.7-rc.5` is the current release candidate. It adds authenticated local
+Writer session checkpoints while preserving the roots, commitments, proofs,
+and wire contracts from rc.4. `/v1` profile suffixes do not declare MALT or
+its Go APIs stable at v1.
 
 ## Boundary
 
@@ -92,7 +92,7 @@ conformance tests and examples, not deployment.
 ## Install
 
 ```bash
-go get github.com/dewebprotocol/malt@v0.0.7-rc.4
+go get github.com/dewebprotocol/malt@v0.0.7-rc.5
 ```
 
 ### Verify a resolve result

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,14 +13,14 @@ untrusted caller-supplied evidence.
 | Version | Security support |
 | --- | --- |
 | `main` | Best-effort review of current integration code |
-| `v0.0.7-rc.4` | Current experimental release candidate |
-| `v0.0.7-rc.3` | Previous experimental release candidate |
+| `v0.0.7-rc.5` | Current experimental release candidate |
+| `v0.0.7-rc.4` | Previous experimental release candidate |
 | `v0.0.6` | Previous non-prerelease experimental source release |
 | `v0.0.5` and earlier | Not supported |
 
 MALT remains pre-`v1.0.0` and experimental. Security fixes may require
 breaking API, proof, root, or wire-format changes. Consumers evaluating the
-current typed-root and Map-proof contracts should pin `v0.0.7-rc.4` rather
+current typed-root and Map-proof contracts should pin `v0.0.7-rc.5` rather
 than depend on `main`. Consumers remaining on v0.0.6 must not assume its flat
 roots are wire-compatible with this release candidate.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ research narrative remain in `DeWebProtocol/documents`.
 - [Threat model](./policy/threat-model.md)
 - [Compatibility policy](./policy/compatibility.md)
 - [Release process](./policy/releasing.md)
-- [v0.0.7-rc.4 release notes](./releases/v0.0.7.md)
+- [v0.0.7-rc.5 release notes](./releases/v0.0.7.md)
 - [v0.0.6 release notes](./releases/v0.0.6.md)
 - [v0.0.5 release notes](./releases/v0.0.5.md)
 - [v0.0.4 release notes](./releases/v0.0.4.md)

--- a/docs/policy/README.md
+++ b/docs/policy/README.md
@@ -6,7 +6,7 @@ This folder collects implementation-bound policy and release documents.
 - [Compatibility policy](./compatibility.md)
 - [Release process](./releasing.md)
 - [WASM release assets](./wasm-release-assets.md)
-- [v0.0.7-rc.4 release notes and checklist](../releases/v0.0.7.md)
+- [v0.0.7-rc.5 release notes and checklist](../releases/v0.0.7.md)
 - [v0.0.6 release notes and checklist](../releases/v0.0.6.md)
 - [v0.0.5 release notes and checklist](../releases/v0.0.5.md)
 - [v0.0.4 release notes and checklist](../releases/v0.0.4.md)

--- a/docs/policy/releasing.md
+++ b/docs/policy/releasing.md
@@ -7,11 +7,11 @@ MALT core uses source tags for experimental releases.
 Run from the repository root:
 
 Set `MALT_RELEASE_BASE` to the previous authoritative source tag. For
-v0.0.7-rc.4, that tag is `v0.0.7-rc.3`.
+v0.0.7-rc.5, that tag is `v0.0.7-rc.4`.
 
 ```bash
 set -euo pipefail
-MALT_RELEASE_BASE=v0.0.7-rc.3
+MALT_RELEASE_BASE=v0.0.7-rc.4
 git fetch --prune --tags origin
 git rev-parse --verify "${MALT_RELEASE_BASE}^{commit}"
 git merge-base --is-ancestor "$MALT_RELEASE_BASE" HEAD

--- a/docs/releases/v0.0.7.md
+++ b/docs/releases/v0.0.7.md
@@ -1,6 +1,6 @@
-# MALT v0.0.7-rc.4
+# MALT v0.0.7-rc.5
 
-Release date: 2026-08-13
+Release date: 2026-08-16
 
 This is a prerelease for integration and verifier testing. MALT remains pre-v1,
 experimental, and not production-ready.
@@ -25,7 +25,32 @@ selection or retry policy.
 
 `MALTVersionID=3` is a wire-format version, not the source release version.
 
-## Changes Since v0.0.7-rc.3
+## Changes Since v0.0.7-rc.4
+
+### Authenticated Writer session checkpoints
+
+The SDK Writer can now seal a verified session checkpoint using a caller-owned
+32-byte key. The checkpoint authenticates the normalized update view, every
+working root, and a caller-supplied digest of the materializer bytes. A valid
+checkpoint restores the verified session state without recomputing every
+complete vector.
+
+The in-memory ArcSet materializer now supports deterministic detached state
+export and strict restoration. Restore rejects duplicate scopes, roots, paths,
+conflicting targets, invalid CIDs, and missing or multiply owned node paths.
+
+Checkpoint persistence and key protection remain trusted-client policy. The
+caller must restore the exact materializer bytes bound by the authenticated
+digest before restoring a session. Cache misses, corrupt state, or unavailable
+keys must fall back to normal `Session.Load` verification. A checkpoint is a
+local execution cache, not a portable transition, publication, freshness, or
+trust proof.
+
+This SDK addition does not alter roots, CIDs, commitment parameters,
+commitments, proofs, transcripts, ProofLists, receipts, schemas, or wire
+encodings.
+
+## Changes Since v0.0.7-rc.3 Through v0.0.7-rc.4
 
 ### Batched Map Writer commitments
 
@@ -103,8 +128,8 @@ archive filenames bind both the extracted asset-set digest and the exact
 compressed archive digest:
 
 ```text
-malt-verifier-v0.0.7-rc.4-<asset-set-sha256>-<archive-sha256>.tar.gz
-malt-writer-v0.0.7-rc.4-<asset-set-sha256>-<archive-sha256>.tar.gz
+malt-verifier-v0.0.7-rc.5-<asset-set-sha256>-<archive-sha256>.tar.gz
+malt-writer-v0.0.7-rc.5-<asset-set-sha256>-<archive-sha256>.tar.gz
 ```
 
 Only complete digest paths are immutable. Consumers must load every file in a
@@ -177,7 +202,7 @@ sound collision-bucket non-membership. The release adds `MapProofRequest`,
 
 ## Compatibility
 
-The rc.2, rc.3, and rc.4 changes do not alter MALT roots, CIDs, transcripts,
+The rc.2, rc.3, rc.4, and rc.5 changes do not alter MALT roots, CIDs, transcripts,
 parameter sets, commitments, ProofLists, receipts, or proof encodings. Browser
 integrations built against v0.0.7-rc.1 must adopt the split Writer filenames
 and the `createMaltWriterWorker` controller API. Writer asset consumers must
@@ -227,9 +252,9 @@ The release candidate gate includes:
 ```bash
 set -euo pipefail
 git fetch --prune --tags origin
-git rev-parse --verify 'v0.0.7-rc.3^{commit}'
-git merge-base --is-ancestor v0.0.7-rc.3 HEAD
-git diff --check v0.0.7-rc.3...HEAD
+git rev-parse --verify 'v0.0.7-rc.4^{commit}'
+git merge-base --is-ancestor v0.0.7-rc.4 HEAD
+git diff --check v0.0.7-rc.4...HEAD
 test -z "$(gofmt -l $(find . -name '*.go' -not -path './vendor/*'))"
 go test ./...
 GOARCH=386 go test ./auth/commitment/kzg ./auth/commitment/ipa
@@ -237,7 +262,7 @@ sh scripts/test-verifier-wasm-vectors.sh
 scripts/test-writer-wasm.sh
 go vet ./...
 go build -buildvcs=false ./...
-scripts/build-wasm-release.sh v0.0.7-rc.4 dist/wasm-release
+scripts/build-wasm-release.sh v0.0.7-rc.5 dist/wasm-release
 scripts/check-wasm-release.sh dist/wasm-release
 node scripts/test-wasm-release-adversarial.mjs dist/wasm-release
 ```


### PR DESCRIPTION
## Summary

- publish v0.0.7-rc.5 release notes for authenticated Writer session checkpoints
- document deterministic in-memory materializer export and strict restore validation
- advance README, security policy, release links, and release commands from rc.4 to rc.5

## Compatibility

The checkpoint is a trusted-client local execution cache. It is not a portable transition, publication, freshness, or trust proof. This release does not change roots, CIDs, commitment parameters, commitments, proofs, transcripts, ProofLists, receipts, schemas, or wire encodings.

## Validation

- `git diff --check v0.0.7-rc.4...HEAD`
- repository-wide `gofmt` check
- `go test -p=7 -parallel=7 ./...`
- `GOARCH=386 go test -p=6 -parallel=6 ./auth/commitment/kzg ./auth/commitment/ipa`
- `sh scripts/test-verifier-wasm-vectors.sh`
- `scripts/test-writer-wasm.sh`
- `go vet -p=7 ./...`
- `go build -p=7 -buildvcs=false ./...`
- temporary external consumer build against the candidate
- two independent `scripts/build-wasm-release.sh v0.0.7-rc.5` builds under different ambient settings and umasks; byte-identical output
- `scripts/check-wasm-release.sh` and adversarial ustar validation
- independent release review: no actionable findings
