### PR TITLE
Avoid duplicate root-bound map openings

### DIFF
--- a/auth/semantic/mapping/radix/absence_internal_test.go
+++ b/auth/semantic/mapping/radix/absence_internal_test.go
@@ -226,6 +226,7 @@ type commitCountingRootScheme struct {
 	commitment.IndexCommitment
 	rootProver commitment.IndexRootProver
 	commits    int
+	proves     int
 }
 
 func (s *commitCountingRootScheme) Commit(values []commitment.Cell) (cid.Cid, error) {
@@ -234,6 +235,7 @@ func (s *commitCountingRootScheme) Commit(values []commitment.Cell) (cid.Cid, er
 }
 
 func (s *commitCountingRootScheme) ProveAtRoot(root cid.Cid, values []commitment.Cell, index uint64) (commitment.Cell, []byte, error) {
+	s.proves++
 	return s.rootProver.ProveAtRoot(root, values, index)
 }
 

--- a/auth/semantic/mapping/radix/observation_test.go
+++ b/auth/semantic/mapping/radix/observation_test.go
@@ -64,6 +64,34 @@ func TestProveReportsMaterializationOpenAndSerialization(t *testing.T) {
 	}
 }
 
+func TestProveUsesOneRootBoundOpeningPerVisitedNode(t *testing.T) {
+	base, err := kzg.NewScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheme := &commitCountingRootScheme{IndexCommitment: base, rootProver: base}
+	semanticMap, err := NewMap(scheme, materializermemory.New(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := observedRawCID(t, []byte("single-root-bound-opening"))
+	root, err := semanticMap.Commit(t.Context(), "prove-once", mapping.NewViewFrom(map[string]cid.Cid{"payload": target}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheme.proves = 0
+	binding, proof, err := semanticMap.Prove(t.Context(), "prove-once", root, arcset.Path("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !binding.Present || !binding.Value.Equals(target) || len(proof) == 0 {
+		t.Fatalf("binding=%#v proof=%d", binding, len(proof))
+	}
+	if scheme.proves != 1 {
+		t.Fatalf("ProveAtRoot calls = %d, want one opening for one visited radix node", scheme.proves)
+	}
+}
+
 func observedRawCID(t *testing.T, data []byte) cid.Cid {
 	t.Helper()
 	digest, err := mh.Sum(data, mh.SHA2_256, -1)

--- a/auth/semantic/mapping/radix/radix.go
+++ b/auth/semantic/mapping/radix/radix.go
@@ -207,7 +207,11 @@ func (s *Map) Prove(ctx context.Context, namespace string, root cid.Cid, key arc
 
 	for depth := 0; depth < s.geometry.MapDepth(len(digest)); depth++ {
 		finishMaterialization := observation.Start(ctx, observation.PhaseMaterialization)
-		slots, err := s.loadValidatedNode(ctx, namespace, currentRoot)
+		// ProveSlot below is root-bound: every supported commitment backend either
+		// opens directly against currentRoot or recomputes and compares the root.
+		// Loading through loadValidatedNode here would therefore perform a second
+		// cryptographic opening at slot zero before opening the requested slot.
+		slots, err := s.loadNodeSlots(ctx, namespace, currentRoot)
 		var materializedBytes uint64
 		if observation.Enabled(ctx) {
 			materializedBytes = cidVectorBytes(slots)


### PR DESCRIPTION
## What

- Load radix-node slots once per visited map node.
- Reuse the requested `ProveSlot` root-bound opening instead of performing an extra slot-0 opening.
- Add regressions asserting one `ProveAtRoot` call per visited node.

## Why

Gateway proof timing showed that the root-bound opening dominates cold proof generation. The previous path opened each node twice even though the requested slot proof already authenticates the node root.

## Soundness

KZG, IPA, and fallback paths remain root-bound and fail closed: every visited node is authenticated by the requested slot opening before traversal continues.

## Verification

- Targeted mapping/radix tests
- Full `go test ./...`
- Full `go vet ./...`
- Full `go build ./...`